### PR TITLE
Don't raise 500 when path is too short

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -594,8 +594,6 @@ lazy val Dependencies = new {
   val Cats = new {
     val core: Def.Initialize[ModuleID] =
       Def.setting("org.typelevel" %%% "cats-core" % "2.7.0")
-    val effect: Def.Initialize[ModuleID] =
-      Def.setting("org.typelevel" %%% "cats-effect" % "2.2.0")
   }
 
   object Fs2 {

--- a/modules/core/src/smithy4s/http/matchPath.scala
+++ b/modules/core/src/smithy4s/http/matchPath.scala
@@ -55,12 +55,16 @@ object matchPath {
     ): Option[Map[String, String]] =
       path match {
         case Nil if i >= size => Some(acc)
-        case StaticSegment(value) :: lt if compareStrings(value, received(i)) =>
+        case StaticSegment(value) :: lt
+            if i < size && compareStrings(value, received(i)) =>
           matchPathAux(lt, i + 1, acc, Nil)
-        case (LabelSegment(name) :: lt) =>
+        case (LabelSegment(name) :: lt) if i < size =>
           matchPathAux(lt, i + 1, acc + (name -> received(i)), Nil)
         case (GreedySegment(name) :: StaticSegment(value) :: lt)
-            if compareStrings(value, received(i)) && greedyAcc.nonEmpty =>
+            if i < size && compareStrings(
+              value,
+              received(i)
+            ) && greedyAcc.nonEmpty =>
           val value = greedyAcc.reverse.mkString("/")
           matchPathAux(lt, i + 1, acc + (name -> value), Nil)
         case p @ (GreedySegment(_) :: Nil) if i < size =>

--- a/modules/core/test/src/smithy4s/http/MatchPathSpec.scala
+++ b/modules/core/test/src/smithy4s/http/MatchPathSpec.scala
@@ -67,7 +67,7 @@ object MatchPathSpec extends SimpleMutableIOSuite with Checkers {
 
   test("Doesn't throw on partially matching paths") {
     forall(Gen.listOf(genLabelOrStatic)) { prefix =>
-      forall { segments: NonEmptyList[PathSegment] =>
+      forall { (segments: NonEmptyList[PathSegment]) =>
         val fullPath = prefix ::: segments.toList
         val actual = prefix.map(renderExampleSegment).mkString("/")
         expect.eql(doMatch(fullPath)(actual), None)

--- a/modules/tests/src/smithy4s/tests/PizzaSpec.scala
+++ b/modules/tests/src/smithy4s/tests/PizzaSpec.scala
@@ -254,6 +254,14 @@ abstract class PizzaSpec
     }
   }
 
+  routerTest("Negative: / doesn't match") { (client, uri, log) =>
+    for {
+      status <- client.status(GET(uri))
+    } yield {
+      expect(status.code == 404)
+    }
+  }
+
   routerTest("Health check") { (client, uri, log) =>
     for {
       res <- client.send(GET(uri / "health"), log)


### PR DESCRIPTION
Manual reproduction (before this change):

Start pizza service, send a request to `/`. This will fail with a 500 (index out of bounds: i = 0, array size = 0) regardless of the backend, as long as it uses `HttpEndpoint.matches`.