### PR TITLE
Improve type inference in Scala 3

### DIFF
--- a/modules/codegen/src/smithy4s/codegen/Renderer.scala
+++ b/modules/codegen/src/smithy4s/codegen/Renderer.scala
@@ -111,7 +111,7 @@ private[codegen] class Renderer(compilationUnit: CompilationUnit) { self =>
     case s: Service =>
       val name = s.name
       lines(
-        s"type $name[F[_]] = ${name}Gen[smithy4s.GenLift[F]#λ]",
+        s"type $name[F[_]] = smithy4s.Monadic[${name}Gen, F]",
         s"val $name : smithy4s.Service[${name}Gen, ${name}Operation] = ${name}Gen"
       )
     case _ => empty

--- a/modules/core/src-2/TypeAliases.scala
+++ b/modules/core/src-2/TypeAliases.scala
@@ -1,3 +1,19 @@
+/*
+ *  Copyright 2021 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 package smithy4s
 
 protected[smithy4s] trait TypeAliases {

--- a/modules/core/src-2/TypeAliases.scala
+++ b/modules/core/src-2/TypeAliases.scala
@@ -1,0 +1,11 @@
+package smithy4s
+
+protected[smithy4s] trait TypeAliases {
+
+  type Monadic[Alg[_[_, _, _, _, _]], F[_]] =
+    Alg[Lambda[(I, E, O, SI, SO) => F[O]]]
+
+  type Interpreter[Op[_, _, _, _, _], F[_]] =
+    Transformation[Op, Lambda[(I, E, O, SI, SO) => F[O]]]
+
+}

--- a/modules/core/src-3/TypeAliases.scala
+++ b/modules/core/src-3/TypeAliases.scala
@@ -1,0 +1,11 @@
+package smithy4s
+
+protected[smithy4s] trait TypeAliases {
+
+  type Monadic[Alg[_[_, _, _, _, _]], F[_]] =
+    Alg[[I, E, O, SI, SO] =>> F[O]]
+
+  type Interpreter[Op[_, _, _, _, _], F[_]] =
+    Transformation[Op, [I, E, O, SI, SO] =>> F[O]]
+
+}

--- a/modules/core/src-3/TypeAliases.scala
+++ b/modules/core/src-3/TypeAliases.scala
@@ -1,3 +1,19 @@
+/*
+ *  Copyright 2021 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 package smithy4s
 
 protected[smithy4s] trait TypeAliases {

--- a/modules/core/src/smithy4s/Service.scala
+++ b/modules/core/src/smithy4s/Service.scala
@@ -47,7 +47,7 @@ trait Service[Alg[_[_, _, _, _, _]], Op[_, _, _, _, _]] extends Transformable[Al
 
   def transform[P[_, _, _, _, _]](transformation: Transformation[Op, P]): Alg[P]
 
-  def asTransformation[F[_]](impl: Alg[GenLift[F]#λ]): Transformation[Op, GenLift[F]#λ] = asTransformationGen[GenLift[F]#λ](impl)
+  def asTransformation[F[_]](impl: Monadic[Alg, F]): Interpreter[Op, F] = asTransformationGen[GenLift[F]#λ](impl)
 
   def asTransformationGen[P[_, _, _, _, _]](impl: Alg[P]): Transformation[Op, P]
 

--- a/modules/core/src/smithy4s/package.scala
+++ b/modules/core/src/smithy4s/package.scala
@@ -14,7 +14,7 @@
  *  limitations under the License.
  */
 
-package object smithy4s {
+package object smithy4s extends TypeAliases {
 
   type Id[A] = A
   type Hint = Hints.Binding[_]
@@ -28,8 +28,6 @@ package object smithy4s {
 
   def segment(s: Any): String = URIEncoderDecoder.encodeOthers(s.toString())
   def greedySegment(s: String) = s.split("/").map(segment).mkString("/")
-
-  type Interpreter[Op[_, _, _, _, _], F[_]] = Transformation[Op, GenLift[F]#λ]
 
   // Allows to "inject" F[_] types in places that require F[_,_,_,_,_]
   type GenLift[F[_]] = {

--- a/modules/core/test/src/smithy4s/EmptyServiceSmokeSpec.scala
+++ b/modules/core/test/src/smithy4s/EmptyServiceSmokeSpec.scala
@@ -1,3 +1,19 @@
+/*
+ *  Copyright 2021 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 package smithy4s
 
 import weaver._

--- a/modules/core/test/src/smithy4s/TypeInferenceSmokeSpec.scala
+++ b/modules/core/test/src/smithy4s/TypeInferenceSmokeSpec.scala
@@ -1,0 +1,37 @@
+package smithy4s
+
+import weaver._
+import smithy4s.example._
+import cats.Functor
+import cats.syntax.all._
+import cats.effect.IO
+
+object TypeInferenceSmokeSpec extends SimpleIOSuite {
+
+  test("Type inference works with service calls") {
+    /*
+     * Checks that `map` can be called without upcasting the result of
+     * the service call to F[something].
+     */
+    def foo[F[_]: Functor](dummyService: DummyService[F]): F[Int] =
+      dummyService.dummy().map(_ => 1)
+
+    val dummyInstance = new DummyService[IO] {
+
+      override def dummy(
+          str: Option[String],
+          int: Option[Int],
+          ts1: Option[Timestamp],
+          ts2: Option[Timestamp],
+          ts3: Option[Timestamp],
+          ts4: Option[Timestamp],
+          b: Option[Boolean],
+          sl: Option[List[String]],
+          slm: Option[Map[String, List[String]]]
+      ): IO[Unit] = IO.unit
+
+    }
+    foo(dummyInstance).map(x => expect(x == 1))
+  }
+
+}

--- a/modules/core/test/src/smithy4s/TypeInferenceSmokeSpec.scala
+++ b/modules/core/test/src/smithy4s/TypeInferenceSmokeSpec.scala
@@ -1,3 +1,19 @@
+/*
+ *  Copyright 2021 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 package smithy4s
 
 import weaver._

--- a/modules/example/src/smithy4s/example/package.scala
+++ b/modules/example/src/smithy4s/example/package.scala
@@ -3,11 +3,11 @@ package smithy4s
 package object example {
   val NAMESPACE: String = "smithy4s.example"
 
-  type StreamedObjects[F[_]] = StreamedObjectsGen[smithy4s.GenLift[F]#λ]
+  type StreamedObjects[F[_]] = smithy4s.Monadic[StreamedObjectsGen, F]
   val StreamedObjects : smithy4s.Service[StreamedObjectsGen, StreamedObjectsOperation] = StreamedObjectsGen
-  type FooService[F[_]] = FooServiceGen[smithy4s.GenLift[F]#λ]
+  type FooService[F[_]] = smithy4s.Monadic[FooServiceGen, F]
   val FooService : smithy4s.Service[FooServiceGen, FooServiceOperation] = FooServiceGen
-  type ObjectService[F[_]] = ObjectServiceGen[smithy4s.GenLift[F]#λ]
+  type ObjectService[F[_]] = smithy4s.Monadic[ObjectServiceGen, F]
   val ObjectService : smithy4s.Service[ObjectServiceGen, ObjectServiceOperation] = ObjectServiceGen
 
   type ArbitraryData = smithy4s.example.ArbitraryData.Type

--- a/modules/http4s/src/smithy4s/http4s/SimpleProtocolBuilder.scala
+++ b/modules/http4s/src/smithy4s/http4s/SimpleProtocolBuilder.scala
@@ -39,7 +39,7 @@ abstract class SimpleProtocolBuilder[P](codecs: CodecAPI)(implicit
   ): ServiceBuilder[Alg, Op] = new ServiceBuilder(service)
 
   def routes[Alg[_[_, _, _, _, _]], Op[_, _, _, _, _], F[_]](
-      impl: Alg[GenLift[F]#λ]
+      impl: Monadic[Alg, F]
   )(implicit
       service: smithy4s.Service[Alg, Op],
       F: EffectCompat[F]
@@ -58,7 +58,7 @@ abstract class SimpleProtocolBuilder[P](codecs: CodecAPI)(implicit
     def client[F[_]: EffectCompat](
         http4sClient: Client[F],
         baseUri: Uri
-    ): Either[UnsupportedProtocolError, Alg[GenLift[F]#λ]] =
+    ): Either[UnsupportedProtocolError, Monadic[Alg, F]] =
       checkProtocol(service, protocolKey)
         .as(
           new SmithyHttp4sReverseRouter[Alg, Op, F](
@@ -73,7 +73,7 @@ abstract class SimpleProtocolBuilder[P](codecs: CodecAPI)(implicit
     def client[F[_]: EffectCompat](
         http4sApp: HttpApp[F],
         baseUri: Uri
-    ): Either[UnsupportedProtocolError, Alg[GenLift[F]#λ]] =
+    ): Either[UnsupportedProtocolError, Monadic[Alg, F]] =
       checkProtocol(service, protocolKey)
         .as(
           new SmithyHttp4sReverseRouter[Alg, Op, F](
@@ -88,7 +88,7 @@ abstract class SimpleProtocolBuilder[P](codecs: CodecAPI)(implicit
     def clientResource[F[_]: EffectCompat](
         http4sClient: Client[F],
         baseUri: Uri
-    ): Resource[F, Alg[GenLift[F]#λ]] =
+    ): Resource[F, Monadic[Alg, F]] =
       this
         .client[F](http4sClient, baseUri)
         .leftWiden[Throwable]
@@ -97,14 +97,14 @@ abstract class SimpleProtocolBuilder[P](codecs: CodecAPI)(implicit
     def clientResource[F[_]: EffectCompat](
         http4sApp: HttpApp[F],
         baseUri: Uri
-    ): Resource[F, Alg[GenLift[F]#λ]] =
+    ): Resource[F, Monadic[Alg, F]] =
       this
         .client[F](http4sApp, baseUri)
         .leftWiden[Throwable]
         .liftTo[Resource[F, *]]
 
     def routes[F[_]: EffectCompat](
-        impl: Alg[GenLift[F]#λ]
+        impl: Monadic[Alg, F]
     ): RouterBuilder[Alg, Op, F] =
       new RouterBuilder[Alg, Op, F](
         service,


### PR DESCRIPTION
By changing the type alias use for monadic algebra.