### PR TITLE
Make ShapeId a datatype

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -584,7 +584,7 @@ lazy val Dependencies = new {
     )
 
   val Smithy = new {
-    val smithyVersion = "1.15.0"
+    val smithyVersion = "1.16.0"
     val model = "software.amazon.smithy" % "smithy-model" % smithyVersion
     val awsTraits =
       "software.amazon.smithy" % "smithy-aws-traits" % smithyVersion

--- a/modules/aws-kernel/src/smithy4s/aws/AwsRegion.scala
+++ b/modules/aws-kernel/src/smithy4s/aws/AwsRegion.scala
@@ -20,8 +20,7 @@ import smithy4s.Newtype
 
 object AwsRegion extends Newtype[String] {
 
-  val namespace = "smithy4s.aws"
-  val name = "AwsRegion"
+  val id = smithy4s.ShapeId("smithy4s.aws", "AwsRegion")
 
   val AF_SOUTH_1: AwsRegion = apply("af-south-1")
   val AP_EAST_1: AwsRegion = apply("ap-east-1")

--- a/modules/aws/src/smithy4s/aws/AwsClient.scala
+++ b/modules/aws/src/smithy4s/aws/AwsClient.scala
@@ -33,14 +33,14 @@ object AwsClient {
       awsService <- service.hints
         .get(_root_.aws.api.Service)
         .liftTo[Resource[F, *]](
-          initError(s"${service.identifier} is not an AWS service")
+          initError(s"${service.id.show} is not an AWS service")
         )
       endpointPrefix <- awsService.endpointPrefix.liftTo[Resource[F, *]](
         initError(s"No endpoint prefix for $awsService")
       )
       awsProtocol <- AwsProtocol(service.hints).liftTo[Resource[F, *]](
         initError(
-          s"AWS protocol used by ${service.identifier} is not yet supported"
+          s"AWS protocol used by ${service.id.show} is not yet supported"
         )
       )
     } yield service.transform(

--- a/modules/aws/src/smithy4s/aws/internals/AwsJsonRPCInterpreter.scala
+++ b/modules/aws/src/smithy4s/aws/internals/AwsJsonRPCInterpreter.scala
@@ -42,7 +42,7 @@ private[aws] class AwsJsonRPCInterpreter[Alg[_[_, _, _, _, _]], Op[_,_,_,_,_], F
   }
 
   private val signer: AwsSigner[F] = AwsSigner.rpcSigner[F](
-    service,
+    service.id,
     endpointPrefix,
     awsEnv,
     contentType

--- a/modules/aws/src/smithy4s/aws/internals/AwsSigner.scala
+++ b/modules/aws/src/smithy4s/aws/internals/AwsSigner.scala
@@ -19,11 +19,11 @@ package internals
 
 import cats.Monad
 import cats.syntax.all._
-import smithy4s.HasId
 import smithy4s.aws.kernel.AwsSignature
 import smithy4s.http.CaseInsensitive
 import smithy4s.http.HttpMethod
 import smithy4s.http.Metadata
+import smithy4s.ShapeId
 
 private[aws] trait AwsSigner[F[_]] {
   def sign(
@@ -38,7 +38,7 @@ object AwsSigner {
   private[aws] val EMPTY_PATH = "/"
 
   private[aws] def rpcSigner[F[_]: Monad](
-      serviceId: HasId,
+      serviceId: ShapeId,
       endpointPrefix: String,
       environment: AwsEnvironment[F],
       contentType: String
@@ -46,7 +46,7 @@ object AwsSigner {
     new RPCSigner[F](serviceId, endpointPrefix, environment, contentType)
 
   private class RPCSigner[F[_]: Monad](
-      serviceId: HasId,
+      serviceId: ShapeId,
       endpointPrefix: String,
       awsEnv: AwsEnvironment[F],
       contentType: String

--- a/modules/codegen/src/smithy4s/codegen/CollisionAvoidance.scala
+++ b/modules/codegen/src/smithy4s/codegen/CollisionAvoidance.scala
@@ -31,6 +31,7 @@ object CollisionAvoidance {
         val newOps = ops.map {
           case Operation(
                 name,
+                ns,
                 params,
                 input,
                 errors,
@@ -41,6 +42,7 @@ object CollisionAvoidance {
               ) =>
             Operation(
               protect(name.capitalize),
+              ns,
               params.map(modField),
               modType(input),
               errors.map(modType),
@@ -224,6 +226,7 @@ object CollisionAvoidance {
     val Service_ = "smithy4s.Service"
     val Endpoint_ = "smithy4s.Endpoint"
     val NoInput_ = "smithy4s.NoInput"
+    val ShapeId_ = "smithy4s.ShapeId"
     val Schema_ = "smithy4s.Schema"
     val StreamingSchema_ = "smithy4s.StreamingSchema"
     val Enumeration_ = "smithy4s.Enumeration"

--- a/modules/codegen/src/smithy4s/codegen/IR.scala
+++ b/modules/codegen/src/smithy4s/codegen/IR.scala
@@ -42,6 +42,7 @@ case class Service(
 
 case class Operation(
     name: String,
+    originalNamespace: String,
     params: List[Field],
     input: Type,
     errors: List[Type],

--- a/modules/codegen/src/smithy4s/codegen/Renderer.scala
+++ b/modules/codegen/src/smithy4s/codegen/Renderer.scala
@@ -166,7 +166,7 @@ private[codegen] class Renderer(compilationUnit: CompilationUnit) { self =>
         newline,
         renderId(originalName),
         newline,
-        renderHintsVal(hints),
+        renderHintsValWithId(hints),
         newline,
         line(s"val endpoints = List").args(ops.map(_.name)),
         newline,
@@ -286,7 +286,7 @@ private[codegen] class Renderer(compilationUnit: CompilationUnit) { self =>
         renderStreamingSchemaVal("streamedInput", op.streamedInput),
         renderStreamingSchemaVal("streamedOutput", op.streamedOutput),
         renderId(op.name, op.originalNamespace),
-        renderHintsVal(op.hints),
+        renderHintsValWithId(op.hints),
         s"def wrap(input: ${op.input.render}) = ${opName}($input)",
         renderErrorable(op),
         renderHttpSpecific(op)
@@ -346,7 +346,7 @@ private[codegen] class Renderer(compilationUnit: CompilationUnit) { self =>
       obj(name, ext = hintKey(name, hints))(
         renderId(name),
         newline,
-        renderHintsVal(hints),
+        renderHintsValWithId(hints),
         newline,
         if (fields.nonEmpty) {
           val definition = if (recursive) "recursive(struct" else "struct"
@@ -449,7 +449,7 @@ private[codegen] class Renderer(compilationUnit: CompilationUnit) { self =>
       obj(name, ext = hintKey(name, hints))(
         renderId(name),
         newline,
-        renderHintsVal(hints),
+        renderHintsValWithId(hints),
         newline,
         alts.map { case Alt(altName, _, tpe, _) =>
           val cn = caseName(altName)
@@ -534,7 +534,7 @@ private[codegen] class Renderer(compilationUnit: CompilationUnit) { self =>
     val (hintsVal, hintsRef, withHints) =
       if (hints.nonEmpty)
         (
-          renderHintsVal(hints),
+          renderHintsValWithId(hints),
           s"val hints: $Hints_ = T.hints",
           ".withHints(hints)"
         )
@@ -690,9 +690,14 @@ private[codegen] class Renderer(compilationUnit: CompilationUnit) { self =>
   def renderId(name: String, ns: String = namespace): RenderResult =
     line(s"""val id: $ShapeId_ = $ShapeId_("$ns", "$name")""")
 
-  def renderHintsVal(hints: List[Hint]): RenderResult =
+  def renderHintsValWithId(hints: List[Hint]): RenderResult =
     line(s"val hints : $Hints_ = $Hints_").args {
       "id" :: hints.flatMap(renderHint(_).toList)
+    }
+
+  def renderHintsVal(hints: List[Hint]): RenderResult =
+    line(s"val hints : $Hints_ = $Hints_").args {
+      hints.flatMap(renderHint(_).toList)
     }
 
   def memberHints(hints: List[Hint]): String = {

--- a/modules/codegen/src/smithy4s/codegen/SmithyToIR.scala
+++ b/modules/codegen/src/smithy4s/codegen/SmithyToIR.scala
@@ -142,6 +142,7 @@ private[codegen] class SmithyToIR(model: Model, namespace: String) {
 
             Operation(
               op.name,
+              op.namespace,
               params,
               inputType,
               errorTypes,

--- a/modules/core/src-2/Hints.scala
+++ b/modules/core/src-2/Hints.scala
@@ -28,7 +28,8 @@ package smithy4s
   */
 trait Hints {
   def isEmpty: Boolean
-  def all: Seq[Hints.Binding[_]]
+  def toMap: Map[Hints.Key[_], Hint]
+  def all: Iterable[Hints.Binding[_]]
   def get[A](implicit key: Hints.Key[A]): Option[A]
   final def get[A](key: Hints.Key.Has[A]): Option[A] = get(key.getKey)
   final def get[T](nt: Newtype[T]): Option[nt.Type] = get(nt.key)
@@ -38,7 +39,7 @@ trait Hints {
 object Hints {
 
   def apply[S](bindings: Hint*): Hints = {
-    new Impl(bindings, bindings.map(_.tuple: (Key[_], Hint)).toMap)
+    new Impl(bindings.map(_.tuple: (Key[_], Hint)).toMap)
   }
 
   trait Schematic[F[_]] {
@@ -79,21 +80,19 @@ object Hints {
   }
 
   private[smithy4s] class Impl(
-      bindings: Seq[Hint],
-      map: Map[Key[_], Hint]
+      val toMap: Map[Key[_], Hint]
   ) extends Hints {
-    val isEmpty = bindings.isEmpty
-    val all: Seq[Hint] = bindings
+    val isEmpty = toMap.isEmpty
+    def all: Iterable[Hint] = toMap.values
     def get[A](implicit key: Key[A]): Option[A] =
-      map.get(key).map { case Binding(_, value) =>
+      toMap.get(key).map { case Binding(_, value) =>
         value.asInstanceOf[A]
       }
     def ++(other: Hints): Hints = {
-      val b = bindings ++ other.all
-      new Impl(b, b.map(_.tuple: (Key[_], Hint)).toMap)
+      new Impl(toMap ++ other.toMap)
     }
     override def toString(): String =
-      s"Hints(${bindings.map(_.value).mkString(", ")})"
+      s"Hints(${all.map(_.value).mkString(", ")})"
   }
 
   case class Binding[A](key: Key[A], value: A) {

--- a/modules/core/src-3/Newtype.scala
+++ b/modules/core/src-3/Newtype.scala
@@ -26,8 +26,7 @@ abstract class Newtype[A] extends HasId { self =>
   def unapply(orig: Type): Some[A] = Some(orig.value)
 
   implicit val key: Hints.Key[Type] = new Hints.Key[Type] {
-    def namespace: String = self.namespace
-    def name: String = self.name
+    def id: ShapeId = self.id
   }
 
 }

--- a/modules/core/src/smithy4s/HasId.scala
+++ b/modules/core/src/smithy4s/HasId.scala
@@ -17,7 +17,5 @@
 package smithy4s
 
 trait HasId {
-  def namespace: String
-  def name: String
-  def identifier: String = namespace + '.' + name
+  def id: ShapeId
 }

--- a/modules/core/src/smithy4s/ShapeId.scala
+++ b/modules/core/src/smithy4s/ShapeId.scala
@@ -16,26 +16,11 @@
 
 package smithy4s
 
-abstract class Newtype[A] extends HasId { self =>
-  // This encoding originally comes from this library:
-  // https://github.com/alexknvl/newtypes#what-does-it-do
-  type Base
-  trait _Tag extends Any
-  type Type <: Base with _Tag
+case class ShapeId(namespace: String, name: String) {
+  def show = s"$namespace#$name"
+  override def toString = show
+}
 
-  @inline final def apply(a: A): Type = a.asInstanceOf[Type]
-
-  @inline final def value(x: Type): A =
-    x.asInstanceOf[A]
-
-  implicit final class Ops(val self: Type) {
-    @inline def value: A = Newtype.this.value(self)
-  }
-
-  implicit val key: Hints.Key[Type] = new Hints.Key[Type] {
-    def id: ShapeId = self.id
-  }
-
-  def unapply(t: Type): Some[A] = Some(t.value)
-
+object ShapeId extends Hints.Key.Companion[ShapeId] {
+  def id: ShapeId = ShapeId("smithy4s", "ShapeId")
 }

--- a/modules/core/src/smithy4s/UnsupportedProtocolError.scala
+++ b/modules/core/src/smithy4s/UnsupportedProtocolError.scala
@@ -19,5 +19,5 @@ package smithy4s
 final case class UnsupportedProtocolError(service: HasId, protocolKey: HasId)
     extends Throwable {
   override def getMessage(): String =
-    s"Service ${service.identifier} does not support the ${protocolKey.identifier} protocol"
+    s"Service ${service.id.show} does not support the ${protocolKey.id.show} protocol"
 }

--- a/modules/core/src/smithy4s/http/HttpBinding.scala
+++ b/modules/core/src/smithy4s/http/HttpBinding.scala
@@ -42,8 +42,7 @@ sealed abstract class HttpBinding(val tpe: HttpBinding.Type)
 
 object HttpBinding extends Hints.Key.Companion[HttpBinding] {
 
-  def namespace: String = "smithy4s.http"
-  def name: String = "HttpBinding"
+  val id: ShapeId = ShapeId("smithy4s.http", "HttpBinding")
 
   sealed trait Type
   object Type {

--- a/modules/core/src/smithy4s/http/HttpMediaType.scala
+++ b/modules/core/src/smithy4s/http/HttpMediaType.scala
@@ -19,6 +19,5 @@ package smithy4s.http
 import smithy4s.Newtype
 
 object HttpMediaType extends Newtype[String] {
-  def namespace: String = "smithy4s.http"
-  def name: String = "HttpBinding"
+  def id: smithy4s.ShapeId = smithy4s.ShapeId("smithy4s.http", "HttpMediaType")
 }

--- a/modules/core/src/smithy4s/internals/InputOutput.scala
+++ b/modules/core/src/smithy4s/internals/InputOutput.scala
@@ -21,8 +21,7 @@ sealed trait InputOutput
 
 object InputOutput extends Hints.Key.Companion[InputOutput] {
 
-  def namespace: String = "smithy4s"
-  def name: String = "InputOuput"
+  def id: ShapeId = ShapeId("smithy4s", "InputOutput")
 
   case object Input extends InputOutput
   case object Output extends InputOutput

--- a/modules/core/test/src/smithy4s/NewtypesSpec.scala
+++ b/modules/core/test/src/smithy4s/NewtypesSpec.scala
@@ -20,14 +20,12 @@ object NewtypesSpec extends weaver.FunSuite {
 
   type AccountId = AccountId.Type
   object AccountId extends Newtype[String] {
-    def name = "AccountId"
-    def namespace = "foo"
+    def id = ShapeId("foo", "AccountId")
   }
 
   type DeviceId = DeviceId.Type
   object DeviceId extends Newtype[String] {
-    def name = "DeviceId"
-    def namespace = "foo"
+    def id = ShapeId("foo", "DeviceId")
   }
 
   val id1 = "id-1"

--- a/modules/core/test/src/smithy4s/TypeInferenceSmokeSpec.scala
+++ b/modules/core/test/src/smithy4s/TypeInferenceSmokeSpec.scala
@@ -43,7 +43,7 @@ object TypeInferenceSmokeSpec extends SimpleIOSuite {
           ts4: Option[Timestamp],
           b: Option[Boolean],
           sl: Option[List[String]],
-          slm: Option[Map[String, List[String]]]
+          slm: Option[Map[String, String]]
       ): IO[Unit] = IO.unit
 
     }

--- a/modules/core/test/src/smithy4s/http/internals/MetadataSpec.scala
+++ b/modules/core/test/src/smithy4s/http/internals/MetadataSpec.scala
@@ -30,6 +30,7 @@ import smithy4s.http.MetadataError
 import smithy4s.syntax._
 import weaver._
 import smithy4s.internals.InputOutput
+import cats.syntax.all._
 
 object MetadataSpec extends FunSuite {
 
@@ -211,9 +212,9 @@ object MetadataSpec extends FunSuite {
 
   test("map of list of strings query param") {
     val map =
-      Map("hello" -> List("a", "b", "c"), "world" -> List("f", "g", "h"))
+      Map("hello" -> "a", "world" -> "b")
     val queries = Queries(slm = Some(map))
-    val expected = Metadata(query = map)
+    val expected = Metadata(query = map.fmap(Seq(_)))
     checkRoundTrip(queries, expected)
   }
 
@@ -278,13 +279,13 @@ object MetadataSpec extends FunSuite {
   test("map of list of strings header") {
     val map =
       Map(
-        "hello" -> List("a", "b", "c"),
-        "world" -> List("f", "g", "h")
+        "hello" -> "a",
+        "world" -> "b"
       )
     val expectedHeaders =
       Map(
-        CaseInsensitive("foo-hello") -> List("a", "b", "c"),
-        CaseInsensitive("foo-world") -> List("f", "g", "h")
+        CaseInsensitive("foo-hello") -> List("a"),
+        CaseInsensitive("foo-world") -> List("b")
       )
     val expected = Metadata(headers = expectedHeaders)
     val headers = Headers(slm = Some(map))

--- a/modules/core/test/src/smithy4s/http/internals/MetadataSpec.scala
+++ b/modules/core/test/src/smithy4s/http/internals/MetadataSpec.scala
@@ -210,7 +210,7 @@ object MetadataSpec extends FunSuite {
     checkRoundTrip(queries, expected)
   }
 
-  test("map of list of strings query param") {
+  test("map of strings query param") {
     val map =
       Map("hello" -> "a", "world" -> "b")
     val queries = Queries(slm = Some(map))
@@ -276,7 +276,7 @@ object MetadataSpec extends FunSuite {
     checkRoundTrip(headers, expected)
   }
 
-  test("map of list of strings header") {
+  test("map of strings header") {
     val map =
       Map(
         "hello" -> "a",

--- a/modules/example/resources/smithy4s.example.ObjectService.json
+++ b/modules/example/resources/smithy4s.example.ObjectService.json
@@ -103,6 +103,9 @@
                     }
                 ],
                 "responses": {
+                    "200": {
+                        "description": "PutObject 200 response"
+                    },
                     "500": {
                         "description": "ServerError 500 response",
                         "content": {

--- a/modules/example/src/smithy4s/example/ArbitraryData.scala
+++ b/modules/example/src/smithy4s/example/ArbitraryData.scala
@@ -7,13 +7,13 @@ import smithy4s.syntax._
 object ArbitraryData extends Newtype[Document] {
   object T {
     val hints : smithy4s.Hints = smithy4s.Hints(
+      id,
       smithy.api.Trait(None, None, None),
     )
     val schema : smithy4s.Schema[Document] = document.withHints(hints)
     implicit val staticSchema : schematic.Static[smithy4s.Schema[Document]] = schematic.Static(schema)
   }
-  def namespace = NAMESPACE
-  val name = "ArbitraryData"
+  val id: smithy4s.ShapeId = smithy4s.ShapeId("smithy4s.example", "ArbitraryData")
   val hints: smithy4s.Hints = T.hints
   val schema : smithy4s.Schema[ArbitraryData] = bijection(T.schema, ArbitraryData(_), (_ : ArbitraryData).value)
   implicit val staticSchema : schematic.Static[smithy4s.Schema[ArbitraryData]] = schematic.Static(schema)

--- a/modules/example/src/smithy4s/example/ArbitraryData.scala
+++ b/modules/example/src/smithy4s/example/ArbitraryData.scala
@@ -5,16 +5,12 @@ import smithy4s.Newtype
 import smithy4s.syntax._
 
 object ArbitraryData extends Newtype[Document] {
-  object T {
-    val hints : smithy4s.Hints = smithy4s.Hints(
-      id,
-      smithy.api.Trait(None, None, None),
-    )
-    val schema : smithy4s.Schema[Document] = document.withHints(hints)
-    implicit val staticSchema : schematic.Static[smithy4s.Schema[Document]] = schematic.Static(schema)
-  }
   val id: smithy4s.ShapeId = smithy4s.ShapeId("smithy4s.example", "ArbitraryData")
-  val hints: smithy4s.Hints = T.hints
-  val schema : smithy4s.Schema[ArbitraryData] = bijection(T.schema, ArbitraryData(_), (_ : ArbitraryData).value)
+  val hints : smithy4s.Hints = smithy4s.Hints(
+    id,
+    smithy.api.Trait(None, None, None),
+  )
+  val underlyingSchema : smithy4s.Schema[Document] = document.withHints(hints)
+  val schema : smithy4s.Schema[ArbitraryData] = bijection(underlyingSchema, ArbitraryData(_), (_ : ArbitraryData).value)
   implicit val staticSchema : schematic.Static[smithy4s.Schema[ArbitraryData]] = schematic.Static(schema)
 }

--- a/modules/example/src/smithy4s/example/ArbitraryDataTest.scala
+++ b/modules/example/src/smithy4s/example/ArbitraryDataTest.scala
@@ -4,10 +4,10 @@ import smithy4s.syntax._
 
 case class ArbitraryDataTest()
 object ArbitraryDataTest {
-  def namespace: String = NAMESPACE
-  val name: String = "ArbitraryDataTest"
+  val id: smithy4s.ShapeId = smithy4s.ShapeId("smithy4s.example", "ArbitraryDataTest")
 
   val hints : smithy4s.Hints = smithy4s.Hints(
+    id,
     smithy4s.example.ArbitraryData(smithy4s.Document.obj("str" -> smithy4s.Document.fromString("hello"),"int" -> smithy4s.Document.fromDouble(1.0),"bool" -> smithy4s.Document.fromBoolean(true),"arr" -> smithy4s.Document.array(smithy4s.Document.fromString("one"),smithy4s.Document.fromString("two"),smithy4s.Document.fromString("three")),"obj" -> smithy4s.Document.obj("str" -> smithy4s.Document.fromString("s"),"i" -> smithy4s.Document.fromDouble(1.0)))),
   )
 

--- a/modules/example/src/smithy4s/example/BucketName.scala
+++ b/modules/example/src/smithy4s/example/BucketName.scala
@@ -8,8 +8,7 @@ object BucketName extends Newtype[String] {
     val schema : smithy4s.Schema[String] = string
     implicit val staticSchema : schematic.Static[smithy4s.Schema[String]] = schematic.Static(schema)
   }
-  def namespace = NAMESPACE
-  val name = "BucketName"
+  val id: smithy4s.ShapeId = smithy4s.ShapeId("smithy4s.example", "BucketName")
 
   val schema : smithy4s.Schema[BucketName] = bijection(T.schema, BucketName(_), (_ : BucketName).value)
   implicit val staticSchema : schematic.Static[smithy4s.Schema[BucketName]] = schematic.Static(schema)

--- a/modules/example/src/smithy4s/example/BucketName.scala
+++ b/modules/example/src/smithy4s/example/BucketName.scala
@@ -4,12 +4,8 @@ import smithy4s.Newtype
 import smithy4s.syntax._
 
 object BucketName extends Newtype[String] {
-  object T {
-    val schema : smithy4s.Schema[String] = string
-    implicit val staticSchema : schematic.Static[smithy4s.Schema[String]] = schematic.Static(schema)
-  }
   val id: smithy4s.ShapeId = smithy4s.ShapeId("smithy4s.example", "BucketName")
-
-  val schema : smithy4s.Schema[BucketName] = bijection(T.schema, BucketName(_), (_ : BucketName).value)
+  val underlyingSchema : smithy4s.Schema[String] = string
+  val schema : smithy4s.Schema[BucketName] = bijection(underlyingSchema, BucketName(_), (_ : BucketName).value)
   implicit val staticSchema : schematic.Static[smithy4s.Schema[BucketName]] = schematic.Static(schema)
 }

--- a/modules/example/src/smithy4s/example/Foo.scala
+++ b/modules/example/src/smithy4s/example/Foo.scala
@@ -4,21 +4,26 @@ import smithy4s.syntax._
 
 sealed trait Foo
 object Foo {
-  def namespace: String = NAMESPACE
-  val name: String = "Foo"
+  val id: smithy4s.ShapeId = smithy4s.ShapeId("smithy4s.example", "Foo")
 
-  val hints : smithy4s.Hints = smithy4s.Hints()
+  val hints : smithy4s.Hints = smithy4s.Hints(
+    id,
+  )
 
   case class IntCase(int: Int) extends Foo
   case class StrCase(str: String) extends Foo
 
   object IntCase {
-    val hints : smithy4s.Hints = smithy4s.Hints()
+    val hints : smithy4s.Hints = smithy4s.Hints(
+      id,
+    )
     val schema: smithy4s.Schema[IntCase] = bijection(int, IntCase(_), _.int)
     val alt = schema.oneOf[Foo]("int")
   }
   object StrCase {
-    val hints : smithy4s.Hints = smithy4s.Hints()
+    val hints : smithy4s.Hints = smithy4s.Hints(
+      id,
+    )
     val schema: smithy4s.Schema[StrCase] = bijection(string, StrCase(_), _.str)
     val alt = schema.oneOf[Foo]("str")
   }

--- a/modules/example/src/smithy4s/example/Foo.scala
+++ b/modules/example/src/smithy4s/example/Foo.scala
@@ -14,16 +14,12 @@ object Foo {
   case class StrCase(str: String) extends Foo
 
   object IntCase {
-    val hints : smithy4s.Hints = smithy4s.Hints(
-      id,
-    )
+    val hints : smithy4s.Hints = smithy4s.Hints()
     val schema: smithy4s.Schema[IntCase] = bijection(int, IntCase(_), _.int)
     val alt = schema.oneOf[Foo]("int")
   }
   object StrCase {
-    val hints : smithy4s.Hints = smithy4s.Hints(
-      id,
-    )
+    val hints : smithy4s.Hints = smithy4s.Hints()
     val schema: smithy4s.Schema[StrCase] = bijection(string, StrCase(_), _.str)
     val alt = schema.oneOf[Foo]("str")
   }

--- a/modules/example/src/smithy4s/example/FooService.scala
+++ b/modules/example/src/smithy4s/example/FooService.scala
@@ -18,14 +18,16 @@ object FooServiceGen extends smithy4s.Service[FooServiceGen, FooServiceOperation
 
   def apply[F[_]](implicit F: smithy4s.Monadic[FooServiceGen, F]): F.type = F
 
-  val hints : smithy4s.Hints = smithy4s.Hints()
+  val id: smithy4s.ShapeId = smithy4s.ShapeId("smithy4s.example", "FooService")
+
+  val hints : smithy4s.Hints = smithy4s.Hints(
+    id,
+  )
 
   val endpoints = List(
     GetFoo,
   )
 
-  def namespace: String = "smithy4s.example"
-  val name: String = "FooService"
   val version: String = "1.0.0"
 
   def endpoint[I, E, O, SI, SO](op : FooServiceOperation[I, E, O, SI, SO]) = op match {
@@ -52,7 +54,9 @@ object FooServiceGen extends smithy4s.Service[FooServiceGen, FooServiceOperation
     val output: smithy4s.Schema[GetFooOutput] = GetFooOutput.schema.withHints(smithy4s.internals.InputOutput.Output)
     val streamedInput : smithy4s.StreamingSchema[Nothing] = smithy4s.StreamingSchema.nothing
     val streamedOutput : smithy4s.StreamingSchema[Nothing] = smithy4s.StreamingSchema.nothing
+    val id: smithy4s.ShapeId = smithy4s.ShapeId("smithy4s.example", "GetFoo")
     val hints : smithy4s.Hints = smithy4s.Hints(
+      id,
       smithy.api.Http(smithy.api.NonEmptyString("GET"), smithy.api.NonEmptyString("/foo"), Some(200)),
       smithy.api.Readonly(),
     )

--- a/modules/example/src/smithy4s/example/GetFooOutput.scala
+++ b/modules/example/src/smithy4s/example/GetFooOutput.scala
@@ -4,10 +4,11 @@ import smithy4s.syntax._
 
 case class GetFooOutput(foo: Option[Foo] = None)
 object GetFooOutput {
-  def namespace: String = NAMESPACE
-  val name: String = "GetFooOutput"
+  val id: smithy4s.ShapeId = smithy4s.ShapeId("smithy4s.example", "GetFooOutput")
 
-  val hints : smithy4s.Hints = smithy4s.Hints()
+  val hints : smithy4s.Hints = smithy4s.Hints(
+    id,
+  )
 
   val schema: smithy4s.Schema[GetFooOutput] = struct(
     Foo.schema.optional[GetFooOutput]("foo", _.foo),

--- a/modules/example/src/smithy4s/example/GetObjectInput.scala
+++ b/modules/example/src/smithy4s/example/GetObjectInput.scala
@@ -4,10 +4,11 @@ import smithy4s.syntax._
 
 case class GetObjectInput(key: ObjectKey, bucketName: BucketName)
 object GetObjectInput {
-  def namespace: String = NAMESPACE
-  val name: String = "GetObjectInput"
+  val id: smithy4s.ShapeId = smithy4s.ShapeId("smithy4s.example", "GetObjectInput")
 
-  val hints : smithy4s.Hints = smithy4s.Hints()
+  val hints : smithy4s.Hints = smithy4s.Hints(
+    id,
+  )
 
   val schema: smithy4s.Schema[GetObjectInput] = struct(
     ObjectKey.schema.required[GetObjectInput]("key", _.key).withHints(smithy.api.Required(), smithy.api.HttpLabel()),

--- a/modules/example/src/smithy4s/example/GetObjectOutput.scala
+++ b/modules/example/src/smithy4s/example/GetObjectOutput.scala
@@ -4,10 +4,11 @@ import smithy4s.syntax._
 
 case class GetObjectOutput(size: ObjectSize, data: Option[String] = None)
 object GetObjectOutput {
-  def namespace: String = NAMESPACE
-  val name: String = "GetObjectOutput"
+  val id: smithy4s.ShapeId = smithy4s.ShapeId("smithy4s.example", "GetObjectOutput")
 
-  val hints : smithy4s.Hints = smithy4s.Hints()
+  val hints : smithy4s.Hints = smithy4s.Hints(
+    id,
+  )
 
   val schema: smithy4s.Schema[GetObjectOutput] = struct(
     ObjectSize.schema.required[GetObjectOutput]("size", _.size).withHints(smithy.api.HttpHeader("X-Size"), smithy.api.Required()),

--- a/modules/example/src/smithy4s/example/GetStreamedObjectInput.scala
+++ b/modules/example/src/smithy4s/example/GetStreamedObjectInput.scala
@@ -4,10 +4,11 @@ import smithy4s.syntax._
 
 case class GetStreamedObjectInput(key: String)
 object GetStreamedObjectInput {
-  def namespace: String = NAMESPACE
-  val name: String = "GetStreamedObjectInput"
+  val id: smithy4s.ShapeId = smithy4s.ShapeId("smithy4s.example", "GetStreamedObjectInput")
 
-  val hints : smithy4s.Hints = smithy4s.Hints()
+  val hints : smithy4s.Hints = smithy4s.Hints(
+    id,
+  )
 
   val schema: smithy4s.Schema[GetStreamedObjectInput] = struct(
     string.required[GetStreamedObjectInput]("key", _.key).withHints(smithy.api.Required()),

--- a/modules/example/src/smithy4s/example/GetStreamedObjectOutput.scala
+++ b/modules/example/src/smithy4s/example/GetStreamedObjectOutput.scala
@@ -4,10 +4,11 @@ import smithy4s.syntax._
 
 case class GetStreamedObjectOutput()
 object GetStreamedObjectOutput {
-  def namespace: String = NAMESPACE
-  val name: String = "GetStreamedObjectOutput"
+  val id: smithy4s.ShapeId = smithy4s.ShapeId("smithy4s.example", "GetStreamedObjectOutput")
 
-  val hints : smithy4s.Hints = smithy4s.Hints()
+  val hints : smithy4s.Hints = smithy4s.Hints(
+    id,
+  )
 
   val schema: smithy4s.Schema[GetStreamedObjectOutput] = constant(GetStreamedObjectOutput()).withHints(hints)
   implicit val staticSchema : schematic.Static[smithy4s.Schema[GetStreamedObjectOutput]] = schematic.Static(schema)

--- a/modules/example/src/smithy4s/example/LowHigh.scala
+++ b/modules/example/src/smithy4s/example/LowHigh.scala
@@ -4,8 +4,7 @@ import smithy4s.syntax._
 
 sealed abstract class LowHigh(val value: String, val ordinal: Int) extends Product with Serializable
 object LowHigh extends smithy4s.Enumeration[LowHigh] {
-  def namespace: String = NAMESPACE
-  val name: String = "LowHigh"
+  val id: smithy4s.ShapeId = smithy4s.ShapeId("smithy4s.example", "LowHigh")
 
   case object Low extends LowHigh("Low", 0)
   case object High extends LowHigh("High", 1)

--- a/modules/example/src/smithy4s/example/NoMoreSpace.scala
+++ b/modules/example/src/smithy4s/example/NoMoreSpace.scala
@@ -6,10 +6,10 @@ case class NoMoreSpace(message: String, foo: Option[Foo] = None) extends Throwab
   override def getMessage() : String = message
 }
 object NoMoreSpace {
-  def namespace: String = NAMESPACE
-  val name: String = "NoMoreSpace"
+  val id: smithy4s.ShapeId = smithy4s.ShapeId("smithy4s.example", "NoMoreSpace")
 
   val hints : smithy4s.Hints = smithy4s.Hints(
+    id,
     smithy.api.Error.SERVER,
     smithy.api.HttpError(507),
   )

--- a/modules/example/src/smithy4s/example/ObjectKey.scala
+++ b/modules/example/src/smithy4s/example/ObjectKey.scala
@@ -7,13 +7,13 @@ import smithy4s.syntax._
 object ObjectKey extends Newtype[UUID] {
   object T {
     val hints : smithy4s.Hints = smithy4s.Hints(
+      id,
       smithy4s.api.UuidFormat(),
     )
     val schema : smithy4s.Schema[UUID] = uuid.withHints(hints)
     implicit val staticSchema : schematic.Static[smithy4s.Schema[UUID]] = schematic.Static(schema)
   }
-  def namespace = NAMESPACE
-  val name = "ObjectKey"
+  val id: smithy4s.ShapeId = smithy4s.ShapeId("smithy4s.example", "ObjectKey")
   val hints: smithy4s.Hints = T.hints
   val schema : smithy4s.Schema[ObjectKey] = bijection(T.schema, ObjectKey(_), (_ : ObjectKey).value)
   implicit val staticSchema : schematic.Static[smithy4s.Schema[ObjectKey]] = schematic.Static(schema)

--- a/modules/example/src/smithy4s/example/ObjectKey.scala
+++ b/modules/example/src/smithy4s/example/ObjectKey.scala
@@ -5,16 +5,12 @@ import smithy4s.Newtype
 import smithy4s.syntax._
 
 object ObjectKey extends Newtype[UUID] {
-  object T {
-    val hints : smithy4s.Hints = smithy4s.Hints(
-      id,
-      smithy4s.api.UuidFormat(),
-    )
-    val schema : smithy4s.Schema[UUID] = uuid.withHints(hints)
-    implicit val staticSchema : schematic.Static[smithy4s.Schema[UUID]] = schematic.Static(schema)
-  }
   val id: smithy4s.ShapeId = smithy4s.ShapeId("smithy4s.example", "ObjectKey")
-  val hints: smithy4s.Hints = T.hints
-  val schema : smithy4s.Schema[ObjectKey] = bijection(T.schema, ObjectKey(_), (_ : ObjectKey).value)
+  val hints : smithy4s.Hints = smithy4s.Hints(
+    id,
+    smithy4s.api.UuidFormat(),
+  )
+  val underlyingSchema : smithy4s.Schema[UUID] = uuid.withHints(hints)
+  val schema : smithy4s.Schema[ObjectKey] = bijection(underlyingSchema, ObjectKey(_), (_ : ObjectKey).value)
   implicit val staticSchema : schematic.Static[smithy4s.Schema[ObjectKey]] = schematic.Static(schema)
 }

--- a/modules/example/src/smithy4s/example/ObjectService.scala
+++ b/modules/example/src/smithy4s/example/ObjectService.scala
@@ -22,7 +22,10 @@ object ObjectServiceGen extends smithy4s.Service[ObjectServiceGen, ObjectService
 
   def apply[F[_]](implicit F: smithy4s.Monadic[ObjectServiceGen, F]): F.type = F
 
+  val id: smithy4s.ShapeId = smithy4s.ShapeId("smithy4s.example", "ObjectService")
+
   val hints : smithy4s.Hints = smithy4s.Hints(
+    id,
     smithy4s.api.SimpleRestJson(),
   )
 
@@ -31,8 +34,6 @@ object ObjectServiceGen extends smithy4s.Service[ObjectServiceGen, ObjectService
     GetObject,
   )
 
-  def namespace: String = "smithy4s.example"
-  val name: String = "ObjectService"
   val version: String = "1.0.0"
 
   def endpoint[I, E, O, SI, SO](op : ObjectServiceOperation[I, E, O, SI, SO]) = op match {
@@ -62,7 +63,9 @@ object ObjectServiceGen extends smithy4s.Service[ObjectServiceGen, ObjectService
     val output: smithy4s.Schema[Unit] = unit.withHints(smithy4s.internals.InputOutput.Output)
     val streamedInput : smithy4s.StreamingSchema[Nothing] = smithy4s.StreamingSchema.nothing
     val streamedOutput : smithy4s.StreamingSchema[Nothing] = smithy4s.StreamingSchema.nothing
+    val id: smithy4s.ShapeId = smithy4s.ShapeId("smithy4s.example", "PutObject")
     val hints : smithy4s.Hints = smithy4s.Hints(
+      id,
       smithy.api.Idempotent(),
       smithy.api.Http(smithy.api.NonEmptyString("PUT"), smithy.api.NonEmptyString("/{bucketName}/{key}"), Some(200)),
     )
@@ -85,21 +88,26 @@ object ObjectServiceGen extends smithy4s.Service[ObjectServiceGen, ObjectService
   }
   sealed trait PutObjectError
   object PutObjectError {
-    def namespace: String = NAMESPACE
-    val name: String = "PutObjectError"
+    val id: smithy4s.ShapeId = smithy4s.ShapeId("smithy4s.example", "PutObjectError")
 
-    val hints : smithy4s.Hints = smithy4s.Hints()
+    val hints : smithy4s.Hints = smithy4s.Hints(
+      id,
+    )
 
     case class ServerErrorCase(serverError: ServerError) extends PutObjectError
     case class NoMoreSpaceCase(noMoreSpace: NoMoreSpace) extends PutObjectError
 
     object ServerErrorCase {
-      val hints : smithy4s.Hints = smithy4s.Hints()
+      val hints : smithy4s.Hints = smithy4s.Hints(
+        id,
+      )
       val schema: smithy4s.Schema[ServerErrorCase] = bijection(ServerError.schema, ServerErrorCase(_), _.serverError)
       val alt = schema.oneOf[PutObjectError]("ServerError")
     }
     object NoMoreSpaceCase {
-      val hints : smithy4s.Hints = smithy4s.Hints()
+      val hints : smithy4s.Hints = smithy4s.Hints(
+        id,
+      )
       val schema: smithy4s.Schema[NoMoreSpaceCase] = bijection(NoMoreSpace.schema, NoMoreSpaceCase(_), _.noMoreSpace)
       val alt = schema.oneOf[PutObjectError]("NoMoreSpace")
     }
@@ -120,7 +128,9 @@ object ObjectServiceGen extends smithy4s.Service[ObjectServiceGen, ObjectService
     val output: smithy4s.Schema[GetObjectOutput] = GetObjectOutput.schema.withHints(smithy4s.internals.InputOutput.Output)
     val streamedInput : smithy4s.StreamingSchema[Nothing] = smithy4s.StreamingSchema.nothing
     val streamedOutput : smithy4s.StreamingSchema[Nothing] = smithy4s.StreamingSchema.nothing
+    val id: smithy4s.ShapeId = smithy4s.ShapeId("smithy4s.example", "GetObject")
     val hints : smithy4s.Hints = smithy4s.Hints(
+      id,
       smithy.api.Http(smithy.api.NonEmptyString("GET"), smithy.api.NonEmptyString("/{bucketName}/{key}"), Some(200)),
       smithy.api.Readonly(),
     )
@@ -141,15 +151,18 @@ object ObjectServiceGen extends smithy4s.Service[ObjectServiceGen, ObjectService
   }
   sealed trait GetObjectError
   object GetObjectError {
-    def namespace: String = NAMESPACE
-    val name: String = "GetObjectError"
+    val id: smithy4s.ShapeId = smithy4s.ShapeId("smithy4s.example", "GetObjectError")
 
-    val hints : smithy4s.Hints = smithy4s.Hints()
+    val hints : smithy4s.Hints = smithy4s.Hints(
+      id,
+    )
 
     case class ServerErrorCase(serverError: ServerError) extends GetObjectError
 
     object ServerErrorCase {
-      val hints : smithy4s.Hints = smithy4s.Hints()
+      val hints : smithy4s.Hints = smithy4s.Hints(
+        id,
+      )
       val schema: smithy4s.Schema[ServerErrorCase] = bijection(ServerError.schema, ServerErrorCase(_), _.serverError)
       val alt = schema.oneOf[GetObjectError]("ServerError")
     }

--- a/modules/example/src/smithy4s/example/ObjectService.scala
+++ b/modules/example/src/smithy4s/example/ObjectService.scala
@@ -98,16 +98,12 @@ object ObjectServiceGen extends smithy4s.Service[ObjectServiceGen, ObjectService
     case class NoMoreSpaceCase(noMoreSpace: NoMoreSpace) extends PutObjectError
 
     object ServerErrorCase {
-      val hints : smithy4s.Hints = smithy4s.Hints(
-        id,
-      )
+      val hints : smithy4s.Hints = smithy4s.Hints()
       val schema: smithy4s.Schema[ServerErrorCase] = bijection(ServerError.schema, ServerErrorCase(_), _.serverError)
       val alt = schema.oneOf[PutObjectError]("ServerError")
     }
     object NoMoreSpaceCase {
-      val hints : smithy4s.Hints = smithy4s.Hints(
-        id,
-      )
+      val hints : smithy4s.Hints = smithy4s.Hints()
       val schema: smithy4s.Schema[NoMoreSpaceCase] = bijection(NoMoreSpace.schema, NoMoreSpaceCase(_), _.noMoreSpace)
       val alt = schema.oneOf[PutObjectError]("NoMoreSpace")
     }
@@ -160,9 +156,7 @@ object ObjectServiceGen extends smithy4s.Service[ObjectServiceGen, ObjectService
     case class ServerErrorCase(serverError: ServerError) extends GetObjectError
 
     object ServerErrorCase {
-      val hints : smithy4s.Hints = smithy4s.Hints(
-        id,
-      )
+      val hints : smithy4s.Hints = smithy4s.Hints()
       val schema: smithy4s.Schema[ServerErrorCase] = bijection(ServerError.schema, ServerErrorCase(_), _.serverError)
       val alt = schema.oneOf[GetObjectError]("ServerError")
     }

--- a/modules/example/src/smithy4s/example/ObjectSize.scala
+++ b/modules/example/src/smithy4s/example/ObjectSize.scala
@@ -4,12 +4,8 @@ import smithy4s.Newtype
 import smithy4s.syntax._
 
 object ObjectSize extends Newtype[Int] {
-  object T {
-    val schema : smithy4s.Schema[Int] = int
-    implicit val staticSchema : schematic.Static[smithy4s.Schema[Int]] = schematic.Static(schema)
-  }
   val id: smithy4s.ShapeId = smithy4s.ShapeId("smithy4s.example", "ObjectSize")
-
-  val schema : smithy4s.Schema[ObjectSize] = bijection(T.schema, ObjectSize(_), (_ : ObjectSize).value)
+  val underlyingSchema : smithy4s.Schema[Int] = int
+  val schema : smithy4s.Schema[ObjectSize] = bijection(underlyingSchema, ObjectSize(_), (_ : ObjectSize).value)
   implicit val staticSchema : schematic.Static[smithy4s.Schema[ObjectSize]] = schematic.Static(schema)
 }

--- a/modules/example/src/smithy4s/example/ObjectSize.scala
+++ b/modules/example/src/smithy4s/example/ObjectSize.scala
@@ -8,8 +8,7 @@ object ObjectSize extends Newtype[Int] {
     val schema : smithy4s.Schema[Int] = int
     implicit val staticSchema : schematic.Static[smithy4s.Schema[Int]] = schematic.Static(schema)
   }
-  def namespace = NAMESPACE
-  val name = "ObjectSize"
+  val id: smithy4s.ShapeId = smithy4s.ShapeId("smithy4s.example", "ObjectSize")
 
   val schema : smithy4s.Schema[ObjectSize] = bijection(T.schema, ObjectSize(_), (_ : ObjectSize).value)
   implicit val staticSchema : schematic.Static[smithy4s.Schema[ObjectSize]] = schematic.Static(schema)

--- a/modules/example/src/smithy4s/example/PutObjectInput.scala
+++ b/modules/example/src/smithy4s/example/PutObjectInput.scala
@@ -4,10 +4,11 @@ import smithy4s.syntax._
 
 case class PutObjectInput(key: ObjectKey, bucketName: BucketName, data: String, foo: Option[LowHigh] = None, someValue: Option[SomeValue] = None)
 object PutObjectInput {
-  def namespace: String = NAMESPACE
-  val name: String = "PutObjectInput"
+  val id: smithy4s.ShapeId = smithy4s.ShapeId("smithy4s.example", "PutObjectInput")
 
-  val hints : smithy4s.Hints = smithy4s.Hints()
+  val hints : smithy4s.Hints = smithy4s.Hints(
+    id,
+  )
 
   val schema: smithy4s.Schema[PutObjectInput] = struct(
     ObjectKey.schema.required[PutObjectInput]("key", _.key).withHints(smithy.api.Required(), smithy.api.HttpLabel()),

--- a/modules/example/src/smithy4s/example/PutStreamedObjectInput.scala
+++ b/modules/example/src/smithy4s/example/PutStreamedObjectInput.scala
@@ -4,10 +4,11 @@ import smithy4s.syntax._
 
 case class PutStreamedObjectInput(key: String)
 object PutStreamedObjectInput {
-  def namespace: String = NAMESPACE
-  val name: String = "PutStreamedObjectInput"
+  val id: smithy4s.ShapeId = smithy4s.ShapeId("smithy4s.example", "PutStreamedObjectInput")
 
-  val hints : smithy4s.Hints = smithy4s.Hints()
+  val hints : smithy4s.Hints = smithy4s.Hints(
+    id,
+  )
 
   val schema: smithy4s.Schema[PutStreamedObjectInput] = struct(
     string.required[PutStreamedObjectInput]("key", _.key).withHints(smithy.api.Required()),

--- a/modules/example/src/smithy4s/example/ServerError.scala
+++ b/modules/example/src/smithy4s/example/ServerError.scala
@@ -6,10 +6,10 @@ case class ServerError(message: Option[String] = None) extends Throwable {
   override def getMessage() : String = message.orNull
 }
 object ServerError {
-  def namespace: String = NAMESPACE
-  val name: String = "ServerError"
+  val id: smithy4s.ShapeId = smithy4s.ShapeId("smithy4s.example", "ServerError")
 
   val hints : smithy4s.Hints = smithy4s.Hints(
+    id,
     smithy.api.Error.SERVER,
   )
 

--- a/modules/example/src/smithy4s/example/SomeValue.scala
+++ b/modules/example/src/smithy4s/example/SomeValue.scala
@@ -4,12 +4,8 @@ import smithy4s.Newtype
 import smithy4s.syntax._
 
 object SomeValue extends Newtype[String] {
-  object T {
-    val schema : smithy4s.Schema[String] = string
-    implicit val staticSchema : schematic.Static[smithy4s.Schema[String]] = schematic.Static(schema)
-  }
   val id: smithy4s.ShapeId = smithy4s.ShapeId("smithy4s.example", "SomeValue")
-
-  val schema : smithy4s.Schema[SomeValue] = bijection(T.schema, SomeValue(_), (_ : SomeValue).value)
+  val underlyingSchema : smithy4s.Schema[String] = string
+  val schema : smithy4s.Schema[SomeValue] = bijection(underlyingSchema, SomeValue(_), (_ : SomeValue).value)
   implicit val staticSchema : schematic.Static[smithy4s.Schema[SomeValue]] = schematic.Static(schema)
 }

--- a/modules/example/src/smithy4s/example/SomeValue.scala
+++ b/modules/example/src/smithy4s/example/SomeValue.scala
@@ -8,8 +8,7 @@ object SomeValue extends Newtype[String] {
     val schema : smithy4s.Schema[String] = string
     implicit val staticSchema : schematic.Static[smithy4s.Schema[String]] = schematic.Static(schema)
   }
-  def namespace = NAMESPACE
-  val name = "SomeValue"
+  val id: smithy4s.ShapeId = smithy4s.ShapeId("smithy4s.example", "SomeValue")
 
   val schema : smithy4s.Schema[SomeValue] = bijection(T.schema, SomeValue(_), (_ : SomeValue).value)
   implicit val staticSchema : schematic.Static[smithy4s.Schema[SomeValue]] = schematic.Static(schema)

--- a/modules/example/src/smithy4s/example/StreamedBlob.scala
+++ b/modules/example/src/smithy4s/example/StreamedBlob.scala
@@ -6,13 +6,13 @@ import smithy4s.syntax._
 object StreamedBlob extends Newtype[Byte] {
   object T {
     val hints : smithy4s.Hints = smithy4s.Hints(
+      id,
       smithy.api.Streaming(),
     )
     val schema : smithy4s.Schema[Byte] = byte.withHints(hints)
     implicit val staticSchema : schematic.Static[smithy4s.Schema[Byte]] = schematic.Static(schema)
   }
-  def namespace = NAMESPACE
-  val name = "StreamedBlob"
+  val id: smithy4s.ShapeId = smithy4s.ShapeId("smithy4s.example", "StreamedBlob")
   val hints: smithy4s.Hints = T.hints
   val schema : smithy4s.Schema[StreamedBlob] = bijection(T.schema, StreamedBlob(_), (_ : StreamedBlob).value)
   implicit val staticSchema : schematic.Static[smithy4s.Schema[StreamedBlob]] = schematic.Static(schema)

--- a/modules/example/src/smithy4s/example/StreamedBlob.scala
+++ b/modules/example/src/smithy4s/example/StreamedBlob.scala
@@ -4,16 +4,12 @@ import smithy4s.Newtype
 import smithy4s.syntax._
 
 object StreamedBlob extends Newtype[Byte] {
-  object T {
-    val hints : smithy4s.Hints = smithy4s.Hints(
-      id,
-      smithy.api.Streaming(),
-    )
-    val schema : smithy4s.Schema[Byte] = byte.withHints(hints)
-    implicit val staticSchema : schematic.Static[smithy4s.Schema[Byte]] = schematic.Static(schema)
-  }
   val id: smithy4s.ShapeId = smithy4s.ShapeId("smithy4s.example", "StreamedBlob")
-  val hints: smithy4s.Hints = T.hints
-  val schema : smithy4s.Schema[StreamedBlob] = bijection(T.schema, StreamedBlob(_), (_ : StreamedBlob).value)
+  val hints : smithy4s.Hints = smithy4s.Hints(
+    id,
+    smithy.api.Streaming(),
+  )
+  val underlyingSchema : smithy4s.Schema[Byte] = byte.withHints(hints)
+  val schema : smithy4s.Schema[StreamedBlob] = bijection(underlyingSchema, StreamedBlob(_), (_ : StreamedBlob).value)
   implicit val staticSchema : schematic.Static[smithy4s.Schema[StreamedBlob]] = schematic.Static(schema)
 }

--- a/modules/example/src/smithy4s/example/StreamedObjects.scala
+++ b/modules/example/src/smithy4s/example/StreamedObjects.scala
@@ -19,15 +19,17 @@ object StreamedObjectsGen extends smithy4s.Service[StreamedObjectsGen, StreamedO
 
   def apply[F[_]](implicit F: smithy4s.Monadic[StreamedObjectsGen, F]): F.type = F
 
-  val hints : smithy4s.Hints = smithy4s.Hints()
+  val id: smithy4s.ShapeId = smithy4s.ShapeId("smithy4s.example", "StreamedObjects")
+
+  val hints : smithy4s.Hints = smithy4s.Hints(
+    id,
+  )
 
   val endpoints = List(
     PutStreamedObject,
     GetStreamedObject,
   )
 
-  def namespace: String = "smithy4s.example"
-  val name: String = "StreamedObjects"
   val version: String = "1.0.0"
 
   def endpoint[I, E, O, SI, SO](op : StreamedObjectsOperation[I, E, O, SI, SO]) = op match {
@@ -57,7 +59,10 @@ object StreamedObjectsGen extends smithy4s.Service[StreamedObjectsGen, StreamedO
     val output: smithy4s.Schema[Unit] = unit.withHints(smithy4s.internals.InputOutput.Output)
     val streamedInput : smithy4s.StreamingSchema[StreamedBlob] = smithy4s.StreamingSchema("PutStreamedObjectInput", StreamedBlob.schema)
     val streamedOutput : smithy4s.StreamingSchema[Nothing] = smithy4s.StreamingSchema.nothing
-    val hints : smithy4s.Hints = smithy4s.Hints()
+    val id: smithy4s.ShapeId = smithy4s.ShapeId("smithy4s.example", "PutStreamedObject")
+    val hints : smithy4s.Hints = smithy4s.Hints(
+      id,
+    )
     def wrap(input: PutStreamedObjectInput) = PutStreamedObject(input)
   }
   case class GetStreamedObject(input: GetStreamedObjectInput) extends StreamedObjectsOperation[GetStreamedObjectInput, Nothing, GetStreamedObjectOutput, Nothing, StreamedBlob]
@@ -67,7 +72,10 @@ object StreamedObjectsGen extends smithy4s.Service[StreamedObjectsGen, StreamedO
     val output: smithy4s.Schema[GetStreamedObjectOutput] = GetStreamedObjectOutput.schema.withHints(smithy4s.internals.InputOutput.Output)
     val streamedInput : smithy4s.StreamingSchema[Nothing] = smithy4s.StreamingSchema.nothing
     val streamedOutput : smithy4s.StreamingSchema[StreamedBlob] = smithy4s.StreamingSchema("GetStreamedObjectOutput", StreamedBlob.schema)
-    val hints : smithy4s.Hints = smithy4s.Hints()
+    val id: smithy4s.ShapeId = smithy4s.ShapeId("smithy4s.example", "GetStreamedObject")
+    val hints : smithy4s.Hints = smithy4s.Hints(
+      id,
+    )
     def wrap(input: GetStreamedObjectInput) = GetStreamedObject(input)
   }
 }

--- a/modules/example/src/smithy4s/example/package.scala
+++ b/modules/example/src/smithy4s/example/package.scala
@@ -1,28 +1,23 @@
 package smithy4s
 
 package object example {
-  val NAMESPACE: String = "smithy4s.example"
-
   type StreamedObjects[F[_]] = smithy4s.Monadic[StreamedObjectsGen, F]
   object StreamedObjects extends smithy4s.Service.Provider[StreamedObjectsGen, StreamedObjectsOperation] {
     def apply[F[_]](implicit F: StreamedObjects[F]): F.type = F
     def service : smithy4s.Service[StreamedObjectsGen, StreamedObjectsOperation] = StreamedObjectsGen
-    def namespace: String = service.namespace
-    def name: String = service.name
+    val id: smithy4s.ShapeId = service.id
   }
   type FooService[F[_]] = smithy4s.Monadic[FooServiceGen, F]
   object FooService extends smithy4s.Service.Provider[FooServiceGen, FooServiceOperation] {
     def apply[F[_]](implicit F: FooService[F]): F.type = F
     def service : smithy4s.Service[FooServiceGen, FooServiceOperation] = FooServiceGen
-    def namespace: String = service.namespace
-    def name: String = service.name
+    val id: smithy4s.ShapeId = service.id
   }
   type ObjectService[F[_]] = smithy4s.Monadic[ObjectServiceGen, F]
   object ObjectService extends smithy4s.Service.Provider[ObjectServiceGen, ObjectServiceOperation] {
     def apply[F[_]](implicit F: ObjectService[F]): F.type = F
     def service : smithy4s.Service[ObjectServiceGen, ObjectServiceOperation] = ObjectServiceGen
-    def namespace: String = service.namespace
-    def name: String = service.name
+    val id: smithy4s.ShapeId = service.id
   }
 
   type ArbitraryData = smithy4s.example.ArbitraryData.Type

--- a/modules/http4s-swagger/src-jvm/smithy4s/http4s/swagger/Docs.scala
+++ b/modules/http4s-swagger/src-jvm/smithy4s/http4s/swagger/Docs.scala
@@ -33,7 +33,7 @@ private[smithy4s] abstract class Docs[F[_]](
     extends Http4sDsl[F]
     with Compat.DocsClass[F] {
 
-  val jsonSpec = hasId.identifier + ".json"
+  val jsonSpec = hasId.id.namespace + '.' + hasId.id.name + ".json"
 
   val actualPath: Path = Uri.Path.unsafeFromString("/" + path)
 

--- a/modules/http4s-swagger/test/src-ce2/TestCompat.scala
+++ b/modules/http4s-swagger/test/src-ce2/TestCompat.scala
@@ -16,6 +16,7 @@
 
 package smithy4s.http4s.swagger
 
+import smithy4s.ShapeId
 import cats.effect.Blocker
 import cats.effect.IO
 import smithy4s.HasId
@@ -29,8 +30,7 @@ trait TestCompat { self: BaseIOSuite with RunnableSuite[IO] =>
     Blocker.liftExecutionContext(ExecutionContext.Implicits.global)
 
   def service = new HasId {
-    def namespace: String = "foobar"
-    def name: String = "test-spec"
+    def id: ShapeId = ShapeId("foobar", "test-spec")
   }
 
   def docs(path: String) =

--- a/modules/http4s-swagger/test/src-ce3/TestCompat.scala
+++ b/modules/http4s-swagger/test/src-ce3/TestCompat.scala
@@ -16,6 +16,7 @@
 
 package smithy4s.http4s.swagger
 
+import smithy4s.ShapeId
 import cats.effect.IO
 import smithy4s.HasId
 import weaver.BaseIOSuite
@@ -23,8 +24,7 @@ import weaver.BaseIOSuite
 trait TestCompat { self: BaseIOSuite =>
 
   def service = new HasId {
-    def namespace: String = "foobar"
-    def name: String = "test-spec"
+    def id: ShapeId = ShapeId("foobar", "test-spec")
   }
 
   def docs(path: String) =

--- a/modules/openapi/src/software/amazon/smithy/openapi/fromsmithy/protocols/Smithy4sAbstractRestProtocol.scala
+++ b/modules/openapi/src/software/amazon/smithy/openapi/fromsmithy/protocols/Smithy4sAbstractRestProtocol.scala
@@ -395,7 +395,7 @@ abstract class Smithy4sAbstractRestProtocol[T <: Trait]
     val result = new util.TreeMap[String, ResponseObject]
     val operationIndex = OperationIndex.of(updatedModel)
     operationIndex
-      .getOutput(operation)
+      .getOutputShape(operation)
       .asScala
       .foreach((output: StructureShape) => {
         updateResponsesMapWithResponseStatusAndObject(

--- a/sampleSpecs/metadata.smithy
+++ b/sampleSpecs/metadata.smithy
@@ -32,7 +32,7 @@ structure Queries {
   @httpQuery("sl")
   sl : StringList,
   @httpQueryParams
-  slm: StringListMap
+  slm: StringMap
 }
 
 structure Headers {
@@ -56,7 +56,7 @@ structure Headers {
   @httpHeader("sl")
   sl : StringList,
   @httpPrefixHeaders("foo-")
-  slm: StringListMap
+  slm: StringMap
 }
 
 structure PathParams {
@@ -93,11 +93,6 @@ list StringList {
 map StringMap {
   key: String,
   value: String
-}
-
-map StringListMap {
-  key: String,
-  value: StringList
 }
 
 structure ValidationChecks {


### PR DESCRIPTION
And use it as a hint everywhere. The rationale is as follows :

1. would be useful for error messages
2. will be required for implementing some protocols
3. `ShapeId` can be used as a map key for dynamic purposes