### PR TITLE
add header validator

### DIFF
--- a/modules/protocol/resources/META-INF/services/software.amazon.smithy.model.validation.Validator
+++ b/modules/protocol/resources/META-INF/services/software.amazon.smithy.model.validation.Validator
@@ -1,1 +1,2 @@
 smithy4s.api.validation.SimpleRestJsonValidator
+smithy4s.api.validation.HttpHeaderValidator

--- a/modules/protocol/src/smithy4s/api/validation/HttpHeaderValidator.java
+++ b/modules/protocol/src/smithy4s/api/validation/HttpHeaderValidator.java
@@ -33,8 +33,8 @@ public final class HttpHeaderValidator extends AbstractValidator {
     public List<ValidationEvent> validate(Model model) {
         return model.getShapesWithTrait(HttpHeaderTrait.class).stream().flatMap(headerShape -> {
             String value = headerShape.getTrait(HttpHeaderTrait.class).get().getValue();
-            if (disallowedHeaderNames.contains(value)) {
-                return Stream.of(error(headerShape, String.format("Header named `%s` should not be present since it is automatically filled", value)));
+            if (disallowedHeaderNames.contains(value.toLowerCase())) {
+                return Stream.of(warning(headerShape, String.format("Header named `%s` should not be present since it is automatically filled", value)));
             } else {
                 return Stream.empty();
             }

--- a/modules/protocol/src/smithy4s/api/validation/HttpHeaderValidator.java
+++ b/modules/protocol/src/smithy4s/api/validation/HttpHeaderValidator.java
@@ -1,0 +1,43 @@
+/*
+ *  Copyright 2021 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package smithy4s.api.validation;
+
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.traits.HttpHeaderTrait;
+import software.amazon.smithy.model.validation.AbstractValidator;
+import software.amazon.smithy.model.validation.ValidationEvent;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public final class HttpHeaderValidator extends AbstractValidator {
+
+    List<String> disallowedHeaderNames = java.util.Arrays.asList("content-type");
+
+    @Override
+    public List<ValidationEvent> validate(Model model) {
+        return model.getShapesWithTrait(HttpHeaderTrait.class).stream().flatMap(headerShape -> {
+            String value = headerShape.getTrait(HttpHeaderTrait.class).get().getValue();
+            if (disallowedHeaderNames.contains(value)) {
+                return Stream.of(error(headerShape, String.format("Header named `%s` should not be present since it is automatically filled", value)));
+            } else {
+                return Stream.empty();
+            }
+        }).collect(Collectors.toList());
+    }
+}

--- a/modules/protocol/src/smithy4s/api/validation/HttpHeaderValidator.java
+++ b/modules/protocol/src/smithy4s/api/validation/HttpHeaderValidator.java
@@ -34,7 +34,7 @@ public final class HttpHeaderValidator extends AbstractValidator {
         return model.getShapesWithTrait(HttpHeaderTrait.class).stream().flatMap(headerShape -> {
             String value = headerShape.getTrait(HttpHeaderTrait.class).get().getValue();
             if (disallowedHeaderNames.contains(value.toLowerCase())) {
-                return Stream.of(warning(headerShape, String.format("Header named `%s` should not be present since it is automatically filled", value)));
+                return Stream.of(warning(headerShape, String.format("Header named `%s` may be overridden in client/server implementations", value)));
             } else {
                 return Stream.empty();
             }

--- a/modules/protocol/test/src/smithy4s/api/validation/HttpHeaderValidatorSpec.scala
+++ b/modules/protocol/test/src/smithy4s/api/validation/HttpHeaderValidatorSpec.scala
@@ -31,7 +31,7 @@ object HttpHeaderValidatorSpec extends weaver.FunSuite {
       .builder()
       .id("test#struct$testing")
       .target("smithy.api#String")
-      .addTrait(new HttpHeaderTrait("content-type"))
+      .addTrait(new HttpHeaderTrait("Content-Type"))
       .build()
     val struct =
       StructureShape.builder().id("test#struct").addMember(member).build()
@@ -46,9 +46,9 @@ object HttpHeaderValidatorSpec extends weaver.FunSuite {
         .builder()
         .id("HttpHeader")
         .shape(member)
-        .severity(Severity.ERROR)
+        .severity(Severity.WARNING)
         .message(
-          "Header named `content-type` should not be present since it is automatically filled"
+          "Header named `Content-Type` should not be present since it is automatically filled"
         )
         .build()
     )

--- a/modules/protocol/test/src/smithy4s/api/validation/HttpHeaderValidatorSpec.scala
+++ b/modules/protocol/test/src/smithy4s/api/validation/HttpHeaderValidatorSpec.scala
@@ -1,0 +1,77 @@
+/*
+ *  Copyright 2021 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package smithy4s.api.validation
+
+import software.amazon.smithy.model.Model
+import software.amazon.smithy.model.shapes.{MemberShape, StructureShape}
+import software.amazon.smithy.model.traits.HttpHeaderTrait
+import software.amazon.smithy.model.validation.{Severity, ValidationEvent}
+
+import scala.jdk.CollectionConverters._
+
+object HttpHeaderValidatorSpec extends weaver.FunSuite {
+
+  test("reject models with content-type header") {
+    val validator = new HttpHeaderValidator()
+    val member = MemberShape
+      .builder()
+      .id("test#struct$testing")
+      .target("smithy.api#String")
+      .addTrait(new HttpHeaderTrait("content-type"))
+      .build()
+    val struct =
+      StructureShape.builder().id("test#struct").addMember(member).build()
+
+    val model =
+      Model.builder().addShape(struct).build()
+
+    val result = validator.validate(model).asScala.toList
+
+    val expected = List(
+      ValidationEvent
+        .builder()
+        .id("HttpHeader")
+        .shape(member)
+        .severity(Severity.ERROR)
+        .message(
+          "Header named `content-type` should not be present since it is automatically filled"
+        )
+        .build()
+    )
+    expect(result == expected)
+  }
+
+  test("accept random arbitrary header") {
+    val validator = new HttpHeaderValidator()
+    val member = MemberShape
+      .builder()
+      .id("test#struct$testing")
+      .target("smithy.api#String")
+      .addTrait(new HttpHeaderTrait("random"))
+      .build()
+    val struct =
+      StructureShape.builder().id("test#struct").addMember(member).build()
+
+    val model =
+      Model.builder().addShape(struct).build()
+
+    val result = validator.validate(model).asScala.toList
+
+    expect(result == List.empty)
+  }
+
+}

--- a/modules/protocol/test/src/smithy4s/api/validation/HttpHeaderValidatorSpec.scala
+++ b/modules/protocol/test/src/smithy4s/api/validation/HttpHeaderValidatorSpec.scala
@@ -48,7 +48,7 @@ object HttpHeaderValidatorSpec extends weaver.FunSuite {
         .shape(member)
         .severity(Severity.WARNING)
         .message(
-          "Header named `Content-Type` should not be present since it is automatically filled"
+          "Header named `Content-Type` may be overridden in client/server implementations"
         )
         .build()
     )


### PR DESCRIPTION
Adds validator to make sure headers cannot be set if they are automatically set down the line.

Closes #28.