### PR TITLE
Render ShapeId for operations 

### DIFF
--- a/modules/aws-kernel/src/smithy4s/aws/AwsSignature.scala
+++ b/modules/aws-kernel/src/smithy4s/aws/AwsSignature.scala
@@ -16,7 +16,7 @@
 
 package smithy4s.aws.kernel
 
-import smithy4s.URIEncoderDecoder.{encodeOthers => uriEncode}
+import smithy4s.http.internals.URIEncoderDecoder.{encodeOthers => uriEncode}
 import smithy4s.http.CaseInsensitive
 import smithy4s.http.HttpMethod
 

--- a/modules/codegen/src/smithy4s/codegen/Renderer.scala
+++ b/modules/codegen/src/smithy4s/codegen/Renderer.scala
@@ -280,12 +280,11 @@ private[codegen] class Renderer(compilationUnit: CompilationUnit) { self =>
         ext =
           s"$Endpoint_[${traitName}, ${op.renderAlgParams}]$httpEndpoint$errorable"
       )(
-        s"""def name: String = "${opName}"""",
+        renderId(op.name, op.originalNamespace),
         s"val input: $Schema_[${op.input.render}] = ${op.input.schemaRef}.withHints(smithy4s.internals.InputOutput.Input)",
         s"val output: $Schema_[${op.output.render}] = ${op.output.schemaRef}.withHints(smithy4s.internals.InputOutput.Output)",
         renderStreamingSchemaVal("streamedInput", op.streamedInput),
         renderStreamingSchemaVal("streamedOutput", op.streamedOutput),
-        renderId(op.name, op.originalNamespace),
         renderHintsValWithId(op.hints),
         s"def wrap(input: ${op.input.render}) = ${opName}($input)",
         renderErrorable(op),

--- a/modules/core/src/smithy4s/Endpoint.scala
+++ b/modules/core/src/smithy4s/Endpoint.scala
@@ -40,7 +40,8 @@ package smithy4s
   * be encoded a great many ways, using a greatt many libraries)
   */
 trait Endpoint[Op[_, _, _, _, _], I, E, O, SI, SO] { outer =>
-  def name: String
+  def id: ShapeId
+  final def name: String = id.name
   def input: Schema[I]
   def output: Schema[O]
   def streamedInput: StreamingSchema[SI]

--- a/modules/core/src/smithy4s/http/UnknownErrorResponse.scala
+++ b/modules/core/src/smithy4s/http/UnknownErrorResponse.scala
@@ -14,7 +14,7 @@
  *  limitations under the License.
  */
 
-package smithy4s
+package smithy4s.http
 
 case class UnknownErrorResponse(
     code: Int,

--- a/modules/core/src/smithy4s/http/internals/URIEncoderDecoder.scala
+++ b/modules/core/src/smithy4s/http/internals/URIEncoderDecoder.scala
@@ -15,11 +15,13 @@
  */
 
 package smithy4s
+package http
+package internals
 
 import java.io.ByteArrayOutputStream
 import java.net._
 
-object URIEncoderDecoder {
+private[smithy4s] object URIEncoderDecoder {
 
   val digits: String = "0123456789ABCDEF"
 

--- a/modules/core/src/smithy4s/package.scala
+++ b/modules/core/src/smithy4s/package.scala
@@ -14,6 +14,8 @@
  *  limitations under the License.
  */
 
+import smithy4s.http.internals.URIEncoderDecoder
+
 package object smithy4s extends TypeAliases {
 
   type Hint = Hints.Binding[_]

--- a/modules/example/src/smithy4s/example/FooService.scala
+++ b/modules/example/src/smithy4s/example/FooService.scala
@@ -49,12 +49,11 @@ object FooServiceGen extends smithy4s.Service[FooServiceGen, FooServiceOperation
   }
   case class GetFoo() extends FooServiceOperation[Unit, Nothing, GetFooOutput, Nothing, Nothing]
   object GetFoo extends smithy4s.Endpoint[FooServiceOperation, Unit, Nothing, GetFooOutput, Nothing, Nothing] with http.HttpEndpoint[Unit] {
-    def name: String = "GetFoo"
+    val id: smithy4s.ShapeId = smithy4s.ShapeId("smithy4s.example", "GetFoo")
     val input: smithy4s.Schema[Unit] = unit.withHints(smithy4s.internals.InputOutput.Input)
     val output: smithy4s.Schema[GetFooOutput] = GetFooOutput.schema.withHints(smithy4s.internals.InputOutput.Output)
     val streamedInput : smithy4s.StreamingSchema[Nothing] = smithy4s.StreamingSchema.nothing
     val streamedOutput : smithy4s.StreamingSchema[Nothing] = smithy4s.StreamingSchema.nothing
-    val id: smithy4s.ShapeId = smithy4s.ShapeId("smithy4s.example", "GetFoo")
     val hints : smithy4s.Hints = smithy4s.Hints(
       id,
       smithy.api.Http(smithy.api.NonEmptyString("GET"), smithy.api.NonEmptyString("/foo"), Some(200)),

--- a/modules/example/src/smithy4s/example/ObjectService.scala
+++ b/modules/example/src/smithy4s/example/ObjectService.scala
@@ -58,12 +58,11 @@ object ObjectServiceGen extends smithy4s.Service[ObjectServiceGen, ObjectService
   }
   case class PutObject(input: PutObjectInput) extends ObjectServiceOperation[PutObjectInput, PutObjectError, Unit, Nothing, Nothing]
   object PutObject extends smithy4s.Endpoint[ObjectServiceOperation, PutObjectInput, PutObjectError, Unit, Nothing, Nothing] with http.HttpEndpoint[PutObjectInput] with smithy4s.Errorable[PutObjectError] {
-    def name: String = "PutObject"
+    val id: smithy4s.ShapeId = smithy4s.ShapeId("smithy4s.example", "PutObject")
     val input: smithy4s.Schema[PutObjectInput] = PutObjectInput.schema.withHints(smithy4s.internals.InputOutput.Input)
     val output: smithy4s.Schema[Unit] = unit.withHints(smithy4s.internals.InputOutput.Output)
     val streamedInput : smithy4s.StreamingSchema[Nothing] = smithy4s.StreamingSchema.nothing
     val streamedOutput : smithy4s.StreamingSchema[Nothing] = smithy4s.StreamingSchema.nothing
-    val id: smithy4s.ShapeId = smithy4s.ShapeId("smithy4s.example", "PutObject")
     val hints : smithy4s.Hints = smithy4s.Hints(
       id,
       smithy.api.Idempotent(),
@@ -119,12 +118,11 @@ object ObjectServiceGen extends smithy4s.Service[ObjectServiceGen, ObjectService
   }
   case class GetObject(input: GetObjectInput) extends ObjectServiceOperation[GetObjectInput, GetObjectError, GetObjectOutput, Nothing, Nothing]
   object GetObject extends smithy4s.Endpoint[ObjectServiceOperation, GetObjectInput, GetObjectError, GetObjectOutput, Nothing, Nothing] with http.HttpEndpoint[GetObjectInput] with smithy4s.Errorable[GetObjectError] {
-    def name: String = "GetObject"
+    val id: smithy4s.ShapeId = smithy4s.ShapeId("smithy4s.example", "GetObject")
     val input: smithy4s.Schema[GetObjectInput] = GetObjectInput.schema.withHints(smithy4s.internals.InputOutput.Input)
     val output: smithy4s.Schema[GetObjectOutput] = GetObjectOutput.schema.withHints(smithy4s.internals.InputOutput.Output)
     val streamedInput : smithy4s.StreamingSchema[Nothing] = smithy4s.StreamingSchema.nothing
     val streamedOutput : smithy4s.StreamingSchema[Nothing] = smithy4s.StreamingSchema.nothing
-    val id: smithy4s.ShapeId = smithy4s.ShapeId("smithy4s.example", "GetObject")
     val hints : smithy4s.Hints = smithy4s.Hints(
       id,
       smithy.api.Http(smithy.api.NonEmptyString("GET"), smithy.api.NonEmptyString("/{bucketName}/{key}"), Some(200)),

--- a/modules/example/src/smithy4s/example/StreamedObjects.scala
+++ b/modules/example/src/smithy4s/example/StreamedObjects.scala
@@ -54,12 +54,11 @@ object StreamedObjectsGen extends smithy4s.Service[StreamedObjectsGen, StreamedO
   }
   case class PutStreamedObject(input: PutStreamedObjectInput) extends StreamedObjectsOperation[PutStreamedObjectInput, Nothing, Unit, StreamedBlob, Nothing]
   object PutStreamedObject extends smithy4s.Endpoint[StreamedObjectsOperation, PutStreamedObjectInput, Nothing, Unit, StreamedBlob, Nothing] {
-    def name: String = "PutStreamedObject"
+    val id: smithy4s.ShapeId = smithy4s.ShapeId("smithy4s.example", "PutStreamedObject")
     val input: smithy4s.Schema[PutStreamedObjectInput] = PutStreamedObjectInput.schema.withHints(smithy4s.internals.InputOutput.Input)
     val output: smithy4s.Schema[Unit] = unit.withHints(smithy4s.internals.InputOutput.Output)
     val streamedInput : smithy4s.StreamingSchema[StreamedBlob] = smithy4s.StreamingSchema("PutStreamedObjectInput", StreamedBlob.schema)
     val streamedOutput : smithy4s.StreamingSchema[Nothing] = smithy4s.StreamingSchema.nothing
-    val id: smithy4s.ShapeId = smithy4s.ShapeId("smithy4s.example", "PutStreamedObject")
     val hints : smithy4s.Hints = smithy4s.Hints(
       id,
     )
@@ -67,12 +66,11 @@ object StreamedObjectsGen extends smithy4s.Service[StreamedObjectsGen, StreamedO
   }
   case class GetStreamedObject(input: GetStreamedObjectInput) extends StreamedObjectsOperation[GetStreamedObjectInput, Nothing, GetStreamedObjectOutput, Nothing, StreamedBlob]
   object GetStreamedObject extends smithy4s.Endpoint[StreamedObjectsOperation, GetStreamedObjectInput, Nothing, GetStreamedObjectOutput, Nothing, StreamedBlob] {
-    def name: String = "GetStreamedObject"
+    val id: smithy4s.ShapeId = smithy4s.ShapeId("smithy4s.example", "GetStreamedObject")
     val input: smithy4s.Schema[GetStreamedObjectInput] = GetStreamedObjectInput.schema.withHints(smithy4s.internals.InputOutput.Input)
     val output: smithy4s.Schema[GetStreamedObjectOutput] = GetStreamedObjectOutput.schema.withHints(smithy4s.internals.InputOutput.Output)
     val streamedInput : smithy4s.StreamingSchema[Nothing] = smithy4s.StreamingSchema.nothing
     val streamedOutput : smithy4s.StreamingSchema[StreamedBlob] = smithy4s.StreamingSchema("GetStreamedObjectOutput", StreamedBlob.schema)
-    val id: smithy4s.ShapeId = smithy4s.ShapeId("smithy4s.example", "GetStreamedObject")
     val hints : smithy4s.Hints = smithy4s.Hints(
       id,
     )


### PR DESCRIPTION
Also move URIEncoderDecoder to http.internals package and UnkownErrorResponse to the http package