### PR TITLE
remove core dependency auto-add from sbt plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,11 @@ import smithy4s.codegen.Smithy4sCodegenPlugin
 val myModule = project
   .in(file("modules/my-module"))
   .enablePlugins(Smithy4sCodegenPlugin)
+  // version for smithy4s-core is sourced from Smithy4sCodegenPlugin
+  .settings(libraryDependencies += "com.disneystreaming.smithy4s" %%% "smithy4s-core" % smithy4sVersion.value)
 ```
 
-This will add the `smithy-core` dependency to `myModule`, since it is needed
+This will enable the plugin on `myModule`. We also need to add `smithy4s-core here since it is needed
 for compiling the generated code.
 
 This will look for the smithy specs in the folder `$MY_MODULE/src/main/smithy` and will write scala code in `$MY_MODULE/target/scala-<version>/src_managed/` when invoking `compile`. The paths are configurable via the `smithy4sInputDir` and `smithy4sOutputDir` settings keys.
@@ -46,7 +48,8 @@ val myModule = project
   .settings(
     scalaVersion := "2.13.6",
     smithy4sInputDir in Compile  := (baseDirectory in ThisBuild).value / "smithy_input",
-    smithy4sOutputDir in Compile := (baseDirectory in ThisBuild).value / "smithy_output"
+    smithy4sOutputDir in Compile := (baseDirectory in ThisBuild).value / "smithy_output",
+    libraryDependencies += "com.disneystreaming.smithy4s" %%% "smithy4s-core" % smithy4sVersion.value
   )
 
 ```

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/custom-settings/build.sbt
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/custom-settings/build.sbt
@@ -10,5 +10,6 @@ lazy val root = (project in file("."))
     Compile / smithy4sAllowedNamespaces := List(
       "aws.iam",
       "smithy4s.example"
-    )
+    ),
+    libraryDependencies += "com.disneystreaming.smithy4s" %% "smithy4s-core" % smithy4sVersion.value
   )

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/defaults/build.sbt
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/defaults/build.sbt
@@ -1,5 +1,6 @@
 lazy val root = (project in file("."))
   .enablePlugins(Smithy4sCodegenPlugin)
   .settings(
-    scalaVersion := "2.13.6"
+    scalaVersion := "2.13.6",
+    libraryDependencies += "com.disneystreaming.smithy4s" %% "smithy4s-core" % smithy4sVersion.value
   )

--- a/modules/codegen-plugin/src/smithy4s/codegen/CodegenPlugin.scala
+++ b/modules/codegen-plugin/src/smithy4s/codegen/CodegenPlugin.scala
@@ -72,8 +72,7 @@ object Smithy4sCodegenPlugin extends AutoPlugin {
       Compile / resourceGenerators += (Compile / smithy4sCodegen).map(
         _.filter(_.ext != "scala")
       ),
-      cleanFiles += (Compile / smithy4sOutputDir).value,
-      libraryDependencies += "com.disneystreaming.smithy4s" %% "smithy4s-core" % BuildInfo.version
+      cleanFiles += (Compile / smithy4sOutputDir).value
     )
 
   private def untupled[A, B, C](f: ((A, B)) => C): (A, B) => C = (a, b) =>


### PR DESCRIPTION
Closes #34.

The issue was that the sbt plugin was auto-adding the `smithy4s-core` dependency. This worked in all cases except for Scala JS since that would require the use of `%%%`. We could have updated the plugin to use `%%%`, but that would require the Scala JS SBT plugin be present on all projects using it, which we do not want to require.