### PR TITLE
Add smoke tests to check for hints on schemas

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -117,7 +117,8 @@ lazy val core = projectMatrix
       (ThisBuild / baseDirectory).value / "sampleSpecs" / "metadata.smithy",
       (ThisBuild / baseDirectory).value / "sampleSpecs" / "recursive.smithy",
       (ThisBuild / baseDirectory).value / "sampleSpecs" / "bodies.smithy",
-      (ThisBuild / baseDirectory).value / "sampleSpecs" / "empty.smithy"
+      (ThisBuild / baseDirectory).value / "sampleSpecs" / "empty.smithy",
+      (ThisBuild / baseDirectory).value / "sampleSpecs" / "weather.smithy"
     ),
     (Test / sourceGenerators) := Seq(genSmithyScala(Test).taskValue),
     testFrameworks += new TestFramework("weaver.framework.CatsEffect")

--- a/modules/codegen/src/smithy4s/codegen/Renderer.scala
+++ b/modules/codegen/src/smithy4s/codegen/Renderer.scala
@@ -362,7 +362,7 @@ private[codegen] class Renderer(compilationUnit: CompilationUnit) { self =>
               }
             )
             .block(s"$name.apply")
-            .appendToLast(if (hints.nonEmpty) ".withHints(hints)" else "")
+            .appendToLast(".withHints(hints)")
             .appendToLast(if (recursive) ")" else "")
         } else {
           line(

--- a/modules/core/test/src/smithy4s/ShapeIdHintsSmokeSpec.scala
+++ b/modules/core/test/src/smithy4s/ShapeIdHintsSmokeSpec.scala
@@ -1,0 +1,152 @@
+package smithy4s
+
+import java.util.UUID
+import schematic.ByteArray
+import schematic.Field
+import schematic.Alt
+import cats.Id
+import schematic.struct.GenericAritySchematic
+import smithy4s.capability.Invariant
+
+object ShapeIdHintsSmokeSpec extends weaver.FunSuite {
+
+  type HintTracker[A] = TestHinted[Id, A]
+
+  case class TestHinted[F[_], A](hints: List[Hint], make: List[Hint] => F[A]) {
+    def addHints(h: List[Hint]): TestHinted[F, A] = copy(hints = hints ++ h)
+    def imap[B](to: A => B, from: B => A)(implicit
+        I: Invariant[F]
+    ): TestHinted[F, B] =
+      TestHinted(hints, h => I.imap(make(h))(to, from))
+  }
+
+  object TestHinted {
+    def apply[F[_]]: PartiallyAppliedHintedTest[F] =
+      new PartiallyAppliedHintedTest[F]
+
+    class PartiallyAppliedHintedTest[F[_]] {
+      def from[A](f: List[Hint] => F[A]): TestHinted[F, A] =
+        TestHinted(List.empty, f(_))
+    }
+  }
+
+  implicit def invariantFromCats[F[_]: cats.Invariant]: Invariant[F] =
+    new Invariant[F] {
+      def imap[A, B](fa: F[A])(to: A => B, from: B => A): F[B] =
+        cats.Invariant[F].imap(fa)(to)(from)
+    }
+
+  private object TestCompiler
+      extends Schematic[HintTracker]
+      with GenericAritySchematic[HintTracker] {
+    def short: HintTracker[Short] = ???
+
+    def int: HintTracker[Int] = ???
+
+    def long: HintTracker[Long] = ???
+
+    def double: HintTracker[Double] = ???
+
+    def float: HintTracker[Float] = TestHinted[Id].from(_ => 0f)
+
+    def bigint: HintTracker[BigInt] = ???
+
+    def bigdecimal: HintTracker[BigDecimal] = ???
+
+    def string: HintTracker[String] = TestHinted[Id].from(_ => "")
+
+    def boolean: HintTracker[Boolean] = ???
+
+    def uuid: HintTracker[UUID] = ???
+
+    def byte: HintTracker[Byte] = ???
+
+    def bytes: HintTracker[ByteArray] = ???
+
+    def unit: HintTracker[Unit] = ???
+
+    def list[S](fs: HintTracker[S]): HintTracker[List[S]] = ???
+
+    def set[S](fs: HintTracker[S]): HintTracker[Set[S]] = ???
+
+    def vector[S](fs: HintTracker[S]): HintTracker[Vector[S]] = ???
+
+    def map[K, V](
+        fk: HintTracker[K],
+        fv: HintTracker[V]
+    ): HintTracker[Map[K, V]] = ???
+
+    def genericStruct[S](fields: Vector[Field[HintTracker, S, _]])(
+        const: Vector[Any] => S
+    ): HintTracker[S] = {
+      val result = TestHinted[Id].from(_ => const(fields))
+      val allHints = fields
+        .flatMap(_.instance.hints)
+      result.addHints(allHints.toList)
+    }
+
+    def union[S](
+        first: Alt[HintTracker, S, _],
+        rest: Vector[Alt[HintTracker, S, _]]
+    )(total: S => Alt.WithValue[HintTracker, S, _]): HintTracker[S] = ???
+
+    def enumeration[A](
+        to: A => (String, Int),
+        fromName: Map[String, A],
+        fromOrdinal: Map[Int, A]
+    ): HintTracker[A] = ???
+
+    def suspend[A](f: => HintTracker[A]): HintTracker[A] = ???
+
+    def bijection[A, B](
+        f: HintTracker[A],
+        to: A => B,
+        from: B => A
+    ): HintTracker[B] = f.imap(to, from)
+
+    def timestamp: HintTracker[Timestamp] = ???
+
+    def withHints[A](fa: HintTracker[A], hints: Hints): HintTracker[A] =
+      fa.addHints(hints.all.toList)
+
+    def document: HintTracker[Document] = ???
+
+  }
+
+  test("newtypes contain ShapeId in hints") {
+    val hintTracker = example.CityId.schema.compile(TestCompiler)
+    expect(
+      hintTracker.hints.contains(
+        Hints.Binding.fromValue(
+          ShapeId(
+            "smithy4s.example",
+            "CityId"
+          )
+        )
+      )
+    )
+  }
+
+  test("structure members contain ShapeId in hints") {
+    val hintTracker = example.CityCoordinates.schema.compile(TestCompiler)
+    expect(
+      List(
+        Hints.Binding.fromValue(ShapeId("smithy.api", "Float")),
+        Hints.Binding.fromValue(ShapeId("smithy4s.example", "CityCoordinates"))
+      ).toSet.subsetOf(hintTracker.hints.toSet)
+    )
+  }
+
+  test("union members contain ShapeId in hints") {
+    val hintTracker = example.ForecastResult.schema.compile(TestCompiler)
+    expect(
+      List(
+        Hints.Binding.fromValue(ShapeId("smithy.api", "Float")),
+        Hints.Binding.fromValue(ShapeId("smithy4s.example", "ForecastResult")),
+        Hints.Binding.fromValue(ShapeId("smithy4s.example", "ChanceOfRain")),
+        Hints.Binding.fromValue(ShapeId("smithy4s.example", "UVIndex"))
+      ).toSet.subsetOf(hintTracker.hints.toSet)
+    )
+  }
+
+}

--- a/modules/core/test/src/smithy4s/ShapeIdHintsSmokeSpec.scala
+++ b/modules/core/test/src/smithy4s/ShapeIdHintsSmokeSpec.scala
@@ -1,151 +1,83 @@
 package smithy4s
 
-import java.util.UUID
-import schematic.ByteArray
 import schematic.Field
 import schematic.Alt
-import cats.Id
-import schematic.struct.GenericAritySchematic
-import smithy4s.capability.Invariant
 
 object ShapeIdHintsSmokeSpec extends weaver.FunSuite {
 
-  type HintTracker[A] = TestHinted[Id, A]
+  type ToShapeIds[A] = List[ShapeId]
 
-  case class TestHinted[F[_], A](hints: List[Hint], make: List[Hint] => F[A]) {
-    def addHints(h: List[Hint]): TestHinted[F, A] = copy(hints = hints ++ h)
-    def imap[B](to: A => B, from: B => A)(implicit
-        I: Invariant[F]
-    ): TestHinted[F, B] =
-      TestHinted(hints, h => I.imap(make(h))(to, from))
-  }
+  object TestCompiler extends StubSchematic[ToShapeIds] {
+    def default[A]: List[ShapeId] = Nil
 
-  object TestHinted {
-    def apply[F[_]]: PartiallyAppliedHintedTest[F] =
-      new PartiallyAppliedHintedTest[F]
-
-    class PartiallyAppliedHintedTest[F[_]] {
-      def from[A](f: List[Hint] => F[A]): TestHinted[F, A] =
-        TestHinted(List.empty, f(_))
-    }
-  }
-
-  implicit def invariantFromCats[F[_]: cats.Invariant]: Invariant[F] =
-    new Invariant[F] {
-      def imap[A, B](fa: F[A])(to: A => B, from: B => A): F[B] =
-        cats.Invariant[F].imap(fa)(to)(from)
-    }
-
-  private object TestCompiler
-      extends Schematic[HintTracker]
-      with GenericAritySchematic[HintTracker] {
-    def short: HintTracker[Short] = ???
-
-    def int: HintTracker[Int] = ???
-
-    def long: HintTracker[Long] = ???
-
-    def double: HintTracker[Double] = ???
-
-    def float: HintTracker[Float] = TestHinted[Id].from(_ => 0f)
-
-    def bigint: HintTracker[BigInt] = ???
-
-    def bigdecimal: HintTracker[BigDecimal] = ???
-
-    def string: HintTracker[String] = TestHinted[Id].from(_ => "")
-
-    def boolean: HintTracker[Boolean] = ???
-
-    def uuid: HintTracker[UUID] = ???
-
-    def byte: HintTracker[Byte] = ???
-
-    def bytes: HintTracker[ByteArray] = ???
-
-    def unit: HintTracker[Unit] = ???
-
-    def list[S](fs: HintTracker[S]): HintTracker[List[S]] = ???
-
-    def set[S](fs: HintTracker[S]): HintTracker[Set[S]] = ???
-
-    def vector[S](fs: HintTracker[S]): HintTracker[Vector[S]] = ???
-
-    def map[K, V](
-        fk: HintTracker[K],
-        fv: HintTracker[V]
-    ): HintTracker[Map[K, V]] = ???
-
-    def genericStruct[S](fields: Vector[Field[HintTracker, S, _]])(
-        const: Vector[Any] => S
-    ): HintTracker[S] = {
-      val result = TestHinted[Id].from(_ => const(fields))
-      val allHints = fields
-        .flatMap(_.instance.hints)
-      result.addHints(allHints.toList)
-    }
-
-    def union[S](
-        first: Alt[HintTracker, S, _],
-        rest: Vector[Alt[HintTracker, S, _]]
-    )(total: S => Alt.WithValue[HintTracker, S, _]): HintTracker[S] = ???
-
-    def enumeration[A](
-        to: A => (String, Int),
-        fromName: Map[String, A],
-        fromOrdinal: Map[Int, A]
-    ): HintTracker[A] = ???
-
-    def suspend[A](f: => HintTracker[A]): HintTracker[A] = ???
-
-    def bijection[A, B](
-        f: HintTracker[A],
+    override def bijection[A, B](
+        f: ToShapeIds[A],
         to: A => B,
         from: B => A
-    ): HintTracker[B] = f.imap(to, from)
+    ): ToShapeIds[B] = f
 
-    def timestamp: HintTracker[Timestamp] = ???
+    override def genericStruct[S](fields: Vector[Field[ToShapeIds, S, _]])(
+        const: Vector[Any] => S
+    ): ToShapeIds[S] =
+      fields.flatMap(_.instance).toList
 
-    def withHints[A](fa: HintTracker[A], hints: Hints): HintTracker[A] =
-      fa.addHints(hints.all.toList)
+    override def list[S](fs: ToShapeIds[S]): ToShapeIds[List[S]] = fs
 
-    def document: HintTracker[Document] = ???
+    override def union[S](
+        first: Alt[ToShapeIds, S, _],
+        rest: Vector[Alt[ToShapeIds, S, _]]
+    )(total: S => Alt.WithValue[ToShapeIds, S, _]): ToShapeIds[S] = {
+      first.instance ++ rest.flatMap(_.instance)
+    }
 
+    override def withHints[A](fa: ToShapeIds[A], hints: Hints): ToShapeIds[A] =
+      fa ++ hints.get(ShapeId)
   }
 
   test("newtypes contain ShapeId in hints") {
-    val hintTracker = example.CityId.schema.compile(TestCompiler)
+    val shapeIds = example.CityId.schema.compile(TestCompiler)
     expect(
-      hintTracker.hints.contains(
-        Hints.Binding.fromValue(
-          ShapeId(
-            "smithy4s.example",
-            "CityId"
-          )
+      shapeIds.contains(
+        ShapeId(
+          "smithy4s.example",
+          "CityId"
         )
       )
     )
   }
 
   test("structure members contain ShapeId in hints") {
-    val hintTracker = example.CityCoordinates.schema.compile(TestCompiler)
+    val shapeIds =
+      example.CityCoordinates.schema.compile(TestCompiler).toSet
     expect(
-      List(
-        Hints.Binding.fromValue(ShapeId("smithy.api", "Float")),
-        Hints.Binding.fromValue(ShapeId("smithy4s.example", "CityCoordinates"))
-      ).toSet.subsetOf(hintTracker.hints.toSet)
+      Set(
+        ShapeId("smithy.api", "Float"),
+        ShapeId("smithy4s.example", "CityCoordinates")
+      ).subsetOf(shapeIds)
     )
   }
 
   test("union members contain ShapeId in hints") {
-    val hintTracker = example.ForecastResult.schema.compile(TestCompiler)
+    val shapeIds =
+      example.ForecastResult.schema.compile(TestCompiler).toSet
     expect(
-      List(
-        Hints.Binding.fromValue(ShapeId("smithy.api", "Float")),
-        Hints.Binding.fromValue(ShapeId("smithy4s.example", "ForecastResult")),
-        Hints.Binding.fromValue(ShapeId("smithy4s.example", "ChanceOfRain")),
-        Hints.Binding.fromValue(ShapeId("smithy4s.example", "UVIndex"))
-      ).toSet.subsetOf(hintTracker.hints.toSet)
+      Set(
+        ShapeId("smithy4s.example", "ForecastResult"),
+        ShapeId("smithy4s.example", "ChanceOfRain"),
+        ShapeId("smithy4s.example", "UVIndex")
+      ).subsetOf(shapeIds)
+    )
+  }
+
+  test("List items contain ShapeId in hints") {
+    val shapeIds =
+      example.ListCitiesOutput.schema.compile(TestCompiler).toSet
+    expect(
+      Set(
+        ShapeId("smithy4s.example", "ListCitiesOutput"),
+        ShapeId("smithy4s.example", "CitySummary"),
+        ShapeId("smithy4s.example", "CityId")
+      ).subsetOf(shapeIds)
     )
   }
 

--- a/modules/example/src/smithy4s/example/GetFooOutput.scala
+++ b/modules/example/src/smithy4s/example/GetFooOutput.scala
@@ -14,6 +14,6 @@ object GetFooOutput {
     Foo.schema.optional[GetFooOutput]("foo", _.foo),
   ){
     GetFooOutput.apply
-  }
+  }.withHints(hints)
   implicit val staticSchema : schematic.Static[smithy4s.Schema[GetFooOutput]] = schematic.Static(schema)
 }

--- a/modules/example/src/smithy4s/example/GetObjectInput.scala
+++ b/modules/example/src/smithy4s/example/GetObjectInput.scala
@@ -15,6 +15,6 @@ object GetObjectInput {
     BucketName.schema.required[GetObjectInput]("bucketName", _.bucketName).withHints(smithy.api.Required(), smithy.api.HttpLabel()),
   ){
     GetObjectInput.apply
-  }
+  }.withHints(hints)
   implicit val staticSchema : schematic.Static[smithy4s.Schema[GetObjectInput]] = schematic.Static(schema)
 }

--- a/modules/example/src/smithy4s/example/GetObjectOutput.scala
+++ b/modules/example/src/smithy4s/example/GetObjectOutput.scala
@@ -15,6 +15,6 @@ object GetObjectOutput {
     string.optional[GetObjectOutput]("data", _.data).withHints(smithy.api.HttpPayload()),
   ){
     GetObjectOutput.apply
-  }
+  }.withHints(hints)
   implicit val staticSchema : schematic.Static[smithy4s.Schema[GetObjectOutput]] = schematic.Static(schema)
 }

--- a/modules/example/src/smithy4s/example/GetStreamedObjectInput.scala
+++ b/modules/example/src/smithy4s/example/GetStreamedObjectInput.scala
@@ -14,6 +14,6 @@ object GetStreamedObjectInput {
     string.required[GetStreamedObjectInput]("key", _.key).withHints(smithy.api.Required()),
   ){
     GetStreamedObjectInput.apply
-  }
+  }.withHints(hints)
   implicit val staticSchema : schematic.Static[smithy4s.Schema[GetStreamedObjectInput]] = schematic.Static(schema)
 }

--- a/modules/example/src/smithy4s/example/PutObjectInput.scala
+++ b/modules/example/src/smithy4s/example/PutObjectInput.scala
@@ -18,6 +18,6 @@ object PutObjectInput {
     SomeValue.schema.optional[PutObjectInput]("someValue", _.someValue).withHints(smithy.api.HttpQuery("paramName")),
   ){
     PutObjectInput.apply
-  }
+  }.withHints(hints)
   implicit val staticSchema : schematic.Static[smithy4s.Schema[PutObjectInput]] = schematic.Static(schema)
 }

--- a/modules/example/src/smithy4s/example/PutStreamedObjectInput.scala
+++ b/modules/example/src/smithy4s/example/PutStreamedObjectInput.scala
@@ -14,6 +14,6 @@ object PutStreamedObjectInput {
     string.required[PutStreamedObjectInput]("key", _.key).withHints(smithy.api.Required()),
   ){
     PutStreamedObjectInput.apply
-  }
+  }.withHints(hints)
   implicit val staticSchema : schematic.Static[smithy4s.Schema[PutStreamedObjectInput]] = schematic.Static(schema)
 }

--- a/sampleSpecs/weather.smithy
+++ b/sampleSpecs/weather.smithy
@@ -1,9 +1,8 @@
-namespace example.weather
+namespace smithy4s.example
 
 /// Provides weather forecasts.
 @paginated(inputToken: "nextToken", outputToken: "nextToken",
            pageSize: "pageSize")
-
 service Weather {
     version: "2006-03-01",
     resources: [City],
@@ -127,5 +126,13 @@ structure GetForecastInput {
 }
 
 structure GetForecastOutput {
-    chanceOfRain: Float
+    forecast: ForecastResult
 }
+
+union ForecastResult {
+    rain: ChanceOfRain,
+    sun: UVIndex
+}
+
+float ChanceOfRain
+integer UVIndex


### PR DESCRIPTION
This is still a WIP, but the idea is adding a few test cases to ensure the fix in #36 is working.

It seems like there may be an easier way than the approach I am taking here, so please let me know if there is. I couldn't find a great way to get the hints from a schema without compiling the schema.

The union test is not working as of right now, but the other two are.