### PR TITLE
Derive http endpoints from hints

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -284,7 +284,6 @@ lazy val `aws-http4s` = projectMatrix
       (ThisBuild / baseDirectory).value / "sampleSpecs" / "dynamodb.2012-08-10.json"
     )
   )
-  .settings(Smithy4sPlugin.doNotPublishArtifact)
   .jvmPlatform(latest2ScalaVersions, jvmDimSettings)
   .jsPlatform(latest2ScalaVersions, jsDimSettings)
 

--- a/modules/aws-kernel/src/smithy4s/aws/AwsSignature.scala
+++ b/modules/aws-kernel/src/smithy4s/aws/AwsSignature.scala
@@ -16,7 +16,7 @@
 
 package smithy4s.aws.kernel
 
-import smithy4s.http.internals.URIEncoderDecoder.{encodeOthers => uriEncode}
+import smithy4s.http.internals.URIEncoderDecoder.{encode => uriEncode}
 import smithy4s.http.CaseInsensitive
 import smithy4s.http.HttpMethod
 

--- a/modules/core/src/smithy4s/http/Method.scala
+++ b/modules/core/src/smithy4s/http/Method.scala
@@ -40,4 +40,10 @@ object HttpMethod {
   case object DELETE extends HttpMethod
   case object GET extends HttpMethod
   case object PATCH extends HttpMethod
+
+  val values = List(PUT, POST, DELETE, GET, PATCH)
+
+  def fromString(s: String): Option[HttpMethod] = values.find { m =>
+    CaseInsensitive(s) == CaseInsensitive(m.showCapitalised)
+  }
 }

--- a/modules/core/src/smithy4s/http/PathSegment.scala
+++ b/modules/core/src/smithy4s/http/PathSegment.scala
@@ -26,4 +26,5 @@ object PathSegment {
   case class StaticSegment(value: String) extends PathSegment
   case class LabelSegment(value: String) extends PathSegment
   case class GreedySegment(value: String) extends PathSegment
+
 }

--- a/modules/core/src/smithy4s/http/internals/PathEncode.scala
+++ b/modules/core/src/smithy4s/http/internals/PathEncode.scala
@@ -1,3 +1,19 @@
+/*
+ *  Copyright 2021 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 package smithy4s.http.internals
 
 import smithy4s.internals.Hinted

--- a/modules/core/src/smithy4s/http/internals/PathEncode.scala
+++ b/modules/core/src/smithy4s/http/internals/PathEncode.scala
@@ -1,0 +1,44 @@
+package smithy4s.http.internals
+
+import smithy4s.internals.Hinted
+
+trait PathEncode[A] { self =>
+  def encode(sb: StringBuilder, a: A): Unit
+  def encodeGreedy(sb: StringBuilder, a: A): Unit
+
+  def contramap[B](from: B => A): PathEncode[B] = new PathEncode[B] {
+    def encode(sb: StringBuilder, b: B): Unit = self.encode(sb, from(b))
+
+    def encodeGreedy(sb: StringBuilder, b: B): Unit =
+      self.encodeGreedy(sb, from(b))
+  }
+}
+
+object PathEncode {
+
+  type MaybePathEncode[A] = Option[PathEncode[A]]
+  type Make[A] = Hinted[MaybePathEncode, A]
+
+  object Make {
+    def from[A](f: A => String): Make[A] = Hinted.static[MaybePathEncode, A] {
+      Some {
+        new PathEncode[A] {
+          def encode(sb: StringBuilder, a: A): Unit = {
+            val _ = sb.append(URIEncoderDecoder.encodeOthers(f(a)))
+          }
+          def encodeGreedy(sb: StringBuilder, a: A): Unit = {
+            f(a).split('/').foreach {
+              case s if s.isEmpty() => ()
+              case s => sb.append('/').append(URIEncoderDecoder.encodeOthers(s))
+            }
+          }
+        }
+      }
+    }
+
+    def fromToString[A]: Make[A] = from(_.toString)
+
+    def noop[A]: Make[A] = Hinted.static[MaybePathEncode, A](None)
+  }
+
+}

--- a/modules/core/src/smithy4s/http/internals/PathEncode.scala
+++ b/modules/core/src/smithy4s/http/internals/PathEncode.scala
@@ -45,12 +45,12 @@ object PathEncode {
     def raw[A](f: A => String): PathEncode[A] = {
       new PathEncode[A] {
         def encode(sb: StringBuilder, a: A): Unit = {
-          val _ = sb.append(URIEncoderDecoder.encodeOthers(f(a)))
+          val _ = sb.append(URIEncoderDecoder.encode(f(a)))
         }
         def encodeGreedy(sb: StringBuilder, a: A): Unit = {
           f(a).split('/').foreach {
             case s if s.isEmpty() => ()
-            case s => sb.append('/').append(URIEncoderDecoder.encodeOthers(s))
+            case s => sb.append('/').append(URIEncoderDecoder.encode(s))
           }
         }
       }

--- a/modules/core/src/smithy4s/http/internals/PathEncode.scala
+++ b/modules/core/src/smithy4s/http/internals/PathEncode.scala
@@ -38,15 +38,19 @@ object PathEncode {
   object Make {
     def from[A](f: A => String): Make[A] = Hinted.static[MaybePathEncode, A] {
       Some {
-        new PathEncode[A] {
-          def encode(sb: StringBuilder, a: A): Unit = {
-            val _ = sb.append(URIEncoderDecoder.encodeOthers(f(a)))
-          }
-          def encodeGreedy(sb: StringBuilder, a: A): Unit = {
-            f(a).split('/').foreach {
-              case s if s.isEmpty() => ()
-              case s => sb.append('/').append(URIEncoderDecoder.encodeOthers(s))
-            }
+        raw(f)
+      }
+    }
+
+    def raw[A](f: A => String): PathEncode[A] = {
+      new PathEncode[A] {
+        def encode(sb: StringBuilder, a: A): Unit = {
+          val _ = sb.append(URIEncoderDecoder.encodeOthers(f(a)))
+        }
+        def encodeGreedy(sb: StringBuilder, a: A): Unit = {
+          f(a).split('/').foreach {
+            case s if s.isEmpty() => ()
+            case s => sb.append('/').append(URIEncoderDecoder.encodeOthers(s))
           }
         }
       }

--- a/modules/core/src/smithy4s/http/internals/SchematicPathEncoder.scala
+++ b/modules/core/src/smithy4s/http/internals/SchematicPathEncoder.scala
@@ -1,3 +1,19 @@
+/*
+ *  Copyright 2021 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 package smithy4s
 package http.internals
 

--- a/modules/core/src/smithy4s/http/internals/SchematicPathEncoder.scala
+++ b/modules/core/src/smithy4s/http/internals/SchematicPathEncoder.scala
@@ -28,11 +28,10 @@ import smithy4s.http.PathSegment.GreedySegment
 
 object SchematicPathEncoder
     extends Schematic[PathEncode.Make]
-    with schematic.StubSchematic[PathEncode.Make] {
+    with StubSchematic[PathEncode.Make] {
 
   def default[A]: PathEncode.Make[A] = PathEncode.Make.noop
-  def document: PathEncode.Make[Document] = PathEncode.Make.noop
-  def withHints[A](
+  override def withHints[A](
       fa: PathEncode.Make[A],
       hints: smithy4s.Hints
   ): PathEncode.Make[A] =
@@ -65,7 +64,7 @@ object SchematicPathEncoder
   override val unit: PathEncode.Make[Unit] =
     genericStruct(Vector.empty)(_ => ())
 
-  def genericStruct[S](fields: Vector[Field[PathEncode.Make, S, _]])(
+  override def genericStruct[S](fields: Vector[Field[PathEncode.Make, S, _]])(
       const: Vector[Any] => S
   ): PathEncode.Make[S] = {
     type Writer = (StringBuilder, S) => Unit

--- a/modules/core/src/smithy4s/http/internals/SchematicPathEncoder.scala
+++ b/modules/core/src/smithy4s/http/internals/SchematicPathEncoder.scala
@@ -59,8 +59,14 @@ object SchematicPathEncoder
   override val uuid: PathEncode.Make[java.util.UUID] =
     PathEncode.Make.fromToString
   override val boolean: PathEncode.Make[Boolean] = PathEncode.Make.fromToString
+
   override val timestamp: PathEncode.Make[Timestamp] =
-    PathEncode.Make.from(_.format(TimestampFormat.DATE_TIME))
+    Hinted[PathEncode.MaybePathEncode].from { hints =>
+      val fmt = hints.get(TimestampFormat).getOrElse(TimestampFormat.DATE_TIME)
+
+      Some(PathEncode.Make.raw(_.format(fmt)))
+    }
+
   override val unit: PathEncode.Make[Unit] =
     genericStruct(Vector.empty)(_ => ())
 

--- a/modules/core/src/smithy4s/http/internals/SchematicPathEncoder.scala
+++ b/modules/core/src/smithy4s/http/internals/SchematicPathEncoder.scala
@@ -1,0 +1,115 @@
+package smithy4s
+package http.internals
+
+import smithy.api.TimestampFormat
+import schematic.Field
+import smithy4s.internals.Hinted
+import smithy.api.Http
+import smithy4s.http.PathSegment
+import smithy4s.http.PathSegment.StaticSegment
+import smithy4s.http.PathSegment.LabelSegment
+import smithy4s.http.PathSegment.GreedySegment
+
+object SchematicPathEncoder
+    extends Schematic[PathEncode.Make]
+    with schematic.StubSchematic[PathEncode.Make] {
+
+  def default[A]: PathEncode.Make[A] = PathEncode.Make.noop
+  def document: PathEncode.Make[Document] = PathEncode.Make.noop
+  def withHints[A](
+      fa: PathEncode.Make[A],
+      hints: smithy4s.Hints
+  ): PathEncode.Make[A] =
+    fa.addHints(hints)
+
+  override def bijection[A, B](
+      f: PathEncode.Make[A],
+      to: A => B,
+      from: B => A
+  ): PathEncode.Make[B] =
+    Hinted[PathEncode.MaybePathEncode, B](
+      f.hints,
+      make = hints => f.make(hints).map(_.contramap(from))
+    )
+
+  override val bigdecimal: PathEncode.Make[BigDecimal] =
+    PathEncode.Make.fromToString
+  override val bigint: PathEncode.Make[BigInt] = PathEncode.Make.fromToString
+  override val double: PathEncode.Make[Double] = PathEncode.Make.fromToString
+  override val int: PathEncode.Make[Int] = PathEncode.Make.fromToString
+  override val float: PathEncode.Make[Float] = PathEncode.Make.fromToString
+  override val short: PathEncode.Make[Short] = PathEncode.Make.fromToString
+  override val long: PathEncode.Make[Long] = PathEncode.Make.fromToString
+  override val string: PathEncode.Make[String] = PathEncode.Make.fromToString
+  override val uuid: PathEncode.Make[java.util.UUID] =
+    PathEncode.Make.fromToString
+  override val boolean: PathEncode.Make[Boolean] = PathEncode.Make.fromToString
+  override val timestamp: PathEncode.Make[Timestamp] =
+    PathEncode.Make.from(_.format(TimestampFormat.DATE_TIME))
+  override val unit: PathEncode.Make[Unit] =
+    genericStruct(Vector.empty)(_ => ())
+
+  def genericStruct[S](fields: Vector[Field[PathEncode.Make, S, _]])(
+      const: Vector[Any] => S
+  ): PathEncode.Make[S] = {
+    type Writer = (StringBuilder, S) => Unit
+
+    def toPathEncoder[A](
+        field: Field[PathEncode.Make, S, A],
+        greedy: Boolean
+    ): Option[Writer] = {
+      field.fold(new Field.Folder[PathEncode.Make, S, Option[Writer]] {
+        def onRequired[AA](
+            label: String,
+            instance: PathEncode.Make[AA],
+            get: S => AA
+        ): Option[Writer] =
+          if (greedy)
+            instance.get.map(encoder =>
+              (sb, s) => encoder.encodeGreedy(sb, get(s))
+            )
+          else
+            instance.get.map(encoder => (sb, s) => encoder.encode(sb, get(s)))
+        def onOptional[AA](
+            label: String,
+            instance: PathEncode.Make[AA],
+            get: S => Option[AA]
+        ): Option[Writer] = None
+      })
+    }
+
+    def compile1(path: PathSegment): Option[Writer] = path match {
+      case StaticSegment(value) =>
+        Some((sb, _) => { val _ = sb.append(value) })
+      case LabelSegment(value) =>
+        fields
+          .find(_.label == value)
+          .flatMap(field => toPathEncoder(field, greedy = false))
+      case GreedySegment(value) =>
+        fields
+          .find(_.label == value)
+          .flatMap(field => toPathEncoder(field, greedy = true))
+    }
+
+    def compilePath(path: Vector[PathSegment]): Option[Vector[Writer]] =
+      path.traverse(compile1(_))
+
+    Hinted[PathEncode.MaybePathEncode].onHintOpt[Http, S] { maybeHttpHint =>
+      for {
+        httpHint <- maybeHttpHint
+        path <- pathSegments(httpHint.uri.value)
+        writers <- compilePath(path)
+      } yield new PathEncode[S] {
+        def encode(sb: StringBuilder, s: S): Unit = {
+          var first = true
+          writers.foreach { w =>
+            if (first) { w.apply(sb, s); first = false }
+            else w.apply(sb.append('/'), s)
+          }
+        }
+
+        def encodeGreedy(sb: StringBuilder, s: S) = ()
+      }
+    }
+  }
+}

--- a/modules/core/src/smithy4s/http/internals/package.scala
+++ b/modules/core/src/smithy4s/http/internals/package.scala
@@ -52,4 +52,23 @@ package object internals {
       }
   }
 
+  private[smithy4s] def pathSegments(
+      str: String
+  ): Option[Vector[PathSegment]] = {
+    str
+      .split('/')
+      .toVector
+      .filterNot(_.isEmpty())
+      .traverse(fromToString(_))
+  }
+
+  private def fromToString(str: String): Option[PathSegment] = {
+    if (str.isEmpty()) None
+    else if (str.startsWith("{") && str.endsWith("+}"))
+      Some(PathSegment.greedy(str.substring(1, str.length() - 2)))
+    else if (str.startsWith("{") && str.endsWith("}"))
+      Some(PathSegment.label(str.substring(1, str.length() - 1)))
+    else Some(PathSegment.static(str))
+  }
+
 }

--- a/modules/core/src/smithy4s/package.scala
+++ b/modules/core/src/smithy4s/package.scala
@@ -14,8 +14,6 @@
  *  limitations under the License.
  */
 
-import smithy4s.http.internals.URIEncoderDecoder
-
 package object smithy4s extends TypeAliases {
 
   type Hint = Hints.Binding[_]
@@ -26,9 +24,6 @@ package object smithy4s extends TypeAliases {
   type UnionSchema[A] = schematic.union.Schema[UnionSchematic, A]
 
   val errorTypeHeader = "X-Error-Type"
-
-  def segment(s: Any): String = URIEncoderDecoder.encodeOthers(s.toString())
-  def greedySegment(s: String) = s.split("/").map(segment).mkString("/")
 
   // Allows to "inject" F[_] types in places that require F[_,_,_,_,_]
   type GenLift[F[_]] = {

--- a/modules/core/test/src-js/smithy4s/JsConvertersSpec.scala
+++ b/modules/core/test/src-js/smithy4s/JsConvertersSpec.scala
@@ -1,3 +1,19 @@
+/*
+ *  Copyright 2021 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 package smithy4s
 
 import weaver._

--- a/modules/core/test/src/smithy4s/TypeInferenceSmokeSpec.scala
+++ b/modules/core/test/src/smithy4s/TypeInferenceSmokeSpec.scala
@@ -16,38 +16,17 @@
 
 package smithy4s
 
-import weaver._
 import smithy4s.example._
 import cats.Functor
 import cats.syntax.all._
-import cats.effect.IO
 
-object TypeInferenceSmokeSpec extends SimpleIOSuite {
+// compile-time tests
+object TypeInferenceSmokeSpec {
 
-  test("Type inference works with service calls") {
-    /*
-     * Checks that `map` can be called without upcasting the result of
-     * the service call to F[something].
-     */
-    def foo[F[_]: Functor](dummyService: DummyService[F]): F[Int] =
-      dummyService.dummy().map(_ => 1)
-
-    val dummyInstance = new DummyService[IO] {
-
-      override def dummy(
-          str: Option[String],
-          int: Option[Int],
-          ts1: Option[Timestamp],
-          ts2: Option[Timestamp],
-          ts3: Option[Timestamp],
-          ts4: Option[Timestamp],
-          b: Option[Boolean],
-          sl: Option[List[String]],
-          slm: Option[Map[String, String]]
-      ): IO[Unit] = IO.unit
-
-    }
-    foo(dummyInstance).map(x => expect(x == 1))
-  }
-
+  /*
+   * Checks that `map` can be called without upcasting the result of
+   * the service call to F[something].
+   */
+  def foo[F[_]: Functor](dummyService: DummyService[F]): F[Int] =
+    dummyService.dummy().map(_ => 1)
 }

--- a/modules/core/test/src/smithy4s/http/internals/PathParsingSpec.scala
+++ b/modules/core/test/src/smithy4s/http/internals/PathParsingSpec.scala
@@ -1,0 +1,20 @@
+package smithy4s.http.internals
+
+import smithy4s.http.PathSegment
+
+object PathParsingSpec extends weaver.FunSuite {
+
+  test("Parse path pattern into path segments") {
+    val result = pathSegments("/{head}/foo/{tail+}")
+    expect(
+      result == Option(
+        Vector(
+          PathSegment.label("head"),
+          PathSegment.static("foo"),
+          PathSegment.greedy("tail")
+        )
+      )
+    )
+  }
+
+}

--- a/modules/core/test/src/smithy4s/http/internals/PathParsingSpec.scala
+++ b/modules/core/test/src/smithy4s/http/internals/PathParsingSpec.scala
@@ -1,3 +1,19 @@
+/*
+ *  Copyright 2021 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 package smithy4s.http.internals
 
 import smithy4s.http.PathSegment

--- a/modules/core/test/src/smithy4s/http/internals/PathParsingSpec.scala
+++ b/modules/core/test/src/smithy4s/http/internals/PathParsingSpec.scala
@@ -16,6 +16,10 @@
 
 package smithy4s.http.internals
 
+import smithy4s.Timestamp
+import smithy4s.example.DummyServiceGen.DummyPath
+import smithy4s.example.PathParams
+import smithy4s.http.HttpEndpoint
 import smithy4s.http.PathSegment
 
 object PathParsingSpec extends weaver.FunSuite {
@@ -30,6 +34,31 @@ object PathParsingSpec extends weaver.FunSuite {
           PathSegment.greedy("tail")
         )
       )
+    )
+  }
+
+  test("Write PathParams") {
+    val result = HttpEndpoint
+      .cast(
+        DummyPath
+      )
+      .get
+      .path(
+        PathParams(
+          "example with spaces, %, / and \\",
+          10,
+          Timestamp.fromEpochSecond(0L),
+          Timestamp.fromEpochSecond(0L),
+          Timestamp.fromEpochSecond(0L),
+          Timestamp.fromEpochSecond(0L),
+          true
+        )
+      )
+
+    // todo this should probably be URLencoded already
+    assert.eql(
+      result,
+      "dummy-path/example with spaces, %, / and \\/10/1970-01-01T00:00:00Z/1970-01-01T00:00:00Z/0/Thu, 01 Jan 1970 00:00:00 GMT/true"
     )
   }
 

--- a/modules/core/test/src/smithy4s/http/internals/PathSpec.scala
+++ b/modules/core/test/src/smithy4s/http/internals/PathSpec.scala
@@ -22,7 +22,7 @@ import smithy4s.example.PathParams
 import smithy4s.http.HttpEndpoint
 import smithy4s.http.PathSegment
 
-object PathParsingSpec extends weaver.FunSuite {
+object PathSpec extends weaver.FunSuite {
 
   test("Parse path pattern into path segments") {
     val result = pathSegments("/{head}/foo/{tail+}")
@@ -55,10 +55,9 @@ object PathParsingSpec extends weaver.FunSuite {
         )
       )
 
-    // todo this should probably be URLencoded already
     assert.eql(
       result,
-      "dummy-path/example with spaces, %, / and \\/10/1970-01-01T00:00:00Z/1970-01-01T00:00:00Z/0/Thu, 01 Jan 1970 00:00:00 GMT/true"
+      "dummy-path/example+with+spaces%2C+%25%2C+%2F+and+%5C/10/1970-01-01T00%3A00%3A00Z/1970-01-01T00%3A00%3A00Z/0/Thu%2C+01+Jan+1970+00%3A00%3A00+GMT/true"
     )
   }
 

--- a/modules/core/test/src/smithy4s/http/internals/PathSpec.scala
+++ b/modules/core/test/src/smithy4s/http/internals/PathSpec.scala
@@ -55,10 +55,13 @@ object PathSpec extends weaver.FunSuite {
         )
       )
 
-    assert.eql(
-      result,
+    val expected = if (weaver.Platform.isJS) {
+      "dummy-path/example+with+spaces%2C+%25%2C+%2F+and+%5C/10/1970-01-01T00%3A00%3A00.000Z/1970-01-01T00%3A00%3A00.000Z/0/Thu%2C+01+Jan+1970+00%3A00%3A00+GMT/true"
+    } else {
       "dummy-path/example+with+spaces%2C+%25%2C+%2F+and+%5C/10/1970-01-01T00%3A00%3A00Z/1970-01-01T00%3A00%3A00Z/0/Thu%2C+01+Jan+1970+00%3A00%3A00+GMT/true"
-    )
+    }
+
+    assert.eql(result, expected)
   }
 
 }

--- a/modules/example/src/smithy4s/example/FooService.scala
+++ b/modules/example/src/smithy4s/example/FooService.scala
@@ -1,6 +1,5 @@
 package smithy4s.example
 
-import smithy4s.http
 import smithy4s.syntax._
 
 trait FooServiceGen[F[_, _, _, _, _]] {
@@ -48,7 +47,7 @@ object FooServiceGen extends smithy4s.Service[FooServiceGen, FooServiceOperation
     }
   }
   case class GetFoo() extends FooServiceOperation[Unit, Nothing, GetFooOutput, Nothing, Nothing]
-  object GetFoo extends smithy4s.Endpoint[FooServiceOperation, Unit, Nothing, GetFooOutput, Nothing, Nothing] with http.HttpEndpoint[Unit] {
+  object GetFoo extends smithy4s.Endpoint[FooServiceOperation, Unit, Nothing, GetFooOutput, Nothing, Nothing] {
     val id: smithy4s.ShapeId = smithy4s.ShapeId("smithy4s.example", "GetFoo")
     val input: smithy4s.Schema[Unit] = unit.withHints(smithy4s.internals.InputOutput.Input)
     val output: smithy4s.Schema[GetFooOutput] = GetFooOutput.schema.withHints(smithy4s.internals.InputOutput.Output)
@@ -60,10 +59,6 @@ object FooServiceGen extends smithy4s.Service[FooServiceGen, FooServiceOperation
       smithy.api.Readonly(),
     )
     def wrap(input: Unit) = GetFoo()
-    def path(input: Unit) = s"foo"
-    val path = List(http.PathSegment.static("foo"))
-    val code: Int = 200
-    val method: http.HttpMethod = http.HttpMethod.GET
   }
 }
 

--- a/modules/example/src/smithy4s/example/ObjectService.scala
+++ b/modules/example/src/smithy4s/example/ObjectService.scala
@@ -2,7 +2,6 @@ package smithy4s.example
 
 import ObjectServiceGen.GetObjectError
 import ObjectServiceGen.PutObjectError
-import smithy4s.http
 import smithy4s.syntax._
 
 trait ObjectServiceGen[F[_, _, _, _, _]] {
@@ -57,7 +56,7 @@ object ObjectServiceGen extends smithy4s.Service[ObjectServiceGen, ObjectService
     }
   }
   case class PutObject(input: PutObjectInput) extends ObjectServiceOperation[PutObjectInput, PutObjectError, Unit, Nothing, Nothing]
-  object PutObject extends smithy4s.Endpoint[ObjectServiceOperation, PutObjectInput, PutObjectError, Unit, Nothing, Nothing] with http.HttpEndpoint[PutObjectInput] with smithy4s.Errorable[PutObjectError] {
+  object PutObject extends smithy4s.Endpoint[ObjectServiceOperation, PutObjectInput, PutObjectError, Unit, Nothing, Nothing] with smithy4s.Errorable[PutObjectError] {
     val id: smithy4s.ShapeId = smithy4s.ShapeId("smithy4s.example", "PutObject")
     val input: smithy4s.Schema[PutObjectInput] = PutObjectInput.schema.withHints(smithy4s.internals.InputOutput.Input)
     val output: smithy4s.Schema[Unit] = unit.withHints(smithy4s.internals.InputOutput.Output)
@@ -80,10 +79,6 @@ object ObjectServiceGen extends smithy4s.Service[ObjectServiceGen, ObjectService
       case PutObjectError.ServerErrorCase(e) => e
       case PutObjectError.NoMoreSpaceCase(e) => e
     }
-    def path(input: PutObjectInput) = s"${smithy4s.segment(input.bucketName)}/${smithy4s.segment(input.key)}"
-    val path = List(http.PathSegment.label("bucketName"), http.PathSegment.label("key"))
-    val code: Int = 200
-    val method: http.HttpMethod = http.HttpMethod.PUT
   }
   sealed trait PutObjectError
   object PutObjectError {
@@ -117,7 +112,7 @@ object ObjectServiceGen extends smithy4s.Service[ObjectServiceGen, ObjectService
     implicit val staticSchema : schematic.Static[smithy4s.Schema[PutObjectError]] = schematic.Static(schema)
   }
   case class GetObject(input: GetObjectInput) extends ObjectServiceOperation[GetObjectInput, GetObjectError, GetObjectOutput, Nothing, Nothing]
-  object GetObject extends smithy4s.Endpoint[ObjectServiceOperation, GetObjectInput, GetObjectError, GetObjectOutput, Nothing, Nothing] with http.HttpEndpoint[GetObjectInput] with smithy4s.Errorable[GetObjectError] {
+  object GetObject extends smithy4s.Endpoint[ObjectServiceOperation, GetObjectInput, GetObjectError, GetObjectOutput, Nothing, Nothing] with smithy4s.Errorable[GetObjectError] {
     val id: smithy4s.ShapeId = smithy4s.ShapeId("smithy4s.example", "GetObject")
     val input: smithy4s.Schema[GetObjectInput] = GetObjectInput.schema.withHints(smithy4s.internals.InputOutput.Input)
     val output: smithy4s.Schema[GetObjectOutput] = GetObjectOutput.schema.withHints(smithy4s.internals.InputOutput.Output)
@@ -138,10 +133,6 @@ object ObjectServiceGen extends smithy4s.Service[ObjectServiceGen, ObjectService
     def unliftError(e: GetObjectError) : Throwable = e match {
       case GetObjectError.ServerErrorCase(e) => e
     }
-    def path(input: GetObjectInput) = s"${smithy4s.segment(input.bucketName)}/${smithy4s.segment(input.key)}"
-    val path = List(http.PathSegment.label("bucketName"), http.PathSegment.label("key"))
-    val code: Int = 200
-    val method: http.HttpMethod = http.HttpMethod.GET
   }
   sealed trait GetObjectError
   object GetObjectError {

--- a/modules/protocol/test/src/smithy4s/api/validation/DiscriminatedUnionValidatorSpec.scala
+++ b/modules/protocol/test/src/smithy4s/api/validation/DiscriminatedUnionValidatorSpec.scala
@@ -1,3 +1,19 @@
+/*
+ *  Copyright 2021 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 package smithy4s.api.validation
 
 import software.amazon.smithy.model.shapes.UnionShape

--- a/sampleSpecs/metadata.smithy
+++ b/sampleSpecs/metadata.smithy
@@ -4,11 +4,19 @@ namespace smithy4s.example
 /// when testing core
 service DummyService {
   version: "0.0",
-  operations: [Dummy]
+  operations: [Dummy, DummyPath]
 }
 
+@http(method: "GET", uri: "/dummy")
+@readonly
 operation Dummy {
   input: Queries
+}
+
+@http(method: "GET", uri: "/dummy-path/{str}/{int}/{ts1}/{ts2}/{ts3}/{ts4}/{b}")
+@readonly
+operation DummyPath {
+  input: PathParams
 }
 
 structure Queries {
@@ -58,6 +66,7 @@ structure Headers {
   @httpPrefixHeaders("foo-")
   slm: StringMap
 }
+
 
 structure PathParams {
   @httpLabel

--- a/sampleSpecs/pizza.smithy
+++ b/sampleSpecs/pizza.smithy
@@ -60,6 +60,7 @@ structure AddMenuItemResult {
   added: Timestamp
 }
 
+@readonly
 @http(method: "GET", uri: "/version", code: 200)
 operation Version {
   output: VersionOutput


### PR DESCRIPTION
Derive HttpEndpoint from Hint instead of relying on subtyping
  
This derives the HttpEndpoint instance associated to an Endpoint, by searching smithy.api.Http in the the Endpoint's hints, and compiling the found data to the correct interface, by means of Schematic.
  
The rationale is the following :
  1. allow for dynamically instantiated service to have HttpService without any bespoke processing.
  2. open the door for splitting the http package away from the core module