### PR TITLE
add flag to CI to trigger snapshot build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,12 @@
 name: CI
 on:
   push:
+    workflow_dispatch:
+    inputs:
+      publishSnapshot:
+        description: 'Publish Snapshot'
+        required: true
+        default: 'false'
     branches: ["main"]
     tags: ["v*"]
   pull_request:
@@ -79,7 +85,7 @@ jobs:
   release:
     name: Release
     needs: [build]
-    if: startsWith(github.ref, 'refs/tags/v') # || (github.ref == 'refs/heads/main')
+    if: startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && github.event.inputs.publishSnapshot == 'true') # || (github.ref == 'refs/heads/main')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout current branch (full)


### PR DESCRIPTION
This will make it so we can manually trigger a build that will publish a snapshot.