### PR TITLE
Tentative fix of the signature implementation

### DIFF
--- a/modules/aws-kernel/src/smithy4s/aws/AwsSignature.scala
+++ b/modules/aws-kernel/src/smithy4s/aws/AwsSignature.scala
@@ -50,6 +50,7 @@ private[aws] object AwsSignature {
     def timestamp: Timestamp
     def region: String
     def endpointPrefix: String
+    def sigName: String
 
     def credentialsScope =
       s"${timestamp.conciseDate}/$region/${endpointPrefix.toLowerCase}/aws4_request"
@@ -92,7 +93,7 @@ private[aws] object AwsSignature {
       request.secretKey,
       request.timestamp.conciseDate,
       request.region,
-      request.endpointPrefix.toLowerCase
+      request.sigName
     )
     val stringToSign = List[String](
       algorithm,

--- a/modules/aws/src/smithy4s/aws/internals/AwsJsonRPCInterpreter.scala
+++ b/modules/aws/src/smithy4s/aws/internals/AwsJsonRPCInterpreter.scala
@@ -29,7 +29,8 @@ private[aws] class AwsJsonRPCInterpreter[Alg[_[_, _, _, _, _]], Op[_,_,_,_,_], F
     service: smithy4s.Service[Alg, Op],
     endpointPrefix: String,
     awsEnv: AwsEnvironment[F],
-    contentType: String
+    contentType: String,
+    sigName: String
 )(implicit F: MonadThrow[F])
     extends Transformation[Op, AwsCall[F, *, *, *, *, *]] {
 // format: on
@@ -45,7 +46,8 @@ private[aws] class AwsJsonRPCInterpreter[Alg[_[_, _, _, _, _]], Op[_,_,_,_,_], F
     service.id,
     endpointPrefix,
     awsEnv,
-    contentType
+    contentType,
+    sigName
   )
 
   private val awsEndpoints =

--- a/modules/aws/src/smithy4s/aws/internals/AwsSigner.scala
+++ b/modules/aws/src/smithy4s/aws/internals/AwsSigner.scala
@@ -41,15 +41,23 @@ object AwsSigner {
       serviceId: ShapeId,
       endpointPrefix: String,
       environment: AwsEnvironment[F],
-      contentType: String
+      contentType: String,
+      sigName: String
   ): AwsSigner[F] =
-    new RPCSigner[F](serviceId, endpointPrefix, environment, contentType)
+    new RPCSigner[F](
+      serviceId,
+      endpointPrefix,
+      environment,
+      contentType,
+      sigName
+    )
 
   private class RPCSigner[F[_]: Monad](
       serviceId: ShapeId,
       endpointPrefix: String,
       awsEnv: AwsEnvironment[F],
-      contentType: String
+      contentType: String,
+      sigName: String
   ) extends AwsSigner[F] {
     def sign(
         endpointName: String,
@@ -74,7 +82,8 @@ object AwsSigner {
           metadata = metadata,
           timestamp = t,
           body = body,
-          contentType = contentType
+          contentType = contentType,
+          sigName = sigName
         )
       }
     }
@@ -98,7 +107,8 @@ object AwsSigner {
       accessToken: Option[String],
       timestamp: Timestamp,
       body: Option[Array[Byte]],
-      contentType: String
+      contentType: String,
+      sigName: String
   ) extends HttpRequest
       with AwsSignature.Signable {
 

--- a/modules/benchmark/src/main/scala/Codecs.scala
+++ b/modules/benchmark/src/main/scala/Codecs.scala
@@ -58,4 +58,3 @@ object Circe {
   implicit val s3ObjectCodec: Codec[S3Object] =
     io.circe.generic.semiauto.deriveCodec[S3Object]
 }
-


### PR DESCRIPTION
The sigv4 trait contains what seems to be the service-specific name
that should be used during the signature of the request.