### PR TITLE
Use FQNs in rendered `Product` and `Serializable` inheritance

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -123,6 +123,7 @@ lazy val core = projectMatrix
       (ThisBuild / baseDirectory).value / "sampleSpecs" / "recursive.smithy",
       (ThisBuild / baseDirectory).value / "sampleSpecs" / "bodies.smithy",
       (ThisBuild / baseDirectory).value / "sampleSpecs" / "empty.smithy",
+      (ThisBuild / baseDirectory).value / "sampleSpecs" / "product.smithy",
       (ThisBuild / baseDirectory).value / "sampleSpecs" / "weather.smithy",
       (ThisBuild / baseDirectory).value / "sampleSpecs" / "discriminated.smithy"
     ),

--- a/modules/benchmark/src/main/scala/Codecs.scala
+++ b/modules/benchmark/src/main/scala/Codecs.scala
@@ -58,4 +58,3 @@ object Circe {
   implicit val s3ObjectCodec: Codec[S3Object] =
     io.circe.generic.semiauto.deriveCodec[S3Object]
 }
-

--- a/modules/codegen/src/smithy4s/codegen/Renderer.scala
+++ b/modules/codegen/src/smithy4s/codegen/Renderer.scala
@@ -401,7 +401,7 @@ private[codegen] class Renderer(compilationUnit: CompilationUnit) { self =>
     val caseNames = alts.map(_.name).map(caseName)
     val imports = alts.foldMap(_.tpe.imports) ++ syntaxImport
     lines(
-      s"sealed trait $name",
+      s"sealed trait $name extends scala.Product with scala.Serializable",
       obj(name, ext = hintKey(name, hints))(
         renderId(name),
         newline,
@@ -460,7 +460,7 @@ private[codegen] class Renderer(compilationUnit: CompilationUnit) { self =>
       values: List[EnumValue],
       hints: List[Hint]
   ): RenderResult = lines(
-    s"sealed abstract class $name(val value: String, val ordinal: Int) extends Product with Serializable",
+    s"sealed abstract class $name(val value: String, val ordinal: Int) extends scala.Product with scala.Serializable",
     obj(name, ext = s"$Enumeration_[$name]", w = hintKey(name, hints))(
       renderId(name),
       newline,

--- a/modules/core/test/src/smithy4s/ProductSerialSmokeSpec.scala
+++ b/modules/core/test/src/smithy4s/ProductSerialSmokeSpec.scala
@@ -1,0 +1,32 @@
+/*
+ *  Copyright 2021 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package smithy4s
+
+import weaver._
+
+object ProductSerialSmokeSpec extends FunSuite {
+
+  test(
+    "Enumeration compiles when shapes called Product or Serializable exist"
+  ) {
+    val product = smithy4s.example.Product
+    val serial = smithy4s.example.Serializable
+    val foo = smithy4s.example.FooEnum.FOO
+    expect(List(product, serial, foo).forall(_ != null))
+  }
+
+}

--- a/modules/example/src/smithy4s/example/Foo.scala
+++ b/modules/example/src/smithy4s/example/Foo.scala
@@ -2,7 +2,7 @@ package smithy4s.example
 
 import smithy4s.syntax._
 
-sealed trait Foo
+sealed trait Foo extends scala.Product with scala.Serializable
 object Foo {
   val id: smithy4s.ShapeId = smithy4s.ShapeId("smithy4s.example", "Foo")
 

--- a/modules/example/src/smithy4s/example/LowHigh.scala
+++ b/modules/example/src/smithy4s/example/LowHigh.scala
@@ -2,7 +2,7 @@ package smithy4s.example
 
 import smithy4s.syntax._
 
-sealed abstract class LowHigh(val value: String, val ordinal: Int) extends Product with Serializable
+sealed abstract class LowHigh(val value: String, val ordinal: Int) extends scala.Product with scala.Serializable
 object LowHigh extends smithy4s.Enumeration[LowHigh] {
   val id: smithy4s.ShapeId = smithy4s.ShapeId("smithy4s.example", "LowHigh")
 

--- a/modules/example/src/smithy4s/example/ObjectService.scala
+++ b/modules/example/src/smithy4s/example/ObjectService.scala
@@ -80,7 +80,7 @@ object ObjectServiceGen extends smithy4s.Service[ObjectServiceGen, ObjectService
       case PutObjectError.NoMoreSpaceCase(e) => e
     }
   }
-  sealed trait PutObjectError
+  sealed trait PutObjectError extends scala.Product with scala.Serializable
   object PutObjectError {
     val id: smithy4s.ShapeId = smithy4s.ShapeId("smithy4s.example", "PutObjectError")
 
@@ -134,7 +134,7 @@ object ObjectServiceGen extends smithy4s.Service[ObjectServiceGen, ObjectService
       case GetObjectError.ServerErrorCase(e) => e
     }
   }
-  sealed trait GetObjectError
+  sealed trait GetObjectError extends scala.Product with scala.Serializable
   object GetObjectError {
     val id: smithy4s.ShapeId = smithy4s.ShapeId("smithy4s.example", "GetObjectError")
 

--- a/sampleSpecs/product.smithy
+++ b/sampleSpecs/product.smithy
@@ -1,0 +1,7 @@
+namespace smithy4s.example
+
+@enum([{name: "FOO", value: "Foo"}])
+string FooEnum
+
+structure Product {}
+structure Serializable {}


### PR DESCRIPTION
Using full-qualified-names because users encounter issues when they use `Product` as a shape name. 