### PR TITLE
allow site publish for snapshots

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,15 +122,12 @@ jobs:
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
 
       - name: Compile Documentation Markdown Files
-        if: startsWith(github.ref, 'refs/tags/v') # do not run for snapshots
         run: sbt "docs/mdoc"
 
       - name: Build Microsite
-        if: startsWith(github.ref, 'refs/tags/v') # do not run for snapshots
         run: cd ./modules/website && yarn && yarn build
 
       - name: Publish Microsite
-        if: startsWith(github.ref, 'refs/tags/v') # do not run for snapshots
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Now that we have the version pulling the latest stable for snapshots, we should enable publishing the website on snapshot builds.