### PR TITLE
spelling

### DIFF
--- a/modules/docs/src/01-overview/01-intro.md
+++ b/modules/docs/src/01-overview/01-intro.md
@@ -8,8 +8,8 @@ title: Intro
 smithy4s is a tool that generates third-party-free, protocol-agnostic scala code from smithy specifications.
 
 Smithy4s can be used to:
-* quickly synthetise http/rest servers and clients
-* synthetise pure-scala AWS clients
-* synthetise CLI tools
+* quickly synthesize http/rest servers and clients
+* synthesize pure-scala AWS clients
+* synthesize CLI tools
 * and has the potential for much, much more!
 


### PR DESCRIPTION
While "synthetize" is a correct spelling it appears to be an uncommon form of the word. (I initially thought incorrect)

IMO "synthesize CLI tools" seems a little odd, would consider if this is really what is meant.