### PR TITLE
Render ShapeTags for everything

### DIFF
--- a/modules/codegen/src/smithy4s/codegen/Renderer.scala
+++ b/modules/codegen/src/smithy4s/codegen/Renderer.scala
@@ -346,7 +346,7 @@ private[codegen] class Renderer(compilationUnit: CompilationUnit) { self =>
           }
         }
       } else line(decl),
-      obj(name, ext = hintKey(name, hints))(
+      obj(name, ext = shapeTag(name))(
         renderId(name),
         newline,
         renderHintsValWithId(hints),
@@ -417,7 +417,7 @@ private[codegen] class Renderer(compilationUnit: CompilationUnit) { self =>
     val imports = alts.foldMap(_.tpe.imports) ++ syntaxImport
     lines(
       s"sealed trait $name extends scala.Product with scala.Serializable",
-      obj(name, ext = hintKey(name, hints))(
+      obj(name, ext = shapeTag(name))(
         renderId(name),
         newline,
         renderHintsValWithId(hints),
@@ -476,7 +476,7 @@ private[codegen] class Renderer(compilationUnit: CompilationUnit) { self =>
       hints: List[Hint]
   ): RenderResult = lines(
     s"sealed abstract class $name(val value: String, val ordinal: Int) extends scala.Product with scala.Serializable",
-    obj(name, ext = s"$Enumeration_[$name]", w = hintKey(name, hints))(
+    obj(name, ext = s"$Enumeration_[$name]", w = shapeTag(name))(
       renderId(name),
       newline,
       renderHintsValWithId(hints),
@@ -667,8 +667,8 @@ private[codegen] class Renderer(compilationUnit: CompilationUnit) { self =>
     if (h.isEmpty) "" else h.mkString(", ")
   }
 
-  private def hintKey(name: String, hints: List[Hint]): String =
-    if (hints.contains(Hint.Trait)) s"$ShapeTag_.Companion[$name]" else ""
+  private def shapeTag(name: String): String =
+    s"$ShapeTag_.Companion[$name]"
 
   type TopLevel = Boolean
   type InCollection = Boolean

--- a/modules/core/src/smithy4s/HintMask.scala
+++ b/modules/core/src/smithy4s/HintMask.scala
@@ -27,8 +27,8 @@ object HintMask {
 
   def empty: HintMask = apply()
 
-  def apply(hintKeys: ShapeTag[_]*): HintMask = {
-    new Impl(hintKeys.toSet)
+  def apply(shapeTags: ShapeTag[_]*): HintMask = {
+    new Impl(shapeTags.toSet)
   }
 
   private[this] case object Permissive extends HintMask {

--- a/modules/example/src/smithy4s/example/ArbitraryDataTest.scala
+++ b/modules/example/src/smithy4s/example/ArbitraryDataTest.scala
@@ -3,7 +3,7 @@ package smithy4s.example
 import smithy4s.syntax._
 
 case class ArbitraryDataTest()
-object ArbitraryDataTest {
+object ArbitraryDataTest extends smithy4s.ShapeTag.Companion[ArbitraryDataTest] {
   val id: smithy4s.ShapeId = smithy4s.ShapeId("smithy4s.example", "ArbitraryDataTest")
 
   val hints : smithy4s.Hints = smithy4s.Hints(

--- a/modules/example/src/smithy4s/example/Foo.scala
+++ b/modules/example/src/smithy4s/example/Foo.scala
@@ -3,7 +3,7 @@ package smithy4s.example
 import smithy4s.syntax._
 
 sealed trait Foo extends scala.Product with scala.Serializable
-object Foo {
+object Foo extends smithy4s.ShapeTag.Companion[Foo] {
   val id: smithy4s.ShapeId = smithy4s.ShapeId("smithy4s.example", "Foo")
 
   val hints : smithy4s.Hints = smithy4s.Hints(

--- a/modules/example/src/smithy4s/example/GetFooOutput.scala
+++ b/modules/example/src/smithy4s/example/GetFooOutput.scala
@@ -3,7 +3,7 @@ package smithy4s.example
 import smithy4s.syntax._
 
 case class GetFooOutput(foo: Option[Foo] = None)
-object GetFooOutput {
+object GetFooOutput extends smithy4s.ShapeTag.Companion[GetFooOutput] {
   val id: smithy4s.ShapeId = smithy4s.ShapeId("smithy4s.example", "GetFooOutput")
 
   val hints : smithy4s.Hints = smithy4s.Hints(

--- a/modules/example/src/smithy4s/example/GetObjectInput.scala
+++ b/modules/example/src/smithy4s/example/GetObjectInput.scala
@@ -3,7 +3,7 @@ package smithy4s.example
 import smithy4s.syntax._
 
 case class GetObjectInput(key: ObjectKey, bucketName: BucketName)
-object GetObjectInput {
+object GetObjectInput extends smithy4s.ShapeTag.Companion[GetObjectInput] {
   val id: smithy4s.ShapeId = smithy4s.ShapeId("smithy4s.example", "GetObjectInput")
 
   val hints : smithy4s.Hints = smithy4s.Hints(

--- a/modules/example/src/smithy4s/example/GetObjectOutput.scala
+++ b/modules/example/src/smithy4s/example/GetObjectOutput.scala
@@ -3,7 +3,7 @@ package smithy4s.example
 import smithy4s.syntax._
 
 case class GetObjectOutput(size: ObjectSize, data: Option[String] = None)
-object GetObjectOutput {
+object GetObjectOutput extends smithy4s.ShapeTag.Companion[GetObjectOutput] {
   val id: smithy4s.ShapeId = smithy4s.ShapeId("smithy4s.example", "GetObjectOutput")
 
   val hints : smithy4s.Hints = smithy4s.Hints(

--- a/modules/example/src/smithy4s/example/GetStreamedObjectInput.scala
+++ b/modules/example/src/smithy4s/example/GetStreamedObjectInput.scala
@@ -3,7 +3,7 @@ package smithy4s.example
 import smithy4s.syntax._
 
 case class GetStreamedObjectInput(key: String)
-object GetStreamedObjectInput {
+object GetStreamedObjectInput extends smithy4s.ShapeTag.Companion[GetStreamedObjectInput] {
   val id: smithy4s.ShapeId = smithy4s.ShapeId("smithy4s.example", "GetStreamedObjectInput")
 
   val hints : smithy4s.Hints = smithy4s.Hints(

--- a/modules/example/src/smithy4s/example/GetStreamedObjectOutput.scala
+++ b/modules/example/src/smithy4s/example/GetStreamedObjectOutput.scala
@@ -3,7 +3,7 @@ package smithy4s.example
 import smithy4s.syntax._
 
 case class GetStreamedObjectOutput()
-object GetStreamedObjectOutput {
+object GetStreamedObjectOutput extends smithy4s.ShapeTag.Companion[GetStreamedObjectOutput] {
   val id: smithy4s.ShapeId = smithy4s.ShapeId("smithy4s.example", "GetStreamedObjectOutput")
 
   val hints : smithy4s.Hints = smithy4s.Hints(

--- a/modules/example/src/smithy4s/example/LowHigh.scala
+++ b/modules/example/src/smithy4s/example/LowHigh.scala
@@ -3,7 +3,7 @@ package smithy4s.example
 import smithy4s.syntax._
 
 sealed abstract class LowHigh(val value: String, val ordinal: Int) extends scala.Product with scala.Serializable
-object LowHigh extends smithy4s.Enumeration[LowHigh] {
+object LowHigh extends smithy4s.Enumeration[LowHigh] with smithy4s.ShapeTag.Companion[LowHigh] {
   val id: smithy4s.ShapeId = smithy4s.ShapeId("smithy4s.example", "LowHigh")
 
   val hints : smithy4s.Hints = smithy4s.Hints(

--- a/modules/example/src/smithy4s/example/NoMoreSpace.scala
+++ b/modules/example/src/smithy4s/example/NoMoreSpace.scala
@@ -5,7 +5,7 @@ import smithy4s.syntax._
 case class NoMoreSpace(message: String, foo: Option[Foo] = None) extends Throwable {
   override def getMessage() : String = message
 }
-object NoMoreSpace {
+object NoMoreSpace extends smithy4s.ShapeTag.Companion[NoMoreSpace] {
   val id: smithy4s.ShapeId = smithy4s.ShapeId("smithy4s.example", "NoMoreSpace")
 
   val hints : smithy4s.Hints = smithy4s.Hints(

--- a/modules/example/src/smithy4s/example/ObjectService.scala
+++ b/modules/example/src/smithy4s/example/ObjectService.scala
@@ -81,7 +81,7 @@ object ObjectServiceGen extends smithy4s.Service[ObjectServiceGen, ObjectService
     }
   }
   sealed trait PutObjectError extends scala.Product with scala.Serializable
-  object PutObjectError {
+  object PutObjectError extends smithy4s.ShapeTag.Companion[PutObjectError] {
     val id: smithy4s.ShapeId = smithy4s.ShapeId("smithy4s.example", "PutObjectError")
 
     val hints : smithy4s.Hints = smithy4s.Hints(
@@ -135,7 +135,7 @@ object ObjectServiceGen extends smithy4s.Service[ObjectServiceGen, ObjectService
     }
   }
   sealed trait GetObjectError extends scala.Product with scala.Serializable
-  object GetObjectError {
+  object GetObjectError extends smithy4s.ShapeTag.Companion[GetObjectError] {
     val id: smithy4s.ShapeId = smithy4s.ShapeId("smithy4s.example", "GetObjectError")
 
     val hints : smithy4s.Hints = smithy4s.Hints(

--- a/modules/example/src/smithy4s/example/PutObjectInput.scala
+++ b/modules/example/src/smithy4s/example/PutObjectInput.scala
@@ -3,7 +3,7 @@ package smithy4s.example
 import smithy4s.syntax._
 
 case class PutObjectInput(key: ObjectKey, bucketName: BucketName, data: String, foo: Option[LowHigh] = None, someValue: Option[SomeValue] = None)
-object PutObjectInput {
+object PutObjectInput extends smithy4s.ShapeTag.Companion[PutObjectInput] {
   val id: smithy4s.ShapeId = smithy4s.ShapeId("smithy4s.example", "PutObjectInput")
 
   val hints : smithy4s.Hints = smithy4s.Hints(

--- a/modules/example/src/smithy4s/example/PutStreamedObjectInput.scala
+++ b/modules/example/src/smithy4s/example/PutStreamedObjectInput.scala
@@ -3,7 +3,7 @@ package smithy4s.example
 import smithy4s.syntax._
 
 case class PutStreamedObjectInput(key: String)
-object PutStreamedObjectInput {
+object PutStreamedObjectInput extends smithy4s.ShapeTag.Companion[PutStreamedObjectInput] {
   val id: smithy4s.ShapeId = smithy4s.ShapeId("smithy4s.example", "PutStreamedObjectInput")
 
   val hints : smithy4s.Hints = smithy4s.Hints(

--- a/modules/example/src/smithy4s/example/ServerError.scala
+++ b/modules/example/src/smithy4s/example/ServerError.scala
@@ -5,7 +5,7 @@ import smithy4s.syntax._
 case class ServerError(message: Option[String] = None) extends Throwable {
   override def getMessage() : String = message.orNull
 }
-object ServerError {
+object ServerError extends smithy4s.ShapeTag.Companion[ServerError] {
   val id: smithy4s.ShapeId = smithy4s.ShapeId("smithy4s.example", "ServerError")
 
   val hints : smithy4s.Hints = smithy4s.Hints(


### PR DESCRIPTION
Since Hint keys are now ShapeTags, they are conceptually no longer
specific to keys, so might as well render them for all shapes.