### PR TITLE
Update .mergify.yml

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -9,7 +9,7 @@ pull_request_rules:
       - status-success="Test CE3 2_13 (js)"
       - status-success="Test CE3 3_0 (jvm)"
       - status-success="Test CE3 3_0 (js)"
-      - body~=labels:.*semver-patch.*
+      - body~=labels:.*semver-spec-patch.*
     actions:
       review:
         type: APPROVE


### PR DESCRIPTION
Not entirely sure why, but scala-steward does not always put the label `early-semver-patch` on PRs when they are patch releases. However, it does seem to put `semver-spec-patch` on all path releases. Further, this is the label that is used by the creator of scala-steward as seen here: https://github.com/fthomas/refined/blob/master/.mergify.yml. There isn't any documentation that I can find regarding when different labels appear or don't appear, but this seems like a good indicator that we can rely on `early-semver-patch`