### PR TITLE
Adds a way to get packed inputs in operations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        java: [adoptium@17]
+        java: [temurin@17]
         scalaVersion: ["2_12", "2_13", "3_0"]
         scalaPlatform: ["jvm", "js"]
         ceVersion: ["CE2", "CE3"]
@@ -98,7 +98,7 @@ jobs:
       - name: Setup Java and Scala
         uses: olafurpg/setup-scala@v13
         with:
-          java-version: adoptium@17
+          java-version: temurin@17
 
       - name: Cache
         uses: coursier/cache-action@v6

--- a/build.sbt
+++ b/build.sbt
@@ -133,7 +133,8 @@ lazy val core = projectMatrix
       (ThisBuild / baseDirectory).value / "sampleSpecs" / "empty.smithy",
       (ThisBuild / baseDirectory).value / "sampleSpecs" / "product.smithy",
       (ThisBuild / baseDirectory).value / "sampleSpecs" / "weather.smithy",
-      (ThisBuild / baseDirectory).value / "sampleSpecs" / "discriminated.smithy"
+      (ThisBuild / baseDirectory).value / "sampleSpecs" / "discriminated.smithy",
+      (ThisBuild / baseDirectory).value / "sampleSpecs" / "packedInputs.smithy"
     ),
     (Test / sourceGenerators) := Seq(genSmithyScala(Test).taskValue),
     testFrameworks += new TestFramework("weaver.framework.CatsEffect")

--- a/modules/codegen/src/smithy4s/codegen/IR.scala
+++ b/modules/codegen/src/smithy4s/codegen/IR.scala
@@ -174,6 +174,7 @@ sealed trait Hint
 object Hint {
   case object Trait extends Hint
   case object Error extends Hint
+  case object PackedInputs extends Hint
   case class Protocol(traits: List[Type.Ref]) extends Hint
   // traits that get rendered generically
   case class Native(typedNode: Fix[TypedNode]) extends Hint

--- a/modules/codegen/src/smithy4s/codegen/PostProcessor.scala
+++ b/modules/codegen/src/smithy4s/codegen/PostProcessor.scala
@@ -1,0 +1,49 @@
+/*
+ *  Copyright 2021 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package smithy4s.codegen
+
+trait PostProcessor extends (CompilationUnit => CompilationUnit) {}
+
+object PostProcessor extends PostProcessor {
+
+  val all: List[PostProcessor] = List(PackedInputsShift)
+
+  def apply(unit: CompilationUnit): CompilationUnit = {
+    all.foldLeft(unit)((acc, f) => f(acc))
+  }
+
+}
+
+object PackedInputsShift extends PostProcessor {
+  def apply(unit: CompilationUnit): CompilationUnit = {
+    val newDecls = unit.declarations.map {
+      case s: Service => transformService(s)
+      case other      => other
+    }
+    unit.copy(declarations = newDecls)
+  }
+
+  def transformService(s: Service): Service = {
+    if (s.hints.contains(Hint.PackedInputs)) {
+      val newOps = s.ops.map { op =>
+        op.copy(hints = Hint.PackedInputs :: op.hints)
+      }
+      s.copy(ops = newOps)
+    } else s
+  }
+
+}

--- a/modules/core/test/src/smithy4s/PackedInputsSmokeSpec.scala
+++ b/modules/core/test/src/smithy4s/PackedInputsSmokeSpec.scala
@@ -22,7 +22,7 @@ import smithy4s.example.{PackedInputsService, PackedInput}
 
 object PackedInputsSmokeSpec extends FunSuite {
 
-  test("Algebra can be summoned from monadic alias") {
+  test("Methods with packed inputs have a single case-class parameter") {
     val service: PackedInputsService[Id] = new PackedInputsService[Id] {
       def packedInputOperation(input: PackedInput): Unit = ()
     }

--- a/modules/core/test/src/smithy4s/PackedInputsSmokeSpec.scala
+++ b/modules/core/test/src/smithy4s/PackedInputsSmokeSpec.scala
@@ -1,0 +1,32 @@
+/*
+ *  Copyright 2021 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package smithy4s
+
+import weaver._
+import cats.Id
+import smithy4s.example.{PackedInputsService, PackedInput}
+
+object PackedInputsSmokeSpec extends FunSuite {
+
+  test("Algebra can be summoned from monadic alias") {
+    val service: PackedInputsService[Id] = new PackedInputsService[Id] {
+      def packedInputOperation(input: PackedInput): Unit = ()
+    }
+    expect.same(service.packedInputOperation(PackedInput(key = "foo")), ())
+  }
+
+}

--- a/modules/docs/src/04-codegen/01-customisation.md
+++ b/modules/docs/src/04-codegen/01-customisation.md
@@ -1,0 +1,64 @@
+---
+sidebar_label: Protocols and smithy4s
+title: Protocols and smithy4s
+---
+
+Smithy4s is opinionated in what the generated code look like, there are a few things that can be tweaked.
+
+#### Packed inputs
+
+By default, smithy4s generates methods the parameters of which map to the fields of the input structure of the corresponding operation.
+
+For instance :
+
+```kotlin
+service PackedInputsService {
+  version: "1.0.0",
+  operations: [PackedInputOperation]
+}
+
+operation PackedInputOperation {
+  input: PackedInput,
+}
+
+structure PackedInput {
+    @required
+    a: String,
+    @required
+    b: String
+}
+```
+
+leads to something conceptually equivalent to :
+
+```scala
+trait PackedInputServiceGen[F[_]] {
+
+  def packedInputOperation(a: String, b: String) : F[Unit]
+
+}
+```
+
+It is however possible to annotate the service (or operation) definition with the `smithy.meta#packedInputs` trait, in order for the rendered method to contain a single parameter, typed with actual input case class of the operation.
+
+For instance :
+
+```scala
+use smithy4s.meta#packedInputs
+
+@packedInputs
+service PackedInputsService {
+  version: "1.0.0",
+  operations: [PackedInputOperation]
+}
+```
+
+will produce the following Scala code
+
+```scala  
+trait PackedInputServiceGen[F[_]] {
+
+  def packedInputOperation(input: PackedInput) : F[Unit]
+
+}
+```

--- a/modules/docs/src/04-codegen/01-customisation.md
+++ b/modules/docs/src/04-codegen/01-customisation.md
@@ -39,7 +39,7 @@ trait PackedInputServiceGen[F[_]] {
 }
 ```
 
-It is however possible to annotate the service (or operation) definition with the `smithy.meta#packedInputs` trait, in order for the rendered method to contain a single parameter, typed with actual input case class of the operation.
+It is however possible to annotate the service (or operation) definition with the `smithy4s.meta#packedInputs` trait, in order for the rendered method to contain a single parameter, typed with actual input case class of the operation.
 
 For instance :
 

--- a/modules/protocol/resources/META-INF/services/software.amazon.smithy.model.traits.TraitService
+++ b/modules/protocol/resources/META-INF/services/software.amazon.smithy.model.traits.TraitService
@@ -2,3 +2,4 @@ smithy4s.api.SimpleRestJsonTrait$Provider
 smithy4s.api.UncheckedExamplesTrait$Provider
 smithy4s.api.UuidFormatTrait$Provider
 smithy4s.api.DiscriminatedUnionTrait$Provider
+smithy4s.meta.PackedInputsTrait$Provider

--- a/modules/protocol/resources/META-INF/smithy/manifest
+++ b/modules/protocol/resources/META-INF/smithy/manifest
@@ -1,1 +1,2 @@
 smithy4s.smithy
+smithy4s.meta.smithy

--- a/modules/protocol/resources/META-INF/smithy/smithy4s.meta.smithy
+++ b/modules/protocol/resources/META-INF/smithy/smithy4s.meta.smithy
@@ -1,0 +1,15 @@
+$version: "1.0"
+
+metadata suppressions = [
+    {
+        id: "UnreferencedShape",
+        namespace: "smithy4s.meta",
+        reason: "This is a library namespace."
+    }
+]
+
+
+namespace smithy4s.meta
+
+@trait(selector: ":is(service, operation)")
+structure packedInputs {}

--- a/modules/protocol/src/smithy4s/meta/PackedInputsTrait.java
+++ b/modules/protocol/src/smithy4s/meta/PackedInputsTrait.java
@@ -1,0 +1,47 @@
+/*
+ *  Copyright 2021 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package smithy4s.meta;
+
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ObjectNode;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.traits.AnnotationTrait;
+import software.amazon.smithy.model.traits.AbstractTrait;
+
+public class PackedInputsTrait extends AnnotationTrait {
+
+  public static ShapeId ID = ShapeId.from("smithy4s.meta#packedInputs");
+
+  public PackedInputsTrait(ObjectNode node) {
+    super(ID, node);
+  }
+
+  public PackedInputsTrait() {
+    super(ID, Node.objectNode());
+  }
+
+  public static final class Provider extends AbstractTrait.Provider {
+    public Provider() {
+      super(ID);
+    }
+
+    @Override
+    public PackedInputsTrait createTrait(ShapeId target, Node node) {
+      return new PackedInputsTrait(node.expectObjectNode());
+    }
+  }
+}

--- a/sampleSpecs/packedInputs.smithy
+++ b/sampleSpecs/packedInputs.smithy
@@ -1,0 +1,18 @@
+namespace smithy4s.example
+
+use smithy4s.meta#packedInputs
+
+@packedInputs
+service PackedInputsService {
+  version: "1.0.0",
+  operations: [PackedInputOperation]
+}
+
+operation PackedInputOperation {
+  input: PackedInput,
+}
+
+structure PackedInput {
+    @required
+    key: String
+}


### PR DESCRIPTION
Closes https://github.com/disneystreaming/smithy4s/issues/114

* Adds a way for users to tweak rendering of services methods, and substitute a list of parameters in methods for a single case-class parameter (which smithy4s uses under the hood anyway), corresponding to the smithy shape of the operation's input (when present). This might offer better UX in some occurences.
* Adds documentation