### PR TITLE
Fix codegen rendering for AWS Kinesis service

### DIFF
--- a/modules/codegen/src/smithy4s/codegen/Renderer.scala
+++ b/modules/codegen/src/smithy4s/codegen/Renderer.scala
@@ -631,7 +631,7 @@ private[codegen] class Renderer(compilationUnit: CompilationUnit) { self =>
         case Primitive.ByteArray  => Set("schematic.ByteArray") -> "ByteArray"
         case Primitive.Bool       => Set.empty -> "Boolean"
         case Primitive.String     => Set.empty -> "String"
-        case Primitive.Timestamp  => Set("smithy4s.Timestamp") -> "Timestamp"
+        case Primitive.Timestamp  => Set.empty -> "smithy4s.Timestamp"
         case Primitive.Byte       => Set.empty -> "Byte"
         case Primitive.Int        => Set.empty -> "Int"
         case Primitive.Short      => Set.empty -> "Short"
@@ -641,7 +641,7 @@ private[codegen] class Renderer(compilationUnit: CompilationUnit) { self =>
         case Primitive.BigDecimal => Set.empty -> "BigDecimal"
         case Primitive.BigInteger => Set.empty -> "BigInteger"
         case Primitive.Uuid       => Set("java.util.UUID") -> "UUID"
-        case Primitive.Document   => Set("smithy4s.Document") -> "Document"
+        case Primitive.Document   => Set.empty -> "smithy4s.Document"
       }
 
     def schemaRef: String = tpe match {

--- a/modules/codegen/src/smithy4s/codegen/Renderer.scala
+++ b/modules/codegen/src/smithy4s/codegen/Renderer.scala
@@ -305,7 +305,7 @@ private[codegen] class Renderer(compilationUnit: CompilationUnit) { self =>
       sField: Option[StreamingField]
   ) = sField match {
     case Some(StreamingField(name, tpe, hints)) =>
-      val mh = if (hints.isEmpty) "" else s".withHints${memberHints(hints)}"
+      val mh = if (hints.isEmpty) "" else s".withHints(${memberHints(hints)})"
       line(
         s"""val $valName : $StreamingSchema_[${tpe.render}] = $StreamingSchema_("$name", ${tpe.schemaRef}$mh)"""
       )

--- a/modules/example/src/smithy4s/example/ArbitraryData.scala
+++ b/modules/example/src/smithy4s/example/ArbitraryData.scala
@@ -1,16 +1,15 @@
 package smithy4s.example
 
-import smithy4s.Document
 import smithy4s.Newtype
 import smithy4s.syntax._
 
-object ArbitraryData extends Newtype[Document] {
+object ArbitraryData extends Newtype[smithy4s.Document] {
   val id: smithy4s.ShapeId = smithy4s.ShapeId("smithy4s.example", "arbitraryData")
   val hints : smithy4s.Hints = smithy4s.Hints(
     id,
     smithy.api.Trait(None, None, None),
   )
-  val underlyingSchema : smithy4s.Schema[Document] = document.withHints(hints)
+  val underlyingSchema : smithy4s.Schema[smithy4s.Document] = document.withHints(hints)
   val schema : smithy4s.Schema[ArbitraryData] = bijection(underlyingSchema, ArbitraryData(_), (_ : ArbitraryData).value)
   implicit val staticSchema : schematic.Static[smithy4s.Schema[ArbitraryData]] = schematic.Static(schema)
 }


### PR DESCRIPTION
Includes a couple of changes to codegen rendering to fix compilation of code generated by smithy4s from the [AWS Kinesis service definition](https://github.com/aws/aws-sdk-js-v3/blob/v3.63.0/codegen/sdk-codegen/aws-models/kinesis.json).

**[Change codegen to render fully qualified smithy4s types](https://github.com/disneystreaming/smithy4s/pull/166/commits/9b08aadebdf19d9231fb5e70dea7bf574d6369b0)**
 
Changes codegen to render smithy4s.Timestamp and smithy4s.Document instead of importing these and using just the type name. 

Without this change a custom Timestamp type aliasing smithy4s.Timestamp (as is the case for the AWS Kinesis service) results in compilation error due to type collisions.

Fixes https://github.com/disneystreaming/smithy4s/issues/163

**[Fix codegen rendering of member hints for streaming schemas](https://github.com/disneystreaming/smithy4s/pull/166/commits/f63ffb9ba1ef11d5a7cd3a1823951fd78ae89ec9)**

withHints was being rendered for streaming schemas without parentheses around the member hints. This change adds the parentheses in which fixes the compilation errors from the resulting generated code.

Fixes https://github.com/disneystreaming/smithy4s/issues/164

---

<details>

<summary>Before (0.12.8)</summary>

```
[info] compiling 133 Scala sources to <redacted>/modules/codegen/target/scala-2.13/classes ...
[error] <redacted>/modules/codegen/src/main/scala/com/amazonaws/kinesis/Consumer.scala:18:72: type mismatch;
[error]  found   : com.amazonaws.kinesis.Timestamp
[error]     (which expands to)  com.amazonaws.kinesis.Timestamp.Type
[error]  required: smithy4s.Timestamp
[error]     Timestamp.schema.required[Consumer]("ConsumerCreationTimestamp", _.consumerCreationTimestamp).withHints(smithy.api.Required(), smithy.api.Documentation("<p></p>")),
[error]                                                                        ^
[error] <redacted>/modules/codegen/src/main/scala/com/amazonaws/kinesis/Consumer.scala:20:14: missing argument list for method apply in object Consumer
[error] Unapplied methods are only converted to functions when a function type is expected.
[error] You can make this conversion explicit by writing `apply _` or `apply(_,_,_,_)` instead of `apply`.
[error]     Consumer.apply
[error]              ^
[error] <redacted>/modules/codegen/src/main/scala/com/amazonaws/kinesis/ConsumerDescription.scala:18:83: type mismatch;
[error]  found   : com.amazonaws.kinesis.Timestamp
[error]     (which expands to)  com.amazonaws.kinesis.Timestamp.Type
[error]  required: smithy4s.Timestamp
[error]     Timestamp.schema.required[ConsumerDescription]("ConsumerCreationTimestamp", _.consumerCreationTimestamp).withHints(smithy.api.Required(), smithy.api.Documentation("<p></p>")),
[error]                                                                                   ^
[error] <redacted>/modules/codegen/src/main/scala/com/amazonaws/kinesis/ConsumerDescription.scala:21:25: missing argument list for method apply in object ConsumerDescription
[error] Unapplied methods are only converted to functions when a function type is expected.
[error] You can make this conversion explicit by writing `apply _` or `apply(_,_,_,_,_)` instead of `apply`.
[error]     ConsumerDescription.apply
[error]                         ^
[error] <redacted>/modules/codegen/src/main/scala/com/amazonaws/kinesis/GetShardIteratorInput.scala:19:69: type mismatch;
[error]  found   : Option[com.amazonaws.kinesis.Timestamp]
[error]     (which expands to)  Option[com.amazonaws.kinesis.Timestamp.Type]
[error]  required: Option[smithy4s.Timestamp]
[error]     Timestamp.schema.optional[GetShardIteratorInput]("Timestamp", _.timestamp).withHints(smithy.api.Documentation("<p>The time stamp of the data record from which to start reading. Used with shard\n            iterator type AT_TIMESTAMP. A time stamp is the Unix epoch date with precision in\n            milliseconds. For example, <code>2016-04-04T19:58:46.480-00:00</code> or\n                <code>1459799926.480</code>. If a record with this exact time stamp does not exist,\n            the iterator returned is for the next (later) record. If the time stamp is older than\n            the current trim horizon, the iterator returned is for the oldest untrimmed data record\n            (TRIM_HORIZON).</p>")),
[error]                                                                     ^
[error] <redacted>/modules/codegen/src/main/scala/com/amazonaws/kinesis/GetShardIteratorInput.scala:21:27: missing argument list for method apply in object GetShardIteratorInput
[error] Unapplied methods are only converted to functions when a function type is expected.
[error] You can make this conversion explicit by writing `apply _` or `apply(_,_,_,_,_)` instead of `apply`.
[error]     GetShardIteratorInput.apply
[error]                           ^
[error] <redacted>/modules/codegen/src/main/scala/com/amazonaws/kinesis/Kinesis.scala:2310:224: too many arguments (found 3, expected 2) for method apply: (fieldName: String, schema: smithy4s.Schema[A]): smithy4s.StreamingSchema[A] in object StreamingSchema
[error]     val streamedOutput : smithy4s.StreamingSchema[SubscribeToShardEventStream] = smithy4s.StreamingSchema("SubscribeToShardOutput", SubscribeToShardEventStream.schema.withHintssmithy.api.Required(), smithy.api.Documentation("<p>The event stream that your consumer can use to read records from the shard.</p>"))
[error]                                                                                                                                                                                                                                ^
[error] <redacted>/modules/codegen/src/main/scala/com/amazonaws/kinesis/ListShardsInput.scala:18:77: type mismatch;
[error]  found   : Option[com.amazonaws.kinesis.Timestamp]
[error]     (which expands to)  Option[com.amazonaws.kinesis.Timestamp.Type]
[error]  required: Option[smithy4s.Timestamp]
[error]     Timestamp.schema.optional[ListShardsInput]("StreamCreationTimestamp", _.streamCreationTimestamp).withHints(smithy.api.Documentation("<p>Specify this input parameter to distinguish data streams that have the same name. For\n            example, if you create a data stream and then delete it, and you later create another\n            data stream with the same name, you can use this input parameter to specify which of the\n            two streams you want to list the shards for.</p>\n        <p>You cannot specify this parameter if you specify the <code>NextToken</code>\n            parameter.</p>")),
[error]                                                                             ^
[error] <redacted>/modules/codegen/src/main/scala/com/amazonaws/kinesis/ListShardsInput.scala:21:21: missing argument list for method apply in object ListShardsInput
[error] Unapplied methods are only converted to functions when a function type is expected.
[error] You can make this conversion explicit by writing `apply _` or `apply(_,_,_,_,_,_)` instead of `apply`.
[error]     ListShardsInput.apply
[error]                     ^
[error] <redacted>/modules/codegen/src/main/scala/com/amazonaws/kinesis/ListStreamConsumersInput.scala:17:86: type mismatch;
[error]  found   : Option[com.amazonaws.kinesis.Timestamp]
[error]     (which expands to)  Option[com.amazonaws.kinesis.Timestamp.Type]
[error]  required: Option[smithy4s.Timestamp]
[error]     Timestamp.schema.optional[ListStreamConsumersInput]("StreamCreationTimestamp", _.streamCreationTimestamp).withHints(smithy.api.Documentation("<p>Specify this input parameter to distinguish data streams that have the same name. For\n            example, if you create a data stream and then delete it, and you later create another\n            data stream with the same name, you can use this input parameter to specify which of the\n            two streams you want to list the consumers for. </p>\n        <p>You can\'t specify this parameter if you specify the NextToken parameter. </p>")),
[error]                                                                                      ^
[error] <redacted>/modules/codegen/src/main/scala/com/amazonaws/kinesis/ListStreamConsumersInput.scala:19:30: missing argument list for method apply in object ListStreamConsumersInput
[error] Unapplied methods are only converted to functions when a function type is expected.
[error] You can make this conversion explicit by writing `apply _` or `apply(_,_,_,_)` instead of `apply`.
[error]     ListStreamConsumersInput.apply
[error]                              ^
[error] <redacted>/modules/codegen/src/main/scala/com/amazonaws/kinesis/Record.scala:18:72: type mismatch;
[error]  found   : Option[com.amazonaws.kinesis.Timestamp]
[error]     (which expands to)  Option[com.amazonaws.kinesis.Timestamp.Type]
[error]  required: Option[smithy4s.Timestamp]
[error]     Timestamp.schema.optional[Record]("ApproximateArrivalTimestamp", _.approximateArrivalTimestamp).withHints(smithy.api.Documentation("<p>The approximate time that the record was inserted into the stream.</p>")),
[error]                                                                        ^
[error] <redacted>/modules/codegen/src/main/scala/com/amazonaws/kinesis/Record.scala:21:12: missing argument list for method apply in object Record
[error] Unapplied methods are only converted to functions when a function type is expected.
[error] You can make this conversion explicit by writing `apply _` or `apply(_,_,_,_,_)` instead of `apply`.
[error]     Record.apply
[error]            ^
[error] <redacted>/modules/codegen/src/main/scala/com/amazonaws/kinesis/ShardFilter.scala:17:59: type mismatch;
[error]  found   : Option[com.amazonaws.kinesis.Timestamp]
[error]     (which expands to)  Option[com.amazonaws.kinesis.Timestamp.Type]
[error]  required: Option[smithy4s.Timestamp]
[error]     Timestamp.schema.optional[ShardFilter]("Timestamp", _.timestamp).withHints(smithy.api.Documentation("<p>The timestamps specified in the <code>ShardFilter</code> parameter. A timestamp is a\n            Unix epoch date with precision in milliseconds. For example,\n            2016-04-04T19:58:46.480-00:00 or 1459799926.480. This property can only be used if\n                <code>FROM_TIMESTAMP</code> or <code>AT_TIMESTAMP</code> shard types are\n            specified.</p>")),
[error]                                                           ^
[error] <redacted>/modules/codegen/src/main/scala/com/amazonaws/kinesis/ShardFilter.scala:19:17: missing argument list for method apply in object ShardFilter
[error] Unapplied methods are only converted to functions when a function type is expected.
[error] You can make this conversion explicit by writing `apply _` or `apply(_,_,_)` instead of `apply`.
[error]     ShardFilter.apply
[error]                 ^
[error] <redacted>/modules/codegen/src/main/scala/com/amazonaws/kinesis/StartingPosition.scala:17:64: type mismatch;
[error]  found   : Option[com.amazonaws.kinesis.Timestamp]
[error]     (which expands to)  Option[com.amazonaws.kinesis.Timestamp.Type]
[error]  required: Option[smithy4s.Timestamp]
[error]     Timestamp.schema.optional[StartingPosition]("Timestamp", _.timestamp).withHints(smithy.api.Documentation("<p>The time stamp of the data record from which to start reading. To specify a time\n            stamp, set <code>StartingPosition</code> to <code>Type AT_TIMESTAMP</code>. A time stamp\n            is the Unix epoch date with precision in milliseconds. For example,\n                <code>2016-04-04T19:58:46.480-00:00</code> or <code>1459799926.480</code>. If a\n            record with this exact time stamp does not exist, records will be streamed from the next\n            (later) record. If the time stamp is older than the current trim horizon, records will\n            be streamed from the oldest untrimmed data record (<code>TRIM_HORIZON</code>).</p>")),
[error]                                                                ^
[error] <redacted>/modules/codegen/src/main/scala/com/amazonaws/kinesis/StartingPosition.scala:19:22: missing argument list for method apply in object StartingPosition
[error] Unapplied methods are only converted to functions when a function type is expected.
[error] You can make this conversion explicit by writing `apply _` or `apply(_,_,_)` instead of `apply`.
[error]     StartingPosition.apply
[error]                      ^
[error] <redacted>/modules/codegen/src/main/scala/com/amazonaws/kinesis/StreamDescription.scala:21:79: type mismatch;
[error]  found   : com.amazonaws.kinesis.Timestamp
[error]     (which expands to)  com.amazonaws.kinesis.Timestamp.Type
[error]  required: smithy4s.Timestamp
[error]     Timestamp.schema.required[StreamDescription]("StreamCreationTimestamp", _.streamCreationTimestamp).withHints(smithy.api.Required(), smithy.api.Documentation("<p>The approximate time that the stream was created.</p>")),
[error]                                                                               ^
[error] <redacted>/modules/codegen/src/main/scala/com/amazonaws/kinesis/StreamDescription.scala:27:23: missing argument list for method apply in object StreamDescription
[error] Unapplied methods are only converted to functions when a function type is expected.
[error] You can make this conversion explicit by writing `apply _` or `apply(_,_,_,_,_,_,_,_,_,_,_)` instead of `apply`.
[error]     StreamDescription.apply
[error]                       ^
[error] <redacted>/modules/codegen/src/main/scala/com/amazonaws/kinesis/StreamDescriptionSummary.scala:19:86: type mismatch;
[error]  found   : com.amazonaws.kinesis.Timestamp
[error]     (which expands to)  com.amazonaws.kinesis.Timestamp.Type
[error]  required: smithy4s.Timestamp
[error]     Timestamp.schema.required[StreamDescriptionSummary]("StreamCreationTimestamp", _.streamCreationTimestamp).withHints(smithy.api.Required(), smithy.api.Documentation("<p>The approximate time that the stream was created.</p>")),
[error]                                                                                      ^
[error] <redacted>/modules/codegen/src/main/scala/com/amazonaws/kinesis/StreamDescriptionSummary.scala:27:30: missing argument list for method apply in object StreamDescriptionSummary
[error] Unapplied methods are only converted to functions when a function type is expected.
[error] You can make this conversion explicit by writing `apply _` or `apply(_,_,_,_,_,_,_,_,_,_,_)` instead of `apply`.
[error]     StreamDescriptionSummary.apply
[error]                              ^
[error] <redacted>/modules/codegen/src/main/scala/com/amazonaws/kinesis/Timestamp.scala:13:83: missing parameter type for expanded function ((<x$1: error>) => Timestamp(x$1))
[error]   val schema : smithy4s.Schema[Timestamp] = bijection(underlyingSchema, Timestamp(_), (_ : Timestamp).value)
[error]                                                                                   ^
[error] <redacted>/modules/codegen/src/main/scala/com/amazonaws/kinesis/Timestamp.scala:13:103: value value is not a member of smithy4s.Timestamp
[error]   val schema : smithy4s.Schema[Timestamp] = bijection(underlyingSchema, Timestamp(_), (_ : Timestamp).value)
[error]                                                                                                       ^
[warn] <redacted>/modules/codegen/src/main/scala/com/amazonaws/kinesis/Timestamp.scala:4:17: imported `Timestamp` is permanently hidden by definition of object Timestamp in package kinesis
[warn] import smithy4s.Timestamp
[warn]                 ^
[warn] one warning found
[error] 23 errors found
[error] (codegen / Compile / compileIncremental) Compilation failed
[error] Total time: 6 s, completed 5 Apr 2022, 09:30:25
```

</details>

<details>

<summary>After (this branch)</summary>

```
[info] compiling 133 Scala sources to <redacted>/modules/codegen/target/scala-2.13/classes ...
[info] done compiling
[success] Total time: 13 s, completed 5 Apr 2022, 10:01:20
```

</details>