### PR TITLE
Fix Content-Type for AWS service requests using http4s client

### DIFF
--- a/modules/aws-http4s/src/smithy4s/aws/http4s/AwsHttp4sBackend.scala
+++ b/modules/aws-http4s/src/smithy4s/aws/http4s/AwsHttp4sBackend.scala
@@ -59,13 +59,14 @@ object AwsHttp4sBackend {
         case HttpMethod.PUT    => PUT
         case HttpMethod.DELETE => DELETE
       }
-      req = request.body.foldLeft(
-        Request[F](
-          method = method,
-          uri = endpoint,
-          headers = Headers(headers.map { case (k, v) => Header.Raw(k, v) })
-        )
-      )(_.withEntity(_))
+      req = request.body
+        .foldLeft(
+          Request[F](
+            method = method,
+            uri = endpoint
+          )
+        )(_.withEntity(_))
+        .putHeaders(Headers(headers.map { case (k, v) => Header.Raw(k, v) }))
     } yield req
   }
 


### PR DESCRIPTION
Before this change requests were using an incorrect `Content-Type` header `application/octet-stream` rather than using the `Content-Type` header defined by the `AwsProtocol`. This was because `withEntity` on http4s client requests sets the headers according to the implicit `EntityEncoder` and the simple `HttpRequest` body is `Option[Array[Byte]]`.

This changes the request so that the headers from the simple `HttpRequest` take priority over those set by `withEntity`.

Fixes https://github.com/disneystreaming/smithy4s/issues/167

Here's an example for Kinesis ListShards operation:

<details>

<summary>Before</summary>

```sh
curl \
  --request POST \
  --url 'https://kinesis.us-east-1.amazonaws.com/' \
  --header 'Authorization: <REDACTED>' \
  --header 'host: kinesis.us-east-1.amazonaws.com' \
  --header 'X-Amz-Date: 20220405T171758Z' \
  --header 'X-Amz-Security-Token: <REDACTED>' \
  --header 'X-Amz-Target: Kinesis_20131202.ListShards' \
  --header 'Content-Length: 66' \
  --header 'Content-Type: application/octet-stream' \
  --data '{"StreamName":"<REDACTED>"}'
```

</details>


<details>

<summary>After</summary>

```sh
curl \
  --request POST \
  --url 'https://kinesis.us-east-1.amazonaws.com/' \
  --header 'Content-Length: 66' \
  --header 'Authorization: <REDACTED>' \
  --header 'Content-Type: application/x-amz-json-1.1' \
  --header 'host: kinesis.us-east-1.amazonaws.com' \
  --header 'X-Amz-Date: 20220405T174817Z' \
  --header 'X-Amz-Security-Token: <REDACTED>' \
  --header 'X-Amz-Target: Kinesis_20131202.ListShards' \
  --data '{"StreamName":"<REDACTED>"}'
```

</details>