### PR TITLE
http4s make body empty when metadata is total

### DIFF
--- a/modules/tests/src/smithy4s/tests/PizzaSpec.scala
+++ b/modules/tests/src/smithy4s/tests/PizzaSpec.scala
@@ -324,9 +324,10 @@ abstract class PizzaSpec
           log
         )
       } yield {
-        val (code, headers, _) = res
+        val (code, headers, body) = res
 
         expect(code == 200) &&
+        expect(body.isEmpty()) &&
         expect(headers.get("x-uppercase-header") == Some(List("header-1"))) &&
         expect(headers.get("x-capitalized-header") == Some(List("header-2"))) &&
         expect(headers.get("x-lowercase-header") == Some(List("header-3"))) &&


### PR DESCRIPTION
Makes body empty instead of `{}` when the metadata contains all fields in response