### PR TITLE
fix rendering of big integers

### DIFF
--- a/modules/codegen/src/smithy4s/codegen/Renderer.scala
+++ b/modules/codegen/src/smithy4s/codegen/Renderer.scala
@@ -639,7 +639,7 @@ private[codegen] class Renderer(compilationUnit: CompilationUnit) { self =>
         case Primitive.Float      => Set.empty -> "Float"
         case Primitive.Double     => Set.empty -> "Double"
         case Primitive.BigDecimal => Set.empty -> "BigDecimal"
-        case Primitive.BigInteger => Set.empty -> "BigInteger"
+        case Primitive.BigInteger => Set.empty -> "BigInt"
         case Primitive.Uuid       => Set("java.util.UUID") -> "UUID"
         case Primitive.Document   => Set.empty -> "smithy4s.Document"
       }
@@ -792,7 +792,7 @@ private[codegen] class Renderer(compilationUnit: CompilationUnit) { self =>
     prim match {
       case Primitive.BigDecimal =>
         (bd: BigDecimal) => s"scala.math.BigDecimal($bd)"
-      case Primitive.BigInteger => (bi: BigInt) => s"scala.math.BigInteger($bi)"
+      case Primitive.BigInteger => (bi: BigInt) => s"scala.math.BigInt($bi)"
       case Primitive.Unit       => _ => "()"
       case Primitive.Double     => _.toString
       case Primitive.Float      => _.toString

--- a/modules/example/resources/smithy4s.example.ObjectService.json
+++ b/modules/example/resources/smithy4s.example.ObjectService.json
@@ -159,6 +159,30 @@
                         "required": [
                             "str"
                         ]
+                    },
+                    {
+                        "type": "object",
+                        "title": "bInt",
+                        "properties": {
+                            "bInt": {
+                                "type": "number"
+                            }
+                        },
+                        "required": [
+                            "bInt"
+                        ]
+                    },
+                    {
+                        "type": "object",
+                        "title": "bDec",
+                        "properties": {
+                            "bDec": {
+                                "type": "number"
+                            }
+                        },
+                        "required": [
+                            "bDec"
+                        ]
                     }
                 ]
             },

--- a/modules/example/src/smithy4s/example/Foo.scala
+++ b/modules/example/src/smithy4s/example/Foo.scala
@@ -12,6 +12,8 @@ object Foo extends smithy4s.ShapeTag.Companion[Foo] {
 
   case class IntCase(int: Int) extends Foo
   case class StrCase(str: String) extends Foo
+  case class BIntCase(bInt: BigInt) extends Foo
+  case class BDecCase(bDec: BigDecimal) extends Foo
 
   object IntCase {
     val hints : smithy4s.Hints = smithy4s.Hints()
@@ -23,13 +25,27 @@ object Foo extends smithy4s.ShapeTag.Companion[Foo] {
     val schema: smithy4s.Schema[StrCase] = bijection(string, StrCase(_), _.str)
     val alt = schema.oneOf[Foo]("str")
   }
+  object BIntCase {
+    val hints : smithy4s.Hints = smithy4s.Hints()
+    val schema: smithy4s.Schema[BIntCase] = bijection(bigint, BIntCase(_), _.bInt)
+    val alt = schema.oneOf[Foo]("bInt")
+  }
+  object BDecCase {
+    val hints : smithy4s.Hints = smithy4s.Hints()
+    val schema: smithy4s.Schema[BDecCase] = bijection(bigdecimal, BDecCase(_), _.bDec)
+    val alt = schema.oneOf[Foo]("bDec")
+  }
 
   val schema: smithy4s.Schema[Foo] = union(
     IntCase.alt,
     StrCase.alt,
+    BIntCase.alt,
+    BDecCase.alt,
   ){
     case c : IntCase => IntCase.alt(c)
     case c : StrCase => StrCase.alt(c)
+    case c : BIntCase => BIntCase.alt(c)
+    case c : BDecCase => BDecCase.alt(c)
   }.withHints(hints)
   implicit val staticSchema : schematic.Static[smithy4s.Schema[Foo]] = schematic.Static(schema)
 }

--- a/sampleSpecs/example.smithy
+++ b/sampleSpecs/example.smithy
@@ -91,7 +91,9 @@ structure GetFooOutput {
 
 union Foo {
   int: Integer,
-  str: String
+  str: String,
+  bInt: BigInteger,
+  bDec: BigDecimal
 }
 
 @enum([{value : "Low"}, {value : "High"}])


### PR DESCRIPTION
BigInt's were previously rendered as BigInteger on accident. BigInteger is not a type in scala, it is `scala.math.BigInt` which wraps java's `BigInteger` (and adds an optimization where it uses a Long to back it when the number is small enough)