### PR TITLE
Loosen constraints in aws-http4s

### DIFF
--- a/modules/aws-http4s/src/smithy4s/aws/http4s/AwsHttp4sBackend.scala
+++ b/modules/aws-http4s/src/smithy4s/aws/http4s/AwsHttp4sBackend.scala
@@ -17,8 +17,8 @@
 package smithy4s.aws
 package http4s
 
-import cats.effect.Async
 import cats.effect.Concurrent
+import cats.MonadThrow
 import cats.implicits._
 import fs2.Chunk
 import org.http4s.Header
@@ -33,24 +33,25 @@ import smithy4s.aws.SimpleHttpClient
 import smithy4s.http.CaseInsensitive
 import smithy4s.http.HttpMethod
 
-final class AwsHttp4sBackend[F[_]: Async](client: Client[F])
+final class AwsHttp4sBackend[F[_]: Concurrent](client: Client[F])
     extends SimpleHttpClient[F] {
 
   import AwsHttp4sBackend._
   def run(request: HttpRequest): F[HttpResponse] =
-    fromHttpRequest(request).flatMap(client.run(_).use(toHttpResponse[F]))
+    fromHttpRequest[F](request).flatMap(client.run(_).use(toHttpResponse[F]))
 }
 
 object AwsHttp4sBackend {
 
-  def apply[F[_]: Async](client: Client[F]): SimpleHttpClient[F] =
+  def apply[F[_]: Concurrent](client: Client[F]): SimpleHttpClient[F] =
     new AwsHttp4sBackend(client)
 
-  def fromHttpRequest[F[_]: Async](request: HttpRequest): F[Request[F]] = {
+  def fromHttpRequest[F[_]: MonadThrow](request: HttpRequest): F[Request[F]] = {
+    val headers = request.headers.map { case (k, v) =>
+      (CIString(k.toString), v)
+    }
+
     for {
-      headers <- Async[F].delay(request.headers.map { case (k, v) =>
-        (CIString(k.toString), v)
-      })
       endpoint <- Uri.fromString(request.uri).liftTo[F]
       method = request.httpMethod match {
         case HttpMethod.POST   => POST

--- a/modules/aws-http4s/src/smithy4s/aws/http4s/package.scala
+++ b/modules/aws-http4s/src/smithy4s/aws/http4s/package.scala
@@ -17,7 +17,7 @@
 package smithy4s
 package aws
 
-import cats.effect.Async
+import cats.effect.Temporal
 import cats.effect.Resource
 import org.http4s.client.Client
 
@@ -27,7 +27,7 @@ package object http4s {
       private[this] val serviceProvider: smithy4s.Service.Provider[Alg, Op]
   ) {
 
-    def awsClient[F[_]: Async](
+    def awsClient[F[_]: Temporal](
         client: Client[F],
         awsRegion: AwsRegion
     ): Resource[F, AwsClient[Alg, F]] = for {


### PR DESCRIPTION
The purpose of this is twofold:

1. Don't require the full power of `Async` to construct an AWS client
2. Allow building the interpreter in steps: checking the service can be done without doing any credential-related work, then the rest can be executed in a resource (this would be valuable to me for smithy-playground).