### PR TITLE
Use a simpler mechanism to detect file changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,11 @@ jobs:
               pushRemoteCache_$BUILD_KEY \
               -J-Xmx4G
 
+      - name: Run plugin tests
+        if: matrix.scalaVersion == '2_12' && matrix.scalaPlatform == 'jvm' && matrix.ceVersion == 'CE2'
+        run: |
+          sbt scripted
+
       - name: Run checks
         if: matrix.scalaVersion == '2_13' && matrix.scalaPlatform == 'jvm' && matrix.ceVersion == 'CE2'
         run: |

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/custom-settings/project/build.properties
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/custom-settings/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.0
+sbt.version=1.5.5

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/defaults/project/build.properties
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/defaults/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.0
+sbt.version=1.5.5

--- a/modules/codegen-plugin/src/smithy4s/codegen/CodegenPlugin.scala
+++ b/modules/codegen-plugin/src/smithy4s/codegen/CodegenPlugin.scala
@@ -126,6 +126,12 @@ object Smithy4sCodegenPlugin extends AutoPlugin {
       }
       .toList
 
+  /**
+    * This implementation leverages SBT's input & output file tracking
+    * capabilities. We record inputs via `fileInputs` and outputs
+    * via `fileOutputs` and then use the `inputFileChanges` value
+    * to decide whether or not Codegen should run.
+    */
   def cachedSmithyCodegen(conf: Configuration) = Def.task {
     val outputPath = (conf / smithy4sOutputDir).value.getAbsolutePath()
     val openApiOutputPath = (conf / smithy4sOpenapiDir).value.getAbsolutePath()


### PR DESCRIPTION
This greatly simplifies the caching logic and solves the problem I was having - if you run `~compile` on a module with smithy specs, they actually weren't re-generated and re-compiled if you changed a spec.

I've confirmed on my project that this change addresses the problem.