### PR TITLE
Fix DynamicError's shapeId

### DIFF
--- a/modules/dynamic/src/smithy4s/dynamic/internals/DynamicModelCompiler.scala
+++ b/modules/dynamic/src/smithy4s/dynamic/internals/DynamicModelCompiler.scala
@@ -301,7 +301,7 @@ private[dynamic] object Compiler {
       val input = shape.input.map(_.target)
       val output = shape.output.map(_.target)
 
-      val errorId = id.copy(id.name + "Error")
+      val errorId = id.copy(name = id.name + "Error")
       val errorUnionLazy = shape.errors.traverse { err =>
         err
           .collect { case MemberShape(ValidIdRef(id), _) => id }


### PR DESCRIPTION
The name would use the operation's name + "Error" as the namespace and kept the operation's name.