### PR TITLE
Fix sbt plugin regression

### DIFF
--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/dependencies-only/build.sbt
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/dependencies-only/build.sbt
@@ -1,0 +1,11 @@
+lazy val p1 = project
+  .enablePlugins(Smithy4sCodegenPlugin)
+  .settings(
+    scalaVersion := "2.13.6",
+    Compile / smithy4sAllowedNamespaces := List(
+      "aws.iam"
+    ),
+    libraryDependencies += "com.disneystreaming.smithy4s" %% "smithy4s-core" % smithy4sVersion.value,
+    libraryDependencies += "software.amazon.smithy" % "smithy-aws-iam-traits" % "1.14.1" % Smithy4s,
+    smithy4sOutputDir in Compile := baseDirectory.value / "smithy_output"
+  )

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/dependencies-only/project/build.properties
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/dependencies-only/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.5.5

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/dependencies-only/project/plugins.sbt
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/dependencies-only/project/plugins.sbt
@@ -1,0 +1,9 @@
+sys.props.get("plugin.version") match {
+  case Some(x) =>
+    addSbtPlugin("com.disneystreaming.smithy4s" % "smithy4s-sbt-codegen" % x)
+  case _ =>
+    sys.error(
+      """|The system property 'plugin.version' is not defined.
+         |Specify this property using the scriptedLaunchOpts -D.""".stripMargin
+    )
+}

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/dependencies-only/test
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/dependencies-only/test
@@ -1,0 +1,3 @@
+# check if smithy4sCodegen works
+> p1/compile
+$ exists p1/smithy_output/aws/iam/ActionPermissionDescription.scala

--- a/modules/codegen-plugin/src/smithy4s/codegen/CodegenPlugin.scala
+++ b/modules/codegen-plugin/src/smithy4s/codegen/CodegenPlugin.scala
@@ -83,38 +83,30 @@ object Smithy4sCodegenPlugin extends AutoPlugin {
 
   override def projectConfigurations: Seq[Configuration] = Seq(Smithy4s)
 
-  import sbt.nio.Keys.{fileInputs, fileOutputs}
-
   override lazy val projectSettings =
     Seq(
       Compile / smithy4sInputDir := (Compile / sourceDirectory).value / "smithy",
       Compile / smithy4sOutputDir := (Compile / sourceManaged).value,
       Compile / smithy4sOpenapiDir := (Compile / resourceManaged).value,
       Compile / smithy4sCodegen := cachedSmithyCodegen(Compile).value,
-      Compile / smithy4sCodegen / fileInputs ++= {
-        Option((Compile / smithy4sInputDir).value.listFiles())
-          .getOrElse(Array.empty)
-          .toSeq
-          .map(_.toGlob)
-      },
-      Compile / smithy4sCodegen / fileOutputs ++=
-        Option(
-          (Compile / smithy4sOutputDir).value
-            .listFiles()
-        )
-          .getOrElse(Array.empty)
-          .map(_.toGlob)
-          .toSeq,
       Compile / smithy4sCodegenDependencies := List.empty: @annotation.nowarn,
-      Compile / sourceGenerators +=
-        (Compile / smithy4sCodegen).taskValue
-          .map(_.filter(_.ext == "scala")),
-      Compile / resourceGenerators +=
-        (Compile / smithy4sCodegen).taskValue
-          .map(_.filterNot(_.ext == "scala")),
+      Compile / sourceGenerators += (Compile / smithy4sCodegen).map(
+        _.filter(_.ext == "scala")
+      ),
+      Compile / resourceGenerators += (Compile / smithy4sCodegen).map(
+        _.filter(_.ext != "scala")
+      ),
       cleanFiles += (Compile / smithy4sOutputDir).value,
       Compile / smithy4sModelTransformers := List.empty
     )
+
+  private def untupled[A, B, C](f: ((A, B)) => C): (A, B) => C = (a, b) =>
+    f((a, b))
+
+  private type CacheKey = (
+      FilesInfo[HashFileInfo],
+      List[String]
+  )
 
   private def prepareSmithy4sDeps(deps: Seq[ModuleID]): List[String] =
     deps
@@ -126,13 +118,9 @@ object Smithy4sCodegenPlugin extends AutoPlugin {
       }
       .toList
 
-  /**
-    * This implementation leverages SBT's input & output file tracking
-    * capabilities. We record inputs via `fileInputs` and outputs
-    * via `fileOutputs` and then use the `inputFileChanges` value
-    * to decide whether or not Codegen should run.
-    */
   def cachedSmithyCodegen(conf: Configuration) = Def.task {
+    val inputFiles =
+      Option((conf / smithy4sInputDir).value.listFiles()).getOrElse(Array.empty)
     val outputPath = (conf / smithy4sOutputDir).value
     val openApiOutputPath = (conf / smithy4sOpenapiDir).value
     val allowedNamespaces =
@@ -145,47 +133,45 @@ object Smithy4sCodegenPlugin extends AutoPlugin {
         m.root
       }
     val transforms = (conf / smithy4sModelTransformers).value
+    val s = streams.value
 
-    val out = streams.value
-    val cacheFile =
-      out.cacheDirectory / s"smithy4s_${scalaBinaryVersion.value}"
-
-    // This is important - it's what re-triggers this task on file changes
-    val _ = (conf / smithy4sCodegen).inputFileChanges
-
-    val schemas = ((conf / smithy4sInputDir).value ** "*.smithy").get().toSet
-
-    out.log.debug(s"[Smithy4s] discovered specs: $schemas")
-
-    val compile = FileFunction
-      .cached(
-        cacheFile,
-        inStyle = FilesInfo.lastModified,
-        outStyle = FilesInfo.hash
-      ) { (filePaths: Set[File]) =>
-        val codegenArgs = CodegenArgs(
-          filePaths.map(os.Path(_)).toList,
-          output = os.Path(outputPath),
-          openapiOutput = os.Path(openApiOutputPath),
-          skipScala = false,
-          skipOpenapi = false,
-          discoverModels = true, // we need protocol here
-          allowedNS = allowedNamespaces,
-          excludedNS = excludedNamespaces,
-          repositories = res,
-          dependencies = dependencies,
-          transforms
-        )
-
-        val resPaths = smithy4s.codegen.Codegen
-          .processSpecs(codegenArgs)
-          .map(_.toIO)
-
-        out.log.debug(s"[Smithy4s] generated files: $resPaths")
-
-        resPaths
+    val cached =
+      Tracked.inputChanged[CacheKey, Seq[File]](
+        s.cacheStoreFactory.make("input")
+      ) {
+        untupled {
+          Tracked
+            .lastOutput[(Boolean, CacheKey), Seq[File]](
+              s.cacheStoreFactory.make("output")
+            ) { case ((changed, _), outputs) =>
+              if (changed || outputs.isEmpty) {
+                val filePaths = inputFiles.map(_.getAbsolutePath())
+                val codegenArgs = CodegenArgs(
+                  filePaths.map(os.Path(_)).toList,
+                  output = os.Path(outputPath),
+                  openapiOutput = os.Path(openApiOutputPath),
+                  skipScala = false,
+                  skipOpenapi = false,
+                  discoverModels = true, // we need protocol here
+                  allowedNS = allowedNamespaces,
+                  excludedNS = excludedNamespaces,
+                  repositories = res,
+                  dependencies = dependencies,
+                  transforms
+                )
+                val resPaths = smithy4s.codegen.Codegen
+                  .processSpecs(codegenArgs)
+                  .toList
+                resPaths.map(path => new File(path.toString))
+              } else {
+                outputs.getOrElse(Seq.empty)
+              }
+            }
+        }
       }
 
-    compile(schemas).toSeq
+    cached(
+      (FilesInfo(inputFiles.map(FileInfo.hash(_)).toSet), dependencies)
+    )
   }
 }


### PR DESCRIPTION
The recent changes related to the sbt-plugin altered how it decides when to run the codegen and when it is not necessary. Unfortunately, we missed the fact that there are two components of the cache key that are needed: 1) the files if there are any that are colocated, 2) the dependencies that smithy4s can pull down to extract smithy files from jars.

@keynmol my sbt wizardry is not quite capable of keeping what you did and putting into place the changes necessary to fix the dependencies. If you want to take a crack at that, then please feel free. In the meantime, I am going to merge this so we can unblock some other internal projects.