### PR TITLE
Memorize document encoders

### DIFF
--- a/modules/json/src/smithy4s/http/json/SchematicJCodec.scala
+++ b/modules/json/src/smithy4s/http/json/SchematicJCodec.scala
@@ -784,16 +784,18 @@ private[smithy4s] class SchematicJCodec(maxArity: Int)
   ): JCodec[Z] =
     new JCodec[Z] {
 
-      val documentFields =
+      private[this] val documentFields =
         fields.filter { field =>
           val hints = field.instance.hints
           HttpBinding.fromHints(field.label, hints, maybeInputOutput).isEmpty
         }
 
-      val handlers =
+      private[this] val handlers =
         documentFields
           .map(field => jsonLabel(field) -> fieldHandler(field))
           .toMap
+
+      private[this] val documentEncoders = documentFields.map(field => fieldEncoder(field))
 
       val expecting: String = "object"
 
@@ -852,8 +854,6 @@ private[smithy4s] class SchematicJCodec(maxArity: Int)
           const(stage2.toVector)
         }
       }
-
-      def documentEncoders = documentFields.map(field => fieldEncoder(field))
 
       def encodeValue(z: Z, out: JsonWriter): Unit =
         encode(z, out, documentEncoders)


### PR DESCRIPTION
Currently smithy4s spends more than 1/3 of CPU cycles on creation of document encoders during serialization of data structures:
![image](https://user-images.githubusercontent.com/890289/170857480-8225de5a-d1be-49ce-b3fa-6323830d4f7b.png)

This small patch fixes that by storing document encoders locally in codecs and increases throughput of serialization of data structures on ~50%.