### PR TITLE
Fixes #181

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -534,7 +534,8 @@ lazy val tests = projectMatrix
     },
     Compile / smithySpecs := Seq(
       (ThisBuild / baseDirectory).value / "sampleSpecs" / "pizza.smithy",
-      (ThisBuild / baseDirectory).value / "sampleSpecs" / "weather.smithy"
+      (ThisBuild / baseDirectory).value / "sampleSpecs" / "weather.smithy",
+      (ThisBuild / baseDirectory).value / "sampleSpecs" / "recursiveInput.smithy"
     ),
     moduleName := {
       if (virtualAxes.value.contains(CatsEffect2Axis))

--- a/modules/core/src/smithy4s/http/internals/SchemaVisitorPathEncoder.scala
+++ b/modules/core/src/smithy4s/http/internals/SchemaVisitorPathEncoder.scala
@@ -164,5 +164,10 @@ object SchemaVisitorPathEncoder extends SchemaVisitor[MaybePathEncode] { self =>
     self(schema).map(_.contramap(from))
   }
 
-  override def lazily[A](suspend: Lazy[Schema[A]]): MaybePathEncode[A] = default
+  override def lazily[A](suspend: Lazy[Schema[A]]): MaybePathEncode[A] = {
+    // "safe" because the `structure` implementation will not exercise any recursion
+    // due to the fact that httpLabel can only be applied on members targeting
+    // simple shapes.
+    suspend.map(this.apply(_)).value
+  }
 }

--- a/modules/core/test/src/smithy4s/http/internals/PathSpec.scala
+++ b/modules/core/test/src/smithy4s/http/internals/PathSpec.scala
@@ -95,7 +95,7 @@ object PathSpec extends weaver.FunSuite {
           uri = NonEmptyString("/{label}/const/{secondLabel}")
         )
       )
-      val result = SchemaVisitorPathEncoder(schema)
+    val result = SchemaVisitorPathEncoder(schema)
       .map(_.encode(()))
 
     assert.eql(
@@ -116,7 +116,7 @@ object PathSpec extends weaver.FunSuite {
           uri = NonEmptyString("/{label}/const/{greedyLabel+}")
         )
       )
-      val result = SchemaVisitorPathEncoder(schema)
+    val result = SchemaVisitorPathEncoder(schema)
       .map(_.encode(()))
 
     assert.eql(

--- a/modules/http4s/test/src/smithy4s/http4s/RecursiveInputSpec.scala
+++ b/modules/http4s/test/src/smithy4s/http4s/RecursiveInputSpec.scala
@@ -1,0 +1,22 @@
+package smithy4s.http4s
+
+import weaver._
+
+import smithy4s.http4s.SimpleRestJsonBuilder
+import org.http4s.HttpApp
+import cats.effect.IO
+import org.http4s.Uri
+
+// This is a non-regression test for https://github.com/disneystreaming/smithy4s/issues/181
+object RecursiveInputSpec extends FunSuite {
+
+  test("simpleRestJson works with recursive input operations") {
+    val result = SimpleRestJsonBuilder(smithy4s.example.RecursiveInputService).client(
+      HttpApp.notFound[IO],
+      Uri.unsafeFromString("http://localhost")
+    )
+
+    expect(result.isRight)
+  }
+
+}

--- a/sampleSpecs/recursiveInput.smithy
+++ b/sampleSpecs/recursiveInput.smithy
@@ -1,0 +1,19 @@
+namespace smithy4s.example
+
+use smithy4s.api#simpleRestJson
+
+@simpleRestJson
+service RecursiveInputService {
+  version: "0.0.1",
+  operations: [RecursiveInputOperation],
+}
+
+@http(method: "PUT", uri: "/subscriptions")
+@idempotent
+operation RecursiveInputOperation {
+  input: RecursiveInput,
+}
+
+structure RecursiveInput {
+  hello: RecursiveInput
+}


### PR DESCRIPTION
This fixes a bug that would occur when a recursive structure as input
to an operation, leading to a misleading error.

It also makes the recursion detection more concise and accurate by
relying on smithy's PathFinder construct.