### PR TITLE
Fix dynamic compiler applying field/alt hints at the wrong level

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,6 +23,11 @@ Global / licenses := Seq(
 
 sonatypeCredentialHost := "s01.oss.sonatype.org"
 
+ThisBuild / version := {
+  if (!sys.env.contains("CI")) "dev"
+  else (ThisBuild / version).value
+}
+
 lazy val root = project
   .in(file("."))
   .aggregate(allModules: _*)

--- a/build.sbt
+++ b/build.sbt
@@ -390,7 +390,7 @@ lazy val protocolTests = projectMatrix
  */
 lazy val dynamic = projectMatrix
   .in(file("modules/dynamic"))
-  .dependsOn(core)
+  .dependsOn(core, tests % "test->compile", http4s % "test->compile")
   .settings(
     isCE3 := true,
     libraryDependencies ++= Seq(

--- a/modules/core/src/smithy4s/Timestamp.scala
+++ b/modules/core/src/smithy4s/Timestamp.scala
@@ -25,7 +25,7 @@ import smithy4s.Timestamp.sbExt
 /**
   * Platform-agnostic UTC timestamp representation.
   *
-  * The [[schematic.TimePlatformCompat]] trait provides a "nowUTC" method to get the current time.
+  * The [[TimestampPlatformMethods]] trait provides a "nowUTC" method to get the current time.
   */
 abstract class Timestamp private[smithy4s] () extends TimestampPlatformMethods {
   def year: Int
@@ -90,7 +90,7 @@ abstract class Timestamp private[smithy4s] () extends TimestampPlatformMethods {
 }
 
 /**
-  * The [[smithy4s.TimePlatformCompat]] contains all the platform-specific
+  * The [[TimePlatformCompat]] contains all the platform-specific
   * code that has to do with retrieving time from the system, and is provided
   * for the hree platforms (jvm/js/native.)
   */

--- a/modules/dynamic/src/smithy4s/dynamic/DynamicSchemaIndex.scala
+++ b/modules/dynamic/src/smithy4s/dynamic/DynamicSchemaIndex.scala
@@ -24,6 +24,8 @@ package dynamic
   */
 trait DynamicSchemaIndex {
   def allServices: List[DynamicSchemaIndex.ServiceWrapper]
+  def getService(shapeId: ShapeId): Option[DynamicSchemaIndex.ServiceWrapper] =
+    allServices.find(_.service.id == shapeId)
 
   def getSchema(shapeId: ShapeId): Option[Schema[_]]
 }

--- a/modules/dynamic/test/src-jvm/smithy4s/dynamic/DecodingSpec.scala
+++ b/modules/dynamic/test/src-jvm/smithy4s/dynamic/DecodingSpec.scala
@@ -22,6 +22,10 @@ import smithy4s.dynamic.model.Model
 
 object DecodingSpec extends SimpleIOSuite {
 
+  /*
+   * Although not needed for equality, we sort the shapes in the model
+   * to make diffs more readable in case of failed assertions.
+   */
   private def order(model: Model): Model =
     model.copy(shapes =
       scala.collection.immutable.ListMap(

--- a/modules/dynamic/test/src-jvm/smithy4s/dynamic/DynamicJsonProxySpec.scala
+++ b/modules/dynamic/test/src-jvm/smithy4s/dynamic/DynamicJsonProxySpec.scala
@@ -40,8 +40,8 @@ object DynamicJsonProxySpec extends weaver.SimpleIOSuite {
         Utils
           .compileSampleSpec("kvstore.smithy")
           .flatMap { dynamicSchemaIndex =>
-            dynamicSchemaIndex.allServices
-              .find(_.service.id == ShapeId("smithy4s.example", "KVStore"))
+            dynamicSchemaIndex
+              .getService(ShapeId("smithy4s.example", "KVStore"))
               .liftTo[IO](new Throwable("Not found"))
           }
           .map { serviceDef =>

--- a/modules/dynamic/test/src-jvm/smithy4s/dynamic/Http4sDynamicPizzaClientSpec.scala
+++ b/modules/dynamic/test/src-jvm/smithy4s/dynamic/Http4sDynamicPizzaClientSpec.scala
@@ -1,0 +1,55 @@
+package smithy4s.dynamic
+
+import smithy4s.api.SimpleRestJson
+import smithy4s.SchemaIndex
+import smithy4s.ShapeId
+import org.http4s.client.Client
+import org.http4s.implicits._
+import cats.implicits._
+
+import cats.effect.IO
+import cats.effect.Resource
+import org.http4s.HttpApp
+import smithy4s.example._
+import smithy4s.http4s.SimpleRestJsonBuilder
+import smithy.api
+
+class DynamicHttpProxy(client: Client[IO]) {
+
+  val dynamicServiceIO =
+    Utils.parseSampleSpec("pizza.smithy").map { model =>
+      DynamicSchemaIndex
+        .load(
+          model,
+          SimpleRestJson.protocol.schemas ++
+            SchemaIndex(SimpleRestJson, api.Error)
+        )
+        .getService(ShapeId("smithy4s.example", "PizzaAdminService"))
+        .getOrElse(sys.error("service not found in DSI"))
+    }
+
+  val dynamicPizza: IO[smithy4s.Monadic[PizzaAdminServiceGen, IO]] =
+    dynamicServiceIO
+      .flatMap { dsi =>
+        SimpleRestJsonBuilder(dsi.service)
+          .client[IO](client, uri"http://localhost:8080")
+          .liftTo[IO]
+          .map { dynamicClient =>
+            JsonIOProtocol
+              .fromJsonIO[PizzaAdminServiceGen, PizzaAdminServiceOperation](
+                JsonIOProtocol.toJsonIO(dynamicClient)(dsi.service)
+              )
+
+          }
+      }
+}
+
+object Http4sDynamicPizzaClientSpec extends smithy4s.tests.PizzaClientSpec {
+
+  def makeClient = Left { (httpApp: HttpApp[IO]) =>
+    Resource.eval(
+      new DynamicHttpProxy(Client.fromHttpApp(httpApp)).dynamicPizza
+    )
+  }
+
+}

--- a/modules/dynamic/test/src-jvm/smithy4s/dynamic/PlatformUtils.scala
+++ b/modules/dynamic/test/src-jvm/smithy4s/dynamic/PlatformUtils.scala
@@ -47,7 +47,6 @@ private[dynamic] trait PlatformUtils { self: Utils.type =>
       SModel
         .assembler()
         .addImport(s"./sampleSpecs/$fileName")
-        // this is probably not right
         .addImport(
           "./modules/protocol/resources/META-INF/smithy/smithy4s.smithy"
         )

--- a/modules/dynamic/test/src-jvm/smithy4s/dynamic/PlatformUtils.scala
+++ b/modules/dynamic/test/src-jvm/smithy4s/dynamic/PlatformUtils.scala
@@ -47,6 +47,10 @@ private[dynamic] trait PlatformUtils { self: Utils.type =>
       SModel
         .assembler()
         .addImport(s"./sampleSpecs/$fileName")
+        // this is probably not right
+        .addImport(
+          "./modules/protocol/resources/META-INF/smithy/smithy4s.smithy"
+        )
         .discoverModels()
         .assemble()
         .unwrap()


### PR DESCRIPTION
With the recent schema overhaul, fields and alts are supposed to carry hints directly on them. 

Fixes #244

@kubukoz, would you be so kind as to turning your repro repo (which I've tested against) into some unit tests in the dynamic module before we merge this ? 