### PR TITLE
More efficient reading and writing of JSON documents

### DIFF
--- a/modules/json/test/src/smithy4s/http/json/SchematicJCodecTests.scala
+++ b/modules/json/test/src/smithy4s/http/json/SchematicJCodecTests.scala
@@ -475,7 +475,7 @@ object SchematicJCodecTests extends SimpleIOSuite {
       failure("Unexpected success")
     } catch {
       case PayloadError(_, _, message) =>
-        expect(message == "input Json document exceeded max arity of `1024`")
+        expect(message == "input JSON document exceeded max arity of `1024`")
     }
   }
 
@@ -487,7 +487,7 @@ object SchematicJCodecTests extends SimpleIOSuite {
       failure("Unexpected success")
     } catch {
       case PayloadError(_, _, message) =>
-        expect(message == "input Json document exceeded max arity of `1024`")
+        expect(message == "input JSON document exceeded max arity of `1024`")
     }
   }
 


### PR DESCRIPTION
Before:
```
[info] Benchmark                               (size)   Mode  Cnt        Score       Error  Units
[info] ExtractFieldsReading.smithy4sDocument        1  thrpt    5  2103571.715 ± 53265.991  ops/s
[info] ExtractFieldsReading.smithy4sDocument       10  thrpt    5   222313.388 ±  5891.141  ops/s
[info] ExtractFieldsReading.smithy4sDocument      100  thrpt    5    13535.324 ±   180.397  ops/s
[info] ExtractFieldsReading.smithy4sDocument     1000  thrpt    5      333.161 ±     7.923  ops/s
```
After:
```
[info] Benchmark                               (size)   Mode  Cnt        Score       Error  Units
[info] ExtractFieldsReading.smithy4sDocument        1  thrpt    5  3128058.525 ± 91970.963  ops/s
[info] ExtractFieldsReading.smithy4sDocument       10  thrpt    5   291746.400 ±  4470.880  ops/s
[info] ExtractFieldsReading.smithy4sDocument      100  thrpt    5    18772.193 ±   358.538  ops/s
[info] ExtractFieldsReading.smithy4sDocument     1000  thrpt    5      340.740 ±     2.809  ops/s
```