### PR TITLE
SchemaVisitor JCodec

### DIFF
--- a/modules/aws/src/smithy4s/json/AwsSchematicJCodec.scala
+++ b/modules/aws/src/smithy4s/json/AwsSchematicJCodec.scala
@@ -22,28 +22,37 @@ import com.github.plokhotnyuk.jsoniter_scala.core.JsonWriter
 import smithy4s.Timestamp
 import smithy4s.http.json.Cursor
 import smithy4s.http.json.JCodec
-import smithy4s.http.json.SchematicJCodec
-import smithy4s.internals.Hinted
+import smithy4s.http.json.SchemaVisitorJCodec
+import smithy4s.schema.Primitive
 
 private[aws] object AwsSchematicJCodec
-    extends SchematicJCodec(maxArity = 1024) {
+    extends SchemaVisitorJCodec(maxArity = 1024) {
 
-  override def timestamp: JCodec.JCodecMake[Timestamp] = Hinted.static {
-    new JCodec[Timestamp] {
-      val expecting: String = "instant (epoch second)"
-
-      def decodeValue(cursor: Cursor, in: JsonReader): Timestamp =
-        Timestamp.fromEpochSecond(in.readDouble().toLong)
-
-      def encodeValue(x: Timestamp, out: JsonWriter): Unit =
-        out.writeVal(x.epochSecond)
-
-      def decodeKey(in: JsonReader): Timestamp =
-        Timestamp.fromEpochSecond(in.readKeyAsDouble().toLong)
-
-      def encodeKey(x: Timestamp, out: JsonWriter): Unit =
-        out.writeKey(x.epochSecond)
+  override def primitive[P](
+      shapeId: ShapeId,
+      hints: Hints,
+      tag: Primitive[P]
+  ): JCodec[P] = {
+    tag match {
+      case Primitive.PTimestamp => timestamp
+      case _                    => super.primitive(shapeId, hints, tag)
     }
+  }
+
+  private val timestamp: JCodec[Timestamp] = new JCodec[Timestamp] {
+    val expecting: String = "instant (epoch second)"
+
+    def decodeValue(cursor: Cursor, in: JsonReader): Timestamp =
+      Timestamp.fromEpochSecond(in.readDouble().toLong)
+
+    def encodeValue(x: Timestamp, out: JsonWriter): Unit =
+      out.writeVal(x.epochSecond)
+
+    def decodeKey(in: JsonReader): Timestamp =
+      Timestamp.fromEpochSecond(in.readKeyAsDouble().toLong)
+
+    def encodeKey(x: Timestamp, out: JsonWriter): Unit =
+      out.writeKey(x.epochSecond)
   }
 
 }

--- a/modules/aws/src/smithy4s/json/awsJson.scala
+++ b/modules/aws/src/smithy4s/json/awsJson.scala
@@ -17,4 +17,4 @@
 package smithy4s.aws.json
 
 private[aws] object awsJson
-    extends smithy4s.http.json.JsonCodecAPI(AwsSchematicJCodec) {}
+    extends smithy4s.http.json.JsonCodecAPI(AwsSchematicJCodec, None) {}

--- a/modules/core/src/smithy4s/schema/SchemaVisitor.scala
+++ b/modules/core/src/smithy4s/schema/SchemaVisitor.scala
@@ -20,7 +20,7 @@ package schema
 import Schema._
 
 // format: off
-trait SchemaVisitor[F[_]] extends (Schema ~> F){
+trait SchemaVisitor[F[_]] extends (Schema ~> F) {
   def primitive[P](shapeId: ShapeId, hints: Hints, tag: Primitive[P]) : F[P]
   def list[A](shapeId: ShapeId, hints: Hints, member: Schema[A]) : F[List[A]]
   def set[A](shapeId: ShapeId, hints: Hints, member: Schema[A]): F[Set[A]]

--- a/modules/json/src/smithy4s/http/json/JCodec.scala
+++ b/modules/json/src/smithy4s/http/json/JCodec.scala
@@ -21,7 +21,6 @@ package json
 import com.github.plokhotnyuk.jsoniter_scala.core._
 import smithy4s.PolyFunction
 import smithy4s.capability.Invariant
-import smithy4s.internals.Hinted
 
 import scala.collection.{Map => MMap}
 
@@ -120,10 +119,8 @@ object JCodec {
     }
   }
 
-  type JCodecMake[A] = Hinted[JCodec, A]
-
   def fromSchema[A](schema: Schema[A]): JCodec[A] =
-    schema.compile(codecs.schematicJCodec).get
+    schema.compile(codecs.schemaVisitorJCodec)
 
   implicit def deriveJCodecFromSchema[A](implicit
       schema: Schema[A]

--- a/modules/json/src/smithy4s/http/json/JsonCodecAPI.scala
+++ b/modules/json/src/smithy4s/http/json/JsonCodecAPI.scala
@@ -23,10 +23,10 @@ import com.github.plokhotnyuk.jsoniter_scala.core.WriterConfig
 
 import java.nio.ByteBuffer
 
-import JCodec.JCodecMake
+import smithy4s.schema.SchemaVisitor
 
 abstract class JsonCodecAPI(
-    schematicJCodec: Schematic[JCodecMake],
+    schemaVisitorJCodec: SchemaVisitor[JCodec],
     readerConfig: ReaderConfig = JsonCodecAPI.defaultReaderConfig,
     writerConfig: WriterConfig = WriterConfig
 ) extends CodecAPI {
@@ -34,7 +34,7 @@ abstract class JsonCodecAPI(
   type Codec[A] = JCodec[A]
 
   def compileCodec[A](schema: Schema[A]): JCodec[A] =
-    schema.compile(schematicJCodec).get
+    schema.compile(schemaVisitorJCodec)
 
   def mediaType[A](codec: JCodec[A]): HttpMediaType.Type =
     HttpMediaType("application/json")

--- a/modules/json/src/smithy4s/http/json/JsonCodecAPI.scala
+++ b/modules/json/src/smithy4s/http/json/JsonCodecAPI.scala
@@ -27,14 +27,20 @@ import smithy4s.schema.SchemaVisitor
 
 abstract class JsonCodecAPI(
     schemaVisitorJCodec: SchemaVisitor[JCodec],
+    hintMask: Option[HintMask] = None,
     readerConfig: ReaderConfig = JsonCodecAPI.defaultReaderConfig,
     writerConfig: WriterConfig = WriterConfig
 ) extends CodecAPI {
 
   type Codec[A] = JCodec[A]
 
-  def compileCodec[A](schema: Schema[A]): JCodec[A] =
+  def compileCodec[A](schema0: Schema[A]): JCodec[A] = {
+    val schema =
+      hintMask
+        .map(mask => schema0.transformHintsLocally(mask.apply))
+        .getOrElse(schema0)
     schema.compile(schemaVisitorJCodec)
+  }
 
   def mediaType[A](codec: JCodec[A]): HttpMediaType.Type =
     HttpMediaType("application/json")

--- a/modules/json/src/smithy4s/http/json/SchematicJCodec.scala
+++ b/modules/json/src/smithy4s/http/json/SchematicJCodec.scala
@@ -281,7 +281,7 @@ private[smithy4s] class SchemaVisitorJCodec(maxArity: Int)
       out.writeKey(total(x).stringValue)
   }
   private def jsonLabel[A, Z](field: Field[Schema, Z, A]): String =
-    field.instance.hints
+    field.hints
       .get(JsonName)
       .map(_.value)
       .getOrElse(field.label)
@@ -375,8 +375,9 @@ private[smithy4s] class SchemaVisitorJCodec(maxArity: Int)
 
       private[this] val documentFields =
         fields.filter { field =>
-          val hints = field.instance.hints
-          HttpBinding.fromHints(field.label, hints, maybeInputOutput).isEmpty
+          HttpBinding
+            .fromHints(field.label, field.hints, maybeInputOutput)
+            .isEmpty
         }
 
       private[this] val handlers =
@@ -539,7 +540,7 @@ private[smithy4s] class SchemaVisitorJCodec(maxArity: Int)
       DiscriminatedUnionMember.hint.unapply(hints)
     ) match {
       case (maybeInputOutput, maybeDiscriminated) =>
-        fields.find(_.instance.hints.get(HttpPayload).isDefined) match {
+        fields.find(_.hints.get(HttpPayload).isDefined) match {
           case Some(payloadField) =>
             val codec = apply(payloadField.instance)
             payloadStruct(payloadField, fields)(codec, make)
@@ -575,7 +576,7 @@ private[smithy4s] class SchemaVisitorJCodec(maxArity: Int)
       override def canBeKey: Boolean = false
 
       def jsonLabel[A](alt: Alt[Schema, Z, A]): String =
-        alt.instance.hints.get(JsonName).map(_.value).getOrElse(alt.label)
+        alt.hints.get(JsonName).map(_.value).getOrElse(alt.label)
 
       private[this] val handlerMap
           : util.HashMap[String, (Cursor, JsonReader) => Z] =
@@ -700,7 +701,7 @@ private[smithy4s] class SchemaVisitorJCodec(maxArity: Int)
       override def canBeKey: Boolean = false
 
       def jsonLabel[A](alt: Alt[Schema, Z, A]): String =
-        alt.instance.hints.get(JsonName).map(_.value).getOrElse(alt.label)
+        alt.hints.get(JsonName).map(_.value).getOrElse(alt.label)
 
       private[this] val handlerMap
           : util.HashMap[String, (Cursor, JsonReader) => Z] =

--- a/modules/json/src/smithy4s/http/json/SchematicJCodec.scala
+++ b/modules/json/src/smithy4s/http/json/SchematicJCodec.scala
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2021-2022 Disney Streaming
+ *  Copyright 2021 Disney Streaming
  *
  *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -18,341 +18,164 @@ package smithy4s
 package http
 package json
 
-import _root_.smithy.api.JsonName
-import com.github.plokhotnyuk.jsoniter_scala.core._
+import java.util.UUID
+import java.util
+
+import com.github.plokhotnyuk.jsoniter_scala.core.JsonReader
+import com.github.plokhotnyuk.jsoniter_scala.core.JsonWriter
 import smithy.api.HttpPayload
+import smithy.api.JsonName
 import smithy.api.TimestampFormat
-import smithy.api.TimestampFormat._
-import smithy4s.api.Untagged
-import smithy4s.Document.DArray
-import smithy4s.Document.DBoolean
-import smithy4s.Document.DNull
-import smithy4s.Document.DNumber
-import smithy4s.Document.DObject
-import smithy4s.Document.DString
 import smithy4s.api.Discriminated
+import smithy4s.api.Untagged
 import smithy4s.internals.DiscriminatedUnionMember
-import smithy4s.internals.Hinted
 import smithy4s.internals.InputOutput
 import smithy4s.schema._
-import java.util
-import java.util.UUID
+import smithy4s.schema.Primitive._
+import smithy4s.Timestamp
+
 import scala.collection.compat.immutable.ArraySeq
+import scala.collection.immutable.VectorBuilder
 import scala.collection.mutable.ListBuffer
 import scala.collection.mutable.{Map => MMap}
-import scala.collection.immutable.VectorBuilder
-import JCodec.JCodecMake
 
-private[smithy4s] class SchematicJCodec(maxArity: Int) extends Schematic[JCodecMake] {
+private[smithy4s] class SchemaVisitorJCodec(maxArity: Int)
+    extends SchemaVisitor[JCodec] { self =>
+
   private val emptyMetadata: MMap[String, Any] = MMap.empty
-
-  def boolean: JCodecMake[Boolean] = Hinted.static {
-    new JCodec[Boolean] {
-      def expecting: String = "boolean"
-
-      def decodeValue(cursor: Cursor, in: JsonReader): Boolean = in.readBoolean()
-
-      def encodeValue(x: Boolean, out: JsonWriter): Unit = out.writeVal(x)
-
-      def decodeKey(in: JsonReader): Boolean = in.readKeyAsBoolean()
-
-      def encodeKey(x: Boolean, out: JsonWriter): Unit = out.writeKey(x)
-    }
-  }
-
-  def char: JCodecMake[Char] = Hinted.static {
-    new JCodec[Char] {
-      def expecting: String = "char"
-
-      def decodeValue(cursor: Cursor, in: JsonReader): Char = in.readChar()
-
-      def encodeValue(x: Char, out: JsonWriter): Unit = out.writeVal(x)
-
-      def decodeKey(in: JsonReader): Char = in.readKeyAsChar()
-
-      def encodeKey(x: Char, out: JsonWriter): Unit = out.writeKey(x)
-    }
-  }
-
-  def string: JCodecMake[String] = Hinted[JCodec].static {
-    new JCodec[String] {
-      def expecting: String = "string"
-
-      def decodeValue(cursor: Cursor, in: JsonReader): String = in.readString(null)
-
-      def encodeValue(x: String, out: JsonWriter): Unit = out.writeVal(x)
-
-      def decodeKey(in: JsonReader): String = in.readKeyAsString()
-
-      def encodeKey(x: String, out: JsonWriter): Unit = out.writeKey(x)
-    }
-  }
-
-  def int: JCodecMake[Int] = Hinted[JCodec].static {
-    new JCodec[Int] {
-      def expecting: String = "int"
-
-      def decodeValue(cursor: Cursor, in: JsonReader): Int = in.readInt()
-
-      def encodeValue(x: Int, out: JsonWriter): Unit = out.writeVal(x)
-
-      def decodeKey(in: JsonReader): Int = in.readKeyAsInt()
-
-      def encodeKey(x: Int, out: JsonWriter): Unit = out.writeKey(x)
-    }
-  }
-
-  def long: JCodecMake[Long] = Hinted[JCodec].static {
-    new JCodec[Long] {
-      def expecting: String = "long"
-
-      def decodeValue(cursor: Cursor, in: JsonReader): Long = in.readLong()
-
-      def encodeValue(x: Long, out: JsonWriter): Unit = out.writeVal(x)
-
-      def decodeKey(in: JsonReader): Long = in.readKeyAsLong()
-
-      def encodeKey(x: Long, out: JsonWriter): Unit = out.writeKey(x)
-    }
-  }
-
-  def float: JCodecMake[Float] = Hinted[JCodec].static {
-    new JCodec[Float] {
-      def expecting: String = "float"
-
-      def decodeValue(cursor: Cursor, in: JsonReader): Float = in.readFloat()
-
-      def encodeValue(x: Float, out: JsonWriter): Unit = out.writeVal(x)
-
-      def decodeKey(in: JsonReader): Float = in.readKeyAsFloat()
-
-      def encodeKey(x: Float, out: JsonWriter): Unit = out.writeKey(x)
-    }
-  }
-
-  def double: JCodecMake[Double] = Hinted[JCodec].static {
-    new JCodec[Double] {
-      def expecting: String = "double"
-
-      def decodeValue(cursor: Cursor, in: JsonReader): Double = in.readDouble()
-
-      def encodeValue(x: Double, out: JsonWriter): Unit = out.writeVal(x)
-
-      def decodeKey(in: JsonReader): Double = in.readKeyAsDouble()
-
-      def encodeKey(x: Double, out: JsonWriter): Unit = out.writeKey(x)
-    }
-  }
-
-  def short: JCodecMake[Short] = Hinted[JCodec].static {
-    new JCodec[Short] {
-      def expecting: String = "short"
-
-      def decodeValue(cursor: Cursor, in: JsonReader): Short = in.readShort()
-
-      def encodeValue(x: Short, out: JsonWriter): Unit = out.writeVal(x)
-
-      def decodeKey(in: JsonReader): Short = in.readKeyAsShort()
-
-      def encodeKey(x: Short, out: JsonWriter): Unit = out.writeKey(x)
-    }
-  }
-
-  def byte: JCodecMake[Byte] = Hinted[JCodec].static {
-    new JCodec[Byte] {
-      def expecting: String = "byte"
-
-      def decodeValue(cursor: Cursor, in: JsonReader): Byte = in.readByte()
-
-      def encodeValue(x: Byte, out: JsonWriter): Unit = out.writeVal(x)
-
-      def decodeKey(in: JsonReader): Byte = in.readKeyAsByte()
-
-      def encodeKey(x: Byte, out: JsonWriter): Unit = out.writeKey(x)
-    }
-  }
-
-  def bytes: JCodecMake[ByteArray] = Hinted[JCodec].static {
-    new JCodec[ByteArray] {
-      def expecting: String = "byte-array"
-
-      override def canBeKey: Boolean = false
-
-      def decodeValue(cursor: Cursor, in: JsonReader): ByteArray = ByteArray(in.readBase64AsBytes(null))
-
-      def encodeValue(x: ByteArray, out: JsonWriter): Unit = out.writeBase64Val(x.array, doPadding = true)
-
-      def decodeKey(in: JsonReader): ByteArray = in.decodeError("Cannot use byte array as key")
-
-      def encodeKey(x: ByteArray, out: JsonWriter): Unit = out.encodeError("Cannot use byte array as key")
-    }
-  }
-
-  def bigdecimal: JCodecMake[BigDecimal] = Hinted[JCodec].static {
-    new JCodec[BigDecimal] {
-      def expecting: String = "big-decimal"
-
-      def decodeValue(cursor: Cursor, in: JsonReader): BigDecimal = in.readBigDecimal(null)
-
-      def decodeKey(in: JsonReader): BigDecimal = in.readKeyAsBigDecimal()
-
-      def encodeValue(value: BigDecimal, out: JsonWriter): Unit = out.writeVal(value)
-
-      def encodeKey(value: BigDecimal, out: JsonWriter): Unit = out.writeVal(value)
-    }
-  }
-
-  def bigint: JCodecMake[BigInt] = Hinted[JCodec].static {
-    new JCodec[BigInt] {
-      def expecting: String = "big-int"
-
-      def decodeValue(cursor: Cursor, in: JsonReader): BigInt = in.readBigInt(null)
-
-      def decodeKey(in: JsonReader): BigInt = in.readKeyAsBigInt()
-
-      def encodeValue(value: BigInt, out: JsonWriter): Unit = out.writeVal(value)
-
-      def encodeKey(value: BigInt, out: JsonWriter): Unit = out.writeVal(value)
-    }
-  }
-
-  def uuid: JCodecMake[UUID] = Hinted[JCodec].static {
-    new JCodec[UUID] {
-      def expecting: String = "uuid"
-
-      def decodeValue(cursor: Cursor, in: JsonReader): UUID = in.readUUID(null)
-
-      def encodeValue(x: UUID, out: JsonWriter): Unit = out.writeVal(x)
-
-      def decodeKey(in: JsonReader): UUID = in.readKeyAsUUID()
-
-      def encodeKey(x: UUID, out: JsonWriter): Unit = out.writeKey(x)
-    }
-  }
-
-  def timestamp: JCodecMake[Timestamp] = Hinted[JCodec].from { hints =>
-    new JCodec[Timestamp] {
-      private[this] val format = hints.get(TimestampFormat).getOrElse(TimestampFormat.DATE_TIME)
-      val expecting: String = Timestamp.showFormat(format)
-
-      def decodeValue(cursor: Cursor, in: JsonReader): Timestamp =
+  private val documentJCodec = PrimitiveJCodecs.document(maxArity)
+
+  override def primitive[P](
+      shapeId: ShapeId,
+      hints: Hints,
+      tag: Primitive[P]
+  ): JCodec[P] = {
+    tag match {
+      case PBigDecimal => PrimitiveJCodecs.bigdecimal
+      case PBigInt     => PrimitiveJCodecs.bigint
+      case PBlob       => PrimitiveJCodecs.bytes
+      case PBoolean    => PrimitiveJCodecs.boolean
+      case PByte       => PrimitiveJCodecs.byte
+      case PDocument   => documentJCodec
+      case PDouble     => PrimitiveJCodecs.double
+      case PFloat      => PrimitiveJCodecs.float
+      case PInt        => PrimitiveJCodecs.int
+      case PLong       => PrimitiveJCodecs.long
+      case PShort      => PrimitiveJCodecs.short
+      case PString     => PrimitiveJCodecs.string
+      case PTimestamp =>
+        val format =
+          hints.get(TimestampFormat).getOrElse(TimestampFormat.DATE_TIME)
         format match {
-          case EPOCH_SECONDS => Timestamp.fromEpochSecond(in.readLong())
-          case other =>
-            Timestamp.parse(in.readString(null), other) match {
-              case Some(value) => value
-              case None        => in.decodeError("Wrong timestamp format")
-            }
+          case TimestampFormat.DATE_TIME => PrimitiveJCodecs.timestampDateTime
+          case TimestampFormat.EPOCH_SECONDS => PrimitiveJCodecs.timestampEpoch
+          case TimestampFormat.HTTP_DATE => PrimitiveJCodecs.timestampHttpDate
         }
-
-      def encodeValue(x: Timestamp, out: JsonWriter): Unit =
-        format match {
-          case EPOCH_SECONDS => out.writeVal(x.epochSecond)
-          case other         => out.writeVal(x.format(other))
-        }
-
-      def decodeKey(in: JsonReader): Timestamp = Timestamp.fromEpochSecond(in.readKeyAsLong())
-
-      def encodeKey(x: Timestamp, out: JsonWriter): Unit = out.writeKey(x.epochSecond)
+      case PUnit => PrimitiveJCodecs.unit
+      case PUUID => PrimitiveJCodecs.uuid
     }
   }
 
-  def list[A](jc: JCodecMake[A]): JCodecMake[List[A]] = Hinted[JCodec].static {
-    new JCodec[List[A]] {
-      private[this] val a = jc.get
+  private def listImpl[A](member: Schema[A]) = new JCodec[List[A]] {
+    private[this] val a: JCodec[A] = apply(member)
+    def expecting: String = "list"
 
-      def expecting: String = "list"
+    override def canBeKey: Boolean = false
 
-      override def canBeKey: Boolean = false
-
-      def decodeValue(cursor: Cursor, in: JsonReader): List[A] =
-        if (in.isNextToken('[')) {
-          if (in.isNextToken(']')) Nil
-          else {
-            in.rollbackToken()
-            val builder = new ListBuffer[A]
-            var i = 0
-            while ( {
-              if (i >= maxArity)
-                throw cursor.payloadError(
-                  this,
-                  s"input $expecting exceeded max arity of `$maxArity`"
-                )
-              builder += cursor.under(i)(cursor.decode(a, in))
-              i += 1
-              in.isNextToken(',')
-            }) ()
-            if (in.isCurrentToken(']')) builder.result()
-            else in.arrayEndOrCommaError()
-          }
-        } else in.decodeError("Expected JSON array")
-
-      def encodeValue(xs: List[A], out: JsonWriter): Unit = {
-        out.writeArrayStart()
-        var list = xs
-        while (list ne Nil) {
-          a.encodeValue(list.head, out)
-          list = list.tail
+    def decodeValue(cursor: Cursor, in: JsonReader): List[A] =
+      if (in.isNextToken('[')) {
+        if (in.isNextToken(']')) Nil
+        else {
+          in.rollbackToken()
+          val builder = new ListBuffer[A]
+          var i = 0
+          while ({
+            if (i >= maxArity)
+              throw cursor.payloadError(
+                this,
+                s"input $expecting exceeded max arity of `$maxArity`"
+              )
+            builder += cursor.under(i)(cursor.decode(a, in))
+            i += 1
+            in.isNextToken(',')
+          }) ()
+          if (in.isCurrentToken(']')) builder.result()
+          else in.arrayEndOrCommaError()
         }
-        out.writeArrayEnd()
+      } else in.decodeError("Expected JSON array")
+
+    def encodeValue(xs: List[A], out: JsonWriter): Unit = {
+      out.writeArrayStart()
+      var list = xs
+      while (list ne Nil) {
+        a.encodeValue(list.head, out)
+        list = list.tail
       }
-
-      def decodeKey(in: JsonReader): List[A] = in.decodeError("Cannot use vectors as keys")
-
-      def encodeKey(xs: List[A], out: JsonWriter): Unit = out.encodeError("Cannot use vectors as keys")
+      out.writeArrayEnd()
     }
+
+    def decodeKey(in: JsonReader): List[A] =
+      in.decodeError("Cannot use vectors as keys")
+
+    def encodeKey(xs: List[A], out: JsonWriter): Unit =
+      out.encodeError("Cannot use vectors as keys")
   }
 
-  def set[A](jc: JCodecMake[A]): JCodecMake[Set[A]] = Hinted[JCodec].static {
-    new JCodec[Set[A]] {
-      private[this] val a = jc.get
+  override def list[A](
+      shapeId: ShapeId,
+      hints: Hints,
+      member: Schema[A]
+  ): JCodec[List[A]] = listImpl(member)
 
-      def expecting: String = "list"
+  override def set[A](
+      shapeId: ShapeId,
+      hints: Hints,
+      member: Schema[A]
+  ): JCodec[Set[A]] = new JCodec[Set[A]] {
+    private[this] val a = apply(member)
+    def expecting: String = "list"
 
-      override def canBeKey: Boolean = false
+    override def canBeKey: Boolean = false
 
-      def decodeValue(cursor: Cursor, in: JsonReader): Set[A] =
-        if (in.isNextToken('[')) {
-          if (in.isNextToken(']')) Set.empty
-          else {
-            in.rollbackToken()
-            val builder = Set.newBuilder[A]
-            var i = 0
-            while ({
-              if (i >= maxArity)
-                throw cursor.payloadError(
-                  this,
-                  s"input $expecting exceeded max arity of `$maxArity`"
-                )
-              builder += cursor.under(i)(cursor.decode(a, in))
-              i += 1
-              in.isNextToken(',')
-            }) ()
-            if (in.isCurrentToken(']')) builder.result()
-            else in.arrayEndOrCommaError()
-          }
-        } else in.decodeError("Expected JSON array")
+    def decodeValue(cursor: Cursor, in: JsonReader): Set[A] =
+      if (in.isNextToken('[')) {
+        if (in.isNextToken(']')) Set.empty
+        else {
+          in.rollbackToken()
+          val builder = Set.newBuilder[A]
+          var i = 0
+          while ({
+            if (i >= maxArity)
+              throw cursor.payloadError(
+                this,
+                s"input $expecting exceeded max arity of `$maxArity`"
+              )
+            builder += cursor.under(i)(cursor.decode(a, in))
+            i += 1
+            in.isNextToken(',')
+          }) ()
+          if (in.isCurrentToken(']')) builder.result()
+          else in.arrayEndOrCommaError()
+        }
+      } else in.decodeError("Expected JSON array")
 
-      def encodeValue(xs: Set[A], out: JsonWriter): Unit = {
-        out.writeArrayStart()
-        xs.foreach(x => a.encodeValue(x, out))
-        out.writeArrayEnd()
-      }
-
-      def decodeKey(in: JsonReader): Set[A] = in.decodeError("Cannot use vectors as keys")
-
-      def encodeKey(xs: Set[A], out: JsonWriter): Unit = out.encodeError("Cannot use vectors as keys")
+    def encodeValue(xs: Set[A], out: JsonWriter): Unit = {
+      out.writeArrayStart()
+      xs.foreach(x => a.encodeValue(x, out))
+      out.writeArrayEnd()
     }
-  }
 
-  def map[K, V](jk: JCodecMake[K], jv: JCodecMake[V]): JCodecMake[Map[K, V]] =
-    if (jk.get.canBeKey) objectMap(jk, jv)
-    else arrayMap(jk, jv)
+    def decodeKey(in: JsonReader): Set[A] =
+      in.decodeError("Cannot use vectors as keys")
+
+    def encodeKey(xs: Set[A], out: JsonWriter): Unit =
+      out.encodeError("Cannot use vectors as keys")
+  }
 
   private def objectMap[K, V](
-      jk: JCodecMake[K],
-      jv: JCodecMake[V]
-  ): JCodecMake[Map[K, V]] = jk.productTransform(jv) { (k, v) =>
+      jk: JCodec[K],
+      jv: JCodec[V]
+  ): JCodec[Map[K, V]] = {
     new JCodec[Map[K, V]] {
       val expecting: String = "map"
 
@@ -371,7 +194,12 @@ private[smithy4s] class SchematicJCodec(maxArity: Int) extends Schematic[JCodecM
                   this,
                   s"input $expecting exceeded max arity of `$maxArity`"
                 )
-              builder += ((k.decodeKey(in), cursor.under(i)(cursor.decode(v, in))))
+              builder += (
+                (
+                  jk.decodeKey(in),
+                  cursor.under(i)(cursor.decode(jv, in))
+                )
+              )
               i += 1
               in.isNextToken(',')
             }) ()
@@ -383,277 +211,76 @@ private[smithy4s] class SchematicJCodec(maxArity: Int) extends Schematic[JCodecM
       def encodeValue(xs: Map[K, V], out: JsonWriter): Unit = {
         out.writeObjectStart()
         xs.foreach { case (key, value) =>
-          k.encodeKey(key, out)
-          v.encodeValue(value, out)
+          jk.encodeKey(key, out)
+          jv.encodeValue(value, out)
         }
         out.writeObjectEnd()
       }
 
-      def decodeKey(in: JsonReader): Map[K, V] = in.decodeError("Cannot use maps as keys")
+      def decodeKey(in: JsonReader): Map[K, V] =
+        in.decodeError("Cannot use maps as keys")
 
-      def encodeKey(xs: Map[K, V], out: JsonWriter): Unit = out.encodeError("Cannot use maps as keys")
+      def encodeKey(xs: Map[K, V], out: JsonWriter): Unit =
+        out.encodeError("Cannot use maps as keys")
     }
   }
 
   private def arrayMap[K, V](
-      k: JCodecMake[K],
-      v: JCodecMake[V]
-  ): JCodecMake[Map[K, V]] = {
-    val kField = Field.required[JCodecMake, (K, V), K]("key", k, _._1)
-    val vField = Field.required[JCodecMake, (K, V), V]("value", v, _._2)
-    val kvCodec = struct(Vector(kField, vField))(vec => (vec(0).asInstanceOf[K], vec(1).asInstanceOf[V]))
-    list(kvCodec).transform(_.biject(_.toMap, _.toList))
+      k: Schema[K],
+      v: Schema[V]
+  ): JCodec[Map[K, V]] = {
+    val kField = Field.required[Schema, (K, V), K]("key", k, _._1)
+    val vField = Field.required[Schema, (K, V), V]("value", v, _._2)
+    val kvCodec = Schema.struct(Vector(kField, vField))(vec =>
+      (vec(0).asInstanceOf[K], vec(1).asInstanceOf[V])
+    )
+    listImpl(kvCodec).biject(_.toMap, _.toList)
   }
-
-  def bijection[A, B](
-      a: JCodecMake[A],
-      to: A => B,
-      from: B => A
-  ): JCodecMake[B] = a.transform(_.biject(to, from))
-
-  def surjection[A, B](
-      a: JCodecMake[A],
-      to: Refinement[A, B],
-      from: B => A
-  ): JCodecMake[B] = a.xmap(to.asFunction, from)
-
-  def suspend[A](a: Lazy[JCodecMake[A]]): JCodecMake[A] = Hinted.static {
-    new JCodec[A] {
-      lazy val underlying = a.value.get
-
-      def expecting: String = underlying.expecting
-
-      def decodeValue(cursor: Cursor, in: JsonReader): A = underlying.decodeValue(cursor, in)
-
-      def encodeValue(x: A, out: JsonWriter): Unit = underlying.encodeValue(x, out)
-
-      def decodeKey(in: JsonReader): A = underlying.decodeKey(in)
-
-      def encodeKey(x: A, out: JsonWriter): Unit = underlying.encodeKey(x, out)
-    }
+  override def map[K, V](
+      shapeId: ShapeId,
+      hints: Hints,
+      key: Schema[K],
+      value: Schema[V]
+  ): JCodec[Map[K, V]] = {
+    val jk = apply(key)
+    val jv = apply(value)
+    if (jk.canBeKey) objectMap(jk, jv)
+    else arrayMap(key, value)
   }
+  override def enumeration[E](
+      shapeId: ShapeId,
+      hints: Hints,
+      values: List[EnumValue[E]],
+      total: E => EnumValue[E]
+  ): JCodec[E] = new JCodec[E] {
+    def fromName(v: String): Option[E] =
+      values.find(_.stringValue == v).map(_.value)
+    val expecting: String =
+      s"enumeration: [${values.map(_.stringValue).mkString(", ")}]"
 
-  private def taggedUnion[Z](
-      first: Alt[JCodecMake, Z, _],
-      rest: Vector[Alt[JCodecMake, Z, _]]
-  )(total: Z => Alt.WithValue[JCodecMake, Z, _]): JCodec[Z] =
-    new JCodec[Z] {
-      val expecting: String = "tagged-union"
-
-      override def canBeKey: Boolean = false
-
-      def jsonLabel[A](alt: Alt[JCodecMake, Z, A]): String =
-        alt.instance.hints.get(JsonName).map(_.value).getOrElse(alt.label)
-
-      private[this] val handlerMap: util.HashMap[String, (Cursor, JsonReader) => Z] =
-        new util.HashMap[String, (Cursor, JsonReader) => Z] {
-          def handler[A](alt: Alt[JCodecMake, Z, A]) = {
-            val codec = alt.instance.get
-            (cursor: Cursor, reader: JsonReader) =>
-              alt.inject(cursor.decode(codec, reader))
-          }
-
-          put(jsonLabel(first), handler(first))
-          rest.foreach(alt => put(jsonLabel(alt), handler(alt)))
-        }
-
-      def decodeValue(cursor: Cursor, in: JsonReader): Z =
-        if (in.isNextToken('{')) {
-          if (in.isNextToken('}')) in.decodeError("Expected a single key/value pair")
-          else {
-            in.rollbackToken()
-            val key = in.readKeyAsString()
-            val result = cursor.under(key) {
-              val handler = handlerMap.get(key)
-              if (handler eq null) in.discriminatorValueError(key)
-              handler(cursor, in)
-            }
-            if (in.isNextToken('}')) result
-            else {
-              in.rollbackToken()
-              in.decodeError(s"Expected no other field after $key")
-            }
-          }
-        } else in.decodeError("Expected JSON object")
-
-      private[this] val altCache = new PolyFunction[Alt[JCodecMake, Z, *], JCodec] {
-        def apply[A](fa: Alt[JCodecMake, Z, A]): JCodec[A] = fa.instance.get
-      }.unsafeCache((first +: rest).map(alt => Existential.wrap(alt)))
-
-      def encodeValue(z: Z, out: JsonWriter): Unit = {
-        def writeValue[A](awv: Alt.WithValue[JCodecMake, Z, A]): Unit =
-          altCache(awv.alt).encodeValue(awv.value, out)
-
-        val awv = total(z)
-        out.writeObjectStart()
-        out.writeKey(jsonLabel(awv.alt))
-        writeValue(awv)
-        out.writeObjectEnd()
+    def decodeValue(cursor: Cursor, in: JsonReader): E = {
+      val str = in.readString(null)
+      fromName(str) match {
+        case Some(value) => value
+        case None        => in.enumValueError(str)
       }
-
-      def decodeKey(in: JsonReader): Z = in.decodeError("Cannot use coproducts as keys")
-
-      def encodeKey(x: Z, out: JsonWriter): Unit = out.encodeError("Cannot use coproducts as keys")
     }
 
-  private def untaggedUnion[Z](
-      first: Alt[JCodecMake, Z, _],
-      rest: Vector[Alt[JCodecMake, Z, _]]
-  )(total: Z => Alt.WithValue[JCodecMake, Z, _]): JCodec[Z] = new JCodec[Z] {
-    def expecting: String = "untaggedUnion"
+    def encodeValue(x: E, out: JsonWriter): Unit =
+      out.writeVal(total(x).stringValue)
 
-    override def canBeKey: Boolean = false
-
-    private[this] val handlerList: Array[(Cursor, JsonReader) => Z] = {
-      val res = Array.newBuilder[(Cursor, JsonReader) => Z]
-      def handler[A](alt: Alt[JCodecMake, Z, A]) = {
-        val codec = alt.instance.get
-        (cursor: Cursor, reader: JsonReader) =>
-          alt.inject(cursor.decode(codec, reader))
+    def decodeKey(in: JsonReader): E = {
+      val str = in.readKeyAsString()
+      fromName(str) match {
+        case Some(value) => value
+        case None        => in.enumValueError(str)
       }
-      res += handler(first)
-      rest.foreach(alt => res += handler(alt))
-      res.result()
     }
 
-    def decodeValue(cursor: Cursor, in: JsonReader): Z = {
-      var z: Z = null.asInstanceOf[Z]
-      val len = handlerList.length
-      var i = 0
-      while (z == null && i < len) {
-        in.setMark()
-        val handler = handlerList(i)
-        try {
-          z = handler(cursor, in)
-        } catch {
-          case _: Throwable =>
-            in.rollbackToMark()
-            i += 1
-        }
-      }
-      if (z != null) z
-      else cursor.payloadError(this, "Could not decode untagged union")
-    }
-
-    private[this] val altCache = new PolyFunction[Alt[JCodecMake, Z, *], JCodec] {
-      def apply[A](fa: Alt[JCodecMake, Z, A]): JCodec[A] = fa.instance.get
-    }.unsafeCache((first +: rest).map(alt => Existential.wrap(alt)))
-
-    def encodeValue(z: Z, out: JsonWriter): Unit = {
-      def writeValue[A](awv: Alt.WithValue[JCodecMake, Z, A]): Unit =
-        altCache(awv.alt).encodeValue(awv.value, out)
-
-      val awv = total(z)
-      writeValue(awv)
-    }
-
-    def decodeKey(in: JsonReader): Z = in.decodeError("Cannot use coproducts as keys")
-
-    def encodeKey(x: Z, out: JsonWriter): Unit = out.encodeError("Cannot use coproducts as keys")
+    def encodeKey(x: E, out: JsonWriter): Unit =
+      out.writeKey(total(x).stringValue)
   }
-
-  private def discriminatedUnion[Z](
-      first: Alt[JCodecMake, Z, _],
-      rest: Vector[Alt[JCodecMake, Z, _]],
-      discriminated: Discriminated
-  )(total: Z => Alt.WithValue[JCodecMake, Z, _]): JCodec[Z] =
-    new JCodec[Z] {
-      def expecting: String = "discriminated-union"
-
-      override def canBeKey: Boolean = false
-
-      def jsonLabel[A](alt: Alt[JCodecMake, Z, A]): String =
-        alt.instance.hints.get(JsonName).map(_.value).getOrElse(alt.label)
-
-      private[this] val handlerMap: util.HashMap[String, (Cursor, JsonReader) => Z] =
-        new util.HashMap[String, (Cursor, JsonReader) => Z] {
-          def handler[A](alt: Alt[JCodecMake, Z, A]): (Cursor, JsonReader) => Z = {
-            val codec = alt.instance.get
-            (cursor: Cursor, reader: JsonReader) =>
-              alt.inject(cursor.decode(codec, reader))
-          }
-
-          put(jsonLabel(first), handler(first))
-          rest.foreach(alt => put(jsonLabel(alt), handler(alt)))
-        }
-
-      def decodeValue(cursor: Cursor, in: JsonReader): Z =
-        if (in.isNextToken('{')) {
-          in.setMark()
-          if (in.skipToKey(discriminated.value)) {
-            val key = in.readString("")
-            in.rollbackToMark()
-            in.rollbackToken()
-            cursor.under(key) {
-              val handler = handlerMap.get(key)
-              if (handler eq null) in.discriminatorValueError(key)
-              handler(cursor, in)
-            }
-          } else in.decodeError(s"Unable to find discriminator ${discriminated.value}")
-        } else in.decodeError("Expected JSON object")
-
-      private[this] val altCache = new PolyFunction[Alt[JCodecMake, Z, *], JCodec] {
-        def apply[A](fa: Alt[JCodecMake, Z, A]): JCodec[A] = {
-          val label = jsonLabel(fa)
-          fa.instance.addHints(Hints(DiscriminatedUnionMember(discriminated.value, label))).get
-        }
-      }.unsafeCache((first +: rest).map(alt => Existential.wrap(alt)))
-
-      def encodeValue(z: Z, out: JsonWriter): Unit = {
-        def writeValue[A](awv: Alt.WithValue[JCodecMake, Z, A]): Unit =
-          altCache(awv.alt).encodeValue(awv.value, out)
-
-        val awv = total(z)
-        writeValue(awv)
-      }
-
-      def decodeKey(in: JsonReader): Z = in.decodeError("Cannot use coproducts as keys")
-
-      def encodeKey(x: Z, out: JsonWriter): Unit = out.encodeError("Cannot use coproducts as keys")
-    }
-
-  def union[Z](
-      first: Alt[JCodecMake, Z, _],
-      rest: Vector[Alt[JCodecMake, Z, _]]
-  )(total: Z => Alt.WithValue[JCodecMake, Z, _]): JCodecMake[Z] = {
-    Hinted[JCodec].from {
-      case Untagged.hint(_) => untaggedUnion(first, rest)(total)
-      case Discriminated.hint(d) => discriminatedUnion(first, rest, d)(total)
-      case _ => taggedUnion(first, rest)(total)
-    }
-  }
-
-  def enumeration[A](
-      to: A => (String, Int),
-      fromName: Map[String, A],
-      fromOrdinal: Map[Int, A]
-  ): JCodecMake[A] = Hinted.static {
-    new JCodec[A] {
-      val expecting: String = s"enumeration: [${fromName.keys.mkString(", ")}]"
-
-      def decodeValue(cursor: Cursor, in: JsonReader): A = {
-        val str = in.readString(null)
-        fromName.get(str) match {
-          case Some(value) => value
-          case None        => in.enumValueError(str)
-        }
-      }
-
-      def encodeValue(x: A, out: JsonWriter): Unit = out.writeVal(to(x)._1)
-
-      def decodeKey(in: JsonReader): A = {
-        val str = in.readKeyAsString()
-        fromName.get(str) match {
-          case Some(value) => value
-          case None        => in.enumValueError(str)
-        }
-      }
-
-      def encodeKey(x: A, out: JsonWriter): Unit = out.writeKey(to(x)._1)
-    }
-  }
-
-  private def jsonLabel[A, Z](field: Field[JCodecMake, Z, A]): String =
+  private def jsonLabel[A, Z](field: Field[Schema, Z, A]): String =
     field.instance.hints
       .get(JsonName)
       .map(_.value)
@@ -662,9 +289,9 @@ private[smithy4s] class SchematicJCodec(maxArity: Int) extends Schematic[JCodecM
   private type Handler = (Cursor, JsonReader, util.HashMap[String, Any]) => Unit
 
   private def fieldHandler[Z, A](
-      field: Field[JCodecMake, Z, A]
+      field: Field[Schema, Z, A]
   ): Handler = {
-    val codec = field.instance.get
+    val codec = apply(field.instance)
     val label = field.label
     if (field.isRequired) { (cursor, in, mmap) =>
       val _ = mmap.put(label, cursor.under(label)(cursor.decode(codec, in)))
@@ -680,23 +307,24 @@ private[smithy4s] class SchematicJCodec(maxArity: Int) extends Schematic[JCodecM
   }
 
   private def fieldEncoder[Z, A](
-      field: Field[JCodecMake, Z, A]
+      field: Field[Schema, Z, A]
   ): (Z, JsonWriter) => Unit = {
-    field.fold(new Field.Folder[JCodecMake, Z, (Z, JsonWriter) => Unit] {
+    field.fold(new Field.Folder[Schema, Z, (Z, JsonWriter) => Unit] {
       def onRequired[AA](
           label: String,
-          instance: JCodecMake[AA],
+          instance: Schema[AA],
           get: Z => AA
       ): (Z, JsonWriter) => Unit = {
-        val codec = instance.get
+        val codec = apply(instance)
         val jLabel = jsonLabel(field)
         if (jLabel.forall(JsonWriter.isNonEscapedAscii)) {
-          (z: Z, out: JsonWriter) => {
-            out.writeNonEscapedAsciiKey(jLabel)
-            codec.encodeValue(get(z), out)
-          }
-        } else {
-          (z: Z, out: JsonWriter) => {
+          (z: Z, out: JsonWriter) =>
+            {
+              out.writeNonEscapedAsciiKey(jLabel)
+              codec.encodeValue(get(z), out)
+            }
+        } else { (z: Z, out: JsonWriter) =>
+          {
             out.writeKey(jLabel)
             codec.encodeValue(get(z), out)
           }
@@ -705,22 +333,23 @@ private[smithy4s] class SchematicJCodec(maxArity: Int) extends Schematic[JCodecM
 
       def onOptional[AA](
           label: String,
-          instance: JCodecMake[AA],
+          instance: Schema[AA],
           get: Z => Option[AA]
       ): (Z, JsonWriter) => Unit = {
-        val codec = instance.get
+        val codec = apply(instance)
         val jLabel = jsonLabel(field)
         if (jLabel.forall(JsonWriter.isNonEscapedAscii)) {
-          (z: Z, out: JsonWriter) => {
-            get(z) match {
-              case Some(aa) =>
-                out.writeNonEscapedAsciiKey(jLabel)
-                codec.encodeValue(aa, out)
-              case _ =>
+          (z: Z, out: JsonWriter) =>
+            {
+              get(z) match {
+                case Some(aa) =>
+                  out.writeNonEscapedAsciiKey(jLabel)
+                  codec.encodeValue(aa, out)
+                case _ =>
+              }
             }
-          }
-        } else {
-          (z: Z, out: JsonWriter) => {
+        } else { (z: Z, out: JsonWriter) =>
+          {
             get(z) match {
               case Some(aa) =>
                 out.writeKey(jLabel)
@@ -733,7 +362,7 @@ private[smithy4s] class SchematicJCodec(maxArity: Int) extends Schematic[JCodecM
     })
   }
 
-  private type Fields[Z] = Vector[Field[JCodecMake, Z, _]]
+  private type Fields[Z] = Vector[Field[Schema, Z, _]]
 
   private def nonPayloadStruct[Z](
       fields: Fields[Z],
@@ -743,25 +372,33 @@ private[smithy4s] class SchematicJCodec(maxArity: Int) extends Schematic[JCodecM
       encode: (Z, JsonWriter, Vector[(Z, JsonWriter) => Unit]) => Unit
   ): JCodec[Z] =
     new JCodec[Z] {
+
       private[this] val documentFields =
         fields.filter { field =>
           val hints = field.instance.hints
           HttpBinding.fromHints(field.label, hints, maybeInputOutput).isEmpty
         }
 
-      private[this] val handlers = new util.HashMap[String, Handler](documentFields.length) {
-        documentFields.foreach(field => put(jsonLabel(field), fieldHandler(field)))
-      }
+      private[this] val handlers =
+        new util.HashMap[String, Handler](documentFields.length) {
+          documentFields.foreach(field =>
+            put(jsonLabel(field), fieldHandler(field))
+          )
+        }
 
-      private[this] val documentEncoders = documentFields.map(field => fieldEncoder(field))
+      private[this] val documentEncoders =
+        documentFields.map(field => fieldEncoder(field))
 
       def expecting: String = "object"
 
       override def canBeKey = false
 
-      def decodeValue(cursor: Cursor, in: JsonReader): Z = decodeValue_(cursor, in)(emptyMetadata)
+      def decodeValue(cursor: Cursor, in: JsonReader): Z =
+        decodeValue_(cursor, in)(emptyMetadata)
 
-      override def decodeMessage(in: JsonReader): scala.collection.Map[String, Any] => Z =
+      override def decodeMessage(
+          in: JsonReader
+      ): scala.collection.Map[String, Any] => Z =
         Cursor.withCursor(expecting)(decodeValue_(_, in))
 
       private def decodeValue_(
@@ -793,26 +430,31 @@ private[smithy4s] class SchematicJCodec(maxArity: Int) extends Schematic[JCodecM
         { (meta: scala.collection.Map[String, Any]) =>
           meta.foreach(kv => buffer.put(kv._1, kv._2))
           val stage2 = new VectorBuilder[Any]
-          fields.foreach(f => stage2 += {
-            val value = buffer.get(f.label)
-            if (f.isRequired) {
-              if (value == null) cursor.requiredFieldError(f.label, f.label)
-              value
-            } else Option(value)
-          })
+          fields.foreach(f =>
+            stage2 += {
+              val value = buffer.get(f.label)
+              if (f.isRequired) {
+                if (value == null) cursor.requiredFieldError(f.label, f.label)
+                value
+              } else Option(value)
+            }
+          )
           const(stage2.result())
         }
       }
 
-      def encodeValue(z: Z, out: JsonWriter): Unit = encode(z, out, documentEncoders)
+      def encodeValue(z: Z, out: JsonWriter): Unit =
+        encode(z, out, documentEncoders)
 
-      def decodeKey(in: JsonReader): Z = in.decodeError("Cannot use products as keys")
+      def decodeKey(in: JsonReader): Z =
+        in.decodeError("Cannot use products as keys")
 
-      def encodeKey(x: Z, out: JsonWriter): Unit = out.encodeError("Cannot use products as keys")
+      def encodeKey(x: Z, out: JsonWriter): Unit =
+        out.encodeError("Cannot use products as keys")
     }
 
-  def payloadStruct[A, Z](
-      payloadField: Field[JCodecMake, Z, _],
+  private def payloadStruct[A, Z](
+      payloadField: Field[Schema, Z, _],
       fields: Fields[Z]
   )(codec: JCodec[payloadField.T], const: Vector[Any] => Z): JCodec[Z] =
     new JCodec[Z] {
@@ -820,9 +462,12 @@ private[smithy4s] class SchematicJCodec(maxArity: Int) extends Schematic[JCodecM
 
       override def canBeKey = false
 
-      def decodeValue(cursor: Cursor, in: JsonReader): Z = decodeValue_(cursor, in)(emptyMetadata)
+      def decodeValue(cursor: Cursor, in: JsonReader): Z =
+        decodeValue_(cursor, in)(emptyMetadata)
 
-      override def decodeMessage(in: JsonReader): scala.collection.Map[String, Any] => Z =
+      override def decodeMessage(
+          in: JsonReader
+      ): scala.collection.Map[String, Any] => Z =
         Cursor.withCursor(expecting)(decodeValue_(_, in))
 
       private def decodeValue_(
@@ -843,162 +488,670 @@ private[smithy4s] class SchematicJCodec(maxArity: Int) extends Schematic[JCodecM
         { (meta: scala.collection.Map[String, Any]) =>
           meta.foreach(kv => buffer.put(kv._1, kv._2))
           val stage2 = new VectorBuilder[Any]
-          fields.foreach(f => stage2 += {
-            val value = buffer.get(f.label)
-            if (f.isRequired) {
-              if (value == null) cursor.requiredFieldError(f.label, f.label)
-              value
-            } else Option(value)
-          })
+          fields.foreach(f =>
+            stage2 += {
+              val value = buffer.get(f.label)
+              if (f.isRequired) {
+                if (value == null) cursor.requiredFieldError(f.label, f.label)
+                value
+              } else Option(value)
+            }
+          )
           const(stage2.result())
         }
       }
 
-      def encodeValue(z: Z, out: JsonWriter): Unit = payloadField.foreachT(z)(codec.encodeValue(_, out))
+      def encodeValue(z: Z, out: JsonWriter): Unit =
+        payloadField.foreachT(z)(codec.encodeValue(_, out))
 
-      def decodeKey(in: JsonReader): Z = in.decodeError("Cannot use products as keys")
+      def decodeKey(in: JsonReader): Z =
+        in.decodeError("Cannot use products as keys")
 
-      def encodeKey(x: Z, out: JsonWriter): Unit = out.encodeError("Cannot use products as keys")
+      def encodeKey(x: Z, out: JsonWriter): Unit =
+        out.encodeError("Cannot use products as keys")
     }
 
-  def struct[Z](
-      fields: Vector[Field[JCodecMake, Z, _]]
-  )(const: Vector[Any] => Z): JCodecMake[Z] =
-    Hinted[JCodec].onHintsOpt[InputOutput, DiscriminatedUnionMember, Z] {
+  private def basicStruct[A, S](
+      fields: Fields[S],
+      maybeInputOutput: Option[InputOutput]
+  )(make: Vector[Any] => S): JCodec[S] = {
+    val encode = {
+      (
+          z: S,
+          out: JsonWriter,
+          documentEncoders: Vector[(S, JsonWriter) => Unit]
+      ) =>
+        out.writeObjectStart()
+        documentEncoders.foreach(encoder => encoder(z, out))
+        out.writeObjectEnd()
+    }
+
+    nonPayloadStruct(fields, maybeInputOutput)(make, encode)
+  }
+  override def struct[S](
+      shapeId: ShapeId,
+      hints: Hints,
+      fields: Vector[SchemaField[S, _]],
+      make: IndexedSeq[Any] => S
+  ): JCodec[S] = {
+    (
+      InputOutput.hint.unapply(hints),
+      DiscriminatedUnionMember.hint.unapply(hints)
+    ) match {
       case (maybeInputOutput, maybeDiscriminated) =>
         fields.find(_.instance.hints.get(HttpPayload).isDefined) match {
           case Some(payloadField) =>
-            val codec = payloadField.instance.get
-            payloadStruct(payloadField, fields)(codec, const)
+            val codec = apply(payloadField.instance)
+            payloadStruct(payloadField, fields)(codec, make)
           case None =>
             maybeDiscriminated match {
               case Some(d) =>
                 val encode = {
-                  (z: Z, out: JsonWriter, documentEncoders: Vector[(Z, JsonWriter) => Unit]) =>
+                  (
+                      z: S,
+                      out: JsonWriter,
+                      documentEncoders: Vector[(S, JsonWriter) => Unit]
+                  ) =>
                     out.writeObjectStart()
                     out.writeKey(d.propertyName)
                     out.writeVal(d.alternativeLabel)
                     documentEncoders.foreach(encoder => encoder(z, out))
                     out.writeObjectEnd()
                 }
-                nonPayloadStruct(fields, maybeInputOutput)(const, encode)
+                nonPayloadStruct(fields, maybeInputOutput)(make, encode)
               case None =>
-                val encode = {
-                  (z: Z, out: JsonWriter, documentEncoders: Vector[(Z, JsonWriter) => Unit]) =>
-                    out.writeObjectStart()
-                    documentEncoders.foreach(encoder => encoder(z, out))
-                    out.writeObjectEnd()
-                }
-                nonPayloadStruct(fields, maybeInputOutput)(const, encode)
+                basicStruct(fields, maybeInputOutput)(make)
             }
         }
     }
+  }
 
-  def withHints[A](fa: JCodecMake[A], hints: Hints): JCodecMake[A] = fa.addHints(hints)
+  private def taggedUnion[Z](
+      alternatives: Vector[Alt[Schema, Z, _]]
+  )(total: Z => Alt.WithValue[Schema, Z, _]): JCodec[Z] =
+    new JCodec[Z] {
+      val expecting: String = "tagged-union"
 
-  def unit: JCodecMake[Unit] = Hinted.static {
+      override def canBeKey: Boolean = false
+
+      def jsonLabel[A](alt: Alt[Schema, Z, A]): String =
+        alt.instance.hints.get(JsonName).map(_.value).getOrElse(alt.label)
+
+      private[this] val handlerMap
+          : util.HashMap[String, (Cursor, JsonReader) => Z] =
+        new util.HashMap[String, (Cursor, JsonReader) => Z] {
+          def handler[A](alt: Alt[Schema, Z, A]) = {
+            val codec = apply(alt.instance)
+            (cursor: Cursor, reader: JsonReader) =>
+              alt.inject(cursor.decode(codec, reader))
+          }
+
+          alternatives.foreach(alt => put(jsonLabel(alt), handler(alt)))
+        }
+
+      def decodeValue(cursor: Cursor, in: JsonReader): Z =
+        if (in.isNextToken('{')) {
+          if (in.isNextToken('}'))
+            in.decodeError("Expected a single key/value pair")
+          else {
+            in.rollbackToken()
+            val key = in.readKeyAsString()
+            val result = cursor.under(key) {
+              val handler = handlerMap.get(key)
+              if (handler eq null) in.discriminatorValueError(key)
+              handler(cursor, in)
+            }
+            if (in.isNextToken('}')) result
+            else {
+              in.rollbackToken()
+              in.decodeError(s"Expected no other field after $key")
+            }
+          }
+        } else in.decodeError("Expected JSON object")
+
+      private[this] val altCache =
+        new PolyFunction[Alt[Schema, Z, *], JCodec] {
+          def apply[A](fa: Alt[Schema, Z, A]): JCodec[A] =
+            self.apply(fa.instance)
+        }.unsafeCache((alternatives).map(alt => Existential.wrap(alt)))
+
+      def encodeValue(z: Z, out: JsonWriter): Unit = {
+        def writeValue[A](awv: Alt.WithValue[Schema, Z, A]): Unit =
+          altCache(awv.alt).encodeValue(awv.value, out)
+
+        val awv = total(z)
+        out.writeObjectStart()
+        out.writeKey(jsonLabel(awv.alt))
+        writeValue(awv)
+        out.writeObjectEnd()
+      }
+
+      def decodeKey(in: JsonReader): Z =
+        in.decodeError("Cannot use coproducts as keys")
+
+      def encodeKey(x: Z, out: JsonWriter): Unit =
+        out.encodeError("Cannot use coproducts as keys")
+    }
+
+  private def untaggedUnion[Z](
+      alternatives: Vector[Alt[Schema, Z, _]]
+  )(total: Z => Alt.WithValue[Schema, Z, _]): JCodec[Z] = new JCodec[Z] {
+    def expecting: String = "untaggedUnion"
+
+    override def canBeKey: Boolean = false
+
+    private[this] val handlerList: Array[(Cursor, JsonReader) => Z] = {
+      val res = Array.newBuilder[(Cursor, JsonReader) => Z]
+      def handler[A](alt: Alt[Schema, Z, A]) = {
+        val codec = apply(alt.instance)
+        (cursor: Cursor, reader: JsonReader) =>
+          alt.inject(cursor.decode(codec, reader))
+      }
+      alternatives.foreach(alt => res += handler(alt))
+      res.result()
+    }
+
+    def decodeValue(cursor: Cursor, in: JsonReader): Z = {
+      var z: Z = null.asInstanceOf[Z]
+      val len = handlerList.length
+      var i = 0
+      while (z == null && i < len) {
+        in.setMark()
+        val handler = handlerList(i)
+        try {
+          z = handler(cursor, in)
+        } catch {
+          case _: Throwable =>
+            in.rollbackToMark()
+            i += 1
+        }
+      }
+      if (z != null) z
+      else cursor.payloadError(this, "Could not decode untagged union")
+    }
+
+    private[this] val altCache =
+      new PolyFunction[Alt[Schema, Z, *], JCodec] {
+        def apply[A](fa: Alt[Schema, Z, A]): JCodec[A] = self.apply(fa.instance)
+      }.unsafeCache((alternatives).map(alt => Existential.wrap(alt)))
+
+    def encodeValue(z: Z, out: JsonWriter): Unit = {
+      def writeValue[A](awv: Alt.WithValue[Schema, Z, A]): Unit =
+        altCache(awv.alt).encodeValue(awv.value, out)
+
+      val awv = total(z)
+      writeValue(awv)
+    }
+
+    def decodeKey(in: JsonReader): Z =
+      in.decodeError("Cannot use coproducts as keys")
+
+    def encodeKey(x: Z, out: JsonWriter): Unit =
+      out.encodeError("Cannot use coproducts as keys")
+  }
+
+  private def discriminatedUnion[Z](
+      alternatives: Vector[Alt[Schema, Z, _]],
+      discriminated: Discriminated
+  )(total: Z => Alt.WithValue[Schema, Z, _]): JCodec[Z] =
+    new JCodec[Z] {
+      def expecting: String = "discriminated-union"
+
+      override def canBeKey: Boolean = false
+
+      def jsonLabel[A](alt: Alt[Schema, Z, A]): String =
+        alt.instance.hints.get(JsonName).map(_.value).getOrElse(alt.label)
+
+      private[this] val handlerMap
+          : util.HashMap[String, (Cursor, JsonReader) => Z] =
+        new util.HashMap[String, (Cursor, JsonReader) => Z] {
+          def handler[A](
+              alt: Alt[Schema, Z, A]
+          ): (Cursor, JsonReader) => Z = {
+            val codec = apply(alt.instance)
+            (cursor: Cursor, reader: JsonReader) =>
+              alt.inject(cursor.decode(codec, reader))
+          }
+
+          alternatives.foreach(alt => put(jsonLabel(alt), handler(alt)))
+        }
+
+      def decodeValue(cursor: Cursor, in: JsonReader): Z =
+        if (in.isNextToken('{')) {
+          in.setMark()
+          if (in.skipToKey(discriminated.value)) {
+            val key = in.readString("")
+            in.rollbackToMark()
+            in.rollbackToken()
+            cursor.under(key) {
+              val handler = handlerMap.get(key)
+              if (handler eq null) in.discriminatorValueError(key)
+              handler(cursor, in)
+            }
+          } else
+            in.decodeError(
+              s"Unable to find discriminator ${discriminated.value}"
+            )
+        } else in.decodeError("Expected JSON object")
+
+      private[this] val altCache =
+        new PolyFunction[Alt[Schema, Z, *], JCodec] {
+          def apply[A](fa: Alt[Schema, Z, A]): JCodec[A] = {
+            val label = jsonLabel(fa)
+            self.apply(
+              fa.instance
+                .addHints(
+                  Hints(DiscriminatedUnionMember(discriminated.value, label))
+                )
+            )
+          }
+        }.unsafeCache((alternatives).map(alt => Existential.wrap(alt)))
+
+      def encodeValue(z: Z, out: JsonWriter): Unit = {
+        def writeValue[A](awv: Alt.WithValue[Schema, Z, A]): Unit =
+          altCache(awv.alt).encodeValue(awv.value, out)
+
+        val awv = total(z)
+        writeValue(awv)
+      }
+
+      def decodeKey(in: JsonReader): Z =
+        in.decodeError("Cannot use coproducts as keys")
+
+      def encodeKey(x: Z, out: JsonWriter): Unit =
+        out.encodeError("Cannot use coproducts as keys")
+    }
+
+  override def union[U](
+      shapeId: ShapeId,
+      hints: Hints,
+      alternatives: Vector[SchemaAlt[U, _]],
+      dispatch: U => Alt.SchemaAndValue[U, _]
+  ): JCodec[U] = hints match {
+    case Untagged.hint(_)      => untaggedUnion(alternatives)(dispatch)
+    case Discriminated.hint(d) => discriminatedUnion(alternatives, d)(dispatch)
+    case _                     => taggedUnion(alternatives)(dispatch)
+  }
+  override def biject[A, B](
+      schema: Schema[A],
+      to: A => B,
+      from: B => A
+  ): JCodec[B] =
+    apply(schema).biject(to, from)
+  override def surject[A, B](
+      schema: Schema[A],
+      to: Refinement[A, B],
+      from: B => A
+  ): JCodec[B] =
+    JCodec.jcodecInvariant
+      .xmap(apply(schema))(to.asFunction, from)
+  override def lazily[A](suspend: Lazy[Schema[A]]): JCodec[A] = new JCodec[A] {
+    lazy val underlying = apply(suspend.value)
+
+    def expecting: String = underlying.expecting
+
+    def decodeValue(cursor: Cursor, in: JsonReader): A =
+      underlying.decodeValue(cursor, in)
+
+    def encodeValue(x: A, out: JsonWriter): Unit =
+      underlying.encodeValue(x, out)
+
+    def decodeKey(in: JsonReader): A = underlying.decodeKey(in)
+
+    def encodeKey(x: A, out: JsonWriter): Unit = underlying.encodeKey(x, out)
+  }
+}
+
+private[smithy4s] object PrimitiveJCodecs {
+  val boolean: JCodec[Boolean] =
+    new JCodec[Boolean] {
+      def expecting: String = "boolean"
+
+      def decodeValue(cursor: Cursor, in: JsonReader): Boolean =
+        in.readBoolean()
+
+      def encodeValue(x: Boolean, out: JsonWriter): Unit = out.writeVal(x)
+
+      def decodeKey(in: JsonReader): Boolean = in.readKeyAsBoolean()
+
+      def encodeKey(x: Boolean, out: JsonWriter): Unit = out.writeKey(x)
+    }
+
+  val string: JCodec[String] =
+    new JCodec[String] {
+      def expecting: String = "string"
+
+      def decodeValue(cursor: Cursor, in: JsonReader): String =
+        in.readString(null)
+
+      def encodeValue(x: String, out: JsonWriter): Unit = out.writeVal(x)
+
+      def decodeKey(in: JsonReader): String = in.readKeyAsString()
+
+      def encodeKey(x: String, out: JsonWriter): Unit = out.writeKey(x)
+    }
+
+  val int: JCodec[Int] =
+    new JCodec[Int] {
+      def expecting: String = "int"
+
+      def decodeValue(cursor: Cursor, in: JsonReader): Int = in.readInt()
+
+      def encodeValue(x: Int, out: JsonWriter): Unit = out.writeVal(x)
+
+      def decodeKey(in: JsonReader): Int = in.readKeyAsInt()
+
+      def encodeKey(x: Int, out: JsonWriter): Unit = out.writeKey(x)
+    }
+
+  val long: JCodec[Long] =
+    new JCodec[Long] {
+      def expecting: String = "long"
+
+      def decodeValue(cursor: Cursor, in: JsonReader): Long = in.readLong()
+
+      def encodeValue(x: Long, out: JsonWriter): Unit = out.writeVal(x)
+
+      def decodeKey(in: JsonReader): Long = in.readKeyAsLong()
+
+      def encodeKey(x: Long, out: JsonWriter): Unit = out.writeKey(x)
+    }
+
+  val float: JCodec[Float] =
+    new JCodec[Float] {
+      def expecting: String = "float"
+
+      def decodeValue(cursor: Cursor, in: JsonReader): Float = in.readFloat()
+
+      def encodeValue(x: Float, out: JsonWriter): Unit = out.writeVal(x)
+
+      def decodeKey(in: JsonReader): Float = in.readKeyAsFloat()
+
+      def encodeKey(x: Float, out: JsonWriter): Unit = out.writeKey(x)
+    }
+
+  val double: JCodec[Double] =
+    new JCodec[Double] {
+      def expecting: String = "double"
+
+      def decodeValue(cursor: Cursor, in: JsonReader): Double = in.readDouble()
+
+      def encodeValue(x: Double, out: JsonWriter): Unit = out.writeVal(x)
+
+      def decodeKey(in: JsonReader): Double = in.readKeyAsDouble()
+
+      def encodeKey(x: Double, out: JsonWriter): Unit = out.writeKey(x)
+    }
+
+  val short: JCodec[Short] =
+    new JCodec[Short] {
+      def expecting: String = "short"
+
+      def decodeValue(cursor: Cursor, in: JsonReader): Short = in.readShort()
+
+      def encodeValue(x: Short, out: JsonWriter): Unit = out.writeVal(x)
+
+      def decodeKey(in: JsonReader): Short = in.readKeyAsShort()
+
+      def encodeKey(x: Short, out: JsonWriter): Unit = out.writeKey(x)
+    }
+
+  val byte: JCodec[Byte] =
+    new JCodec[Byte] {
+      def expecting: String = "byte"
+
+      def decodeValue(cursor: Cursor, in: JsonReader): Byte = in.readByte()
+
+      def encodeValue(x: Byte, out: JsonWriter): Unit = out.writeVal(x)
+
+      def decodeKey(in: JsonReader): Byte = in.readKeyAsByte()
+
+      def encodeKey(x: Byte, out: JsonWriter): Unit = out.writeKey(x)
+    }
+
+  val bytes: JCodec[ByteArray] =
+    new JCodec[ByteArray] {
+      def expecting: String = "byte-array" // or blob?
+
+      override def canBeKey: Boolean = false
+
+      def decodeValue(cursor: Cursor, in: JsonReader): ByteArray = ByteArray(
+        in.readBase64AsBytes(null)
+      )
+
+      def encodeValue(x: ByteArray, out: JsonWriter): Unit =
+        out.writeBase64Val(x.array, doPadding = true)
+
+      def decodeKey(in: JsonReader): ByteArray =
+        in.decodeError("Cannot use byte array as key")
+
+      def encodeKey(x: ByteArray, out: JsonWriter): Unit =
+        out.encodeError("Cannot use byte array as key")
+    }
+
+  val bigdecimal: JCodec[BigDecimal] =
+    new JCodec[BigDecimal] {
+      def expecting: String = "big-decimal"
+
+      def decodeValue(cursor: Cursor, in: JsonReader): BigDecimal =
+        in.readBigDecimal(null)
+
+      def decodeKey(in: JsonReader): BigDecimal = in.readKeyAsBigDecimal()
+
+      def encodeValue(value: BigDecimal, out: JsonWriter): Unit =
+        out.writeVal(value)
+
+      def encodeKey(value: BigDecimal, out: JsonWriter): Unit =
+        out.writeVal(value)
+    }
+
+  val bigint: JCodec[BigInt] =
+    new JCodec[BigInt] {
+      def expecting: String = "big-int"
+
+      def decodeValue(cursor: Cursor, in: JsonReader): BigInt =
+        in.readBigInt(null)
+
+      def decodeKey(in: JsonReader): BigInt = in.readKeyAsBigInt()
+
+      def encodeValue(value: BigInt, out: JsonWriter): Unit =
+        out.writeVal(value)
+
+      def encodeKey(value: BigInt, out: JsonWriter): Unit = out.writeVal(value)
+    }
+
+  val uuid: JCodec[UUID] =
+    new JCodec[UUID] {
+      def expecting: String = "uuid"
+
+      def decodeValue(cursor: Cursor, in: JsonReader): UUID = in.readUUID(null)
+
+      def encodeValue(x: UUID, out: JsonWriter): Unit = out.writeVal(x)
+
+      def decodeKey(in: JsonReader): UUID = in.readKeyAsUUID()
+
+      def encodeKey(x: UUID, out: JsonWriter): Unit = out.writeKey(x)
+    }
+
+  val unit: JCodec[Unit] =
     new JCodec[Unit] {
       def expecting: String = "empty object"
 
       override def canBeKey: Boolean = false
 
       def decodeValue(cursor: Cursor, in: JsonReader): Unit =
-        if (!in.isNextToken('{') || !in.isNextToken('}')) in.decodeError("Expected empty object")
+        if (!in.isNextToken('{') || !in.isNextToken('}'))
+          in.decodeError("Expected empty object")
 
       def encodeValue(x: Unit, out: JsonWriter): Unit = {
         out.writeObjectStart()
         out.writeObjectEnd()
       }
 
-      def decodeKey(in: JsonReader): Unit = in.decodeError("Cannot use Unit as keys")
+      def decodeKey(in: JsonReader): Unit =
+        in.decodeError("Cannot use Unit as keys")
 
-      def encodeKey(x: Unit, out: JsonWriter): Unit = out.encodeError("Cannot use Unit as keys")
+      def encodeKey(x: Unit, out: JsonWriter): Unit =
+        out.encodeError("Cannot use Unit as keys")
     }
-  }
 
-  def document: JCodecMake[Document] = Hinted.static {
-    new JCodec[Document] {
-      override def canBeKey: Boolean = false
+  def document(maxArity: Int): JCodec[Document] = new JCodec[Document] {
+    import Document._
+    override def canBeKey: Boolean = false
 
-      def encodeValue(doc: Document, out: JsonWriter): Unit = doc match {
-        case s: DString  => out.writeVal(s.value)
-        case b: DBoolean => out.writeVal(b.value)
-        case n: DNumber  => out.writeVal(n.value)
-        case a: DArray =>
-          out.writeArrayStart()
-          a.value.foreach(encodeValue(_, out))
-          out.writeArrayEnd()
-        case o: DObject =>
-          out.writeObjectStart()
-          o.value.foreach { kv =>
-            out.writeKey(kv._1)
-            encodeValue(kv._2, out)
+    def encodeValue(doc: Document, out: JsonWriter): Unit = doc match {
+      case s: DString  => out.writeVal(s.value)
+      case b: DBoolean => out.writeVal(b.value)
+      case n: DNumber  => out.writeVal(n.value)
+      case a: DArray =>
+        out.writeArrayStart()
+        a.value.foreach(encodeValue(_, out))
+        out.writeArrayEnd()
+      case o: DObject =>
+        out.writeObjectStart()
+        o.value.foreach { kv =>
+          out.writeKey(kv._1)
+          encodeValue(kv._2, out)
+        }
+        out.writeObjectEnd()
+      case _ => out.writeNull()
+    }
+
+    def decodeKey(in: JsonReader): Document =
+      in.decodeError("Cannot use JSON document as keys")
+
+    def encodeKey(x: Document, out: JsonWriter): Unit =
+      out.encodeError("Cannot use JSON documents as keys")
+
+    def expecting: String = "JSON document"
+
+    // Borrowed from: https://github.com/plokhotnyuk/jsoniter-scala/blob/e80d51019b39efacff9e695de97dce0c23ae9135/jsoniter-scala-benchmark/src/main/scala/io/circe/CirceJsoniter.scala
+    def decodeValue(cursor: Cursor, in: JsonReader): Document = {
+      val b = in.nextToken()
+      if (b == '"') {
+        in.rollbackToken()
+        new DString(in.readString(null))
+      } else if (b == 'f' || b == 't') {
+        in.rollbackToken()
+        new DBoolean(in.readBoolean())
+      } else if ((b >= '0' && b <= '9') || b == '-') {
+        in.rollbackToken()
+        new DNumber(in.readBigDecimal(null))
+      } else if (b == '[') {
+        new DArray({
+          if (in.isNextToken(']')) IndexedSeq.empty[Document]
+          else {
+            in.rollbackToken()
+            var arr = new Array[Document](4)
+            var i = 0
+            while ({
+              if (i >= maxArity) maxArityError(cursor)
+              if (i == arr.length) arr = java.util.Arrays.copyOf(arr, i << 1)
+              arr(i) = decodeValue(in, null)
+              i += 1
+              in.isNextToken(',')
+            }) {}
+
+            if (in.isCurrentToken(']')) ArraySeq.unsafeWrapArray {
+              if (i == arr.length) arr
+              else java.util.Arrays.copyOf(arr, i)
+            }
+            else in.arrayEndOrCommaError()
           }
-          out.writeObjectEnd()
-        case _ => out.writeNull()
-      }
-
-      def decodeKey(in: JsonReader): Document = in.decodeError("Cannot use JSON document as keys")
-
-      def encodeKey(x: Document, out: JsonWriter): Unit = out.encodeError("Cannot use JSON documents as keys")
-
-      def expecting: String = "JSON document"
-
-      // Borrowed from: https://github.com/plokhotnyuk/jsoniter-scala/blob/e80d51019b39efacff9e695de97dce0c23ae9135/jsoniter-scala-benchmark/src/main/scala/io/circe/CirceJsoniter.scala
-      def decodeValue(cursor: Cursor, in: JsonReader): Document = {
-        val b = in.nextToken()
-        if (b == '"') {
-          in.rollbackToken()
-          new DString(in.readString(null))
-        } else if (b == 'f' || b == 't') {
-          in.rollbackToken()
-          new DBoolean(in.readBoolean())
-        } else if ((b >= '0' && b <= '9') || b == '-') {
-          in.rollbackToken()
-          new DNumber(in.readBigDecimal(null))
-        } else if (b == '[') {
-          new DArray({
-            if (in.isNextToken(']')) IndexedSeq.empty[Document]
-            else {
-              in.rollbackToken()
-              var arr = new Array[Document](4)
-              var i = 0
-              while ({
-                if (i >= maxArity) maxArityError(cursor)
-                if (i == arr.length) arr = java.util.Arrays.copyOf(arr, i << 1)
-                arr(i) = decodeValue(in, null)
-                i += 1
-                in.isNextToken(',')
-              }) {}
-              if (in.isCurrentToken(']')) ArraySeq.unsafeWrapArray {
-                if (i == arr.length) arr
-                else java.util.Arrays.copyOf(arr, i)
-              } else in.arrayEndOrCommaError()
-            }
-          })
-        } else if (b == '{') {
-          new DObject({
-            if (in.isNextToken('}')) Map.empty
-            else {
-              in.rollbackToken()
-              // We use the maxArity limit to mitigate DoS vulnerability in default Scala `Map` implementation: https://github.com/scala/bug/issues/11203
-              val obj = Map.newBuilder[String, Document]
-              var i = 0
-              while ({
-                if (i >= maxArity) maxArityError(cursor)
-                obj += ((in.readKeyAsString(), decodeValue(in, null)))
-                i += 1
-                in.isNextToken(',')
-              }) {}
-              if (in.isCurrentToken('}')) obj.result()
-              else in.objectEndOrCommaError()
-            }
-          })
-        } else in.readNullOrError(DNull, "expected JSON document")
-      }
-
-      private def maxArityError(cursor: Cursor): Nothing =
-        throw cursor.payloadError(this, s"input $expecting exceeded max arity of `$maxArity`")
+        })
+      } else if (b == '{') {
+        new DObject({
+          if (in.isNextToken('}')) Map.empty
+          else {
+            in.rollbackToken()
+            // We use the maxArity limit to mitigate DoS vulnerability in default Scala `Map` implementation: https://github.com/scala/bug/issues/11203
+            val obj = Map.newBuilder[String, Document]
+            var i = 0
+            while ({
+              if (i >= maxArity) maxArityError(cursor)
+              obj += ((in.readKeyAsString(), decodeValue(in, null)))
+              i += 1
+              in.isNextToken(',')
+            }) {}
+            if (in.isCurrentToken('}')) obj.result()
+            else in.objectEndOrCommaError()
+          }
+        })
+      } else in.readNullOrError(DNull, "expected JSON document")
     }
+
+    private def maxArityError(cursor: Cursor): Nothing =
+      throw cursor.payloadError(
+        this,
+        s"input $expecting exceeded max arity of `$maxArity`"
+      )
   }
+
+  private def forFormat[T](
+      name: String,
+      json: JsonInOut[T, _]
+  ) =
+    new JCodec[Timestamp] {
+      val expecting: String = name
+
+      def decodeValue(cursor: Cursor, in: JsonReader): Timestamp =
+        json.decodeValue(in)
+
+      def encodeValue(x: Timestamp, out: JsonWriter): Unit =
+        json.encodeValue(x, out)
+
+      // key decoding/encoding ignores the format and support only epoch
+      def decodeKey(in: JsonReader): Timestamp =
+        Timestamp.fromEpochSecond(in.readKeyAsLong())
+      def encodeKey(x: Timestamp, out: JsonWriter): Unit =
+        out.writeKey(x.epochSecond)
+    }
+
+  private trait JsonInOut[T, Out] {
+    def decodeValue(in: JsonReader): Timestamp
+    def encodeValue(x: Timestamp, out: JsonWriter): Unit =
+      toOut(toRaw(x), out)
+
+    protected def toRaw(ts: Timestamp): T
+    protected def fromRaw(t: T): Out
+    protected def fromIn(in: JsonReader): T
+    protected def toOut(value: T, out: JsonWriter): Unit
+  }
+  private val longJsonInOut = new JsonInOut[Long, Timestamp] {
+    def decodeValue(in: JsonReader): Timestamp =
+      fromRaw(fromIn(in))
+    def toRaw(ts: Timestamp): Long = ts.epochSecond
+    def fromRaw(t: Long): Timestamp = Timestamp.fromEpochSecond(t)
+    def fromIn(in: JsonReader): Long = in.readLong()
+    def toOut(value: Long, out: JsonWriter): Unit = out.writeVal(value)
+  }
+  private def stringJsonInOut(format: TimestampFormat) =
+    new JsonInOut[String, Option[Timestamp]] {
+      def decodeValue(in: JsonReader): Timestamp =
+        fromRaw(fromIn(in)) match {
+          case Some(value) => value
+          case None        => in.decodeError("Wrong timestamp format")
+        }
+
+      def toRaw(ts: Timestamp): String = ts.format(format)
+      def fromRaw(t: String): Option[Timestamp] = Timestamp.parse(t, format)
+      def fromIn(in: JsonReader): String = in.readString(null)
+      def toOut(value: String, out: JsonWriter): Unit = out.writeVal(value)
+    }
+
+  private val dateTimeFormat = stringJsonInOut(TimestampFormat.DATE_TIME)
+  val timestampDateTime = forFormat[String](
+    Timestamp.showFormat(TimestampFormat.DATE_TIME),
+    dateTimeFormat
+  )
+  private val httpDateFormat = stringJsonInOut(TimestampFormat.HTTP_DATE)
+  val timestampHttpDate = forFormat[String](
+    Timestamp.showFormat(TimestampFormat.HTTP_DATE),
+    httpDateFormat
+  )
+
+  val timestampEpoch = forFormat[Long](
+    Timestamp.showFormat(TimestampFormat.EPOCH_SECONDS),
+    longJsonInOut
+  )
 }

--- a/modules/json/src/smithy4s/http/json/SchematicJCodec.scala
+++ b/modules/json/src/smithy4s/http/json/SchematicJCodec.scala
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2021 Disney Streaming
+ *  Copyright 2021-2022 Disney Streaming
  *
  *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/modules/json/src/smithy4s/http/json/codecs.scala
+++ b/modules/json/src/smithy4s/http/json/codecs.scala
@@ -26,7 +26,7 @@ import smithy4s.internals.InputOutput
 import smithy4s.schema.SchemaVisitor
 
 final case class codecs(hintMask: HintMask = codecs.defaultHintMask)
-    extends JsonCodecAPI(codecs.schemaVisitorJCodec) // TODO hint mask
+    extends JsonCodecAPI(codecs.schemaVisitorJCodec, Some(hintMask))
 
 object codecs {
 

--- a/modules/json/src/smithy4s/http/json/codecs.scala
+++ b/modules/json/src/smithy4s/http/json/codecs.scala
@@ -23,9 +23,10 @@ import smithy4s.api.Discriminated
 import smithy4s.api.Untagged
 import smithy4s.internals.DiscriminatedUnionMember
 import smithy4s.internals.InputOutput
+import smithy4s.schema.SchemaVisitor
 
 final case class codecs(hintMask: HintMask = codecs.defaultHintMask)
-    extends JsonCodecAPI(HintMask.mask(codecs.schematicJCodec, hintMask))
+    extends JsonCodecAPI(codecs.schemaVisitorJCodec) // TODO hint mask
 
 object codecs {
 
@@ -39,7 +40,7 @@ object codecs {
       DiscriminatedUnionMember
     )
 
-  private[smithy4s] val schematicJCodec: Schematic[JCodec.JCodecMake] =
-    new SchematicJCodec(maxArity = 1024)
+  private[smithy4s] val schemaVisitorJCodec: SchemaVisitor[JCodec] =
+    new SchemaVisitorJCodec(maxArity = 1024)
 
 }

--- a/modules/json/test/src/smithy4s/http/json/DocumentPropertyTests.scala
+++ b/modules/json/test/src/smithy4s/http/json/DocumentPropertyTests.scala
@@ -26,7 +26,7 @@ import smithy4s.scalacheck.DynData
 import weaver._
 import weaver.scalacheck._
 
-import codecs.schematicJCodec
+import codecs.schemaVisitorJCodec
 
 object DocumentPropertyTests extends SimpleIOSuite with Checkers {
 
@@ -46,7 +46,7 @@ object DocumentPropertyTests extends SimpleIOSuite with Checkers {
     Show.fromToString
 
   implicit val documentCodec: JCodec[Document] =
-    Schema.document.compile(schematicJCodec).get
+    Schema.document.compile(schemaVisitorJCodec)
 
   loggedTest(
     "Going through json directly or via the adt give the same results"
@@ -57,7 +57,7 @@ object DocumentPropertyTests extends SimpleIOSuite with Checkers {
     forall(genSchemaData) { schemaAndData =>
       val (schema, data) = schemaAndData
       implicit val codec: JCodec[Any] =
-        schema.compile(schematicJCodec).get
+        schema.compile(schemaVisitorJCodec)
       val decoder = Document.Decoder.fromSchema(schema)
       val encoder = Document.Encoder.fromSchema(schema)
       val schemaStr = schema.compile(smithy4s.schema.SchematicRepr)

--- a/modules/json/test/src/smithy4s/http/json/SchematicJCodecPropertyTests.scala
+++ b/modules/json/test/src/smithy4s/http/json/SchematicJCodecPropertyTests.scala
@@ -32,7 +32,7 @@ import smithy4s.schema.Schema._
 import weaver._
 import weaver.scalacheck._
 
-import codecs.schematicJCodec
+import codecs.schemaVisitorJCodec
 
 object SchematicJCodecPropertyTests extends SimpleIOSuite with Checkers {
 
@@ -59,7 +59,7 @@ object SchematicJCodecPropertyTests extends SimpleIOSuite with Checkers {
     forall(genSchemaData) { schemaAndData =>
       val (schema, data) = schemaAndData
       implicit val codec: JCodec[Any] =
-        schema.compile(schematicJCodec).get
+        schema.compile(schemaVisitorJCodec)
       val schemaStr = schema.compile(smithy4s.schema.SchematicRepr)
       val json = writeToString(data)
       val config = ReaderConfig.withThrowReaderExceptionWithStackTrace(true)
@@ -86,7 +86,7 @@ object SchematicJCodecPropertyTests extends SimpleIOSuite with Checkers {
     forall(gen) { case (hints, schema, data) =>
       val hint = hints.all.head
       implicit val codec: JCodec[Any] =
-        schema.compile(schematicJCodec).get
+        schema.compile(schemaVisitorJCodec)
       val json = writeToString(data)
       val config = ReaderConfig.withThrowReaderExceptionWithStackTrace(true)
       val result = scala.util.Try(readFromString[Any](json, config)).toEither


### PR DESCRIPTION
1. renamed SchematicJCodec => SchemaVisitorJCodec
2. most code is the same apart from a few changes (listed below)


noticeable change:
    1. untaggedUnion, discriminatedUnion and taggedUnion signature have changed and received all the alternatives rather than first and rest
    2. pre-computed document, various timestamp format codecs
    
I cherry picked @plokhotnyuk changes. But some of their changes are not formatted so you'll find some differences