### PR TITLE
Add `Alt.WithValue.matchAs`

### DIFF
--- a/modules/core/src/smithy4s/schema/Alt.scala
+++ b/modules/core/src/smithy4s/schema/Alt.scala
@@ -45,6 +45,14 @@ object Alt {
   final case class WithValue[F[_], U, A](alt: Alt[F, U, A], value: A) {
     def mapK[G[_]](fk: PolyFunction[F, G]): WithValue[G, U, A] =
       WithValue(alt.mapK(fk), value)
+
+    /**
+     * Helper function to identify this `WithValue` as an instance of another `Alt`.
+     */
+    def matchAs[B](another: Alt[F, U, B]): Option[WithValue[F, U, B]] =
+      if (another eq alt)
+        Some(this.asInstanceOf[WithValue[F, U, B]])
+      else None
   }
 
   def liftK[F[_], G[_], U](

--- a/modules/core/test/src/smithy4s/schema/AltSpec.scala
+++ b/modules/core/test/src/smithy4s/schema/AltSpec.scala
@@ -1,0 +1,42 @@
+package smithy4s.schema
+import weaver._
+import smithy4s.example._
+
+object AltSpec extends FunSuite {
+
+  test("Alt.WithValue.matchAs: positive case") {
+
+    val instance =
+      ForecastResult.RainCase.alt(ForecastResult.RainCase(ChanceOfRain(42.0f)))
+
+    val matched = instance.matchAs(ForecastResult.RainCase.alt)
+
+    assert(matched == Some(instance))
+  }
+
+  test("Alt.WithValue.matchAs: negative case") {
+    val instance =
+      ForecastResult.RainCase.alt(ForecastResult.RainCase(ChanceOfRain(42.0f)))
+
+    val matched = instance.matchAs(ForecastResult.SunCase.alt)
+
+    assert(matched.isEmpty)
+  }
+
+  test("Alt.WithValue.matchAs used in a Schematic: first case") {
+    val showInstance = ForecastResult.schema.compile(ShowSchematic)
+
+    val result = showInstance.show(ForecastResult.RainCase(ChanceOfRain(42.0f)))
+
+    assert(result == "union case rain: 42.0")
+  }
+
+  test("Alt.WithValue.matchAs used in a Schematic: subsequent case") {
+
+    val showInstance = ForecastResult.schema.compile(ShowSchematic)
+
+    val result = showInstance.show(ForecastResult.SunCase(UVIndex(50)))
+
+    assert(result == "union case sun: 50")
+  }
+}

--- a/modules/core/test/src/smithy4s/schema/ShowSchematic.scala
+++ b/modules/core/test/src/smithy4s/schema/ShowSchematic.scala
@@ -1,0 +1,66 @@
+package smithy4s.schema
+
+import smithy4s.Hints
+import cats.implicits._
+
+// Simplified version of Show, meant for testing
+trait SimpleShow[A] {
+  def show(a: A): String
+}
+
+object ShowSchematic extends StubSchematic[SimpleShow] {
+
+  def default[A]: SimpleShow[A] = _ => "something"
+
+  override def int: SimpleShow[Int] = _.toString
+  override def float: SimpleShow[Float] = "%.1f".format(_)
+
+  override def bijection[A, B](
+      f: SimpleShow[A],
+      to: A => B,
+      from: B => A
+  ): SimpleShow[B] = b => f.show(from(b))
+
+  override def struct[S](
+      fields: Vector[Field[SimpleShow, S, _]]
+  )(const: Vector[Any] => S): SimpleShow[S] =
+    v =>
+      fields
+        .map {
+          def handle[A](field: Field[SimpleShow, S, A]): String = {
+            val fieldValue = field.instanceA(new Field.ToOptional[SimpleShow] {
+              def apply[U](fa: SimpleShow[U]): SimpleShow[Option[U]] =
+                _.fold("None")(v => s"Some(${fa.show(v)})")
+            })
+
+            s"${field.label}: $fieldValue"
+          }
+
+          handle(_)
+        }
+        .mkString(", ")
+
+  override def union[S](
+      first: Alt[SimpleShow, S, _],
+      rest: Vector[Alt[SimpleShow, S, _]]
+  )(
+      total: S => Alt.WithValue[SimpleShow, S, _]
+  ): SimpleShow[S] = { value =>
+    {
+      val tot = total(value)
+      (first +: rest)
+        .collectFirstSome {
+          def handle[A](alt: Alt[SimpleShow, S, A]) = {
+            tot.matchAs(alt).map { result =>
+              s"union case ${result.alt.label}: ${result.alt.instance.show(result.value)}"
+            }
+          }
+
+          handle(_)
+        }
+        .getOrElse(sys.error("impossible - incomplete union schema"))
+    }
+  }
+  override def withHints[A](fa: SimpleShow[A], hints: Hints): SimpleShow[A] = fa
+
+}


### PR DESCRIPTION
Small utility that should serve as a relatively efficient way of matching against available `Alt`s.