### PR TITLE
Switch weaver to munit in core Module.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -114,6 +114,7 @@ lazy val docs =
 lazy val core = projectMatrix
   .in(file("modules/core"))
   .settings(
+    Test / fork := virtualAxes.value.contains(VirtualAxis.jvm),
     allowedNamespaces := Seq(
       "smithy.api",
       "smithy.waiters",
@@ -452,11 +453,10 @@ lazy val json = projectMatrix
     `scalacheck` % "test -> compile"
   )
   .settings(
-    isCE3 := true,
     libraryDependencies ++= Seq(
       Dependencies.Jsoniter.value,
-      Dependencies.Weaver.cats.value % Test,
-      Dependencies.Weaver.scalacheck.value % Test
+      Dependencies.Munit.core.value % Test,
+      Dependencies.Munit.scalacheck.value % Test
     ),
     Test / fork := virtualAxes.value.contains(VirtualAxis.jvm)
   )

--- a/build.sbt
+++ b/build.sbt
@@ -125,10 +125,10 @@ lazy val core = projectMatrix
       .map(Boilerplate.gen(_, Boilerplate.BoilerplateModule.Core))
       .taskValue,
     libraryDependencies ++= Seq(Dependencies.collectionsCompat.value),
-    isCE3 := true,
     libraryDependencies ++= Seq(
-      Dependencies.Weaver.cats.value % Test,
-      Dependencies.Weaver.scalacheck.value % Test
+      Dependencies.Cats.core.value % Test,
+      Dependencies.Munit.core.value % Test,
+      Dependencies.Munit.scalacheck.value % Test
     ),
     Test / allowedNamespaces := Seq(
       "smithy4s.example"
@@ -693,6 +693,15 @@ lazy val Dependencies = new {
       Def.setting(
         "com.disneystreaming" %%% "weaver-scalacheck" % weaverVersion.value
       )
+  }
+
+  object Munit {
+    val munitVersion = "0.7.29"
+
+    val core: Def.Initialize[ModuleID] =
+      Def.setting("org.scalameta" %%% "munit" % munitVersion)
+    val scalacheck: Def.Initialize[ModuleID] =
+      Def.setting("org.scalameta" %%% "munit-scalacheck" % munitVersion)
   }
 
   val Scalacheck = new {

--- a/modules/core/test/src-js/smithy4s/JsConvertersSpec.scala
+++ b/modules/core/test/src-js/smithy4s/JsConvertersSpec.scala
@@ -16,11 +16,11 @@
 
 package smithy4s
 
-import weaver._
+import munit._
 
 import scala.scalajs.js
 
-object JsConvertersSpec extends FunSuite {
+class JsConvertersSpec() extends FunSuite {
 
   test("object - strings") {
     val input = js.Dictionary("one" -> "1")

--- a/modules/core/test/src-js/smithy4s/Platform.scala
+++ b/modules/core/test/src-js/smithy4s/Platform.scala
@@ -1,0 +1,6 @@
+package smithy4s
+
+object Platform {
+  def isJS = true
+  def isJVM = false
+}

--- a/modules/core/test/src-jvm/smithy4s/Platform.scala
+++ b/modules/core/test/src-jvm/smithy4s/Platform.scala
@@ -1,0 +1,6 @@
+package smithy4s
+
+object Platform {
+  def isJS = false
+  def isJVM = true
+}

--- a/modules/core/test/src-jvm/smithy4s/TimestampSpec.scala
+++ b/modules/core/test/src-jvm/smithy4s/TimestampSpec.scala
@@ -76,7 +76,8 @@ class TimestampSpec() extends munit.FunSuite with munit.ScalaCheckSuite {
       val ts = Timestamp.fromInstant(i)
       val formatted = ts.format(TimestampFormat.DATE_TIME)
       val parsed = Timestamp.parse(formatted, TimestampFormat.DATE_TIME)
-      expect.same(formatted, i.toString) && expect.same(parsed, Some(ts))
+      expect.same(formatted, i.toString)
+      expect.same(parsed, Some(ts))
     }
   }
 

--- a/modules/core/test/src-jvm/smithy4s/TimestampSpec.scala
+++ b/modules/core/test/src-jvm/smithy4s/TimestampSpec.scala
@@ -20,14 +20,10 @@ import cats.Show
 import org.scalacheck.Gen.Choose
 import org.scalacheck._
 import smithy.api.TimestampFormat
-import weaver._
-import weaver.scalacheck._
 import java.time._
+import org.scalacheck.Prop._
 
-object TimestampSpec extends SimpleIOSuite with Checkers {
-
-  override def checkConfig: CheckConfig =
-    super.checkConfig.copy(minimumSuccessful = 10000)
+class TimestampSpec() extends munit.FunSuite with munit.ScalaCheckSuite {
 
   private implicit val arbInstant: Arbitrary[Instant] = {
     implicit val c: Choose[Instant] =
@@ -52,31 +48,31 @@ object TimestampSpec extends SimpleIOSuite with Checkers {
 
   private implicit val showInstant: Show[Instant] = Show.fromToString
 
-  test("Converts from/to Instant") {
-    forall { (i: Instant) =>
+  property("Converts from/to Instant") {
+    forAll { (i: Instant) =>
       val ts = Timestamp.fromInstant(i)
       expect.same(ts.toInstant, i)
     }
   }
 
-  test("Converts from/to OffsetDateTime") {
-    forall { (i: Instant) =>
+  property("Converts from/to OffsetDateTime") {
+    forAll { (i: Instant) =>
       val odt = OffsetDateTime.ofInstant(i, ZoneOffset.UTC)
       val ts = Timestamp.fromOffsetDateTime(odt)
       expect.same(ts.toOffsetDateTime, odt)
     }
   }
 
-  test("Converts from/to LocalDate") {
-    forall { (i: Instant) =>
+  property("Converts from/to LocalDate") {
+    forAll { (i: Instant) =>
       val ld = toLocalDate(i)
       val ts = Timestamp.fromLocalDate(ld)
       expect.same(ts.toLocalDate, ld)
     }
   }
 
-  test("Converts to/from DATE_TIME format") {
-    forall { (i: Instant) =>
+  property("Converts to/from DATE_TIME format") {
+    forAll { (i: Instant) =>
       val ts = Timestamp.fromInstant(i)
       val formatted = ts.format(TimestampFormat.DATE_TIME)
       val parsed = Timestamp.parse(formatted, TimestampFormat.DATE_TIME)
@@ -84,8 +80,8 @@ object TimestampSpec extends SimpleIOSuite with Checkers {
     }
   }
 
-  test("Converts to/from EPOCH_SECONDS format") {
-    forall { (i: Instant) =>
+  property("Converts to/from EPOCH_SECONDS format") {
+    forAll { (i: Instant) =>
       val ts = Timestamp.fromInstant(i)
       val formatted = ts.format(TimestampFormat.EPOCH_SECONDS)
       val parsed = Timestamp.parse(formatted, TimestampFormat.EPOCH_SECONDS)
@@ -93,20 +89,19 @@ object TimestampSpec extends SimpleIOSuite with Checkers {
     }
   }
 
-  test("Parse EPOCH_SECONDS format with invalid input") {
+  property("Parse EPOCH_SECONDS format with invalid input") {
     val EpochFormat = """^(\d+)(\.(\d+))?""".r
-    forall { (str: String) =>
+    forAll { (str: String) =>
       val parsed = Timestamp.parse(str, TimestampFormat.EPOCH_SECONDS)
-      val asst = expect(EpochFormat.pattern.matcher(str).matches)
       parsed match {
-        case Some(_) => asst
-        case None    => not(asst)
+        case Some(_) => expect(EpochFormat.pattern.matcher(str).matches)
+        case None    => expect(!EpochFormat.pattern.matcher(str).matches)
       }
     }
   }
 
-  test("Parse EPOCH_SECONDS format with too many decimals") {
-    forall { (i: Int) =>
+  property("Parse EPOCH_SECONDS format with too many decimals") {
+    forAll { (i: Int) =>
       val str = s"$i.${i % 1000}.${i % 1000}"
       val parsed = Timestamp.parse(str, TimestampFormat.EPOCH_SECONDS)
       expect.same(parsed, None)

--- a/modules/core/test/src/smithy4s/BigStructSmokeSpec.scala
+++ b/modules/core/test/src/smithy4s/BigStructSmokeSpec.scala
@@ -16,16 +16,16 @@
 
 package smithy4s
 
-import weaver._
+import munit._
 
-object BigStructSmokeSpec extends FunSuite {
+class BigStructSmokeSpec() extends FunSuite {
 
   test("Big structures do have a schema") {
     val expected =
       "struct23(a1: int, a2: int, a3: int, a4: int, a5: int, a6: int, a7: int, a8: int, a9: int, a10: int, a11: int, a12: int, a13: int, a14: int, a15: int, a16: int, a17: int, a18: int, a19: int, a20: int, a21: int, a22: int, a23: int)"
     val schemaRepr =
       smithy4s.example.BigStruct.schema.compile(schema.SchematicRepr)
-    expect(schemaRepr == expected)
+    expect.same(schemaRepr, expected)
   }
 
 }

--- a/modules/core/test/src/smithy4s/CollectionInTraitsSmokeSpec.scala
+++ b/modules/core/test/src/smithy4s/CollectionInTraitsSmokeSpec.scala
@@ -16,18 +16,18 @@
 
 package smithy4s
 
-import weaver._
+import munit._
 import cats.syntax.all._
 
-object CollectionInTraitsSmokeSpec extends FunSuite {
+class CollectionInTraitsSmokeSpec() extends FunSuite {
 
   test("Traits with collection members do not refer to them using newtypes") {
     val (someList, someSet, someMap) = smithy4s.example.SomeInt.hints
       .get(smithy4s.example.SomeCollections)
       .foldMap(x => (x.someList, x.someSet, x.someMap))
 
-    expect.eql(someList, List("a")) &&
-    expect.eql(someSet, Set("b")) &&
+    expect.eql(someList, List("a"))
+    expect.eql(someSet, Set("b"))
     expect.eql(someMap, Map("a" -> "b"))
   }
 

--- a/modules/core/test/src/smithy4s/DocumentSpec.scala
+++ b/modules/core/test/src/smithy4s/DocumentSpec.scala
@@ -19,9 +19,9 @@ package smithy4s
 import smithy.api.JsonName
 import smithy4s.api.Discriminated
 import smithy4s.example.IntList
-import weaver._
+import munit._
 
-object DocumentSpec extends FunSuite {
+class DocumentSpec() extends FunSuite {
 
   test("Recursive document codecs should not blow up the stack") {
     val recursive: IntList = IntList(1, Some(IntList(2, Some(IntList(3)))))
@@ -39,7 +39,7 @@ object DocumentSpec extends FunSuite {
 
     val roundTripped = Document.decode[IntList](document)
 
-    expect(document == expectedDocument) &&
+    expect(document == expectedDocument)
     expect(roundTripped == Right(recursive))
   }
 
@@ -117,7 +117,7 @@ object DocumentSpec extends FunSuite {
 
     val roundTripped = Document.decode[(Int, String)](document)
 
-    expect(document == expectedDocument) &&
+    expect(document == expectedDocument)
     expect(roundTripped == Right(intAndString))
   }
 
@@ -133,8 +133,8 @@ object DocumentSpec extends FunSuite {
 
     val roundTripped = Document.decode[Either[Int, String]](document)
 
-    expect(document == expectedDocument) &&
-    expect(roundTripped == Right(intOrString))
+    expect.same(document, expectedDocument)
+    expect.same(roundTripped, Right(intOrString))
   }
 
   test("discriminated unions encoding") {
@@ -151,8 +151,8 @@ object DocumentSpec extends FunSuite {
 
     val roundTripped = Document.decode[Either[Foo, Bar]](document)
 
-    expect(document == expectedDocument) &&
-    expect(roundTripped == Right(fooOrBar))
+    expect.same(document, expectedDocument)
+    expect.same(roundTripped, Right(fooOrBar))
   }
 
   test("discriminated unions encoding - empty structure alternative") {
@@ -167,8 +167,8 @@ object DocumentSpec extends FunSuite {
 
     val roundTripped = Document.decode[Either[Foo, Baz]](document)
 
-    expect(document == expectedDocument) &&
-    expect(roundTripped == Right(fooOrBaz))
+    expect.same(document, expectedDocument)
+    expect.same(roundTripped, Right(fooOrBaz))
   }
 
 }

--- a/modules/core/test/src/smithy4s/EmptyServiceSmokeSpec.scala
+++ b/modules/core/test/src/smithy4s/EmptyServiceSmokeSpec.scala
@@ -16,9 +16,9 @@
 
 package smithy4s
 
-import weaver._
+import munit._
 
-object EmptyServiceSmokeSpec extends FunSuite {
+class EmptyServiceSmokeSpec() extends FunSuite {
 
   test("Empty services do compile") {
     val version = smithy4s.example.EmptyService.service.version

--- a/modules/core/test/src/smithy4s/EnumWithSymbolsSmokeSpec.scala
+++ b/modules/core/test/src/smithy4s/EnumWithSymbolsSmokeSpec.scala
@@ -16,9 +16,9 @@
 
 package smithy4s
 
-import weaver._
+import munit._
 
-object EnumWithSymbolsSmokeSpec extends FunSuite {
+class EnumWithSymbolsSmokeSpec() extends FunSuite {
 
   test(
     "Camel case names are issued from enum values when they don't have names"

--- a/modules/core/test/src/smithy4s/HintMaskSpec.scala
+++ b/modules/core/test/src/smithy4s/HintMaskSpec.scala
@@ -22,7 +22,7 @@ import smithy4s.api.Discriminated
 import smithy4s.schema._
 import smithy4s.schema.Schema._
 
-object HintMaskSpec extends weaver.FunSuite {
+class HintMaskSpec() extends munit.FunSuite {
 
   private implicit val hintsEq: Eq[Hints] = (x: Hints, y: Hints) =>
     x.toMap == y.toMap

--- a/modules/core/test/src/smithy4s/HintsSpec.scala
+++ b/modules/core/test/src/smithy4s/HintsSpec.scala
@@ -17,9 +17,9 @@
 package smithy4s
 
 import smithy.api.HttpHeader
-import weaver._
+import munit._
 
-object HintsSpec extends FunSuite {
+class HintsSpec() extends FunSuite {
   test("hints work as expected with newtypes") {
     val hints = Hints(HttpHeader("X-Foobar"))
     expect(hints.get(HttpHeader) == Some(HttpHeader("X-Foobar")))

--- a/modules/core/test/src/smithy4s/NewtypesSpec.scala
+++ b/modules/core/test/src/smithy4s/NewtypesSpec.scala
@@ -16,7 +16,7 @@
 
 package smithy4s
 
-object NewtypesSpec extends weaver.FunSuite {
+class NewtypesSpec() extends munit.FunSuite {
 
   type AccountId = AccountId.Type
   object AccountId extends Newtype[String] {
@@ -32,12 +32,13 @@ object NewtypesSpec extends weaver.FunSuite {
   val id2 = "id-2"
 
   test("Newtypes are consistent") {
-    expect.all(
-      AccountId(id1).value == id1,
-      AccountId(id1).value != AccountId(id2).value,
-      implicitly[ShapeTag[AccountId]] != implicitly[ShapeTag[DeviceId]],
-      AccountId.unapply(AccountId(id1)) == Some(id1)
+    expect.same(AccountId(id1).value, id1)
+    expect.different(AccountId(id1).value, AccountId(id2).value)
+    expect.different(
+      implicitly[ShapeTag[AccountId]],
+      implicitly[ShapeTag[DeviceId]]
     )
+    expect.same(AccountId.unapply(AccountId(id1)), Some(id1))
   }
 
   test("Newtypes have well defined unapply") {

--- a/modules/core/test/src/smithy4s/PackedInputsSmokeSpec.scala
+++ b/modules/core/test/src/smithy4s/PackedInputsSmokeSpec.scala
@@ -19,9 +19,9 @@ package smithy4s
 import cats.Id
 import smithy4s.example.PackedInput
 import smithy4s.example.PackedInputsService
-import weaver._
+import munit._
 
-object PackedInputsSmokeSpec extends FunSuite {
+class PackedInputsSmokeSpec() extends FunSuite {
 
   test("Methods with packed inputs have a single case-class parameter") {
     val service: PackedInputsService[Id] = new PackedInputsService[Id] {

--- a/modules/core/test/src/smithy4s/ProductSerialSmokeSpec.scala
+++ b/modules/core/test/src/smithy4s/ProductSerialSmokeSpec.scala
@@ -16,9 +16,9 @@
 
 package smithy4s
 
-import weaver._
+import munit._
 
-object ProductSerialSmokeSpec extends FunSuite {
+class ProductSerialSmokeSpec() extends FunSuite {
 
   test(
     "Enumeration compiles when shapes called Product or Serializable exist"

--- a/modules/core/test/src/smithy4s/SchemaEqualitySmokeSpec.scala
+++ b/modules/core/test/src/smithy4s/SchemaEqualitySmokeSpec.scala
@@ -19,7 +19,7 @@ package smithy4s
 import smithy4s.schema.Schema._
 
 // Verifies equality of implicit values
-object SchemaEqualitySmokeSpec extends weaver.FunSuite {
+class SchemaEqualitySmokeSpec() extends munit.FunSuite {
 
   case class Recursive(foo: Option[Recursive])
 

--- a/modules/core/test/src/smithy4s/ShapeIdHintsSmokeSpec.scala
+++ b/modules/core/test/src/smithy4s/ShapeIdHintsSmokeSpec.scala
@@ -61,7 +61,7 @@ class ShapeIdHintsSmokeSpec() extends munit.FunSuite {
     )
   }
 
-  test("structure members contain ShapeId in hints".only) {
+  test("structure members contain ShapeId in hints") {
     val shapeIds =
       example.CityCoordinates.schema.compile(TestCompiler).toSet
     expect(

--- a/modules/core/test/src/smithy4s/ShapeIdHintsSmokeSpec.scala
+++ b/modules/core/test/src/smithy4s/ShapeIdHintsSmokeSpec.scala
@@ -18,7 +18,7 @@ package smithy4s
 
 import smithy4s.schema._
 
-object ShapeIdHintsSmokeSpec extends weaver.FunSuite {
+class ShapeIdHintsSmokeSpec() extends munit.FunSuite {
 
   type ToShapeIds[A] = List[ShapeId]
 

--- a/modules/core/test/src/smithy4s/SummonSmokeSpec.scala
+++ b/modules/core/test/src/smithy4s/SummonSmokeSpec.scala
@@ -18,9 +18,8 @@ package smithy4s
 
 import cats.Id
 import smithy4s.example.EmptyService
-import weaver._
 
-object SummonSmokeSpec extends FunSuite {
+class SummonSmokeSpec() extends munit.FunSuite {
 
   test("Algebra can be summoned from monadic alias") {
     implicit val emptyService: EmptyService[Id] = new EmptyService[Id] {}

--- a/modules/core/test/src/smithy4s/expect.scala
+++ b/modules/core/test/src/smithy4s/expect.scala
@@ -1,0 +1,52 @@
+package smithy4s
+
+import munit.Location
+import munit.Assertions
+import cats.Show
+import cats.Eq
+
+object expect {
+
+  def apply(
+      cond: => Boolean,
+      clue: => Any = "assertion failed"
+  )(implicit loc: Location) = Assertions.assert(cond, clue)
+
+  def same[A](left: A, right: A)(implicit
+      loc: Location,
+      eq: Eq[A] = Eq.fromUniversalEquals[A],
+      show: Show[A] = Show.fromToString[A]
+  ) =
+    Assertions.assertEquals(new Wrapper(left), new Wrapper(right))
+
+  def different[A](left: A, right: A)(implicit
+      loc: Location,
+      eq: Eq[A] = Eq.fromUniversalEquals[A],
+      show: Show[A] = Show.fromToString[A]
+  ) =
+    Assertions.assertNotEquals(new Wrapper(left), new Wrapper(right))
+
+  def eql[A](left: A, right: A)(implicit
+      loc: Location,
+      eq: Eq[A],
+      show: Show[A] = Show.fromToString[A]
+  ) =
+    Assertions.assertEquals(new Wrapper(left), new Wrapper(right))
+
+  private class Wrapper[A](val value: A)(implicit show: Show[A], eq: Eq[A]) {
+    override def toString(): String = show.show(value)
+
+    override def equals(obj: Any): Boolean =
+      obj.isInstanceOf[Wrapper[_]] && eq.eqv(
+        value,
+        obj.asInstanceOf[Wrapper[A]].value
+      )
+  }
+
+  def neql[A](left: A, right: A)(implicit
+      loc: Location,
+      eq: Eq[A],
+      show: Show[A] = Show.fromToString[A]
+  ) =
+    Assertions.assertNotEquals(new Wrapper(left), new Wrapper(right))
+}

--- a/modules/core/test/src/smithy4s/http/CaseInsensitiveSpec.scala
+++ b/modules/core/test/src/smithy4s/http/CaseInsensitiveSpec.scala
@@ -14,9 +14,10 @@
  *  limitations under the License.
  */
 
-package smithy4s.http
+package smithy4s
+package http
 
-object CaseInsensitiveSpec extends weaver.FunSuite {
+class CaseInsensitiveSpec() extends munit.FunSuite {
 
   val foo = CaseInsensitive("Foo")
 

--- a/modules/core/test/src/smithy4s/http/StringAndBlobSpec.scala
+++ b/modules/core/test/src/smithy4s/http/StringAndBlobSpec.scala
@@ -14,7 +14,8 @@
  *  limitations under the License.
  */
 
-package smithy4s.http
+package smithy4s
+package http
 
 import smithy4s.ByteArray
 import smithy4s.PayloadPath
@@ -23,7 +24,7 @@ import smithy4s.example._
 
 import java.nio.ByteBuffer
 
-object StringAndBlobSpec extends weaver.FunSuite {
+class StringAndBlobSpec() extends munit.FunSuite {
 
   object Dummy
   def dummy: CodecAPI = new CodecAPI {
@@ -56,8 +57,8 @@ object StringAndBlobSpec extends weaver.FunSuite {
     val result = stringsAndBlobs.writeToArray(codec, input)
     val roundTripped = stringsAndBlobs.decodeFromByteArray(codec, result)
     val mediaType = stringsAndBlobs.mediaType(codec)
-    expect(result.sameElements("hello".getBytes())) &&
-    expect.same(Right(input), roundTripped) &&
+    expect(result.sameElements("hello".getBytes()))
+    expect.same(Right(input), roundTripped)
     expect.same(HttpMediaType("text/plain"), mediaType)
   }
 
@@ -67,8 +68,8 @@ object StringAndBlobSpec extends weaver.FunSuite {
     val result = stringsAndBlobs.writeToArray(codec, input)
     val roundTripped = stringsAndBlobs.decodeFromByteArray(codec, result)
     val mediaType = stringsAndBlobs.mediaType(codec)
-    expect(result.sameElements("hello".getBytes())) &&
-    expect.same(Right(input), roundTripped) &&
+    expect(result.sameElements("hello".getBytes()))
+    expect.same(Right(input), roundTripped)
     expect.same(HttpMediaType("text/csv"), mediaType)
   }
 
@@ -78,8 +79,8 @@ object StringAndBlobSpec extends weaver.FunSuite {
     val result = stringsAndBlobs.writeToArray(codec, input)
     val roundTripped = stringsAndBlobs.decodeFromByteArray(codec, result)
     val mediaType = stringsAndBlobs.mediaType(codec)
-    expect(result.sameElements("hello".getBytes())) &&
-    expect.same(Right(input), roundTripped) &&
+    expect(result.sameElements("hello".getBytes()))
+    expect.same(Right(input), roundTripped)
     expect.same(HttpMediaType("application/octet-stream"), mediaType)
   }
 
@@ -89,8 +90,8 @@ object StringAndBlobSpec extends weaver.FunSuite {
     val result = stringsAndBlobs.writeToArray(codec, input)
     val roundTripped = stringsAndBlobs.decodeFromByteArray(codec, result)
     val mediaType = stringsAndBlobs.mediaType(codec)
-    expect(result.sameElements("hello".getBytes())) &&
-    expect.same(Right(input), roundTripped) &&
+    expect(result.sameElements("hello".getBytes()))
+    expect.same(Right(input), roundTripped)
     expect.same(HttpMediaType("image/png"), mediaType)
   }
 
@@ -101,11 +102,11 @@ object StringAndBlobSpec extends weaver.FunSuite {
     val result = stringsAndBlobs.writeToArray(codec, input)
     val roundTripped = stringsAndBlobs.decodeFromByteArray(codec, result)
     val mediaType = stringsAndBlobs.mediaType(codec)
-    expect(result.isEmpty) &&
+    expect(result.isEmpty)
     expect.same(
       Left(PayloadError(PayloadPath.root, "error", "error")),
       roundTripped
-    ) &&
+    )
     expect.same(HttpMediaType("foo/bar"), mediaType)
   }
 

--- a/modules/core/test/src/smithy4s/http/internals/MetadataSpec.scala
+++ b/modules/core/test/src/smithy4s/http/internals/MetadataSpec.scala
@@ -14,7 +14,8 @@
  *  limitations under the License.
  */
 
-package smithy4s.http.internals
+package smithy4s
+package http.internals
 
 import cats.syntax.all._
 import smithy4s.Schema
@@ -28,9 +29,9 @@ import smithy4s.http.HttpBinding
 import smithy4s.http.Metadata
 import smithy4s.http.MetadataError
 import smithy4s.internals.InputOutput
-import weaver._
+import munit._
 
-object MetadataSpec extends FunSuite {
+class MetadataSpec() extends FunSuite {
 
   implicit val queriesSchema: Schema[Queries] =
     Queries.schema.addHints(InputOutput.Input.widen)
@@ -43,8 +44,8 @@ object MetadataSpec extends FunSuite {
 
   def checkRoundTrip[A](a: A, expectedEncoding: Metadata)(implicit
       s: Schema[A],
-      loc: SourceLocation
-  ): Expectations = {
+      loc: Location
+  ): Unit = {
     val encoded = Metadata.encode(a)
     val result = Metadata
       .decodePartial[A](encoded)
@@ -53,16 +54,16 @@ object MetadataSpec extends FunSuite {
       .flatMap { partial =>
         s.compile(FromMetadataSchematic).read(partial.decoded.toMap)
       }
-    expect.same(encoded, expectedEncoding).traced(loc) &&
-    expect(result == Right(a)).traced(loc) &&
-    checkRoundTripTotal(a, expectedEncoding).traced(loc)
+    expect.same(encoded, expectedEncoding)
+    expect(result == Right(a))
+    checkRoundTripTotal(a, expectedEncoding)
   }
 
   def checkRoundTripError[A](a: A, expectedEncoding: Metadata, message: String)(
       implicit
       s: Schema[A],
-      loc: SourceLocation
-  ): Expectations = {
+      loc: Location
+  ): Unit = {
     val encoded = Metadata.encode(a)
     val result = Metadata
       .decodePartial[A](encoded)
@@ -71,9 +72,9 @@ object MetadataSpec extends FunSuite {
       .flatMap { partial =>
         s.compile(FromMetadataSchematic).read(partial.decoded.toMap)
       }
-    expect.same(encoded, expectedEncoding).traced(loc) &&
-    expect(result == Left(message)).traced(loc) &&
-    checkRoundTripTotalError(a, expectedEncoding, message).traced(loc)
+    expect.same(encoded, expectedEncoding)
+    expect.same(result, Left(message))
+    checkRoundTripTotalError(a, expectedEncoding, message)
   }
 
   def checkRoundTripTotalError[A](
@@ -82,8 +83,8 @@ object MetadataSpec extends FunSuite {
       message: String
   )(implicit
       s: Schema[A],
-      loc: SourceLocation
-  ): Expectations = {
+      loc: Location
+  ): Unit = {
     val encoded = Metadata.encode(a)
     val result = Metadata
       .decodeTotal[A](encoded)
@@ -92,14 +93,14 @@ object MetadataSpec extends FunSuite {
           .map(_.getMessage())
       )
 
-    expect.same(encoded, expectedEncoding).traced(loc) &&
-    expect(result == Some(Left(message))).traced(loc)
+    expect.same(encoded, expectedEncoding)
+    expect.same(result, Some(Left(message)))
   }
 
   def checkRoundTripTotal[A](a: A, expectedEncoding: Metadata)(implicit
       s: Schema[A],
-      loc: SourceLocation
-  ): Expectations = {
+      loc: Location
+  ): Unit = {
     val encoded = Metadata.encode(a)
     val result = Metadata
       .decodeTotal[A](encoded)
@@ -108,8 +109,8 @@ object MetadataSpec extends FunSuite {
           .map(_.getMessage())
       )
 
-    expect.same(encoded, expectedEncoding).traced(here) &&
-    expect(result == Some(Right(a))).traced(loc)
+    expect.same(encoded, expectedEncoding)
+    expect.same(result, Some(Right(a)))
   }
 
   val epochString =

--- a/modules/core/test/src/smithy4s/http/internals/PathSpec.scala
+++ b/modules/core/test/src/smithy4s/http/internals/PathSpec.scala
@@ -14,7 +14,8 @@
  *  limitations under the License.
  */
 
-package smithy4s.http.internals
+package smithy4s
+package http.internals
 
 import smithy.api.Http
 import smithy.api.NonEmptyString
@@ -25,7 +26,7 @@ import smithy4s.example.PathParams
 import smithy4s.http.HttpEndpoint
 import smithy4s.http.PathSegment
 
-object PathSpec extends weaver.FunSuite {
+class PathSpec() extends munit.FunSuite {
   import smithy4s.schema.Schema._
   object util {
 
@@ -74,13 +75,13 @@ object PathSpec extends weaver.FunSuite {
         )
       )
 
-    val expected = if (weaver.Platform.isJS) {
+    val expected = if (Platform.isJS) {
       "dummy-path" :: "example with spaces, %, / and \\" :: "10" :: "1970-01-01T00:00:00.000Z" :: "1970-01-01T00:00:00.000Z" :: "0" :: "Thu, 01 Jan 1970 00:00:00 GMT" :: "true" :: Nil
     } else {
       "dummy-path" :: "example with spaces, %, / and \\" :: "10" :: "1970-01-01T00:00:00Z" :: "1970-01-01T00:00:00Z" :: "0" :: "Thu, 01 Jan 1970 00:00:00 GMT" :: "true" :: Nil
     }
 
-    assert.eql(result, expected)
+    expect.eql(result, expected)
   }
 
   test("Write PathParams for a struct schema") {
@@ -98,7 +99,7 @@ object PathSpec extends weaver.FunSuite {
     val result = SchemaVisitorPathEncoder(schema)
       .map(_.encode(()))
 
-    assert.eql(
+    expect.eql(
       result,
       Some(List("example", "const", "example2"))
     )
@@ -119,21 +120,21 @@ object PathSpec extends weaver.FunSuite {
     val result = SchemaVisitorPathEncoder(schema)
       .map(_.encode(()))
 
-    assert.eql(
+    expect.eql(
       result,
       Some(List("example", "const", "example2", "with", "slashes"))
     )
   }
 
   test("Write PathParams for a simple string") {
-    assert.eql(
+    expect.eql(
       util.simpleString.map(_.encode("example")),
       Some(List("example"))
     )
   }
 
   test("Write PathParams for an int") {
-    assert.eql(
+    expect.eql(
       util.encodePathAs(int).map(_.encode(42)),
       Some(List("42"))
     )
@@ -141,17 +142,17 @@ object PathSpec extends weaver.FunSuite {
 
   test("Write PathParams for a double") {
     val expected = Some(List {
-      if (weaver.Platform.isJS) "42" else "42.0"
+      if (Platform.isJS) "42" else "42.0"
     })
 
-    assert.eql(
+    expect.eql(
       util.encodePathAs(double).map(_.encode(42.0)),
       expected
     )
   }
 
   test("Write PathParams for a boolean") {
-    assert.eql(
+    expect.eql(
       util.encodePathAs(boolean).map(_.encode(true)),
       Some(List("true"))
     )
@@ -160,7 +161,7 @@ object PathSpec extends weaver.FunSuite {
   test("Write PathParams for a string with special characters unencoded") {
     val input = "example with all kinds of strange characters / \\ & "
 
-    assert.eql(
+    expect.eql(
       util.simpleString.map(_.encode(input)),
       Some(List(input))
     )
@@ -171,14 +172,14 @@ object PathSpec extends weaver.FunSuite {
   ) {
     val input = "example/with/slashes and spaces"
 
-    assert.eql(
+    expect.eql(
       util.simpleString.map(_.encodeGreedy(input)),
       Some(List("example", "with", "slashes and spaces"))
     )
   }
 
   test("Write PathParams for unit as None") {
-    assert.eql(
+    expect.eql(
       util.encodePathAs(unit).map(_.encode(())),
       None
     )

--- a/modules/json/test/src/smithy4s/http/json/DocumentPropertyTests.scala
+++ b/modules/json/test/src/smithy4s/http/json/DocumentPropertyTests.scala
@@ -17,23 +17,18 @@
 package smithy4s.http.json
 
 import cats.Show
-import cats.effect.IO
 import com.github.plokhotnyuk.jsoniter_scala.core._
 import org.scalacheck.Gen
 import smithy4s.Document
 import smithy4s.Schema
 import smithy4s.scalacheck.DynData
-import weaver._
-import weaver.scalacheck._
+import munit._
+import org.scalacheck.Prop
+import Prop._
 
 import codecs.schemaVisitorJCodec
 
-object DocumentPropertyTests extends SimpleIOSuite with Checkers {
-
-  override val maxParallelism = 1
-
-  override val checkConfig: CheckConfig =
-    super.checkConfig.copy(perPropertyParallelism = 1)
+class DocumentPropertyTests() extends FunSuite with ScalaCheckSuite {
 
   val genSchemaData: Gen[(Schema[DynData], Any)] = for {
     schema <- Gen.const(
@@ -48,13 +43,13 @@ object DocumentPropertyTests extends SimpleIOSuite with Checkers {
   implicit val documentCodec: JCodec[Document] =
     Schema.document.compile(schemaVisitorJCodec)
 
-  loggedTest(
+  property(
     "Going through json directly or via the adt give the same results"
-  ) { log =>
+  ) {
     // We're randomly generating a schema, and using it
     // to randomly generate compliant data, and
     // asserting roundtrip there.
-    forall(genSchemaData) { schemaAndData =>
+    forAll(genSchemaData) { schemaAndData =>
       val (schema, data) = schemaAndData
       implicit val codec: JCodec[Any] =
         schema.compile(schemaVisitorJCodec)
@@ -75,22 +70,18 @@ object DocumentPropertyTests extends SimpleIOSuite with Checkers {
         .toEither
       val dataFromDocument = documentFromJson.flatMap(decoder.decode)
 
-      val e = expect.all(
-        dataDirect.exists(_ == data),
-        dataFromDocument.exists(_ == data)
-      )
+      val e1 = Prop(dataDirect.exists(_ == data))
+      val e2 = Prop(dataFromDocument.exists(_ == data))
       dataFromDocument.left.foreach(_.printStackTrace())
-      if (e.run.isInvalid) {
-        for {
-          _ <- log.debug("wassup ?")
-          _ <- log.debug("schema: " + schemaStr)
-          _ <- log.debug("data: " + data)
-          _ <- log.debug("jsonFromDocument: " + jsonFromDocument)
-          _ <- log.debug("jsonDirect: + " + jsonDirect)
-          _ <- log.debug("documentFromJson: " + documentFromJson)
-          _ <- log.debug("dataFromDocument: " + dataFromDocument)
-        } yield e
-      } else IO.pure(e)
+      (e1 && e2).label(
+        s"""|schema: $schemaStr
+           |data: $data
+           |jsonFromDocument: $jsonFromDocument
+           |jsonDirect: $jsonDirect
+           |documentFromJson: $documentFromJson
+           |dataFromDocument: $dataFromDocument
+           |""".stripMargin
+      )
     }
 
   }


### PR DESCRIPTION
This switches weaver to Munit. We attempt to reduce the diff via the
creation of an `expect` object that exposes signatures somewhat similar
to weaver's expectations.

The reason for doing this is the impending cross-building to scala-native