### PR TITLE
fix imports for newtypes from other packages

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -567,7 +567,8 @@ lazy val example = projectMatrix
       "smithy4s.example",
       "smithy4s.example.import_test",
       "smithy4s.example.imp",
-      "smithy4s.example.error"
+      "smithy4s.example.error",
+      "smithy4s.example.common"
     ),
     smithySpecs := Seq(
       (ThisBuild / baseDirectory).value / "sampleSpecs" / "example.smithy",
@@ -576,7 +577,9 @@ lazy val example = projectMatrix
       (ThisBuild / baseDirectory).value / "sampleSpecs" / "operation.smithy",
       (ThisBuild / baseDirectory).value / "sampleSpecs" / "import.smithy",
       (ThisBuild / baseDirectory).value / "sampleSpecs" / "importerror.smithy",
-      (ThisBuild / baseDirectory).value / "sampleSpecs" / "adtMember.smithy"
+      (ThisBuild / baseDirectory).value / "sampleSpecs" / "adtMember.smithy",
+      (ThisBuild / baseDirectory).value / "sampleSpecs" / "brands.smithy",
+      (ThisBuild / baseDirectory).value / "sampleSpecs" / "brandscommon.smithy"
     ),
     Compile / resourceDirectory := (ThisBuild / baseDirectory).value / "modules" / "example" / "resources",
     isCE3 := true,

--- a/modules/codegen/src/smithy4s/codegen/ToLine.scala
+++ b/modules/codegen/src/smithy4s/codegen/ToLine.scala
@@ -45,8 +45,7 @@ object ToLine {
       case Type.Alias(ns, name, Type.PrimitiveType(_)) =>
         Line(Set(s"$ns.$name"), name)
       case Type.Alias(_, _, aliased) =>
-        val (imports, t) = render(aliased).tupled
-        Line(imports, t)
+        render(aliased)
       case Type.Ref(namespace, name) =>
         val imports = Set(s"$namespace.$name")
         Line(imports, name)

--- a/modules/codegen/src/smithy4s/codegen/ToLine.scala
+++ b/modules/codegen/src/smithy4s/codegen/ToLine.scala
@@ -46,6 +46,7 @@ object ToLine {
         Line(Set(s"$ns.$name"), name)
       case Type.Alias(ns, name, aliased) =>
         val (imports, t) = render(aliased).tupled
+        // TODO: Sometimes the ns.name should not be added
         Line(imports + s"$ns.$name", t)
       case Type.Ref(namespace, name) =>
         val imports = Set(s"$namespace.$name")

--- a/modules/codegen/src/smithy4s/codegen/ToLine.scala
+++ b/modules/codegen/src/smithy4s/codegen/ToLine.scala
@@ -46,7 +46,6 @@ object ToLine {
         Line(Set(s"$ns.$name"), name)
       case Type.Alias(ns, name, aliased) =>
         val (imports, t) = render(aliased).tupled
-        // TODO: Sometimes the ns.name should not be added
         Line(imports + s"$ns.$name", t)
       case Type.Ref(namespace, name) =>
         val imports = Set(s"$namespace.$name")

--- a/modules/codegen/src/smithy4s/codegen/ToLine.scala
+++ b/modules/codegen/src/smithy4s/codegen/ToLine.scala
@@ -44,9 +44,9 @@ object ToLine {
         Line(kimports ++ vimports, s"Map[${k.mkString("")}, ${v.mkString("")}]")
       case Type.Alias(ns, name, Type.PrimitiveType(_)) =>
         Line(Set(s"$ns.$name"), name)
-      case Type.Alias(ns, name, aliased) =>
+      case Type.Alias(_, _, aliased) =>
         val (imports, t) = render(aliased).tupled
-        Line(imports + s"$ns.$name", t)
+        Line(imports, t)
       case Type.Ref(namespace, name) =>
         val imports = Set(s"$namespace.$name")
         Line(imports, name)
@@ -78,6 +78,7 @@ object ToLine {
 case class Line(imports: Set[String], line: String) {
   def tupled = (imports, line)
   def suffix(suffix: Line) = modify(s => s"$s $suffix")
+  def addImport(imp: String) = copy(imports = imports + imp)
   def modify(f: String => String) = Line(imports, f(line))
   def nonEmpty = line.nonEmpty
   def toLines = Lines(imports, List(line))

--- a/modules/example/src/smithy4s/example/AddBrandsInput.scala
+++ b/modules/example/src/smithy4s/example/AddBrandsInput.scala
@@ -1,0 +1,17 @@
+package smithy4s.example
+
+import smithy4s.example.common.BrandList
+import smithy4s.schema.Schema._
+
+case class AddBrandsInput(brands: Option[List[String]] = None)
+object AddBrandsInput extends smithy4s.ShapeTag.Companion[AddBrandsInput] {
+  val id: smithy4s.ShapeId = smithy4s.ShapeId("smithy4s.example", "AddBrandsInput")
+
+  val hints : smithy4s.Hints = smithy4s.Hints.empty
+
+  implicit val schema: smithy4s.Schema[AddBrandsInput] = struct(
+    BrandList.underlyingSchema.optional[AddBrandsInput]("brands", _.brands),
+  ){
+    AddBrandsInput.apply
+  }.withId(id).addHints(hints)
+}

--- a/modules/example/src/smithy4s/example/BrandService.scala
+++ b/modules/example/src/smithy4s/example/BrandService.scala
@@ -1,0 +1,61 @@
+package smithy4s.example
+
+import smithy4s.schema.Schema._
+
+trait BrandServiceGen[F[_, _, _, _, _]] {
+  self =>
+
+  def addBrands(brands: Option[List[String]] = None) : F[AddBrandsInput, Nothing, Unit, Nothing, Nothing]
+
+  def transform[G[_, _, _, _, _]](transformation : smithy4s.Transformation[F, G]) : BrandServiceGen[G] = new Transformed(transformation)
+  class Transformed[G[_, _, _, _, _]](transformation : smithy4s.Transformation[F, G]) extends BrandServiceGen[G] {
+    def addBrands(brands: Option[List[String]] = None) = transformation[AddBrandsInput, Nothing, Unit, Nothing, Nothing](self.addBrands(brands))
+  }
+}
+
+object BrandServiceGen extends smithy4s.Service[BrandServiceGen, BrandServiceOperation] {
+
+  def apply[F[_]](implicit F: smithy4s.Monadic[BrandServiceGen, F]): F.type = F
+
+  val id: smithy4s.ShapeId = smithy4s.ShapeId("smithy4s.example", "BrandService")
+
+  val hints : smithy4s.Hints = smithy4s.Hints.empty
+
+  val endpoints = List(
+    AddBrands,
+  )
+
+  val version: String = "1"
+
+  def endpoint[I, E, O, SI, SO](op : BrandServiceOperation[I, E, O, SI, SO]) = op match {
+    case AddBrands(input) => (input, AddBrands)
+  }
+
+  object reified extends BrandServiceGen[BrandServiceOperation] {
+    def addBrands(brands: Option[List[String]] = None) = AddBrands(AddBrandsInput(brands))
+  }
+
+  def transform[P[_, _, _, _, _]](transformation: smithy4s.Transformation[BrandServiceOperation, P]): BrandServiceGen[P] = reified.transform(transformation)
+
+  def transform[P[_, _, _, _, _], P1[_, _, _, _, _]](alg: BrandServiceGen[P], transformation: smithy4s.Transformation[P, P1]): BrandServiceGen[P1] = alg.transform(transformation)
+
+  def asTransformation[P[_, _, _, _, _]](impl : BrandServiceGen[P]): smithy4s.Transformation[BrandServiceOperation, P] = new smithy4s.Transformation[BrandServiceOperation, P] {
+    def apply[I, E, O, SI, SO](op : BrandServiceOperation[I, E, O, SI, SO]) : P[I, E, O, SI, SO] = op match  {
+      case AddBrands(AddBrandsInput(brands)) => impl.addBrands(brands)
+    }
+  }
+  case class AddBrands(input: AddBrandsInput) extends BrandServiceOperation[AddBrandsInput, Nothing, Unit, Nothing, Nothing]
+  object AddBrands extends smithy4s.Endpoint[BrandServiceOperation, AddBrandsInput, Nothing, Unit, Nothing, Nothing] {
+    val id: smithy4s.ShapeId = smithy4s.ShapeId("smithy4s.example", "AddBrands")
+    val input: smithy4s.Schema[AddBrandsInput] = AddBrandsInput.schema.addHints(smithy4s.internals.InputOutput.Input.widen)
+    val output: smithy4s.Schema[Unit] = unit.addHints(smithy4s.internals.InputOutput.Output.widen)
+    val streamedInput : smithy4s.StreamingSchema[Nothing] = smithy4s.StreamingSchema.nothing
+    val streamedOutput : smithy4s.StreamingSchema[Nothing] = smithy4s.StreamingSchema.nothing
+    val hints : smithy4s.Hints = smithy4s.Hints(
+      smithy.api.Http(smithy.api.NonEmptyString("POST"), smithy.api.NonEmptyString("/brands"), Some(200)),
+    )
+    def wrap(input: AddBrandsInput) = AddBrands(input)
+  }
+}
+
+sealed trait BrandServiceOperation[Input, Err, Output, StreamedInput, StreamedOutput]

--- a/modules/example/src/smithy4s/example/common/BrandList.scala
+++ b/modules/example/src/smithy4s/example/common/BrandList.scala
@@ -1,0 +1,11 @@
+package smithy4s.example.common
+
+import smithy4s.Newtype
+import smithy4s.schema.Schema._
+
+object BrandList extends Newtype[List[String]] {
+  val id: smithy4s.ShapeId = smithy4s.ShapeId("smithy4s.example.common", "BrandList")
+  val hints : smithy4s.Hints = smithy4s.Hints.empty
+  val underlyingSchema : smithy4s.Schema[List[String]] = list(string).withId(id).addHints(hints)
+  implicit val schema : smithy4s.Schema[BrandList] = bijection(underlyingSchema, BrandList(_), (_ : BrandList).value)
+}

--- a/modules/example/src/smithy4s/example/common/package.scala
+++ b/modules/example/src/smithy4s/example/common/package.scala
@@ -1,0 +1,7 @@
+package smithy4s.example
+
+package object common {
+
+  type BrandList = smithy4s.example.common.BrandList.Type
+
+}

--- a/modules/example/src/smithy4s/example/package.scala
+++ b/modules/example/src/smithy4s/example/package.scala
@@ -13,6 +13,12 @@ package object example {
     def service : smithy4s.Service[FooServiceGen, FooServiceOperation] = FooServiceGen
     val id: smithy4s.ShapeId = service.id
   }
+  type BrandService[F[_]] = smithy4s.Monadic[BrandServiceGen, F]
+  object BrandService extends smithy4s.Service.Provider[BrandServiceGen, BrandServiceOperation] {
+    def apply[F[_]](implicit F: BrandService[F]): F.type = F
+    def service : smithy4s.Service[BrandServiceGen, BrandServiceOperation] = BrandServiceGen
+    val id: smithy4s.ShapeId = service.id
+  }
   type ObjectService[F[_]] = smithy4s.Monadic[ObjectServiceGen, F]
   object ObjectService extends smithy4s.Service.Provider[ObjectServiceGen, ObjectServiceOperation] {
     def apply[F[_]](implicit F: ObjectService[F]): F.type = F

--- a/sampleSpecs/brands.smithy
+++ b/sampleSpecs/brands.smithy
@@ -1,0 +1,17 @@
+namespace smithy4s.example
+
+use smithy4s.example.common#BrandList
+
+service BrandService {
+  version: "1",
+  operations: [AddBrands]
+}
+
+@http(method: "POST", uri: "/brands", code: 200)
+operation AddBrands {
+  input: AddBrandsInput
+}
+
+structure AddBrandsInput {
+  brands: BrandList
+}

--- a/sampleSpecs/brandscommon.smithy
+++ b/sampleSpecs/brandscommon.smithy
@@ -1,0 +1,5 @@
+namespace smithy4s.example.common
+
+list BrandList {
+  member: String
+}


### PR DESCRIPTION
An issue was discovered where extra imports are added to services under the following conditions:

- Service has an operation which has an input parameter from another namespace
- Said input parameter is a newtype

The reason this happens is because the service unpacks the newtype to directly point at the inner type of the newtype. So once this unpacking happens, the import is no longer needed. This issue is masked in the rendering of structures, for example, because they use the newtype inside the construction of the schema.

This fix is kind of a patch, the real fix is to create the import resolution based on carrying fully qualified name information through the rendering process before cleaning up at the end (as we've discussed we want to do).