### PR TITLE
Use internal sbt dependency resolution in codegen-plugin

### DIFF
--- a/modules/codegen-cli/src/smithy4s/codegen/cli/CodegenCommand.scala
+++ b/modules/codegen-cli/src/smithy4s/codegen/cli/CodegenCommand.scala
@@ -125,7 +125,8 @@ object CodegenCommand {
             excludedNS,
             repositories.getOrElse(List.empty),
             dependencies.getOrElse(List.empty),
-            transformers.getOrElse(List.empty)
+            transformers.getOrElse(List.empty),
+            localJars = List.empty
           )
       }
 

--- a/modules/codegen-cli/src/smithy4s/codegen/cli/CodegenCommand.scala
+++ b/modules/codegen-cli/src/smithy4s/codegen/cli/CodegenCommand.scala
@@ -80,20 +80,20 @@ object CodegenCommand {
 
   val allowedNSOpt: Opts[Option[Set[String]]] =
     Opts
-      .option[String](
+      .option[List[String]](
         "allowed-ns",
         "Comma-delimited list of namespaces that should not be processed. If unset, all namespaces are processed (except stdlib ones)"
       )
-      .map(_.split(',').toSet)
+      .map(_.toSet)
       .orNone
 
   val excludedNSOpt: Opts[Option[Set[String]]] =
     Opts
-      .option[String](
+      .option[List[String]](
         "excluded-ns",
         "Comma-delimited list of namespaces that should not be processed. If unset, all namespaces are processed (except stdlib ones)"
       )
-      .map(_.split(',').toSet)
+      .map(_.toSet)
       .orNone
 
   val options =
@@ -108,11 +108,12 @@ object CodegenCommand {
       repositoriesOpt,
       dependenciesOpt,
       transformersOpt,
+      localJarsOpt,
       specsArgs
     )
       .mapN {
         // format: off
-        case (output, openApiOutput, skipScala, skipOpenapi, discoverModels, allowedNS, excludedNS, repositories, dependencies, transformers, specsArgs) =>
+        case (output, openApiOutput, skipScala, skipOpenapi, discoverModels, allowedNS, excludedNS, repositories, dependencies, transformers, localJars, specsArgs) =>
         // format: on
           CodegenArgs(
             specsArgs,
@@ -126,7 +127,7 @@ object CodegenCommand {
             repositories.getOrElse(List.empty),
             dependencies.getOrElse(List.empty),
             transformers.getOrElse(List.empty),
-            localJars = List.empty
+            localJars.getOrElse(List.empty)
           )
       }
 

--- a/modules/codegen-cli/src/smithy4s/codegen/cli/DumpModel.scala
+++ b/modules/codegen-cli/src/smithy4s/codegen/cli/DumpModel.scala
@@ -28,7 +28,7 @@ object DumpModel {
       args.repositories,
       args.transformers,
       discoverModels = false,
-      localJars = Nil
+      args.localJars
     )
 
     Node.prettyPrintJson(ModelSerializer.builder().build.serialize(model))

--- a/modules/codegen-cli/src/smithy4s/codegen/cli/DumpModel.scala
+++ b/modules/codegen-cli/src/smithy4s/codegen/cli/DumpModel.scala
@@ -27,7 +27,8 @@ object DumpModel {
       args.dependencies,
       args.repositories,
       args.transformers,
-      discoverModels = false
+      discoverModels = false,
+      localJars = Nil
     )
 
     Node.prettyPrintJson(ModelSerializer.builder().build.serialize(model))

--- a/modules/codegen-cli/src/smithy4s/codegen/cli/DumpModelCommand.scala
+++ b/modules/codegen-cli/src/smithy4s/codegen/cli/DumpModelCommand.scala
@@ -28,7 +28,8 @@ object DumpModelCommand {
     specsArgs,
     repositoriesOpt.map(_.getOrElse(Nil)),
     dependenciesOpt.map(_.getOrElse(Nil)),
-    transformersOpt.map(_.getOrElse(Nil))
+    transformersOpt.map(_.getOrElse(Nil)),
+    localJarsOpt.map(_.getOrElse(Nil))
   ).mapN(DumpModelArgs.apply)
 
   val command: Command[DumpModel] =

--- a/modules/codegen-cli/src/smithy4s/codegen/cli/Options.scala
+++ b/modules/codegen-cli/src/smithy4s/codegen/cli/Options.scala
@@ -40,6 +40,17 @@ object Options {
 
   }
 
+  implicit def commaDelimitedListArg[A: Argument]: Argument[List[A]] = {
+    val memberArgument = implicitly[Argument[A]]
+    new Argument[List[A]] {
+      def defaultMetavar: String =
+        s"${memberArgument.defaultMetavar},${memberArgument.defaultMetavar},..."
+
+      def read(string: String): ValidatedNel[String, List[A]] =
+        string.split(',').toList.traverse(memberArgument.read)
+    }
+  }
+
   val specsArgs = Opts
     .arguments[os.Path]()
     .mapValidated(
@@ -56,29 +67,33 @@ object Options {
 
   val repositoriesOpt: Opts[Option[List[String]]] =
     Opts
-      .option[String](
+      .option[List[String]](
         "repositories",
         "Comma-delimited list of repositories to look in for resolving any provided dependencies"
       )
-      .map(_.split(',').toList)
       .orNone
 
   val dependenciesOpt: Opts[Option[List[String]]] =
     Opts
-      .option[String](
+      .option[List[String]](
         "dependencies",
         "Comma-delimited list of dependencies containing smithy files"
       )
-      .map(_.split(',').toList)
       .orNone
 
   val transformersOpt: Opts[Option[List[String]]] =
     Opts
-      .option[String](
+      .option[List[String]](
         "transformers",
         "Comma-delimited list of transformer names to apply to smithy files"
       )
-      .map(_.split(',').toList)
       .orNone
 
+  val localJarsOpt: Opts[Option[List[os.Path]]] =
+    Opts
+      .option[List[os.Path]](
+        "localJars",
+        "Comma-delimited list of local JAR files containing smithy files"
+      )
+      .orNone
 }

--- a/modules/codegen-cli/src/smithy4s/codegen/cli/Smithy4sCommand.scala
+++ b/modules/codegen-cli/src/smithy4s/codegen/cli/Smithy4sCommand.scala
@@ -27,7 +27,8 @@ object Smithy4sCommand {
       specs: List[os.Path],
       repositories: List[String],
       dependencies: List[String],
-      transformers: List[String]
+      transformers: List[String],
+      localJars: List[os.Path]
   )
 
 }

--- a/modules/codegen-cli/test/src/smithy4s/codegen/cli/CommandParsingSpec.scala
+++ b/modules/codegen-cli/test/src/smithy4s/codegen/cli/CommandParsingSpec.scala
@@ -62,7 +62,9 @@ object CommandParsingSpec extends FunSuite {
         "--dependencies",
         "dep1,dep2",
         "--transformers",
-        "t1,t2"
+        "t1,t2",
+        "--localJars",
+        "lib1.jar,lib2.jar"
       )
     )
 
@@ -85,7 +87,10 @@ object CommandParsingSpec extends FunSuite {
               repositories = List("repo1", "repo2"),
               dependencies = List("dep1", "dep2"),
               transformers = List("t1", "t2"),
-              localJars = Nil
+              localJars = List(
+                os.pwd / "lib1.jar",
+                os.pwd / "lib2.jar"
+              )
             )
           )
         )
@@ -101,7 +106,8 @@ object CommandParsingSpec extends FunSuite {
               specs = Nil,
               repositories = Nil,
               dependencies = Nil,
-              transformers = Nil
+              transformers = Nil,
+              localJars = Nil
             )
           )
         )
@@ -118,7 +124,9 @@ object CommandParsingSpec extends FunSuite {
         "--dependencies",
         "dep1,dep2",
         "--transformers",
-        "t1,t2"
+        "t1,t2",
+        "--localJars",
+        "lib1.jar,lib2.jar"
       )
     )
     assert(
@@ -132,7 +140,11 @@ object CommandParsingSpec extends FunSuite {
               ),
               repositories = List("repo1", "repo2"),
               dependencies = List("dep1", "dep2"),
-              transformers = List("t1", "t2")
+              transformers = List("t1", "t2"),
+              localJars = List(
+                os.pwd / "lib1.jar",
+                os.pwd / "lib2.jar"
+              )
             )
           )
         )

--- a/modules/codegen-cli/test/src/smithy4s/codegen/cli/CommandParsingSpec.scala
+++ b/modules/codegen-cli/test/src/smithy4s/codegen/cli/CommandParsingSpec.scala
@@ -36,7 +36,8 @@ object CommandParsingSpec extends FunSuite {
               excludedNS = None,
               repositories = Nil,
               dependencies = Nil,
-              transformers = Nil
+              transformers = Nil,
+              localJars = Nil
             )
           )
         )
@@ -83,7 +84,8 @@ object CommandParsingSpec extends FunSuite {
               excludedNS = None,
               repositories = List("repo1", "repo2"),
               dependencies = List("dep1", "dep2"),
-              transformers = List("t1", "t2")
+              transformers = List("t1", "t2"),
+              localJars = Nil
             )
           )
         )

--- a/modules/codegen/src/smithy4s/codegen/Codegen.scala
+++ b/modules/codegen/src/smithy4s/codegen/Codegen.scala
@@ -32,7 +32,8 @@ object Codegen { self =>
       args.dependencies,
       args.repositories,
       args.transformers,
-      args.discoverModels
+      args.discoverModels,
+      args.localJars
     )
 
     val scalaFiles = if (!args.skipScala) {

--- a/modules/codegen/src/smithy4s/codegen/CodegenArgs.scala
+++ b/modules/codegen/src/smithy4s/codegen/CodegenArgs.scala
@@ -27,5 +27,6 @@ case class CodegenArgs(
     excludedNS: Option[Set[String]],
     repositories: List[String],
     dependencies: List[String],
-    transformers: List[String]
+    transformers: List[String],
+    localJars: List[os.Path]
 )


### PR DESCRIPTION
Fixes dependency resolution from a maven repository that requires authentication (tested against a CodeArtifact repo with `sbt-codeartifact`).