### PR TITLE
Add @vector and @indexedSeq 

### DIFF
--- a/modules/codegen/src/smithy4s/codegen/CollisionAvoidance.scala
+++ b/modules/codegen/src/smithy4s/codegen/CollisionAvoidance.scala
@@ -93,8 +93,8 @@ object CollisionAvoidance {
   }
 
   private def modType(tpe: Type): Type = tpe match {
-    case Type.List(member, hints)  => Type.List(modType(member), hints)
-    case Type.Set(member)          => Type.Set(modType(member))
+    case Type.Collection(collectionType, member) =>
+      Type.Collection(collectionType, modType(member))
     case Type.Map(key, value)      => Type.Map(modType(key), modType(value))
     case Type.Ref(namespace, name) => Type.Ref(namespace, name.capitalize)
     case Alias(namespace, name, tpe) =>
@@ -165,10 +165,8 @@ object CollisionAvoidance {
           AltTN(modRef(ref), altName, alt)
         case MapTN(values) =>
           MapTN(values)
-        case ListTN(values) =>
-          ListTN(values)
-        case SetTN(values) =>
-          SetTN(values)
+        case CollectionTN(collectionType, values) =>
+          CollectionTN(collectionType, values)
         case PrimitiveTN(prim, value) =>
           PrimitiveTN(prim, value)
       }

--- a/modules/codegen/src/smithy4s/codegen/CollisionAvoidance.scala
+++ b/modules/codegen/src/smithy4s/codegen/CollisionAvoidance.scala
@@ -93,7 +93,7 @@ object CollisionAvoidance {
   }
 
   private def modType(tpe: Type): Type = tpe match {
-    case Type.List(member)         => Type.List(modType(member))
+    case Type.List(member, hints)  => Type.List(modType(member), hints)
     case Type.Set(member)          => Type.Set(modType(member))
     case Type.Map(key, value)      => Type.Map(modType(key), modType(value))
     case Type.Ref(namespace, name) => Type.Ref(namespace, name.capitalize)

--- a/modules/codegen/src/smithy4s/codegen/IR.scala
+++ b/modules/codegen/src/smithy4s/codegen/IR.scala
@@ -152,6 +152,8 @@ sealed trait Type {
     case Type.Alias(_, _, tpe) => tpe.dealiased
     case other                 => other
   }
+
+  def hints: List[Hint] = Nil
 }
 
 sealed trait Primitive {
@@ -179,10 +181,11 @@ object Primitive {
 }
 
 object Type {
-
+  import scala.collection.{immutable => cols}
   val unit = PrimitiveType(Primitive.Unit)
 
-  case class List(member: Type) extends Type
+  case class List(member: Type, override val hints: cols.List[Hint])
+      extends Type
   case class Set(member: Type) extends Type
   case class Map(key: Type, value: Type) extends Type
   case class Ref(namespace: String, name: String) extends Type {
@@ -202,6 +205,13 @@ object Hint {
   case class Protocol(traits: List[Type.Ref]) extends Hint
   // traits that get rendered generically
   case class Native(typedNode: Fix[TypedNode]) extends Hint
+
+  sealed trait SpecializedList extends Hint
+  object SpecializedList {
+    case object Vector extends SpecializedList
+    case object IndexedSeq extends SpecializedList
+  }
+  case object UniqueItems extends Hint
 }
 
 sealed trait Segment extends scala.Product with Serializable

--- a/modules/codegen/src/smithy4s/codegen/IR.scala
+++ b/modules/codegen/src/smithy4s/codegen/IR.scala
@@ -152,8 +152,6 @@ sealed trait Type {
     case Type.Alias(_, _, tpe) => tpe.dealiased
     case other                 => other
   }
-
-  def hints: List[Hint] = Nil
 }
 
 sealed trait Primitive {
@@ -181,18 +179,24 @@ object Primitive {
 }
 
 object Type {
-  import scala.collection.{immutable => cols}
   val unit = PrimitiveType(Primitive.Unit)
 
-  case class List(member: Type, override val hints: cols.List[Hint])
+  case class Collection(collectionType: CollectionType, member: Type)
       extends Type
-  case class Set(member: Type) extends Type
   case class Map(key: Type, value: Type) extends Type
   case class Ref(namespace: String, name: String) extends Type {
     def show = namespace + "." + name
   }
   case class Alias(namespace: String, name: String, tpe: Type) extends Type
   case class PrimitiveType(prim: Primitive) extends Type
+}
+
+sealed abstract class CollectionType(val tpe: String)
+object CollectionType {
+  case object List extends CollectionType("List")
+  case object Set extends CollectionType("Set")
+  case object Vector extends CollectionType("Vector")
+  case object IndexedSeq extends CollectionType("IndexedSeq")
 }
 
 sealed trait Hint
@@ -271,10 +275,8 @@ object TypedNode {
         AltTN(ref, altName, alt.map(f))
       case MapTN(values) =>
         MapTN(values.map(_.leftMap(f).map(f)))
-      case ListTN(values) =>
-        ListTN(values.map(f))
-      case SetTN(values) =>
-        SetTN(values.map(f))
+      case CollectionTN(collectionType, values) =>
+        CollectionTN(collectionType, values.map(f))
       case PrimitiveTN(prim, value) =>
         PrimitiveTN(prim, value)
     }
@@ -294,8 +296,8 @@ object TypedNode {
   case class AltTN[A](ref: Type.Ref, altName: String, alt: AltValueTN[A])
       extends TypedNode[A]
   case class MapTN[A](values: List[(A, A)]) extends TypedNode[A]
-  case class ListTN[A](values: List[A]) extends TypedNode[A]
-  case class SetTN[A](values: List[A]) extends TypedNode[A]
+  case class CollectionTN[A](collectionType: CollectionType, values: List[A])
+      extends TypedNode[A]
   case class PrimitiveTN[T](prim: Primitive.Aux[T], value: T)
       extends TypedNode[Nothing]
 

--- a/modules/codegen/src/smithy4s/codegen/Renderer.scala
+++ b/modules/codegen/src/smithy4s/codegen/Renderer.scala
@@ -650,8 +650,15 @@ private[codegen] class Renderer(compilationUnit: CompilationUnit) { self =>
   implicit class TypeExt(tpe: Type) {
     def schemaRef: Line = tpe match {
       case Type.PrimitiveType(p) => Line(schemaRefP(p))
-      case Type.List(member)     => line"list(${member.schemaRef})"
-      case Type.Set(member)      => line"set(${member.schemaRef})"
+      case Type.List(member, hints) =>
+        val col = hints
+          .collectFirst {
+            case Hint.SpecializedList.Vector     => "vector"
+            case Hint.SpecializedList.IndexedSeq => "indexedSeq"
+          }
+          .getOrElse { "list" }
+        line"$col(${member.schemaRef})"
+      case Type.Set(member) => line"set(${member.schemaRef})"
       case Type.Map(key, value) =>
         line"map(${key.schemaRef}, ${value.schemaRef})"
       case Type.Alias(ns, name, Type.PrimitiveType(_)) =>

--- a/modules/codegen/src/smithy4s/codegen/SmithyToIR.scala
+++ b/modules/codegen/src/smithy4s/codegen/SmithyToIR.scala
@@ -18,7 +18,10 @@ package smithy4s.codegen
 
 import cats.data.NonEmptyList
 import cats.implicits._
+import smithy4s.meta.AdtMemberTrait
+import smithy4s.meta.IndexedSeqTrait
 import smithy4s.meta.PackedInputsTrait
+import smithy4s.meta.VectorTrait
 import smithy4s.recursion._
 import software.amazon.smithy.aws.traits.ServiceTrait
 import software.amazon.smithy.model.Model
@@ -28,8 +31,8 @@ import software.amazon.smithy.model.traits.RequiredTrait
 import software.amazon.smithy.model.traits._
 
 import scala.jdk.CollectionConverters._
-import smithy4s.meta.AdtMemberTrait
 import software.amazon.smithy.model.selector.PathFinder
+import scala.annotation.nowarn
 
 object SmithyToIR {
 
@@ -286,9 +289,19 @@ private[codegen] class SmithyToIR(model: Model, namespace: String) {
         primitive(x, "smithy.api#Boolean", Primitive.Bool)
 
       def listShape(x: ListShape): Option[Type] =
-        x.getMember().accept(this).map(Type.List.apply).map { tpe =>
-          Type.Alias(x.namespace, x.name, tpe)
-        }
+        x.getMember()
+          .accept(this)
+          .map { tpe =>
+            val _hints = hints(x)
+            if (_hints.contains(Hint.UniqueItems)) {
+              Type.Set.apply(tpe)
+            } else {
+              Type.List.apply(tpe, hints(x))
+            }
+          }
+          .map { tpe =>
+            Type.Alias(x.namespace, x.name, tpe)
+          }
 
       def setShape(x: SetShape): Option[Type] =
         x.getMember().accept(this).map(Type.Set.apply).map { tpe =>
@@ -389,6 +402,10 @@ private[codegen] class SmithyToIR(model: Model, namespace: String) {
       }
   }
 
+  // Remove when upgrading to smithy 2.0
+  @nowarn(
+    "msg=class UniqueItemsTrait in package traits is deprecated"
+  )
   private val traitToHint: PartialFunction[Trait, Hint] = {
     case _: ErrorTrait => Hint.Error
     case t: ProtocolDefinitionTrait =>
@@ -399,6 +416,12 @@ private[codegen] class SmithyToIR(model: Model, namespace: String) {
       Hint.Protocol(refs.toList)
     case _: PackedInputsTrait =>
       Hint.PackedInputs
+    case _: VectorTrait =>
+      Hint.SpecializedList.Vector
+    case _: IndexedSeqTrait =>
+      Hint.SpecializedList.IndexedSeq
+    case _: UniqueItemsTrait =>
+      Hint.UniqueItems
     case t if t.toShapeId() == ShapeId.fromParts("smithy.api", "trait") =>
       Hint.Trait
     case ConstraintTrait(tr) => Hint.Constraint(toTypeRef(tr))
@@ -607,7 +630,7 @@ private[codegen] class SmithyToIR(model: Model, namespace: String) {
           enumDef.getName().asScala
         )
       // List
-      case (N.ArrayNode(list), Type.List(mem)) =>
+      case (N.ArrayNode(list), Type.List(mem, _)) => // todo sure ?
         TypedNode.ListTN(list.map(NodeAndType(_, mem)))
       // Set
       case (N.ArrayNode(set), Type.Set(mem)) =>

--- a/modules/codegen/src/smithy4s/codegen/SmithyToIR.scala
+++ b/modules/codegen/src/smithy4s/codegen/SmithyToIR.scala
@@ -296,7 +296,7 @@ private[codegen] class SmithyToIR(model: Model, namespace: String) {
             if (_hints.contains(Hint.UniqueItems)) {
               Type.Set.apply(tpe)
             } else {
-              Type.List.apply(tpe, hints(x))
+              Type.List.apply(tpe, _hints)
             }
           }
           .map { tpe =>

--- a/modules/codegen/src/smithy4s/codegen/ToLine.scala
+++ b/modules/codegen/src/smithy4s/codegen/ToLine.scala
@@ -32,9 +32,18 @@ object ToLine {
   implicit val stringToLine: ToLine[String] = s => Line(s)
   implicit val typeToLine: ToLine[Type] = new ToLine[Type] {
     override def render(a: Type): Line = a match {
-      case Type.List(member) =>
+      case Type.List(member, hints) =>
         val (imports, m) = render(member).tupled
-        Line(imports, s"List[${m.mkString("")}]")
+        hints
+          .collectFirst {
+            case Hint.SpecializedList.Vector =>
+              Line(imports, s"Vector[${m.mkString("")}]")
+            case Hint.SpecializedList.IndexedSeq =>
+              Line(imports, s"IndexedSeq[${m.mkString("")}]")
+          }
+          .getOrElse {
+            Line(imports, s"List[${m.mkString("")}]")
+          }
       case Type.Set(member) =>
         val (imports, m) = render(member).tupled
         Line(imports, s"Set[${m.mkString("")}]")

--- a/modules/codegen/src/smithy4s/codegen/ToLine.scala
+++ b/modules/codegen/src/smithy4s/codegen/ToLine.scala
@@ -32,21 +32,10 @@ object ToLine {
   implicit val stringToLine: ToLine[String] = s => Line(s)
   implicit val typeToLine: ToLine[Type] = new ToLine[Type] {
     override def render(a: Type): Line = a match {
-      case Type.List(member, hints) =>
+      case Type.Collection(collectionType, member) =>
         val (imports, m) = render(member).tupled
-        hints
-          .collectFirst {
-            case Hint.SpecializedList.Vector =>
-              Line(imports, s"Vector[${m.mkString("")}]")
-            case Hint.SpecializedList.IndexedSeq =>
-              Line(imports, s"IndexedSeq[${m.mkString("")}]")
-          }
-          .getOrElse {
-            Line(imports, s"List[${m.mkString("")}]")
-          }
-      case Type.Set(member) =>
-        val (imports, m) = render(member).tupled
-        Line(imports, s"Set[${m.mkString("")}]")
+        val col = collectionType.tpe
+        Line(imports, s"$col[${m.mkString("")}]")
       case Type.Map(key, value) =>
         val (kimports, k) = render(key).tupled
         val (vimports, v) = render(value).tupled

--- a/modules/core/src/smithy4s/http/internals/MetaEncode.scala
+++ b/modules/core/src/smithy4s/http/internals/MetaEncode.scala
@@ -93,5 +93,4 @@ object MetaEncode {
   def fromToString[A]: MetaEncode[A] = StringValueMetaEncode(_.toString())
   def empty[A]: MetaEncode[A] = EmptyMetaEncode
 
-
 }

--- a/modules/docs/src/04-codegen/01-customisation.md
+++ b/modules/docs/src/04-codegen/01-customisation.md
@@ -134,3 +134,26 @@ whenever the `adtMember` trait is in use.
 Note: The `adtMember` trait has NO impact on the serialization/deserialization behaviors of smithy4s.
 The only thing it changes is what the generated code looks like. This is accomplished by keeping the
 rendered schemas equivalent, even if the case class is rendered in a different place.
+
+#### Specialized collection types
+
+Smithy supports `list` and `set`, Smithy4s renders that to `List[A]` and `Set[A]` respectively. You can also use the `@uniqueItems` annotation on `list` which is equivalent to `set`.
+
+Smithy4s has support for two specialized collection type: `Vector` and `IndexedSeq`. The following examples shows how to use them:
+
+```kotlin
+use smithy4s.meta#indexedSeq
+use smithy4s.meta#vector
+
+@indexedSeq
+list SomeIndexSeq {
+  member: String
+}
+
+@vector
+list SomeVector {
+  member: String
+}
+```
+
+Both annotation are only available on `list`. You can't mix `@vector` with `@indexedSeq`, nor `@uniqueItems`.

--- a/modules/docs/src/04-codegen/01-customisation.md
+++ b/modules/docs/src/04-codegen/01-customisation.md
@@ -139,7 +139,7 @@ rendered schemas equivalent, even if the case class is rendered in a different p
 
 Smithy supports `list` and `set`, Smithy4s renders that to `List[A]` and `Set[A]` respectively. You can also use the `@uniqueItems` annotation on `list` which is equivalent to `set`.
 
-Smithy4s has support for two specialized collection type: `Vector` and `IndexedSeq`. The following examples shows how to use them:
+Smithy4s has support for two specialized collection types: `Vector` and `IndexedSeq`. The following examples show how to use them:
 
 ```kotlin
 use smithy4s.meta#indexedSeq
@@ -156,4 +156,4 @@ list SomeVector {
 }
 ```
 
-Both annotation are only available on `list`. You can't mix `@vector` with `@indexedSeq`, nor `@uniqueItems`.
+Both annotations are only applicable on `list` shapes. You can't mix `@vector` with `@indexedSeq`, and neither one can be used with `@uniqueItems`.

--- a/modules/example/src/smithy4s/example/SomeIndexSeq.scala
+++ b/modules/example/src/smithy4s/example/SomeIndexSeq.scala
@@ -1,0 +1,11 @@
+package smithy4s.example
+
+import smithy4s.Newtype
+import smithy4s.schema.Schema._
+
+object SomeIndexSeq extends Newtype[IndexedSeq[String]] {
+  val id: smithy4s.ShapeId = smithy4s.ShapeId("smithy4s.example", "SomeIndexSeq")
+  val hints : smithy4s.Hints = smithy4s.Hints()
+  val underlyingSchema : smithy4s.Schema[IndexedSeq[String]] = indexedSeq(string).withId(id).addHints(hints)
+  implicit val schema : smithy4s.Schema[SomeIndexSeq] = bijection(underlyingSchema, SomeIndexSeq.make, (_ : SomeIndexSeq).value)
+}

--- a/modules/example/src/smithy4s/example/SomeVector.scala
+++ b/modules/example/src/smithy4s/example/SomeVector.scala
@@ -1,0 +1,11 @@
+package smithy4s.example
+
+import smithy4s.Newtype
+import smithy4s.schema.Schema._
+
+object SomeVector extends Newtype[Vector[String]] {
+  val id: smithy4s.ShapeId = smithy4s.ShapeId("smithy4s.example", "SomeVector")
+  val hints : smithy4s.Hints = smithy4s.Hints()
+  val underlyingSchema : smithy4s.Schema[Vector[String]] = vector(string).withId(id).addHints(hints)
+  implicit val schema : smithy4s.Schema[SomeVector] = bijection(underlyingSchema, SomeVector.make, (_ : SomeVector).value)
+}

--- a/modules/example/src/smithy4s/example/package.scala
+++ b/modules/example/src/smithy4s/example/package.scala
@@ -28,10 +28,12 @@ package object example {
 
   type ArbitraryData = smithy4s.example.ArbitraryData.Type
   type StreamedBlob = smithy4s.example.StreamedBlob.Type
+  type SomeVector = smithy4s.example.SomeVector.Type
   type SomeValue = smithy4s.example.SomeValue.Type
   type TestString = smithy4s.example.TestString.Type
   type ObjectSize = smithy4s.example.ObjectSize.Type
   type BucketName = smithy4s.example.BucketName.Type
+  type SomeIndexSeq = smithy4s.example.SomeIndexSeq.Type
   type ObjectKey = smithy4s.example.ObjectKey.Type
   type OrderNumber = smithy4s.example.OrderNumber.Type
 

--- a/modules/protocol/resources/META-INF/services/software.amazon.smithy.model.traits.TraitService
+++ b/modules/protocol/resources/META-INF/services/software.amazon.smithy.model.traits.TraitService
@@ -4,3 +4,5 @@ smithy4s.api.UuidFormatTrait$Provider
 smithy4s.api.DiscriminatedUnionTrait$Provider
 smithy4s.meta.PackedInputsTrait$Provider
 smithy4s.meta.AdtMemberTrait$Provider
+smithy4s.meta.VectorTrait$Provider
+smithy4s.meta.IndexedSeqTrait$Provider

--- a/modules/protocol/resources/META-INF/smithy/smithy4s.meta.smithy
+++ b/modules/protocol/resources/META-INF/smithy/smithy4s.meta.smithy
@@ -24,3 +24,16 @@ structure packedInputs {}
 @trait(selector: "structure :not([trait|error])")
 @idRef(failWhenMissing: true, selector: "union")
 string adtMember
+
+@trait(selector: """
+        list
+        :not(:test([trait|smithy4s.meta#vector],
+                   [trait|smithy.api#uniqueItems]))""")
+structure indexedSeq {}
+
+
+@trait(selector: """
+        list
+        :not(:test([trait|smithy4s.meta#indexedSeq],
+                   [trait|smithy.api#uniqueItems]))""")
+structure vector {}

--- a/modules/protocol/resources/META-INF/smithy/smithy4s.meta.smithy
+++ b/modules/protocol/resources/META-INF/smithy/smithy4s.meta.smithy
@@ -14,7 +14,7 @@ namespace smithy4s.meta
 @trait(selector: ":is(service, operation)")
 structure packedInputs {}
 
-/// adtMember trait can be added to structures that are targeted by
+/// the adtMember trait can be added to structures that are targeted by
 /// a single union. This trait tells smithy4s to generate the code
 /// such that the structure directly extends the union's sealed trait.
 /// This makes it so the structure can be used directly was a member of
@@ -25,13 +25,19 @@ structure packedInputs {}
 @idRef(failWhenMissing: true, selector: "union")
 string adtMember
 
+// the indexedSeq trait can be added to list shapes in order for the generated collection
+// fields to be of type `IndexedSeq` instead of `List`. When decoding instances of IndexedSeq
+// from various formats, Smithy4s will do a best effort to try and back the IndexedSeq
+// the most efficiently possible, often using `ArraySeq` and storing primitive values
+// in unboxed ways.
 @trait(selector: """
         list
         :not(:test([trait|smithy4s.meta#vector],
                    [trait|smithy.api#uniqueItems]))""")
 structure indexedSeq {}
 
-
+// the vector trait can be added to list shapes in order for the generated collection
+// fields to be of type `Vector` instead of `List`
 @trait(selector: """
         list
         :not(:test([trait|smithy4s.meta#indexedSeq],

--- a/modules/protocol/src/smithy4s/meta/IndexedSeqTrait.java
+++ b/modules/protocol/src/smithy4s/meta/IndexedSeqTrait.java
@@ -1,0 +1,47 @@
+/*
+ *  Copyright 2021-2022 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package smithy4s.meta;
+
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ObjectNode;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.traits.AnnotationTrait;
+import software.amazon.smithy.model.traits.AbstractTrait;
+
+public class IndexedSeqTrait extends AnnotationTrait {
+
+	public static ShapeId ID = ShapeId.from("smithy4s.meta#indexedSeq");
+
+	public IndexedSeqTrait(ObjectNode node) {
+		super(ID, node);
+	}
+
+	public IndexedSeqTrait() {
+		super(ID, Node.objectNode());
+	}
+
+	public static final class Provider extends AbstractTrait.Provider {
+		public Provider() {
+			super(ID);
+		}
+
+		@Override
+		public IndexedSeqTrait createTrait(ShapeId target, Node node) {
+			return new IndexedSeqTrait(node.expectObjectNode());
+		}
+	}
+}

--- a/modules/protocol/src/smithy4s/meta/VectorTrait.java
+++ b/modules/protocol/src/smithy4s/meta/VectorTrait.java
@@ -1,0 +1,47 @@
+/*
+ *  Copyright 2021-2022 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package smithy4s.meta;
+
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ObjectNode;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.traits.AnnotationTrait;
+import software.amazon.smithy.model.traits.AbstractTrait;
+
+public class VectorTrait extends AnnotationTrait {
+
+	public static ShapeId ID = ShapeId.from("smithy4s.meta#vector");
+
+	public VectorTrait(ObjectNode node) {
+		super(ID, node);
+	}
+
+	public VectorTrait() {
+		super(ID, Node.objectNode());
+	}
+
+	public static final class Provider extends AbstractTrait.Provider {
+		public Provider() {
+			super(ID);
+		}
+
+		@Override
+		public VectorTrait createTrait(ShapeId target, Node node) {
+			return new VectorTrait(node.expectObjectNode());
+		}
+	}
+}

--- a/sampleSpecs/example.smithy
+++ b/sampleSpecs/example.smithy
@@ -3,6 +3,8 @@ namespace smithy4s.example
 use smithy4s.api#simpleRestJson
 use smithy4s.api#UUID
 use smithy4s.api#uuidFormat
+use smithy4s.meta#indexedSeq
+use smithy4s.meta#vector
 
 @simpleRestJson
 service ObjectService {
@@ -115,3 +117,13 @@ document arbitraryData
 
 @arbitraryData(str: "hello", int: 1, bool: true, arr: ["one", "two", "three"], obj: { str: "s", i : 1})
 structure ArbitraryDataTest {}
+
+@indexedSeq
+list SomeIndexSeq {
+  member: String
+}
+
+@vector
+list SomeVector {
+  member: String
+}

--- a/sampleSpecs/misc.smithy
+++ b/sampleSpecs/misc.smithy
@@ -1,8 +1,6 @@
 namespace smithy4s.example
 
 use smithy4s.api#untagged
-use smithy4s.meta#vector
-use smithy4s.meta#indexedSeq
 
 service EmptyService {
   version: "1.0"

--- a/sampleSpecs/misc.smithy
+++ b/sampleSpecs/misc.smithy
@@ -1,6 +1,8 @@
 namespace smithy4s.example
 
 use smithy4s.api#untagged
+use smithy4s.meta#vector
+use smithy4s.meta#indexedSeq
 
 service EmptyService {
   version: "1.0"

--- a/smithy-build.json
+++ b/smithy-build.json
@@ -1,3 +1,3 @@
 {
-  "imports" : ["./sampleSpecs", "./modules/protocol"]
+  "imports" : ["./sampleSpecs", "./modules/protocol/resources"]
 }


### PR DESCRIPTION
Adds a mechanism for users to customise the collection type used when generating Scala code from smithy `list` shapes. 

Users can now opt-in `Vector` or `IndexedSeq`. `List` remains the default collection type. 