### PR TITLE
More efficient parsing of JSON arrays and objects

### DIFF
--- a/modules/json/src/smithy4s/http/json/Cursor.scala
+++ b/modules/json/src/smithy4s/http/json/Cursor.scala
@@ -22,9 +22,9 @@ import com.github.plokhotnyuk.jsoniter_scala.core.JsonReaderException
 import smithy4s.http.PayloadError
 
 class Cursor private () {
-
+  private[this] var stack: Array[PayloadPath.Segment] = new Array[PayloadPath.Segment](8)
+  private[this] var top: Int = 0
   private var expecting: String = null
-  private var stack: List[PayloadPath.Segment] = Nil
 
   def decode[A](codec: JCodec[A], in: JsonReader): A = {
     this.expecting = codec.expecting
@@ -32,38 +32,50 @@ class Cursor private () {
   }
 
   def under[A](segment: PayloadPath.Segment)(f: => A): A = {
-    val prev = stack
-    stack = segment :: stack
+    if (top >= stack.length) stack = java.util.Arrays.copyOf(stack, top << 1)
+    stack(top) = segment
+    top += 1
     val res = f
-    stack = prev
+    top -= 1
     res
   }
 
-  def under[A](label: String)(f: => A): A =
-    under(PayloadPath.Segment.Label(label))(f)
-  def under[A](index: Int)(f: => A): A =
-    under(PayloadPath.Segment.Index(index))(f)
+  def under[A](label: String)(f: => A): A = under(new PayloadPath.Segment.Label(label))(f)
 
-  def payloadError[A](codec: JCodec[A], message: String): Nothing = {
-    val path = PayloadPath(stack.reverse)
-    throw PayloadError(path, codec.expecting, message)
-  }
+  def under[A](index: Int)(f: => A): A = under(new PayloadPath.Segment.Index(index))(f)
 
-  def requiredFieldError[A](codec: JCodec[A], field: String): Nothing = {
+  def payloadError[A](codec: JCodec[A], message: String): Nothing =
+    throw PayloadError(getPath(), codec.expecting, message)
+
+  def requiredFieldError[A](codec: JCodec[A], field: String): Nothing =
     requiredFieldError(codec.expecting, field)
-  }
 
   def requiredFieldError[A](expecting: String, field: String): Nothing = {
-    val path = PayloadPath((PayloadPath.Segment.Label(field) :: stack).reverse)
-    throw PayloadError(path, expecting, "Missing required field")
+    var top = this.top
+    if (top >= stack.length) stack = java.util.Arrays.copyOf(stack, top << 1)
+    stack(top) = new PayloadPath.Segment.Label(field)
+    top += 1
+    var list: List[PayloadPath.Segment] = Nil
+    while (top > 0) {
+      top -= 1
+      list = stack(top) :: list
+    }
+    throw PayloadError(PayloadPath(list), expecting, "Missing required field")
   }
 
-  private def getPath(): PayloadPath = PayloadPath(stack.reverse)
+  private def getPath(): PayloadPath = {
+    var top = this.top
+    var list: List[PayloadPath.Segment] = Nil
+    while (top > 0) {
+      top -= 1
+      list = stack(top) :: list
+    }
+    PayloadPath(list)
+  }
 
-  private def getExpected() =
+  private def getExpected(): String =
     if (expecting != null) expecting
     else throw new IllegalStateException("Expected should have been fulfilled")
-
 }
 
 object Cursor {
@@ -74,19 +86,11 @@ object Cursor {
     try {
       f(cursor)
     } catch {
-      case e: JsonReaderException =>
-        throw PayloadError(
-          cursor.getPath(),
-          cursor.getExpected(),
-          e.getMessage()
-        )
-      case ConstraintError(_, message) =>
-        throw PayloadError(
-          cursor.getPath(),
-          cursor.getExpected(),
-          message
-        )
+      case e: JsonReaderException => payloadError(cursor, e.getMessage())
+      case e: ConstraintError => payloadError(cursor, e.message)
     }
   }
 
+  private[this] def payloadError(cursor: Cursor, message: String): Nothing =
+    throw PayloadError(cursor.getPath(), cursor.getExpected(), message)
 }


### PR DESCRIPTION
On JDK 17 it gives up to 2x times speed up on parsing of JSON arrays (see `ArrayOfBooleansReading`, `ArraySeqOfBooleansReading`, `ListOfBooleansReading`, `VectorOfBooleansReading`) and up to 1.3x times speed up on JSON objects (see `GeoJSONReading`) by the cost of slow down parsing of top-level JSON values (see `Base64Reading`, `BigIntReading`, `IntReading`, `StringOfAsciiCharsReading`, `StringOfEscapedCharsReading`, `StringOfNonAsciiCharsReading`)

## Before
```
[info] Benchmark                                  (size)   Mode  Cnt         Score         Error  Units
[info] ADTReading.smithy4sJson                       N/A  thrpt    5   1720855.406 ±   44766.774  ops/s
[info] AnyValsReading.smithy4sJson                   N/A  thrpt    5   1930181.226 ±  115372.354  ops/s
[info] ArrayOfBigDecimalsReading.smithy4sJson        128  thrpt    5    104754.936 ±    3226.595  ops/s
[info] ArrayOfBigIntsReading.smithy4sJson            128  thrpt    5    152503.334 ±    1248.074  ops/s
[info] ArrayOfBooleansReading.smithy4sJson           128  thrpt    5    374631.192 ±    2734.387  ops/s
[info] ArrayOfBytesReading.smithy4sJson              128  thrpt    5    327909.858 ±    5943.541  ops/s
[info] ArrayOfDoublesReading.smithy4sJson            128  thrpt    5    227312.963 ±    4129.372  ops/s
[info] ArrayOfFloatsReading.smithy4sJson             128  thrpt    5    263761.424 ±   54975.976  ops/s
[info] ArrayOfInstantsReading.smithy4sJson           128  thrpt    5    120044.705 ±    5238.271  ops/s
[info] ArrayOfIntsReading.smithy4sJson               128  thrpt    5    271756.767 ±    1342.643  ops/s
[info] ArrayOfLongsReading.smithy4sJson              128  thrpt    5    289464.303 ±   20627.117  ops/s
[info] ArrayOfShortsReading.smithy4sJson             128  thrpt    5    308727.781 ±    5120.904  ops/s
[info] ArrayOfUUIDsReading.smithy4sJson              128  thrpt    5    281017.932 ±    1352.033  ops/s
[info] ArraySeqOfBooleansReading.smithy4sJson        128  thrpt    5    378938.574 ±   25856.760  ops/s
[info] Base64Reading.smithy4sJson                    128  thrpt    5   6480687.823 ±  163358.294  ops/s
[info] BigIntReading.smithy4sJson                    128  thrpt    5   6673234.533 ±  125776.839  ops/s
[info] ExtractFieldsReading.smithy4sJson             128  thrpt    5    192914.181 ±    1197.861  ops/s
[info] GeoJSONReading.smithy4sJson                   N/A  thrpt    5     22173.730 ±     941.651  ops/s
[info] GitHubActionsAPIReading.smithy4sJson          N/A  thrpt    5    345950.801 ±    1187.026  ops/s
[info] GoogleMapsAPIReading.smithy4sJson             N/A  thrpt    5     14138.772 ±      47.450  ops/s
[info] IntReading.smithy4sJson                       N/A  thrpt    5  75367705.939 ± 4254157.285  ops/s
[info] ListOfBooleansReading.smithy4sJson            128  thrpt    5    398708.500 ±   10289.973  ops/s
[info] MapOfIntsToBooleansReading.smithy4sJson       128  thrpt    5    166191.100 ±    1056.413  ops/s
[info] MissingRequiredFieldsReading.smithy4sJson     N/A  thrpt    5   9135223.274 ±   90750.144  ops/s
[info] NestedStructsReading.smithy4sJson             128  thrpt    5     90385.748 ±    4423.973  ops/s
[info] OpenRTBReading.smithy4sJson                   N/A  thrpt    5    156587.388 ±     750.255  ops/s
[info] PrimitivesReading.smithy4sJson                N/A  thrpt    5   2134434.021 ±    8514.364  ops/s
[info] SetOfIntsReading.smithy4sJson                 128  thrpt    5    190333.423 ±    4668.849  ops/s
[info] StringOfAsciiCharsReading.smithy4sJson        128  thrpt    5  15522575.896 ±  741381.817  ops/s
[info] StringOfEscapedCharsReading.smithy4sJson      128  thrpt    5   3176033.452 ±   10376.566  ops/s
[info] StringOfNonAsciiCharsReading.smithy4sJson     128  thrpt    5   3467444.118 ±   46464.133  ops/s
[info] TwitterAPIReading.smithy4sJson                N/A  thrpt    5     32727.527 ±      91.511  ops/s
[info] VectorOfBooleansReading.smithy4sJson          128  thrpt    5    406402.021 ±    2857.359  ops/s
```
## After
```
[info] Benchmark                                  (size)   Mode  Cnt         Score         Error  Units
[info] ADTReading.smithy4sJson                       N/A  thrpt    5   1902588.225 ±   11068.233  ops/s
[info] AnyValsReading.smithy4sJson                   N/A  thrpt    5   2147447.971 ±   10998.383  ops/s
[info] ArrayOfBigDecimalsReading.smithy4sJson        128  thrpt    5    107981.600 ±    1969.252  ops/s
[info] ArrayOfBigIntsReading.smithy4sJson            128  thrpt    5    164448.566 ±    2523.957  ops/s
[info] ArrayOfBooleansReading.smithy4sJson           128  thrpt    5    758826.632 ±   15533.595  ops/s
[info] ArrayOfBytesReading.smithy4sJson              128  thrpt    5    555228.115 ±    6623.299  ops/s
[info] ArrayOfDoublesReading.smithy4sJson            128  thrpt    5    272482.435 ±    7072.706  ops/s
[info] ArrayOfFloatsReading.smithy4sJson             128  thrpt    5    352798.454 ±   20700.371  ops/s
[info] ArrayOfInstantsReading.smithy4sJson           128  thrpt    5    126518.384 ±    1282.320  ops/s
[info] ArrayOfIntsReading.smithy4sJson               128  thrpt    5    446488.891 ±    3054.313  ops/s
[info] ArrayOfLongsReading.smithy4sJson              128  thrpt    5    395105.035 ±    1215.560  ops/s
[info] ArrayOfShortsReading.smithy4sJson             128  thrpt    5    506658.854 ±    2379.684  ops/s
[info] ArrayOfUUIDsReading.smithy4sJson              128  thrpt    5    389755.331 ±   33971.553  ops/s
[info] ArraySeqOfBooleansReading.smithy4sJson        128  thrpt    5    791470.023 ±   19135.197  ops/s
[info] Base64Reading.smithy4sJson                    128  thrpt    5   5824134.440 ±   89041.455  ops/s
[info] BigIntReading.smithy4sJson                    128  thrpt    5   6021176.768 ±   25471.736  ops/s
[info] ExtractFieldsReading.smithy4sJson             128  thrpt    5    184229.760 ±     765.047  ops/s
[info] GeoJSONReading.smithy4sJson                   N/A  thrpt    5     29300.513 ±     475.934  ops/s
[info] GitHubActionsAPIReading.smithy4sJson          N/A  thrpt    5    371540.005 ±   31825.317  ops/s
[info] GoogleMapsAPIReading.smithy4sJson             N/A  thrpt    5     14975.683 ±      66.832  ops/s
[info] IntReading.smithy4sJson                       N/A  thrpt    5  68495278.216 ± 1379306.569  ops/s
[info] ListOfBooleansReading.smithy4sJson            128  thrpt    5    804415.545 ±    8893.539  ops/s
[info] MapOfIntsToBooleansReading.smithy4sJson       128  thrpt    5    173248.692 ±    7264.649  ops/s
[info] MissingRequiredFieldsReading.smithy4sJson     N/A  thrpt    5   9102718.098 ±   10683.069  ops/s
[info] NestedStructsReading.smithy4sJson             128  thrpt    5     92464.670 ±     610.700  ops/s
[info] OpenRTBReading.smithy4sJson                   N/A  thrpt    5    172682.863 ±    3258.562  ops/s
[info] PrimitivesReading.smithy4sJson                N/A  thrpt    5   2389648.503 ±  111842.564  ops/s
[info] SetOfIntsReading.smithy4sJson                 128  thrpt    5    214105.143 ±    1314.110  ops/s
[info] StringOfAsciiCharsReading.smithy4sJson        128  thrpt    5  12046724.407 ±  142157.992  ops/s
[info] StringOfEscapedCharsReading.smithy4sJson      128  thrpt    5   3052402.650 ±  105154.344  ops/s
[info] StringOfNonAsciiCharsReading.smithy4sJson     128  thrpt    5   3261442.880 ±  128143.471  ops/s
[info] TwitterAPIReading.smithy4sJson                N/A  thrpt    5     35793.444 ±     163.018  ops/s
[info] VectorOfBooleansReading.smithy4sJson          128  thrpt    5    924836.727 ±    8931.597  ops/s
```