### PR TITLE
Reduce CPU usage on access to java.util.HashTable

### DIFF
--- a/modules/json/src/smithy4s/http/json/Cursor.scala
+++ b/modules/json/src/smithy4s/http/json/Cursor.scala
@@ -22,7 +22,8 @@ import com.github.plokhotnyuk.jsoniter_scala.core.JsonReaderException
 import smithy4s.http.PayloadError
 
 class Cursor private () {
-  private[this] var stack: Array[PayloadPath.Segment] = new Array[PayloadPath.Segment](8)
+  private[this] var stack: Array[PayloadPath.Segment] =
+    new Array[PayloadPath.Segment](8)
   private[this] var top: Int = 0
   private var expecting: String = null
 
@@ -40,9 +41,11 @@ class Cursor private () {
     res
   }
 
-  def under[A](label: String)(f: => A): A = under(new PayloadPath.Segment.Label(label))(f)
+  def under[A](label: String)(f: => A): A =
+    under(new PayloadPath.Segment.Label(label))(f)
 
-  def under[A](index: Int)(f: => A): A = under(new PayloadPath.Segment.Index(index))(f)
+  def under[A](index: Int)(f: => A): A =
+    under(new PayloadPath.Segment.Index(index))(f)
 
   def payloadError[A](codec: JCodec[A], message: String): Nothing =
     throw PayloadError(getPath(), codec.expecting, message)
@@ -87,7 +90,7 @@ object Cursor {
       f(cursor)
     } catch {
       case e: JsonReaderException => payloadError(cursor, e.getMessage())
-      case e: ConstraintError => payloadError(cursor, e.message)
+      case e: ConstraintError     => payloadError(cursor, e.message)
     }
   }
 

--- a/modules/json/test/src/smithy4s/http/json/SchemaVisitorJCodecTests.scala
+++ b/modules/json/test/src/smithy4s/http/json/SchemaVisitorJCodecTests.scala
@@ -454,7 +454,7 @@ class SchemaVisitorJCodecTests() extends FunSuite {
       fail("Unexpected success")
     } catch {
       case PayloadError(_, _, message) =>
-        expect(message == "input map exceeded max arity of `1024`")
+        expect(message == "Input map exceeded max arity of 1024")
     }
   }
 
@@ -469,7 +469,7 @@ class SchemaVisitorJCodecTests() extends FunSuite {
       fail("Unexpected success")
     } catch {
       case PayloadError(_, _, message) =>
-        expect.same(message, "input list exceeded max arity of `1024`")
+        expect.same(message, "Input list exceeded max arity of 1024")
     }
   }
 
@@ -480,7 +480,7 @@ class SchemaVisitorJCodecTests() extends FunSuite {
       fail("Unexpected success")
     } catch {
       case PayloadError(_, _, message) =>
-        expect.same(message, "input JSON document exceeded max arity of `1024`")
+        expect.same(message, "Input JSON document exceeded max arity of 1024")
     }
   }
 
@@ -492,7 +492,7 @@ class SchemaVisitorJCodecTests() extends FunSuite {
       fail("Unexpected success")
     } catch {
       case PayloadError(_, _, message) =>
-        expect.same(message, "input JSON document exceeded max arity of `1024`")
+        expect.same(message, "Input JSON document exceeded max arity of 1024")
     }
   }
 


### PR DESCRIPTION
Fixing of overlooked capacity sizing. Below are results of benchmarks for real-world messages on JDK 17.

## Before
```
[info] Benchmark                                  (size)   Mode  Cnt         Score         Error  Units
[info] GoogleMapsAPIReading.smithy4sJson             N/A  thrpt    5     15125.336 ±      34.299  ops/s
[info] OpenRTBReading.smithy4sJson                   N/A  thrpt    5    177589.601 ±    2958.052  ops/s
[info] TwitterAPIReading.smithy4sJson                N/A  thrpt    5     34670.625 ±    1334.928  ops/s
```
##
```
[info] Benchmark                                  (size)   Mode  Cnt         Score         Error  Units
[info] GoogleMapsAPIReading.smithy4sJson             N/A  thrpt    5     16034.257 ±      40.094  ops/s
[info] OpenRTBReading.smithy4sJson                   N/A  thrpt    5    183281.757 ±    7169.430  ops/s
[info] TwitterAPIReading.smithy4sJson                N/A  thrpt    5     36217.351 ±     284.032  ops/s
```