### PR TITLE
refinement validate only

### DIFF
--- a/modules/core/src/smithy4s/RefinementProvider.scala
+++ b/modules/core/src/smithy4s/RefinementProvider.scala
@@ -37,6 +37,13 @@ trait RefinementProvider[C, A, B] { self =>
       def make(c: C): Refinement[A0, B0] { type Constraint = C } =
         self.make(c).imapFull(bijectSource, bijectTarget)
     }
+
+  def validateOnly: RefinementProvider.Simple[C, A] =
+    Refinement
+      .drivenBy[C]
+      .contextual[A, A](c =>
+        Surjection(v => this.make(c).apply(v).map(_ => v), identity)
+      )(tag)
 }
 
 object RefinementProvider {


### PR DESCRIPTION
Usecase: in dynamic schemas, if one wants to reuse an existing provider in a generic context (e.g. `Schema ~> Schema` transformation), it is necessary to keep the underlying value unchanged (basically rejecting the result of the surjection) for the types to match up.

For example:

```scala
@refinement(targetType: "java.time.Instant", providerInstance: "playgrind.InstantProvider.provider")
@trait
structure instant { }
```

```scala
object InstantProvider {

  implicit val provider: RefinementProvider[Instant, Timestamp, java.time.Instant] = Refinement
    .drivenBy[Instant](
      Surjection.catching((_: Timestamp).toInstant, Timestamp.fromInstant(_))
    )

}
```

```scala
  def apply[A](schema: Schema[A]): Schema[A] =
    schema match {

      case PrimitiveSchema(_, _, Primitive.PTimestamp) =>
        schema
          .hints
          .get(playground.Instant)
          .fold(schema)(schema.refined(_)(instantProvider.provider)) //this won't compile as it's now a Schema[java.time.Instant]
      case _ => ???
    }
```

If we use `instantProvider.provider.validateOnly` with something like what this PR provides, it'll work - the `Instant` will be ditched after validation.