### PR TITLE
first pass at using mixins to create traits

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -619,7 +619,8 @@ lazy val example = projectMatrix
       (ThisBuild / baseDirectory).value / "sampleSpecs" / "brands.smithy",
       (ThisBuild / baseDirectory).value / "sampleSpecs" / "brandscommon.smithy",
       (ThisBuild / baseDirectory).value / "sampleSpecs" / "refined.smithy",
-      (ThisBuild / baseDirectory).value / "sampleSpecs" / "enums.smithy"
+      (ThisBuild / baseDirectory).value / "sampleSpecs" / "enums.smithy",
+      (ThisBuild / baseDirectory).value / "sampleSpecs" / "mixins.smithy"
     ),
     Compile / resourceDirectory := (ThisBuild / baseDirectory).value / "modules" / "example" / "resources",
     isCE3 := true,

--- a/modules/codegen/src/smithy4s/codegen/CollisionAvoidance.scala
+++ b/modules/codegen/src/smithy4s/codegen/CollisionAvoidance.scala
@@ -159,8 +159,10 @@ object CollisionAvoidance {
       protect(name.capitalize),
       originalName,
       fields.map(modField),
+      mixins.map(modType),
       recursive,
-      hints.map(modHint)
+      hints.map(modHint),
+      isMixin
     )
   }
 

--- a/modules/codegen/src/smithy4s/codegen/IR.scala
+++ b/modules/codegen/src/smithy4s/codegen/IR.scala
@@ -60,8 +60,10 @@ case class Product(
     name: String,
     originalName: String,
     fields: List[Field],
+    mixins: List[Type],
     recursive: Boolean = false,
-    hints: List[Hint] = Nil
+    hints: List[Hint] = Nil,
+    isMixin: Boolean = false
 ) extends Decl
 
 case class Union(

--- a/modules/codegen/src/smithy4s/codegen/SmithyToIR.scala
+++ b/modules/codegen/src/smithy4s/codegen/SmithyToIR.scala
@@ -143,7 +143,18 @@ private[codegen] class SmithyToIR(model: Model, namespace: String) {
         val rec = isRecursive(shape.getId())
 
         val hints = traitsToHints(shape.getAllTraits().asScala.values.toList)
-        val p = Product(shape.name, shape.name, shape.fields, rec, hints).some
+        val mixins = shape.getMixins.asScala.flatMap(_.tpe).toList
+        val isMixin = shape.hasTrait(classOf[MixinTrait])
+        val p =
+          Product(
+            shape.name,
+            shape.name,
+            shape.fields,
+            mixins,
+            rec,
+            hints,
+            isMixin
+          ).some
         if (shape.getTrait(classOf[AdtMemberTrait]).isPresent()) {
           if (renderAdtMemberStructures) p else None
         } else p

--- a/modules/example/src/smithy4s/example/CommonFieldsOne.scala
+++ b/modules/example/src/smithy4s/example/CommonFieldsOne.scala
@@ -1,0 +1,7 @@
+package smithy4s.example
+
+
+trait CommonFieldsOne {
+  def a: Option[String]
+  def b: Option[Int]
+}

--- a/modules/example/src/smithy4s/example/CommonFieldsTwo.scala
+++ b/modules/example/src/smithy4s/example/CommonFieldsTwo.scala
@@ -1,0 +1,6 @@
+package smithy4s.example
+
+
+trait CommonFieldsTwo {
+  def c: Option[Long]
+}

--- a/modules/example/src/smithy4s/example/EmptyMixin.scala
+++ b/modules/example/src/smithy4s/example/EmptyMixin.scala
@@ -1,0 +1,5 @@
+package smithy4s.example
+
+
+trait EmptyMixin {
+}

--- a/modules/example/src/smithy4s/example/MixinErrorExample.scala
+++ b/modules/example/src/smithy4s/example/MixinErrorExample.scala
@@ -1,0 +1,22 @@
+package smithy4s.example
+
+import smithy4s.schema.Schema._
+
+case class MixinErrorExample(a: Option[String] = None, b: Option[Int] = None, c: Option[Long] = None, d: Option[Boolean] = None) extends Throwable with CommonFieldsOne with CommonFieldsTwo {
+}
+object MixinErrorExample extends smithy4s.ShapeTag.Companion[MixinErrorExample] {
+  val id: smithy4s.ShapeId = smithy4s.ShapeId("smithy4s.example", "MixinErrorExample")
+
+  val hints : smithy4s.Hints = smithy4s.Hints(
+    smithy.api.Error.CLIENT.widen,
+  )
+
+  implicit val schema: smithy4s.Schema[MixinErrorExample] = struct(
+    string.optional[MixinErrorExample]("a", _.a),
+    int.optional[MixinErrorExample]("b", _.b),
+    long.optional[MixinErrorExample]("c", _.c),
+    boolean.optional[MixinErrorExample]("d", _.d),
+  ){
+    MixinErrorExample.apply
+  }.withId(id).addHints(hints)
+}

--- a/modules/example/src/smithy4s/example/MixinExample.scala
+++ b/modules/example/src/smithy4s/example/MixinExample.scala
@@ -1,0 +1,19 @@
+package smithy4s.example
+
+import smithy4s.schema.Schema._
+
+case class MixinExample(a: Option[String] = None, b: Option[Int] = None, c: Option[Long] = None, d: Option[Boolean] = None) extends CommonFieldsOne with CommonFieldsTwo
+object MixinExample extends smithy4s.ShapeTag.Companion[MixinExample] {
+  val id: smithy4s.ShapeId = smithy4s.ShapeId("smithy4s.example", "MixinExample")
+
+  val hints : smithy4s.Hints = smithy4s.Hints.empty
+
+  implicit val schema: smithy4s.Schema[MixinExample] = struct(
+    string.optional[MixinExample]("a", _.a),
+    int.optional[MixinExample]("b", _.b),
+    long.optional[MixinExample]("c", _.c),
+    boolean.optional[MixinExample]("d", _.d),
+  ){
+    MixinExample.apply
+  }.withId(id).addHints(hints)
+}

--- a/modules/example/src/smithy4s/example/TestEmptyMixin.scala
+++ b/modules/example/src/smithy4s/example/TestEmptyMixin.scala
@@ -1,0 +1,16 @@
+package smithy4s.example
+
+import smithy4s.schema.Schema._
+
+case class TestEmptyMixin(a: Option[Long] = None) extends EmptyMixin
+object TestEmptyMixin extends smithy4s.ShapeTag.Companion[TestEmptyMixin] {
+  val id: smithy4s.ShapeId = smithy4s.ShapeId("smithy4s.example", "TestEmptyMixin")
+
+  val hints : smithy4s.Hints = smithy4s.Hints.empty
+
+  implicit val schema: smithy4s.Schema[TestEmptyMixin] = struct(
+    long.optional[TestEmptyMixin]("a", _.a),
+  ){
+    TestEmptyMixin.apply
+  }.withId(id).addHints(hints)
+}

--- a/modules/example/src/smithy4s/example/TestMixinAdt.scala
+++ b/modules/example/src/smithy4s/example/TestMixinAdt.scala
@@ -1,0 +1,35 @@
+package smithy4s.example
+
+import smithy4s.schema.Schema._
+
+sealed trait TestMixinAdt extends scala.Product with scala.Serializable {
+  @inline final def widen: TestMixinAdt = this
+}
+object TestMixinAdt extends smithy4s.ShapeTag.Companion[TestMixinAdt] {
+  val id: smithy4s.ShapeId = smithy4s.ShapeId("smithy4s.example", "TestMixinAdt")
+
+  val hints : smithy4s.Hints = smithy4s.Hints.empty
+
+  case class TestAdtMemberWithMixin(a: Option[String] = None, b: Option[Int] = None) extends TestMixinAdt with CommonFieldsOne
+  object TestAdtMemberWithMixin extends smithy4s.ShapeTag.Companion[TestAdtMemberWithMixin] {
+    val id: smithy4s.ShapeId = smithy4s.ShapeId("smithy4s.example", "TestAdtMemberWithMixin")
+
+    val hints : smithy4s.Hints = smithy4s.Hints.empty
+
+    val schema: smithy4s.Schema[TestAdtMemberWithMixin] = struct(
+      string.optional[TestAdtMemberWithMixin]("a", _.a),
+      int.optional[TestAdtMemberWithMixin]("b", _.b),
+    ){
+      TestAdtMemberWithMixin.apply
+    }.withId(id).addHints(hints)
+
+    val alt = schema.oneOf[TestMixinAdt]("test")
+  }
+
+
+  implicit val schema: smithy4s.Schema[TestMixinAdt] = union(
+    TestAdtMemberWithMixin.alt,
+  ){
+    case c : TestAdtMemberWithMixin => TestAdtMemberWithMixin.alt(c)
+  }.withId(id).addHints(hints)
+}

--- a/sampleSpecs/mixins.smithy
+++ b/sampleSpecs/mixins.smithy
@@ -17,3 +17,9 @@ structure MixinExample with [CommonFieldsOne, CommonFieldsTwo] {
   c: Long
   d: Boolean
 }
+
+@error("client")
+structure MixinErrorExample with [CommonFieldsOne, CommonFieldsTwo] {
+  c: Long
+  d: Boolean
+}

--- a/sampleSpecs/mixins.smithy
+++ b/sampleSpecs/mixins.smithy
@@ -1,0 +1,19 @@
+$version: "2.0"
+
+namespace smithy4s.example
+
+@mixin
+structure CommonFieldsOne {
+  a: String
+  b: Integer
+}
+
+@mixin
+structure CommonFieldsTwo {
+  c: Long
+}
+
+structure MixinExample with [CommonFieldsOne, CommonFieldsTwo] {
+  c: Long
+  d: Boolean
+}

--- a/sampleSpecs/mixins.smithy
+++ b/sampleSpecs/mixins.smithy
@@ -2,6 +2,8 @@ $version: "2.0"
 
 namespace smithy4s.example
 
+use smithy4s.meta#adtMember
+
 @mixin
 structure CommonFieldsOne {
   a: String
@@ -23,3 +25,17 @@ structure MixinErrorExample with [CommonFieldsOne, CommonFieldsTwo] {
   c: Long
   d: Boolean
 }
+
+@mixin
+structure EmptyMixin {}
+
+structure TestEmptyMixin with [EmptyMixin] {
+  a: Long
+}
+
+union TestMixinAdt {
+  test: TestAdtMemberWithMixin
+}
+
+@adtMember(TestMixinAdt)
+structure TestAdtMemberWithMixin with [CommonFieldsOne] {}


### PR DESCRIPTION
The purpose of this PR is to use smithy 2.0 mixins to generate traits in the codegen.

Note this PR is based off of the `0.0.15-smithy2` branch.

See the examples in the PR for how traits look and are used.