### PR TITLE
Best-effort error-decoding fix

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -668,7 +668,7 @@ lazy val Dependencies = new {
 
   val Jsoniter =
     Def.setting(
-      "com.github.plokhotnyuk.jsoniter-scala" %%% "jsoniter-scala-core" % "2.13.38"
+      "com.github.plokhotnyuk.jsoniter-scala" %%% "jsoniter-scala-core" % "2.13.39"
     )
 
   val Smithy = new {

--- a/build.sbt
+++ b/build.sbt
@@ -668,7 +668,7 @@ lazy val Dependencies = new {
 
   val Jsoniter =
     Def.setting(
-      "com.github.plokhotnyuk.jsoniter-scala" %%% "jsoniter-scala-core" % "2.13.39"
+      "com.github.plokhotnyuk.jsoniter-scala" %%% "jsoniter-scala-core" % "2.14.0"
     )
 
   val Smithy = new {

--- a/modules/core/src/smithy4s/ShapeId.scala
+++ b/modules/core/src/smithy4s/ShapeId.scala
@@ -24,6 +24,14 @@ final case class ShapeId(namespace: String, name: String) extends HasId {
 }
 
 object ShapeId extends ShapeTag.Has[ShapeId] {
+  def parse(string: String): Option[ShapeId] = {
+    if (!string.contains('#')) None
+    else {
+      val segments = string.split("#")
+      if (segments.length > 1) None
+      else Some(ShapeId(segments(0), segments(1)))
+    }
+  }
 
   final case class Member(shapeId: ShapeId, member: String)
 

--- a/modules/core/src/smithy4s/http/ErrorAltPicker.scala
+++ b/modules/core/src/smithy4s/http/ErrorAltPicker.scala
@@ -33,8 +33,14 @@ import smithy4s.http.ErrorAltPicker.ErrorDiscriminator.StatusCode
   * @param alts alternatives of the error union to choose from
   */
 final class ErrorAltPicker[E](alts: Vector[SchemaAlt[E, _]]) {
-  private val byShapeId = alts.map { alt => alt.instance.shapeId -> alt }.toMap
-  private val byName = alts.map(alt => alt.instance.shapeId.name -> alt).toMap
+  private val byShapeId = alts
+    .map { alt => alt.instance.shapeId -> alt }
+    .toMap[ShapeId, SchemaAlt[E, _]]
+
+  private val byName = alts
+    .map(alt => alt.instance.shapeId.name -> alt)
+    .toMap[String, SchemaAlt[E, _]]
+
   private val byStatusCode = {
     alts
       .groupBy { alt =>
@@ -49,7 +55,7 @@ final class ErrorAltPicker[E](alts: Vector[SchemaAlt[E, _]]) {
       .collect {
         case (Some(key), values) if values.size == 1 => key -> values.head
       }
-  }.toMap
+  }.toMap[Int, SchemaAlt[E, _]]
 
   def getPreciseAlternative(
       discriminator: ErrorDiscriminator

--- a/modules/core/src/smithy4s/http/Metadata.scala
+++ b/modules/core/src/smithy4s/http/Metadata.scala
@@ -169,6 +169,7 @@ object Metadata {
     def decode(metadata: Metadata): Either[MetadataError, MetadataPartial[A]]
 
     def total: Option[TotalDecoder[A]]
+
   }
 
   object PartialDecoder {

--- a/modules/core/src/smithy4s/http/UnknownErrorResponse.scala
+++ b/modules/core/src/smithy4s/http/UnknownErrorResponse.scala
@@ -22,5 +22,5 @@ case class UnknownErrorResponse(
     body: String
 ) extends Throwable {
   override def getMessage(): String =
-    s"Received unknown response: status $code, body:\n$body"
+    s"status $code, headers: $headers, body:\n$body"
 }

--- a/modules/http4s/src/smithy4s/http4s/internals/SmithyHttp4sClientEndpoint.scala
+++ b/modules/http4s/src/smithy4s/http4s/internals/SmithyHttp4sClientEndpoint.scala
@@ -161,7 +161,7 @@ private[smithy4s] class SmithyHttp4sClientEndpointImpl[F[_], Op[_, _, _, _, _], 
                 .map(alt.inject)
             }
           }
-        }.unsafeCache(allAlternatives)
+        }.unsafeCache(allAlternatives.map(Existential.wrap(_)))
 
         (response: Response[F]) => {
           val discriminator = getErrorDiscriminator(response)

--- a/modules/http4s/src/smithy4s/http4s/internals/SmithyHttp4sClientEndpoint.scala
+++ b/modules/http4s/src/smithy4s/http4s/internals/SmithyHttp4sClientEndpoint.scala
@@ -127,84 +127,53 @@ private[smithy4s] class SmithyHttp4sClientEndpointImpl[F[_], Op[_, _, _, _, _], 
     }
   }
 
-  private def outputFromErrorResponse(response: Response[F]): F[O] = {
+  private def getErrorDiscriminator(response: Response[F]) = {
+    getFirstHeader(response, errorTypeHeader)
+      .map(errorType =>
+        ShapeId
+          .parse(errorType)
+          .map(ErrorAltPicker.ErrorDiscriminator.FullId(_))
+          .getOrElse(ErrorAltPicker.ErrorDiscriminator.NameOnly(errorType))
+      )
+      .getOrElse(
+        ErrorAltPicker.ErrorDiscriminator.StatusCode(response.status.code)
+      )
+  }
 
-    /**
-      * Find the error schema alternative that matches the errorTypeHeader.
-      */
-    def findErrorAltForHeader(err: Errorable[E]) = for {
-      discriminator <- getFirstHeader(response, errorTypeHeader)
-      oneOf <- err.error.alternatives.find(_.label == discriminator)
-    } yield oneOf
-
-    /**
-      * Attempt to decode for all union member, return as soon as one
-      * decodes successfully.
-      */
-    def bestEffort(
-        errorable: Errorable[E],
-        alts: Vector[SchemaAlt[E, _]]
-    ): F[O] = {
-      alts
-        .collectFirstSomeM { oneOf =>
-          tryProcessError(errorable, oneOf, response)
-            .map(_.toOption)
-            .handleError { case _: PayloadError => None }
-        }
-        .flatMap {
-          case Some(e) =>
-            effect.raiseError(errorable.unliftError(e))
-          case None =>
-            errorResponseFallBack(response)
-        }
-    }
-
+  private val outputFromErrorResponse: Response[F] => F[O] = {
     endpoint.errorable match {
-      case None => // can't do anything w/o the errorable
-        errorResponseFallBack(response)
-      case Some(errorable) =>
-        val statusInt = response.status.code
-        val errorAltPicker =
-          new ErrorAltPicker(errorable.error.alternatives)
-        // try to find precisely either by status code unique match
-        // or by matching the errorTypeHeader
-        val maybePreciseAlt =
-          errorAltPicker
-            .getPreciseAlternative(statusInt)
-            .orElse(findErrorAltForHeader(errorable))
+      case None => errorResponseFallBack(_)
+      case Some(err) =>
+        val allAlternatives = err.error.alternatives
+        val picker = new ErrorAltPicker(allAlternatives)
+        type ErrorDecoder[A] = Response[F] => F[E]
+        val decodeFunction = new PolyFunction[SchemaAlt[E, *], ErrorDecoder] {
+          def apply[A](alt: SchemaAlt[E, A]): Response[F] => F[E] = {
+            val schema = alt.instance
+            val errorMetadataDecoder =
+              Metadata.PartialDecoder.fromSchema(schema)
+            implicit val errorCodec =
+              entityCompiler.compilePartialEntityDecoder(schema)
 
-        val maybeError = maybePreciseAlt.map { alt =>
-          processError(errorable, alt, response)
-        }
+            (response: Response[F]) => {
+              decodeResponse[A](response, errorMetadataDecoder)
+                .flatMap(_.liftTo[F])
+                .map(alt.inject)
+            }
+          }
+        }.unsafeCache(allAlternatives)
 
-        // if no response is rendered by then, do a best effort
-        maybeError.getOrElse {
-          val sortedAlts = errorAltPicker.orderedForStatus(statusInt)
-          bestEffort(errorable, sortedAlts)
+        (response: Response[F]) => {
+          val discriminator = getErrorDiscriminator(response)
+          picker.getPreciseAlternative(discriminator) match {
+            case None => errorResponseFallBack(response)
+            case Some(alt) =>
+              decodeFunction(alt)(response)
+                .map(err.unliftError)
+                .flatMap(effect.raiseError)
+          }
         }
     }
-  }
-
-  private def processError[ErrorType](
-      errorable: Errorable[E],
-      oneOf: SchemaAlt[E, ErrorType],
-      response: Response[F]
-  ): F[O] = {
-    tryProcessError(errorable, oneOf, response).rethrow
-      .map(errorable.unliftError)
-      .flatMap(effect.raiseError)
-  }
-
-  private def tryProcessError[ErrorType](
-      errorable: Errorable[E],
-      oneOf: SchemaAlt[E, ErrorType],
-      response: Response[F]
-  ): F[Either[MetadataError, E]] = {
-    val schema = oneOf.instance
-    val errorMetadataDecoder = Metadata.PartialDecoder.fromSchema(schema)
-    implicit val errorCodec = entityCompiler.compilePartialEntityDecoder(schema)
-    decodeResponse[ErrorType](response, errorMetadataDecoder)
-      .map(_.map(oneOf.inject))
   }
 
   private def decodeResponse[T](


### PR DESCRIPTION

    Remove the best-effort error-decoding logic
    
    Now, when a client gets an unsuccessful response from a server, it'll
    try to inspect the X-Error-Type header first, and then will try to match
    the received status code against the errors it knows about
    (provided the code in question is uniquely used)
    
    If the client cannot infer a unique alternative based on this
    information, it'll raise a generic "UnknownErrorResponse"