### PR TITLE
Use jsonName on Missing required field error

### DIFF
--- a/modules/core/src/smithy4s/http/HttpContractError.scala
+++ b/modules/core/src/smithy4s/http/HttpContractError.scala
@@ -44,7 +44,7 @@ case class PayloadError(
 ) extends HttpContractError {
   override def toString(): String =
     s"PayloadError($path, expected = $expected, message=$message)"
-  override def getMessage(): String = message
+  override def getMessage(): String = s"$message (path: $path)"
 }
 
 object PayloadError {

--- a/modules/json/src/smithy4s/http/json/Cursor.scala
+++ b/modules/json/src/smithy4s/http/json/Cursor.scala
@@ -63,12 +63,7 @@ class Cursor private () {
       top -= 1
       list = stack(top) :: list
     }
-    val path = PayloadPath(list)
-    throw PayloadError(
-      path,
-      expecting,
-      s"Missing required field at $path"
-    )
+    throw PayloadError(PayloadPath(list), expecting, "Missing required field")
   }
 
   private def getPath(): PayloadPath = {

--- a/modules/json/src/smithy4s/http/json/Cursor.scala
+++ b/modules/json/src/smithy4s/http/json/Cursor.scala
@@ -63,7 +63,12 @@ class Cursor private () {
       top -= 1
       list = stack(top) :: list
     }
-    throw PayloadError(PayloadPath(list), expecting, "Missing required field")
+    val path = PayloadPath(list)
+    throw PayloadError(
+      path,
+      expecting,
+      s"Missing required field at $path"
+    )
   }
 
   private def getPath(): PayloadPath = {

--- a/modules/json/src/smithy4s/http/json/SchemaVisitorJCodec.scala
+++ b/modules/json/src/smithy4s/http/json/SchemaVisitorJCodec.scala
@@ -1157,7 +1157,10 @@ private[smithy4s] class SchemaVisitorJCodec(maxArity: Int)
             stage2 += {
               val value = buffer.get(f.label)
               if (f.isRequired) {
-                if (value == null) cursor.requiredFieldError(f.label, f.label)
+                if (value == null) {
+                  val label = jsonLabel(f)
+                  cursor.requiredFieldError(label, label)
+                }
                 value
               } else Option(value)
             }
@@ -1215,7 +1218,10 @@ private[smithy4s] class SchemaVisitorJCodec(maxArity: Int)
             stage2 += {
               val value = buffer.get(f.label)
               if (f.isRequired) {
-                if (value == null) cursor.requiredFieldError(f.label, f.label)
+                if (value == null) {
+                  val label = jsonLabel(f)
+                  cursor.requiredFieldError(label, label)
+                }
                 value
               } else Option(value)
             }

--- a/modules/json/src/smithy4s/http/json/SchemaVisitorJCodec.scala
+++ b/modules/json/src/smithy4s/http/json/SchemaVisitorJCodec.scala
@@ -1085,9 +1085,10 @@ private[smithy4s] class SchemaVisitorJCodec(maxArity: Int)
   }
 
   private type Fields[Z] = Vector[Field[Schema, Z, _]]
+  private type LabelledFields[Z] = Vector[(Field[Schema, Z, _], String)]
 
   private def nonPayloadStruct[Z](
-      fields: Fields[Z],
+      fields: LabelledFields[Z],
       structHints: Hints
   )(
       const: Vector[Any] => Z,
@@ -1096,7 +1097,7 @@ private[smithy4s] class SchemaVisitorJCodec(maxArity: Int)
     new JCodec[Z] {
 
       private[this] val documentFields =
-        fields.filter { field =>
+        fields.filter { case (field, _) =>
           HttpBinding
             .fromHints(field.label, field.hints, structHints)
             .isEmpty
@@ -1104,13 +1105,13 @@ private[smithy4s] class SchemaVisitorJCodec(maxArity: Int)
 
       private[this] val handlers =
         new util.HashMap[String, Handler](documentFields.length << 1, 0.5f) {
-          documentFields.foreach(field =>
+          documentFields.foreach { case (field, _) =>
             put(jsonLabel(field), fieldHandler(field))
-          )
+          }
         }
 
       private[this] val documentEncoders =
-        documentFields.map(field => fieldEncoder(field))
+        documentFields.map(labelledField => fieldEncoder(labelledField._1))
 
       def expecting: String = "object"
 
@@ -1153,18 +1154,17 @@ private[smithy4s] class SchemaVisitorJCodec(maxArity: Int)
         { (meta: scala.collection.Map[String, Any]) =>
           meta.foreach(kv => buffer.put(kv._1, kv._2))
           val stage2 = new VectorBuilder[Any]
-          fields.foreach(f =>
+          fields.foreach { case (f, jsonLabel) =>
             stage2 += {
               val value = buffer.get(f.label)
               if (f.isRequired) {
                 if (value == null) {
-                  val label = jsonLabel(f)
-                  cursor.requiredFieldError(label, label)
+                  cursor.requiredFieldError(jsonLabel, jsonLabel)
                 }
                 value
               } else Option(value)
             }
-          )
+          }
           const(stage2.result())
         }
       }
@@ -1181,7 +1181,7 @@ private[smithy4s] class SchemaVisitorJCodec(maxArity: Int)
 
   private def payloadStruct[A, Z](
       payloadField: Field[Schema, Z, _],
-      fields: Fields[Z]
+      fields: LabelledFields[Z]
   )(codec: JCodec[payloadField.T], const: Vector[Any] => Z): JCodec[Z] =
     new JCodec[Z] {
       def expecting: String = "object"
@@ -1214,18 +1214,17 @@ private[smithy4s] class SchemaVisitorJCodec(maxArity: Int)
         { (meta: scala.collection.Map[String, Any]) =>
           meta.foreach(kv => buffer.put(kv._1, kv._2))
           val stage2 = new VectorBuilder[Any]
-          fields.foreach(f =>
+          fields.foreach { case (f, jsonLabel) =>
             stage2 += {
               val value = buffer.get(f.label)
               if (f.isRequired) {
                 if (value == null) {
-                  val label = jsonLabel(f)
-                  cursor.requiredFieldError(label, label)
+                  cursor.requiredFieldError(jsonLabel, jsonLabel)
                 }
                 value
               } else Option(value)
             }
-          )
+          }
           const(stage2.result())
         }
       }
@@ -1255,7 +1254,8 @@ private[smithy4s] class SchemaVisitorJCodec(maxArity: Int)
         out.writeObjectEnd()
     }
 
-    nonPayloadStruct(fields, structHints)(make, encode)
+    val labelledFields = fields.map(f => f -> jsonLabel(f))
+    nonPayloadStruct(labelledFields, structHints)(make, encode)
   }
 
   override def struct[S](
@@ -1267,7 +1267,8 @@ private[smithy4s] class SchemaVisitorJCodec(maxArity: Int)
     (fields.find(_.hints.get(HttpPayload).isDefined), hints) match {
       case (Some(payloadField), _) =>
         val codec = apply(payloadField.instance)
-        payloadStruct(payloadField, fields)(codec, make)
+        val labelledField = fields.map(f => f -> jsonLabel(f))
+        payloadStruct(payloadField, labelledField)(codec, make)
       case (None, DiscriminatedUnionMember.hint(d)) =>
         val encode =
           if (
@@ -1296,7 +1297,8 @@ private[smithy4s] class SchemaVisitorJCodec(maxArity: Int)
               documentEncoders.foreach(encoder => encoder(z, out))
               out.writeObjectEnd()
           }
-        nonPayloadStruct(fields, hints)(make, encode)
+        val labelledFields = fields.map(f => f -> jsonLabel(f))
+        nonPayloadStruct(labelledFields, hints)(make, encode)
       case _ =>
         basicStruct(fields, hints)(make)
     }

--- a/modules/json/test/src/smithy4s/http/json/SchemaVisitorJCodecTests.scala
+++ b/modules/json/test/src/smithy4s/http/json/SchemaVisitorJCodecTests.scala
@@ -146,9 +146,7 @@ class SchemaVisitorJCodecTests() extends FunSuite {
     }
   }
 
-  test(
-    "Required: JsonName is used when missing required field is annotated".only
-  ) {
+  test("Required: JsonName is used when missing required field is annotated") {
     val jsonNameValue = "oldName"
     case class Bar(name: String)
     object Bar {

--- a/modules/json/test/src/smithy4s/http/json/SchemaVisitorJCodecTests.scala
+++ b/modules/json/test/src/smithy4s/http/json/SchemaVisitorJCodecTests.scala
@@ -161,9 +161,10 @@ class SchemaVisitorJCodecTests() extends FunSuite {
       val _ = readFromString[Bar](json)
       fail("Unexpected success")
     } catch {
-      case PayloadError(path, expected, _) =>
+      case ex @ PayloadError(path, expected, _) =>
         expect(path == PayloadPath(jsonNameValue))
         expect(expected == jsonNameValue)
+        expect.same(ex.getMessage(), "Missing required field (path: .oldName)")
     }
   }
 
@@ -343,8 +344,8 @@ class SchemaVisitorJCodecTests() extends FunSuite {
     val json = """{"qty":0}"""
     val result = util.Try(readFromString[RangeCheck](json))
     expect(
-      result.failed.get.getMessage == "Input must be >= 1.0, but was 0.0" ||
-        result.failed.get.getMessage == "Input must be >= 1, but was 0" // js
+      result.failed.get.getMessage == "Input must be >= 1.0, but was 0.0 (path: .qty)" ||
+        result.failed.get.getMessage == "Input must be >= 1, but was 0 (path: .qty)" // js
     )
   }
 
@@ -380,7 +381,7 @@ class SchemaVisitorJCodecTests() extends FunSuite {
     val result = util.Try(readFromString[Bar](json))
     expect.same(
       result.failed.get.getMessage,
-      "length required to be <= 10, but was 11"
+      "length required to be <= 10, but was 11 (path: .str)"
     )
   }
 
@@ -390,7 +391,7 @@ class SchemaVisitorJCodecTests() extends FunSuite {
     val result = util.Try(readFromString[Bar](json))
     expect.same(
       result.failed.get.getMessage,
-      "length required to be <= 10, but was 11"
+      "length required to be <= 10, but was 11 (path: .lst)"
     )
   }
 
@@ -401,8 +402,8 @@ class SchemaVisitorJCodecTests() extends FunSuite {
     expect.same(
       result.failed.get.getMessage,
       (if (!Platform.isJS)
-         "Input must be <= 10, but was 11.0"
-       else "Input must be <= 10, but was 11")
+         "Input must be <= 10, but was 11.0 (path: .int)"
+       else "Input must be <= 10, but was 11 (path: .int)")
     )
   }
 
@@ -430,7 +431,7 @@ class SchemaVisitorJCodecTests() extends FunSuite {
     val result = util.Try(readFromString[Foo2](json))
     expect.same(
       result.failed.get.getMessage,
-      "length required to be <= 10, but was 11"
+      "length required to be <= 10, but was 11 (path: .bar.str)"
     )
   }
 


### PR DESCRIPTION
On top of that, I include a change to improve the `message` of such error so that we know the path where a field was expected but not found.