### PR TITLE
Part 1 of httpResponseCode handling

### DIFF
--- a/modules/core/src/smithy4s/http/internals/HttpResponseCodeSchemaVisitor.scala
+++ b/modules/core/src/smithy4s/http/internals/HttpResponseCodeSchemaVisitor.scala
@@ -1,0 +1,72 @@
+/*
+ *  Copyright 2021-2022 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package smithy4s.http.internals
+
+import smithy4s.Hints
+import smithy4s.schema.SchemaField
+import smithy4s.schema.SchemaVisitor
+import smithy4s.ShapeId
+import smithy4s.schema.Field
+import smithy4s.schema.Schema
+
+import smithy4s.http.internals.HttpResponseCodeSchemaVisitor.MaybeExtractor
+
+class HttpResponseCodeSchemaVisitor
+    extends SchemaVisitor.Default[MaybeExtractor] {
+  def default[A]: MaybeExtractor[A] = None
+
+  override def struct[S](
+      shapeId: ShapeId,
+      hints: Hints,
+      fields: Vector[SchemaField[S, _]],
+      make: IndexedSeq[Any] => S
+  ): MaybeExtractor[S] = {
+    def compileField[A](field: SchemaField[S, A]): MaybeExtractor[S] = {
+      val folder = new Field.Folder[Schema, S, ResponseCodeExtractor[S]]() {
+        def onOptional[AA](
+            label: String,
+            instance: Schema[AA],
+            get: S => Option[AA]
+        ): ResponseCodeExtractor[S] =
+          new ResponseCodeExtractor[S] {
+            def apply(s: S): Option[Int] = get(s).map(_.asInstanceOf[Int])
+          }
+        def onRequired[AA](
+            label: String,
+            instance: Schema[AA],
+            get: S => AA
+        ): ResponseCodeExtractor[S] =
+          new ResponseCodeExtractor[S] {
+            def apply(s: S): Option[Int] = Some(get(s).asInstanceOf[Int])
+          }
+      }
+
+      field.hints
+        .get[smithy.api.HttpResponseCode]
+        .map(_ => field.fold(folder))
+    }
+    fields.flatMap(f => compileField(f)).headOption
+  }
+}
+
+object HttpResponseCodeSchemaVisitor {
+  type MaybeExtractor[A] = Option[ResponseCodeExtractor[A]]
+}
+
+trait ResponseCodeExtractor[A] {
+  def apply(a: A): Option[Int]
+}

--- a/modules/core/test/src/smithy4s/ShapeIdHintsSmokeSpec.scala
+++ b/modules/core/test/src/smithy4s/ShapeIdHintsSmokeSpec.scala
@@ -77,7 +77,6 @@ class ShapeIdHintsSmokeSpec() extends munit.FunSuite {
 
   test("newtypes contain ShapeId in hints") {
     val shapeIds = example.CityId.schema.compile(TestCompiler)
-    println(s"YEAH $shapeIds")
     expect(
       shapeIds.contains(
         ShapeId(

--- a/modules/tests/src/smithy4s/tests/PizzaAdminServiceImpl.scala
+++ b/modules/tests/src/smithy4s/tests/PizzaAdminServiceImpl.scala
@@ -103,4 +103,7 @@ class PizzaAdminServiceImpl(ref: Compat.Ref[IO, State])
     RoundTripData(label, header, query, body)
   )
 
+  def customCode(code: Int): IO[CustomCodeOutput] =
+    IO.pure(CustomCodeOutput(if (code != 0) Some(code) else None))
+
 }

--- a/modules/tests/src/smithy4s/tests/PizzaSpec.scala
+++ b/modules/tests/src/smithy4s/tests/PizzaSpec.scala
@@ -401,6 +401,18 @@ abstract class PizzaSpec
     "X-mIxEd-HeAdEr"
   )
 
+  routerTest("httpResponsecode") { (client, uri, log) =>
+    for {
+      res <- client.send[Unit](
+        GET(uri = uri / "custom-code" / "201"),
+        log
+      )
+    } yield {
+      val (code, _, _) = res
+      expect.same(code, 201)
+    }
+  }
+
   // note: these aren't really part of the pizza suite
 
   pureTest("Happy path: httpMatch") {

--- a/sampleSpecs/pizza.smithy
+++ b/sampleSpecs/pizza.smithy
@@ -6,7 +6,7 @@ use smithy4s.api#simpleRestJson
 service PizzaAdminService {
   version: "1.0.0",
   errors: [GenericServerError, GenericClientError],
-  operations: [AddMenuItem, GetMenu, Version, Health, HeaderEndpoint, RoundTrip, GetEnum]
+  operations: [AddMenuItem, GetMenu, Version, Health, HeaderEndpoint, RoundTrip, GetEnum, CustomCode]
 }
 
 @http(method: "POST", uri: "/restaurant/{restaurant}/menu/item", code: 201)
@@ -249,3 +249,22 @@ structure GetEnumOutput {
   {value: "v2", name: "V2"}
 ])
 string TheEnum
+
+@readonly
+@http(method: "GET", uri: "/custom-code/{code}", code: 200)
+operation CustomCode {
+  input: CustomCodeInput,
+  output: CustomCodeOutput,
+  errors: [ UnknownServerError ]
+}
+
+structure CustomCodeInput {
+  @httpLabel
+  @required
+  code: Integer
+}
+
+structure CustomCodeOutput {
+  @httpResponseCode
+  code: Integer
+}


### PR DESCRIPTION
Grab code from output, if there, and use it as a response code. Otherwise, use whatever is defined for the endpoint.

I still need to remove the value from the serialized result (json).