### PR TITLE
Refer to the job name, not the steps

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -2,7 +2,7 @@ pull_request_rules:
   - name: Automatically approve/merge Scala Steward PRs on CI success
     conditions:
       - author=scala-steward
-      - status-success="Build matrix completed"
+      - status-success="build-success-checkpoint"
       - body~=labels:.*semver-spec-patch
     actions:
       review:


### PR DESCRIPTION
![Screen Shot 2022-08-18 at 10 04 48](https://user-images.githubusercontent.com/5230460/185415130-6d46e557-851a-4dbf-bca2-0f891856c7e5.png)


we can see that it does not match in swagger-ui pr (it would not have in all scenario because the bump is not a patch bump)