### PR TITLE
fix init ordering bug

### DIFF
--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/defaults/build.sbt
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/defaults/build.sbt
@@ -1,6 +1,6 @@
 lazy val root = (project in file("."))
   .enablePlugins(Smithy4sCodegenPlugin)
   .settings(
-    scalaVersion := "2.13.6",
+    scalaVersion := "2.13.8",
     libraryDependencies += "com.disneystreaming.smithy4s" %% "smithy4s-core" % smithy4sVersion.value
   )

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/defaults/src/main/scala/Main.scala
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/defaults/src/main/scala/Main.scala
@@ -1,0 +1,27 @@
+/*
+ *  Copyright 2021-2022 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package demo
+
+object Main extends App {
+  try {
+    println(smithy.api.NonEmptyString("nope").value)
+  } catch {
+    case _: java.lang.ExceptionInInitializerError =>
+      println("failed")
+      sys.exit(1)
+  }
+}

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/defaults/test
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/defaults/test
@@ -2,3 +2,7 @@
 > compile
 $ exists target/scala-2.13/src_managed/main/smithy4s/example/ObjectService.scala
 $ exists target/scala-2.13/resource_managed/main/smithy4s.example.ObjectService.json
+
+# check if code can run, this can reveal runtime issues
+# such as initialization errors
+> run

--- a/modules/codegen/src/smithy4s/codegen/CollisionAvoidance.scala
+++ b/modules/codegen/src/smithy4s/codegen/CollisionAvoidance.scala
@@ -70,12 +70,13 @@ object CollisionAvoidance {
           recursive,
           hints.map(modHint)
         )
-      case TypeAlias(name, originalName, tpe, isUnwrapped, hints) =>
+      case TypeAlias(name, originalName, tpe, isUnwrapped, rec, hints) =>
         TypeAlias(
           protect(name.capitalize),
           originalName,
           modType(tpe),
           isUnwrapped,
+          rec,
           hints.map(modHint)
         )
       case Enumeration(name, originalName, values, hints) =>

--- a/modules/codegen/src/smithy4s/codegen/IR.scala
+++ b/modules/codegen/src/smithy4s/codegen/IR.scala
@@ -84,6 +84,7 @@ case class TypeAlias(
     originalName: String,
     tpe: Type,
     isUnwrapped: Boolean,
+    recursive: Boolean = false,
     hints: List[Hint] = Nil
 ) extends Decl
 

--- a/modules/core/src/smithy4s/RefinementProvider.scala
+++ b/modules/core/src/smithy4s/RefinementProvider.scala
@@ -68,10 +68,10 @@ object RefinementProvider {
       iso: Bijection[A, A0]
   ): Simple[C, A0] = constraintOnA.imapFull[A0, A0](iso, iso)
 
-  implicit val stringLengthConstraint: Simple[Length, String] =
+  implicit def stringLengthConstraint: Simple[Length, String] =
     new LengthConstraint[String](_.length)
 
-  implicit val byteArrayLengthConstraint: Simple[Length, ByteArray] =
+  implicit def byteArrayLengthConstraint: Simple[Length, ByteArray] =
     new LengthConstraint[ByteArray](_.array.length)
 
   implicit def iterableLengthConstraint[C[_], A](implicit
@@ -111,7 +111,7 @@ object RefinementProvider {
     }
   }
 
-  implicit val stringPatternConstraints: Simple[Pattern, String] =
+  implicit def stringPatternConstraints: Simple[Pattern, String] =
     new SimpleImpl[Pattern, String] {
 
       def get(

--- a/modules/core/src/smithy4s/RefinementProvider.scala
+++ b/modules/core/src/smithy4s/RefinementProvider.scala
@@ -68,10 +68,10 @@ object RefinementProvider {
       iso: Bijection[A, A0]
   ): Simple[C, A0] = constraintOnA.imapFull[A0, A0](iso, iso)
 
-  implicit def stringLengthConstraint: Simple[Length, String] =
+  implicit val stringLengthConstraint: Simple[Length, String] =
     new LengthConstraint[String](_.length)
 
-  implicit def byteArrayLengthConstraint: Simple[Length, ByteArray] =
+  implicit val byteArrayLengthConstraint: Simple[Length, ByteArray] =
     new LengthConstraint[ByteArray](_.array.length)
 
   implicit def iterableLengthConstraint[C[_], A](implicit
@@ -111,7 +111,7 @@ object RefinementProvider {
     }
   }
 
-  implicit def stringPatternConstraints: Simple[Pattern, String] =
+  implicit val stringPatternConstraints: Simple[Pattern, String] =
     new SimpleImpl[Pattern, String] {
 
       def get(

--- a/modules/example/src/smithy4s/example/ArbitraryData.scala
+++ b/modules/example/src/smithy4s/example/ArbitraryData.scala
@@ -3,6 +3,7 @@ package smithy4s.example
 import smithy4s.Schema
 import smithy4s.Hints
 import smithy4s.ShapeId
+import smithy4s.schema.Schema.recursive
 import smithy4s.schema.Schema.bijection
 import smithy4s.Document
 import smithy4s.Newtype
@@ -14,5 +15,5 @@ object ArbitraryData extends Newtype[Document] {
     smithy.api.Trait(None, None, None, None),
   )
   val underlyingSchema : Schema[Document] = document.withId(id).addHints(hints)
-  implicit val schema : Schema[ArbitraryData] = bijection(underlyingSchema, asBijection)
+  implicit val schema : Schema[ArbitraryData] = recursive(bijection(underlyingSchema, asBijection))
 }

--- a/modules/example/src/smithy4s/example/TestTrait.scala
+++ b/modules/example/src/smithy4s/example/TestTrait.scala
@@ -4,6 +4,7 @@ import smithy4s.Schema
 import smithy4s.Hints
 import smithy4s.ShapeId
 import smithy4s.schema.Schema.struct
+import smithy4s.schema.Schema.recursive
 import smithy4s.ShapeTag
 
 case class TestTrait(orderType: Option[OrderType] = None)
@@ -14,9 +15,9 @@ object TestTrait extends ShapeTag.Companion[TestTrait] {
     smithy.api.Trait(None, None, None, None),
   )
 
-  implicit val schema: Schema[TestTrait] = struct(
+  implicit val schema: Schema[TestTrait] = recursive(struct(
     OrderType.schema.optional[TestTrait]("orderType", _.orderType),
   ){
     TestTrait.apply
-  }.withId(id).addHints(hints)
+  }.withId(id).addHints(hints))
 }


### PR DESCRIPTION
Makes it so that all trait schemas are wrapped in schema.recursive. This is one method of dealing with the bug from #383. I am fine if we decide to go another direction, but wanted to give this a shot.

Closes #383