### PR TITLE
Auto-update GitHub Action dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,7 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+  - package-ecosystem: 'npm'
+    directory: '/modules/website'
+    schedule:
+      interval: 'monthly'


### PR DESCRIPTION
**Summary**
This will keep stuff like `- uses: actions/checkout@v2` updated (v3 is latest) in Github Actions, e.g. in the [CI action](https://github.com/disneystreaming/smithy4s/blob/main/.github/workflows/ci.yml#L50)

> Actions are often updated with bug fixes and new features to make automated processes more reliable, faster, and safer. When you enable Dependabot version updates for GitHub Actions, Dependabot will help ensure that references to actions in a repository's workflow.yml file are kept up to date.
~ https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot