### PR TITLE
update how mixins and structs with mismatches are handled

### DIFF
--- a/modules/codegen/src/smithy4s/codegen/SmithyToIR.scala
+++ b/modules/codegen/src/smithy4s/codegen/SmithyToIR.scala
@@ -171,6 +171,36 @@ private[codegen] class SmithyToIR(model: Model, namespace: String) {
         x
       )
 
+      private def doFieldsMatch(
+          mixinId: ShapeId,
+          fields: List[Field]
+      ): Boolean = {
+        val mixin: StructureShape =
+          model
+            .getShape(mixinId)
+            .asScala
+            .flatMap(_.asStructureShape.asScala)
+            .getOrElse(
+              throw new IllegalArgumentException(
+                s"Unable to find mixin with id: $mixinId"
+              )
+            )
+        val mixinMembers = mixin.getAllMembers().asScala
+        mixinMembers.foldLeft(true) { case (state, (memberName, member)) =>
+          fields.find(_.name == memberName) match {
+            case None => state
+            case Some(field) =>
+              val memberOptional = !member.hasTrait(classOf[RequiredTrait])
+              val memberHasNoDefault = !member.hasTrait(classOf[DefaultTrait])
+
+              // if member has no default and is optional, then the field must be optional
+              if (memberHasNoDefault && memberOptional) {
+                state && !field.required
+              } else state
+          }
+        }
+      }
+
       override def structureShape(shape: StructureShape): Option[Decl] = {
         val hints = traitsToHints(shape.getAllTraits().asScala.values.toList)
         val isTrait = hints.exists {
@@ -179,13 +209,19 @@ private[codegen] class SmithyToIR(model: Model, namespace: String) {
         }
         val rec = isRecursive(shape.getId()) || isTrait
 
-        val mixins = shape.getMixins.asScala.flatMap(_.tpe).toList
+        val fields = shape.fields
+        val filteredMixins = shape
+          .getMixins()
+          .asScala
+          .filter(mixinId => doFieldsMatch(mixinId, fields))
+        val mixins = filteredMixins.flatMap(_.tpe).toList
         val isMixin = shape.hasTrait(classOf[MixinTrait])
+
         val p =
           Product(
             shape.name,
             shape.name,
-            shape.fields,
+            fields,
             mixins,
             rec,
             hints,

--- a/modules/codegen/src/smithy4s/codegen/SmithyToIR.scala
+++ b/modules/codegen/src/smithy4s/codegen/SmithyToIR.scala
@@ -186,18 +186,17 @@ private[codegen] class SmithyToIR(model: Model, namespace: String) {
               )
             )
         val mixinMembers = mixin.getAllMembers().asScala
-        mixinMembers.foldLeft(true) { case (state, (memberName, member)) =>
-          fields.find(_.name == memberName) match {
-            case None => state
-            case Some(field) =>
+        mixinMembers.forall { case (memberName, member) =>
+          fields
+            .find(_.name == memberName)
+            .forall { field =>
               val memberOptional = !member.hasTrait(classOf[RequiredTrait])
-              val memberHasNoDefault = !member.hasTrait(classOf[DefaultTrait])
+              val memberHasDefault = member.hasTrait(classOf[DefaultTrait])
 
               // if member has no default and is optional, then the field must be optional
-              if (memberHasNoDefault && memberOptional) {
-                state && !field.required
-              } else state
-          }
+              if (!memberHasDefault && memberOptional) !field.required
+              else field.required
+            }
         }
       }
 

--- a/modules/example/src/smithy4s/example/MixinOptionalMember.scala
+++ b/modules/example/src/smithy4s/example/MixinOptionalMember.scala
@@ -1,0 +1,6 @@
+package smithy4s.example
+
+
+trait MixinOptionalMember {
+  def a: Option[String]
+}

--- a/modules/example/src/smithy4s/example/MixinOptionalMemberDefaultAdded.scala
+++ b/modules/example/src/smithy4s/example/MixinOptionalMemberDefaultAdded.scala
@@ -1,0 +1,21 @@
+package smithy4s.example
+
+import smithy4s.Schema
+import smithy4s.Hints
+import smithy4s.schema.Schema.string
+import smithy4s.ShapeId
+import smithy4s.schema.Schema.struct
+import smithy4s.ShapeTag
+
+case class MixinOptionalMemberDefaultAdded(a: String = "test")
+object MixinOptionalMemberDefaultAdded extends ShapeTag.Companion[MixinOptionalMemberDefaultAdded] {
+  val id: ShapeId = ShapeId("smithy4s.example", "MixinOptionalMemberDefaultAdded")
+
+  val hints : Hints = Hints.empty
+
+  implicit val schema: Schema[MixinOptionalMemberDefaultAdded] = struct(
+    string.required[MixinOptionalMemberDefaultAdded]("a", _.a).addHints(smithy.api.Default(smithy4s.Document.fromString("test"))),
+  ){
+    MixinOptionalMemberDefaultAdded.apply
+  }.withId(id).addHints(hints)
+}

--- a/modules/example/src/smithy4s/example/MixinOptionalMemberOverride.scala
+++ b/modules/example/src/smithy4s/example/MixinOptionalMemberOverride.scala
@@ -1,0 +1,21 @@
+package smithy4s.example
+
+import smithy4s.Schema
+import smithy4s.Hints
+import smithy4s.schema.Schema.string
+import smithy4s.ShapeId
+import smithy4s.schema.Schema.struct
+import smithy4s.ShapeTag
+
+case class MixinOptionalMemberOverride(a: String)
+object MixinOptionalMemberOverride extends ShapeTag.Companion[MixinOptionalMemberOverride] {
+  val id: ShapeId = ShapeId("smithy4s.example", "MixinOptionalMemberOverride")
+
+  val hints : Hints = Hints.empty
+
+  implicit val schema: Schema[MixinOptionalMemberOverride] = struct(
+    string.required[MixinOptionalMemberOverride]("a", _.a).addHints(smithy.api.Required()),
+  ){
+    MixinOptionalMemberOverride.apply
+  }.withId(id).addHints(hints)
+}

--- a/sampleSpecs/mixins.smithy
+++ b/sampleSpecs/mixins.smithy
@@ -39,3 +39,18 @@ union TestMixinAdt {
 
 @adtMember(TestMixinAdt)
 structure TestAdtMemberWithMixin with [CommonFieldsOne] {}
+
+
+@mixin()
+structure MixinOptionalMember {
+  a: String
+}
+
+structure MixinOptionalMemberOverride with [MixinOptionalMember] {
+  @required
+  a: String
+}
+
+structure MixinOptionalMemberDefaultAdded with [MixinOptionalMember] {
+  a: String = "test"
+}


### PR DESCRIPTION
Update that will make it so case classes no longer extend mixin-related traits when they contain fields that do not match in type (optional vs. required, etc). See examples in this PR for more cases.


Resolves #422.