### PR TITLE
Custom code generator support

### DIFF
--- a/modules/codegen-cli/src/smithy4s/codegen/cli/CodegenCommand.scala
+++ b/modules/codegen-cli/src/smithy4s/codegen/cli/CodegenCommand.scala
@@ -127,7 +127,8 @@ object CodegenCommand {
             repositories.getOrElse(List.empty),
             dependencies.getOrElse(List.empty),
             transformers.getOrElse(List.empty),
-            localJars.getOrElse(List.empty)
+            localJars.getOrElse(List.empty),
+            customGenerators = List.empty
           )
       }
 

--- a/modules/codegen-cli/test/src/smithy4s/codegen/cli/CommandParsingSpec.scala
+++ b/modules/codegen-cli/test/src/smithy4s/codegen/cli/CommandParsingSpec.scala
@@ -37,7 +37,8 @@ object CommandParsingSpec extends FunSuite {
               repositories = Nil,
               dependencies = Nil,
               transformers = Nil,
-              localJars = Nil
+              localJars = Nil,
+              customGenerators = Nil
             )
           )
         )
@@ -90,7 +91,8 @@ object CommandParsingSpec extends FunSuite {
               localJars = List(
                 os.pwd / "lib1.jar",
                 os.pwd / "lib2.jar"
-              )
+              ),
+              customGenerators = Nil
             )
           )
         )

--- a/modules/codegen-plugin/src/smithy4s/codegen/Smithy4sCodegenPlugin.scala
+++ b/modules/codegen-plugin/src/smithy4s/codegen/Smithy4sCodegenPlugin.scala
@@ -73,6 +73,11 @@ object Smithy4sCodegenPlugin extends AutoPlugin {
       settingKey[List[String]](
         "List of transformer names that should be applied to the model prior to codegen"
       )
+
+    val smithy4sCustomGenerators =
+      settingKey[List[CustomGenerator]](
+        "List of custom code generators to run in addition to the built-in codegen"
+      )
   }
 
   import autoImport._
@@ -97,7 +102,8 @@ object Smithy4sCodegenPlugin extends AutoPlugin {
       _.filter(_.ext != "scala")
     ),
     cleanFiles += (config / smithy4sOutputDir).value,
-    config / smithy4sModelTransformers := List.empty
+    config / smithy4sModelTransformers := List.empty,
+    config / smithy4sCustomGenerators := List.empty
   )
 
   override lazy val projectSettings =
@@ -139,6 +145,7 @@ object Smithy4sCodegenPlugin extends AutoPlugin {
       }
     val transforms = (conf / smithy4sModelTransformers).value
     val s = streams.value
+    val customGenerators = (conf / smithy4sCustomGenerators).value
 
     val cached =
       Tracked.inputChanged[CacheKey, Seq[File]](
@@ -163,7 +170,8 @@ object Smithy4sCodegenPlugin extends AutoPlugin {
                   repositories = res,
                   dependencies = List.empty,
                   transformers = transforms,
-                  localJars = localJars
+                  localJars = localJars,
+                  customGenerators = customGenerators
                 )
                 val resPaths = smithy4s.codegen.Codegen
                   .processSpecs(codegenArgs)

--- a/modules/codegen/src/smithy4s/codegen/CodegenArgs.scala
+++ b/modules/codegen/src/smithy4s/codegen/CodegenArgs.scala
@@ -28,5 +28,6 @@ case class CodegenArgs(
     repositories: List[String],
     dependencies: List[String],
     transformers: List[String],
-    localJars: List[os.Path]
+    localJars: List[os.Path],
+    customGenerators: List[CustomGenerator]
 )

--- a/modules/codegen/src/smithy4s/codegen/CustomGenerator.scala
+++ b/modules/codegen/src/smithy4s/codegen/CustomGenerator.scala
@@ -1,0 +1,24 @@
+package smithy4s.codegen
+
+import software.amazon.smithy.model.Model
+
+trait CustomGenerator {
+  def generate(
+      cu: CompilationUnit,
+      model: Model
+  ): List[CustomGenerator.ScalaSourceFile]
+}
+
+object CustomGenerator {
+  case class ScalaSourceFile(
+      smithyNamespace: String,
+      basename: String,
+      content: String
+  ) {
+    private[codegen] def asRendererResult: Renderer.Result = Renderer.Result(
+      namespace = smithyNamespace,
+      name = basename,
+      content = content
+    )
+  }
+}


### PR DESCRIPTION
This is just a draft PR to discuss if something like this would be viable from your point of view. It'd need more refinement, but for the time being, I just wanted to show the interface & the sbt plugin hook that would work for us.

Our use case is to generate some extra Scala code (in separate source files) on top of what's already provided by smithy4s. This hook would allow us to do this based on the intermediate codegen model.