### PR TITLE
Exhaustively capture the codegen input for cache invalidation

### DIFF
--- a/modules/codegen-plugin/src/smithy4s/codegen/JsonConverters.scala
+++ b/modules/codegen-plugin/src/smithy4s/codegen/JsonConverters.scala
@@ -1,0 +1,69 @@
+package smithy4s.codegen
+
+import sjsonnew._
+import BasicJsonProtocol._
+import sbt.FileInfo
+import sbt.HashFileInfo
+import sjsonnew._, LList.:*:
+
+private[smithy4s] object JsonConverters {
+
+  implicit val pathFormat: JsonFormat[os.Path] = {
+    val hashInfoFormat = implicitly[JsonFormat[HashFileInfo]]
+    new JsonFormat[os.Path] {
+      def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): os.Path = {
+        os.Path(hashInfoFormat.read(jsOpt, unbuilder).file)
+      }
+
+      def write[J](obj: os.Path, builder: Builder[J]): Unit =
+        hashInfoFormat.write(FileInfo.hash(obj.toIO), builder)
+    }
+  }
+
+  implicit val codegenArgsIso = LList.iso(
+    { ca: CodegenArgs =>
+      ("specs", ca.specs) :*:
+        ("output", ca.output) :*:
+        ("openapiOutput", ca.openapiOutput) :*:
+        ("skipScala", ca.skipScala) :*:
+        ("skipOpenapi", ca.skipOpenapi) :*:
+        ("discoverModels", ca.discoverModels) :*:
+        ("allowedNS", ca.allowedNS) :*:
+        ("excludedNS", ca.excludedNS) :*:
+        ("repositories", ca.repositories) :*:
+        ("dependencies", ca.dependencies) :*:
+        ("transformers", ca.transformers) :*:
+        ("localJars", ca.localJars) :*:
+        LNil
+    },
+    {
+      case (_, specs) :*:
+          (_, output) :*:
+          (_, openapiOutput) :*:
+          (_, skipScala) :*:
+          (_, skipOpenapi) :*:
+          (_, discoverModels) :*:
+          (_, allowedNS) :*:
+          (_, excludedNS) :*:
+          (_, repositories) :*:
+          (_, dependencies) :*:
+          (_, transformers) :*:
+          (_, localJars) :*: LNil =>
+        CodegenArgs(
+          specs,
+          output,
+          openapiOutput,
+          skipScala,
+          skipOpenapi,
+          discoverModels,
+          allowedNS,
+          excludedNS,
+          repositories,
+          dependencies,
+          transformers,
+          localJars
+        )
+    }
+  )
+
+}

--- a/modules/codegen-plugin/src/smithy4s/codegen/JsonConverters.scala
+++ b/modules/codegen-plugin/src/smithy4s/codegen/JsonConverters.scala
@@ -20,7 +20,6 @@ import sjsonnew._
 import BasicJsonProtocol._
 import sbt.FileInfo
 import sbt.HashFileInfo
-import sjsonnew._
 
 // Json codecs used by SBT's caching constructs
 private[smithy4s] object JsonConverters {

--- a/modules/codegen-plugin/src/smithy4s/codegen/JsonConverters.scala
+++ b/modules/codegen-plugin/src/smithy4s/codegen/JsonConverters.scala
@@ -4,7 +4,7 @@ import sjsonnew._
 import BasicJsonProtocol._
 import sbt.FileInfo
 import sbt.HashFileInfo
-import sjsonnew._, LList.:*:
+import sjsonnew._
 
 private[smithy4s] object JsonConverters {
 
@@ -20,7 +20,10 @@ private[smithy4s] object JsonConverters {
     }
   }
 
-  implicit val codegenArgsIso = LList.iso(
+  // format: off
+  type GenTarget = List[os.Path] :*: os.Path :*: os.Path :*: Boolean :*: Boolean :*: Boolean :*: Option[Set[String]] :*: Option[Set[String]] :*: List[String] :*: List[String] :*: List[String] :*: List[os.Path] :*: LNil
+  // format: on
+  implicit val codegenArgsIso = LList.iso[CodegenArgs, GenTarget](
     { ca: CodegenArgs =>
       ("specs", ca.specs) :*:
         ("output", ca.output) :*:

--- a/modules/codegen-plugin/src/smithy4s/codegen/JsonConverters.scala
+++ b/modules/codegen-plugin/src/smithy4s/codegen/JsonConverters.scala
@@ -1,3 +1,19 @@
+/*
+ *  Copyright 2021-2022 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 package smithy4s.codegen
 
 import sjsonnew._

--- a/modules/codegen-plugin/src/smithy4s/codegen/Smithy4sCodegenPlugin.scala
+++ b/modules/codegen-plugin/src/smithy4s/codegen/Smithy4sCodegenPlugin.scala
@@ -157,19 +157,18 @@ object Smithy4sCodegenPlugin extends AutoPlugin {
         s.cacheStoreFactory.make("input")
       ) {
         Function.untupled {
-          Tracked
-            .lastOutput[(Boolean, CodegenArgs), Seq[File]](
-              s.cacheStoreFactory.make("output")
-            ) { case ((inputChanged, args), outputs) =>
-              if (inputChanged || outputs.isEmpty) {
-                val resPaths = smithy4s.codegen.Codegen
-                  .processSpecs(args)
-                  .toList
-                resPaths.map(path => new File(path.toString))
-              } else {
-                outputs.getOrElse(Seq.empty)
-              }
+          Tracked.lastOutput[(Boolean, CodegenArgs), Seq[File]](
+            s.cacheStoreFactory.make("output")
+          ) { case ((inputChanged, args), outputs) =>
+            if (inputChanged || outputs.isEmpty) {
+              val resPaths = smithy4s.codegen.Codegen
+                .processSpecs(args)
+                .toList
+              resPaths.map(path => new File(path.toString))
+            } else {
+              outputs.getOrElse(Seq.empty)
             }
+          }
         }
       }
 

--- a/modules/codegen-plugin/src/smithy4s/codegen/Smithy4sCodegenPlugin.scala
+++ b/modules/codegen-plugin/src/smithy4s/codegen/Smithy4sCodegenPlugin.scala
@@ -19,6 +19,7 @@ package smithy4s.codegen
 import sbt.Keys._
 import sbt.util.CacheImplicits._
 import sbt.{fileJsonFormatter => _, _}
+import JsonConverters._
 
 object Smithy4sCodegenPlugin extends AutoPlugin {
   override def requires = plugins.JvmPlugin
@@ -103,11 +104,6 @@ object Smithy4sCodegenPlugin extends AutoPlugin {
   override lazy val projectSettings =
     defaultSettings(Compile)
 
-  private type CacheKey = (
-      FilesInfo[HashFileInfo],
-      List[String]
-  )
-
   private def findCodeGenDependencies(
       updateReport: UpdateReport
   ): List[os.Path] =
@@ -140,31 +136,32 @@ object Smithy4sCodegenPlugin extends AutoPlugin {
     val transforms = (conf / smithy4sModelTransformers).value
     val s = streams.value
 
+    val filePaths = inputFiles.map(_.getAbsolutePath())
+    val codegenArgs = CodegenArgs(
+      filePaths.map(os.Path(_)).toList,
+      output = os.Path(outputPath),
+      openapiOutput = os.Path(openApiOutputPath),
+      skipScala = false,
+      skipOpenapi = false,
+      discoverModels = true, // we need protocol here
+      allowedNS = allowedNamespaces,
+      excludedNS = excludedNamespaces,
+      repositories = res,
+      dependencies = List.empty,
+      transformers = transforms,
+      localJars = localJars
+    )
+
     val cached =
-      Tracked.inputChanged[CacheKey, Seq[File]](
+      Tracked.inputChanged[CodegenArgs, Seq[File]](
         s.cacheStoreFactory.make("input")
       ) {
         Function.untupled {
           Tracked
-            .lastOutput[(Boolean, CacheKey), Seq[File]](
+            .lastOutput[(Boolean, CodegenArgs), Seq[File]](
               s.cacheStoreFactory.make("output")
             ) { case ((changed, _), outputs) =>
               if (changed || outputs.isEmpty) {
-                val filePaths = inputFiles.map(_.getAbsolutePath())
-                val codegenArgs = CodegenArgs(
-                  filePaths.map(os.Path(_)).toList,
-                  output = os.Path(outputPath),
-                  openapiOutput = os.Path(openApiOutputPath),
-                  skipScala = false,
-                  skipOpenapi = false,
-                  discoverModels = true, // we need protocol here
-                  allowedNS = allowedNamespaces,
-                  excludedNS = excludedNamespaces,
-                  repositories = res,
-                  dependencies = List.empty,
-                  transformers = transforms,
-                  localJars = localJars
-                )
                 val resPaths = smithy4s.codegen.Codegen
                   .processSpecs(codegenArgs)
                   .toList
@@ -176,11 +173,6 @@ object Smithy4sCodegenPlugin extends AutoPlugin {
         }
       }
 
-    cached(
-      (
-        FilesInfo(inputFiles.map(FileInfo.hash(_)).toSet),
-        localJars.map(_.toString)
-      )
-    )
+    cached(codegenArgs)
   }
 }

--- a/modules/codegen-plugin/src/smithy4s/codegen/Smithy4sCodegenPlugin.scala
+++ b/modules/codegen-plugin/src/smithy4s/codegen/Smithy4sCodegenPlugin.scala
@@ -160,10 +160,10 @@ object Smithy4sCodegenPlugin extends AutoPlugin {
           Tracked
             .lastOutput[(Boolean, CodegenArgs), Seq[File]](
               s.cacheStoreFactory.make("output")
-            ) { case ((changed, _), outputs) =>
-              if (changed || outputs.isEmpty) {
+            ) { case ((inputChanged, args), outputs) =>
+              if (inputChanged || outputs.isEmpty) {
                 val resPaths = smithy4s.codegen.Codegen
-                  .processSpecs(codegenArgs)
+                  .processSpecs(args)
                   .toList
                 resPaths.map(path => new File(path.toString))
               } else {

--- a/modules/codegen/src/smithy4s/codegen/ModelLoader.scala
+++ b/modules/codegen/src/smithy4s/codegen/ModelLoader.scala
@@ -57,6 +57,8 @@ object ModelLoader {
       val upstreamModel = Model
         .assembler()
         .discoverModels(upstreamClassLoader)
+        // disabling cache to support snapshot-driven experimentation
+        .putProperty(ModelAssembler.DISABLE_JAR_CACHE, true)
         .assemble()
         .unwrap()
 

--- a/modules/codegen/test/src/smithy4s/codegen/DefaultRenderModeSpec.scala
+++ b/modules/codegen/test/src/smithy4s/codegen/DefaultRenderModeSpec.scala
@@ -1,3 +1,19 @@
+/*
+ *  Copyright 2021-2022 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 package smithy4s.codegen
 
 final class DefaultRenderModeSpec extends munit.FunSuite {

--- a/modules/codegen/test/src/smithy4s/codegen/TestUtils.scala
+++ b/modules/codegen/test/src/smithy4s/codegen/TestUtils.scala
@@ -1,3 +1,19 @@
+/*
+ *  Copyright 2021-2022 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 package smithy4s.codegen
 
 import munit.{Location, Assertions}

--- a/modules/core/test/src/smithy4s/IntEnumSmokeSpec.scala
+++ b/modules/core/test/src/smithy4s/IntEnumSmokeSpec.scala
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2021 Disney Streaming
+ *  Copyright 2021-2022 Disney Streaming
  *
  *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/modules/json/test/src/smithy4s/http/json/FaceCard.scala
+++ b/modules/json/test/src/smithy4s/http/json/FaceCard.scala
@@ -1,3 +1,19 @@
+/*
+ *  Copyright 2021-2022 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 package smithy4s.http.json
 
 import smithy4s.schema.Schema._


### PR DESCRIPTION
This exhaustively captures the codegenArgs as a way to invalidate SBT's cache to re-trigger codegen every time something changes.

This uses SBT's JsonFormat, converting os-lib's paths into file hashes. In theory, when a local file changes (say, a dependency snapshot), the cache should now be invalidated and trigger a regeneration.

Additionally, this disable jar caching in the Smithy Model assembler that loads local jars. This prevents users who experiment with snapshot artifacts from having to exit/restart SBT when issuing a new local snapshot . 

Unfortunately, this is pretty hard to test in an automated manner. 