### PR TITLE
support root imports in refinements

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -79,13 +79,13 @@ lazy val docs =
     .settings(
       mdocIn := (ThisBuild / baseDirectory).value / "modules" / "docs" / "src",
       mdocVariables := Map(
-        "VERSION" -> (if (isSnapshot.value)
-                        previousStableVersion.value.getOrElse(
-                          throw new Exception(
-                            "No previous version found from dynver"
-                          )
-                        )
-                      else version.value),
+        // "VERSION" -> (if (isSnapshot.value)
+        //                 previousStableVersion.value.getOrElse(
+        //                   throw new Exception(
+        //                     "No previous version found from dynver"
+        //                   )
+        //                 )
+        //               else version.value),
         "SCALA_VERSION" -> scalaVersion.value,
         "HTTP4S_VERSION" -> Dependencies.Http4s.http4sVersion.value
       ),

--- a/build.sbt
+++ b/build.sbt
@@ -79,13 +79,13 @@ lazy val docs =
     .settings(
       mdocIn := (ThisBuild / baseDirectory).value / "modules" / "docs" / "src",
       mdocVariables := Map(
-        // "VERSION" -> (if (isSnapshot.value)
-        //                 previousStableVersion.value.getOrElse(
-        //                   throw new Exception(
-        //                     "No previous version found from dynver"
-        //                   )
-        //                 )
-        //               else version.value),
+        "VERSION" -> (if (isSnapshot.value)
+                        previousStableVersion.value.getOrElse(
+                          throw new Exception(
+                            "No previous version found from dynver"
+                          )
+                        )
+                      else version.value),
         "SCALA_VERSION" -> scalaVersion.value,
         "HTTP4S_VERSION" -> Dependencies.Http4s.http4sVersion.value
       ),

--- a/modules/protocol/resources/META-INF/smithy/smithy4s.meta.smithy
+++ b/modules/protocol/resources/META-INF/smithy/smithy4s.meta.smithy
@@ -84,11 +84,11 @@ structure refinement {
 }
 
 /// e.g. com.test_out.v2.Something
-@pattern("^(?:[a-zA-Z][\\w]*\\.?)*$")
+@pattern("^(?:_root_\\.)?(?:[a-zA-Z][\\w]*\\.?)*$")
 string Classpath
 
 /// e.g. com.test_out.v2.Something._
-@pattern("^(?:[a-zA-Z][\\w]*\\.?)*\\._$")
+@pattern("^(?:_root_\\.)?(?:[a-zA-Z][\\w]*\\.?)*\\._$")
 string Import
 
 /// This trait is used to signal that this type should not be wrapped


### PR DESCRIPTION
Allow imports and classpaths in refinements to contain `_root_` at the beginning of them.