### PR TITLE
Use a document relative url for specs

### DIFF
--- a/modules/http4s-swagger/test/src/smithy4s/http4s/swagger/DocsSpec.scala
+++ b/modules/http4s-swagger/test/src/smithy4s/http4s/swagger/DocsSpec.scala
@@ -73,6 +73,7 @@ object DocsSpec extends SimpleIOSuite with TestCompat {
           )
       }
     }
+
     test(s"GET $path/test-file.json fetches requested file") {
       val filePath = s"/$path/test-file.json"
       val request =
@@ -81,15 +82,17 @@ object DocsSpec extends SimpleIOSuite with TestCompat {
         expect(response.status == Status.Ok)
       }
     }
-  }
 
-  test("GET /test-spec.json fetches service spec") {
-    val filePath = "/foobar.test-spec.json"
-    val request =
-      Request[IO](method = Method.GET, uri = Uri.unsafeFromString(filePath))
-    val app = docs("docs").orNotFound
-    app.run(request).map { response =>
-      expect(response.status == Status.Ok)
+    test(s"GET $path/specs/test-spec.json fetches service spec") {
+      val filePath = "/foobar.test-spec.json"
+      val request =
+        Request[IO](
+          method = Method.GET,
+          uri = Uri.unsafeFromString(s"/$path/specs$filePath")
+        )
+      app.run(request).map { response =>
+        expect(response.status == Status.Ok)
+      }
     }
   }
 

--- a/modules/http4s-swagger/test/src/smithy4s/http4s/swagger/DocsSpec.scala
+++ b/modules/http4s-swagger/test/src/smithy4s/http4s/swagger/DocsSpec.scala
@@ -73,22 +73,6 @@ object DocsSpec extends SimpleIOSuite with TestCompat {
           )
       }
     }
-    test(s"GET /$path/index.html redirects to expected location") {
-      val request =
-        Request[IO](method = Method.GET, uri = Uri.unsafeFromString(s"/$path"))
-      app.run(request).map { response =>
-        val redirectUri = response.headers
-          .get(CIString("Location"))
-          .map(_.head)
-          .map(_.value)
-
-        expect(response.status == Status.Found) and
-          expect.eql(
-            redirectUri,
-            Some(s"/$path/index.html")
-          )
-      }
-    }
     test(s"GET $path/test-file.json fetches requested file") {
       val filePath = s"/$path/test-file.json"
       val request =


### PR DESCRIPTION
That means that what was previously

`"urls": ["/example.SomeSpec.yaml"]`

will now be

`"urls": ["./docs/specs/example.SomeSpec.yaml"]`

`docs` is from the path the user provided when initializing the route, `specs` is added in this PR.

This is to be able to write `./specs/example.SomeSpec.yaml` in the `urls` array for swagger initialization. Rather than asking for `/example.SomeSpec.yaml`, we ask for `./example.SomeSpec.yaml` and because this conflicts with other paths such as `./swagger-ui.css` I've decided to serve specs under a specific path instead.

In the browser, this ends up being:

<img width="801" alt="Screen Shot 2022-09-08 at 15 33 08" src="https://user-images.githubusercontent.com/5230460/189211695-a928c8b0-ad79-425b-8cd9-070144d5fffe.png">

In the screenshot above, we see requests from the browser after loading `/docs/index.html` from behind a proxy at `/admin/docs/index.html`.  Before, the request would be`http://localhost/examples.hello.HelloWorldService.json` and it would fail to resolve (missing `/admin`), where as now `http://localhost/admin/docs/specs/examples.hello.HelloWorldService.json` works.

Relates to #439 but its not sufficient to close it.