### PR TITLE
Servicebuilder revised Feedback Requested

### DIFF
--- a/modules/docs/src/01-overview/02-quickstart.md
+++ b/modules/docs/src/01-overview/02-quickstart.md
@@ -146,10 +146,10 @@ object ClientImpl extends IOApp.Simple {
 
   val helloWorldClient: Resource[IO, HelloWorldService[IO]] = for {
     client <- EmberClientBuilder.default[IO].build
-    helloClient <- SimpleRestJsonBuilder(HelloWorldService).clientResource(
-      client,
-      Uri.unsafeFromString("http://localhost:9000")
-    )
+    helloClient <- SimpleRestJsonBuilder(HelloWorldService)
+    .client(client)
+    .uri(Uri.unsafeFromString("http://localhost:9000"))
+    .resource
   } yield helloClient
 
   val run = helloWorldClient.use(c =>

--- a/modules/docs/src/03-protocols/02-simple-rest-json/03-client.md
+++ b/modules/docs/src/03-protocols/02-simple-rest-json/03-client.md
@@ -28,16 +28,17 @@ import smithy4s.hello._
 
 object Clients {
   def helloWorldClient(http4sClient: Client[IO]) : Resource[IO, HelloWorldService[IO]] =
-    HelloWorldService.simpleRestJson.clientResource(
-      http4sClient,
-      Uri.unsafeFromString("http://localhost")
-    )
+    HelloWorldService.simpleRestJson
+    .client(http4sClient)
+    .uri(Uri.unsafeFromString("http://localhost"))
+    .resource
 
   // alternatively ...
   def helloWorldClient2(http4sClient: Client[IO]) : Resource[IO, HelloWorldService[IO]] =
-    SimpleRestJsonBuilder(HelloWorldService).clientResource(
-      http4sClient,
-      Uri.unsafeFromString("http://localhost")
-    )
+    SimpleRestJsonBuilder(HelloWorldService)
+    .client(http4sClient)
+      .uri(Uri.unsafeFromString("http://localhost"))
+      .resource
+    
 }
 ```

--- a/modules/docs/src/03-protocols/02-simple-rest-json/03-client.md
+++ b/modules/docs/src/03-protocols/02-simple-rest-json/03-client.md
@@ -4,7 +4,7 @@ title: SimpleRestJson client
 ---
 
 The `smithy4s-http4s` module provides functions that transform low-level http4s clients into high-level stubs, provided the corresponding service definitions (in smithy) are annotated with the `simpleRestJson` protocol.
-
+- Uri is optional as it will default to http://localhost:8080
 In `build.sbt`
 
 ```scala

--- a/modules/http4s/src/smithy4s/http4s/SimpleProtocolBuilder.scala
+++ b/modules/http4s/src/smithy4s/http4s/SimpleProtocolBuilder.scala
@@ -59,7 +59,9 @@ abstract class SimpleProtocolBuilder[P](val codecs: CodecAPI)(implicit
 
     def client[F[_]: EffectCompat](client: Client[F]) =
       new ClientBuilder[Alg, Op, F](client, service)
-    @deprecated("Use the ClientBuilder instead,  client(client).uri(baseuri).use")
+    @deprecated(
+      "Use the ClientBuilder instead,  client(client).uri(baseuri).use"
+    )
     def client[F[_]: EffectCompat](
         http4sClient: Client[F],
         baseUri: Uri

--- a/modules/http4s/src/smithy4s/http4s/SimpleProtocolBuilder.scala
+++ b/modules/http4s/src/smithy4s/http4s/SimpleProtocolBuilder.scala
@@ -19,11 +19,11 @@ package http4s
 
 import cats.effect._
 import cats.syntax.all._
-import org.http4s.HttpApp
 import org.http4s.HttpRoutes
 import org.http4s.Uri
 import org.http4s.client.Client
 import smithy4s.http.CodecAPI
+import org.http4s.implicits._
 
 /**
   * Abstract construct helping the construction of routers and clients
@@ -55,57 +55,10 @@ abstract class SimpleProtocolBuilder[P](val codecs: CodecAPI)(implicit
   class ServiceBuilder[
       Alg[_[_, _, _, _, _]],
       Op[_, _, _, _, _]
-  ] private[http4s] (val service: smithy4s.Service[Alg, Op]) {
+  ] private[http4s] (val service: smithy4s.Service[Alg, Op]) { self =>
 
-    def client[F[_]: EffectCompat](
-        http4sClient: Client[F],
-        baseUri: Uri
-    ): Either[UnsupportedProtocolError, Monadic[Alg, F]] =
-      checkProtocol(service, protocolTag)
-        .as(
-          new SmithyHttp4sReverseRouter[Alg, Op, F](
-            baseUri,
-            service,
-            Left(http4sClient),
-            EntityCompiler
-              .fromCodecAPI[F](codecs)
-          )
-        )
-        .map(service.transform[GenLift[F]#λ](_))
-
-    def client[F[_]: EffectCompat](
-        http4sApp: HttpApp[F],
-        baseUri: Uri
-    ): Either[UnsupportedProtocolError, Monadic[Alg, F]] =
-      checkProtocol(service, protocolTag)
-        .as(
-          new SmithyHttp4sReverseRouter[Alg, Op, F](
-            baseUri,
-            service,
-            Right(http4sApp),
-            EntityCompiler
-              .fromCodecAPI[F](codecs)
-          )
-        )
-        .map(service.transform[GenLift[F]#λ](_))
-
-    def clientResource[F[_]: EffectCompat](
-        http4sClient: Client[F],
-        baseUri: Uri
-    ): Resource[F, Monadic[Alg, F]] =
-      this
-        .client[F](http4sClient, baseUri)
-        .leftWiden[Throwable]
-        .liftTo[Resource[F, *]]
-
-    def clientResource[F[_]: EffectCompat](
-        http4sApp: HttpApp[F],
-        baseUri: Uri
-    ): Resource[F, Monadic[Alg, F]] =
-      this
-        .client[F](http4sApp, baseUri)
-        .leftWiden[Throwable]
-        .liftTo[Resource[F, *]]
+    def client[F[_]: EffectCompat](client: Client[F]) =
+      new ClientBuilder[Alg, Op, F](client, service)
 
     def routes[F[_]: EffectCompat](
         impl: Monadic[Alg, F]
@@ -116,6 +69,35 @@ abstract class SimpleProtocolBuilder[P](val codecs: CodecAPI)(implicit
         PartialFunction.empty
       )
 
+  }
+
+  class ClientBuilder[Alg[_[_, _, _, _, _]], Op[_, _, _, _, _], F[
+      _
+  ]: EffectCompat] private[http4s] (
+      client: Client[F],
+      service: smithy4s.Service[Alg, Op],
+      uri: Uri = uri"http://localhost:8080"
+  ) {
+
+    def baseUri(uri: Uri): ClientBuilder[Alg, Op, F] =
+      new ClientBuilder[Alg, Op, F](this.client, this.service, uri)
+
+    def resource: Resource[F, Monadic[Alg, F]] =
+      either.leftWiden[Throwable].liftTo[Resource[F, *]]
+
+    def either: Either[UnsupportedProtocolError, Monadic[Alg, F]] = {
+      checkProtocol(service, protocolTag)
+        .as(
+          new SmithyHttp4sReverseRouter[Alg, Op, F](
+            uri,
+            service,
+            client,
+            EntityCompiler
+              .fromCodecAPI[F](codecs)
+          )
+        )
+        .map(service.transform[GenLift[F]#λ](_))
+    }
   }
 
   class RouterBuilder[

--- a/modules/http4s/src/smithy4s/http4s/SimpleProtocolBuilder.scala
+++ b/modules/http4s/src/smithy4s/http4s/SimpleProtocolBuilder.scala
@@ -79,7 +79,7 @@ abstract class SimpleProtocolBuilder[P](val codecs: CodecAPI)(implicit
       uri: Uri = uri"http://localhost:8080"
   ) {
 
-    def baseUri(uri: Uri): ClientBuilder[Alg, Op, F] =
+    def uri(uri: Uri): ClientBuilder[Alg, Op, F] =
       new ClientBuilder[Alg, Op, F](this.client, this.service, uri)
 
     def resource: Resource[F, Monadic[Alg, F]] =

--- a/modules/http4s/src/smithy4s/http4s/SimpleProtocolBuilder.scala
+++ b/modules/http4s/src/smithy4s/http4s/SimpleProtocolBuilder.scala
@@ -83,9 +83,9 @@ abstract class SimpleProtocolBuilder[P](val codecs: CodecAPI)(implicit
       new ClientBuilder[Alg, Op, F](this.client, this.service, uri)
 
     def resource: Resource[F, Monadic[Alg, F]] =
-      either.leftWiden[Throwable].liftTo[Resource[F, *]]
+      use.leftWiden[Throwable].liftTo[Resource[F, *]]
 
-    def either: Either[UnsupportedProtocolError, Monadic[Alg, F]] = {
+    def use: Either[UnsupportedProtocolError, Monadic[Alg, F]] = {
       checkProtocol(service, protocolTag)
         .as(
           new SmithyHttp4sReverseRouter[Alg, Op, F](

--- a/modules/http4s/src/smithy4s/http4s/SimpleProtocolBuilder.scala
+++ b/modules/http4s/src/smithy4s/http4s/SimpleProtocolBuilder.scala
@@ -59,6 +59,20 @@ abstract class SimpleProtocolBuilder[P](val codecs: CodecAPI)(implicit
 
     def client[F[_]: EffectCompat](client: Client[F]) =
       new ClientBuilder[Alg, Op, F](client, service)
+    @deprecated("Use the ClientBuilder instead,  client(client).uri(baseuri).use")
+    def client[F[_]: EffectCompat](
+        http4sClient: Client[F],
+        baseUri: Uri
+    ): Either[UnsupportedProtocolError, Monadic[Alg, F]] =
+      client(http4sClient).uri(baseUri).use
+
+    @deprecated(
+      "Use the ClientBuilder instead , client(client).uri(baseuri).resource"
+    )
+    def clientResource[F[_]: EffectCompat](
+        http4sClient: Client[F],
+        baseUri: Uri
+    ): Resource[F, Monadic[Alg, F]] = client(http4sClient).uri(baseUri).resource
 
     def routes[F[_]: EffectCompat](
         impl: Monadic[Alg, F]

--- a/modules/http4s/src/smithy4s/http4s/SmithyHttp4sReverseRouter.scala
+++ b/modules/http4s/src/smithy4s/http4s/SmithyHttp4sReverseRouter.scala
@@ -25,7 +25,7 @@ import smithy4s.http4s.internals.SmithyHttp4sClientEndpoint
 class SmithyHttp4sReverseRouter[Alg[_[_, _, _, _, _]], Op[_, _, _, _, _], F[_]](
     baseUri: Uri,
     service: smithy4s.Service[Alg, Op],
-    clientOrApp: Either[Client[F], HttpApp[F]],
+    client: Client[F],
     entityCompiler: EntityCompiler[F]
 )(implicit effect: EffectCompat[F])
     extends Interpreter[Op, F] {
@@ -49,7 +49,7 @@ class SmithyHttp4sReverseRouter[Alg[_[_, _, _, _, _]], Op[_, _, _, _, _], F[_]](
       ): SmithyHttp4sClientEndpoint[F, Op, I, E, O, SI, SO] =
         SmithyHttp4sClientEndpoint(
           baseUri,
-          clientOrApp,
+          client,
           endpoint,
           entityCompiler
         ).getOrElse(

--- a/modules/http4s/src/smithy4s/http4s/internals/SmithyHttp4sClientEndpoint.scala
+++ b/modules/http4s/src/smithy4s/http4s/internals/SmithyHttp4sClientEndpoint.scala
@@ -21,7 +21,6 @@ package internals
 import cats.syntax.all._
 import org.http4s.EntityDecoder
 import org.http4s.EntityEncoder
-import org.http4s.HttpApp
 import org.http4s.Request
 import org.http4s.Response
 import org.http4s.Uri
@@ -43,14 +42,14 @@ private[smithy4s] object SmithyHttp4sClientEndpoint {
 
   def apply[F[_]: EffectCompat, Op[_, _, _, _, _], I, E, O, SI, SO](
       baseUri: Uri,
-      clientOrApp: Either[Client[F], HttpApp[F]],
+      client: Client[F],
       endpoint: Endpoint[Op, I, E, O, SI, SO],
       entityCompiler: EntityCompiler[F]
   ): Option[SmithyHttp4sClientEndpoint[F, Op, I, E, O, SI, SO]] =
     HttpEndpoint.cast(endpoint).map { httpEndpoint =>
       new SmithyHttp4sClientEndpointImpl[F, Op, I, E, O, SI, SO](
         baseUri,
-        clientOrApp,
+        client,
         endpoint,
         httpEndpoint,
         entityCompiler
@@ -61,25 +60,20 @@ private[smithy4s] object SmithyHttp4sClientEndpoint {
 
 // format: off
 private[smithy4s] class SmithyHttp4sClientEndpointImpl[F[_], Op[_, _, _, _, _], I, E, O, SI, SO](
-  baseUri: Uri,
-  clientOrApp: Either[Client[F], HttpApp[F]],
-  endpoint: Endpoint[Op, I, E, O, SI, SO],
-  httpEndpoint: HttpEndpoint[I],
-  entityCompiler: EntityCompiler[F]
+                                                                                                  baseUri: Uri,
+                                                                                                  client: Client[F],
+                                                                                                  endpoint: Endpoint[Op, I, E, O, SI, SO],
+                                                                                                  httpEndpoint: HttpEndpoint[I],
+                                                                                                  entityCompiler: EntityCompiler[F]
 )(implicit effect: EffectCompat[F]) extends SmithyHttp4sClientEndpoint[F, Op, I, E, O, SI, SO] {
 // format: on
 
   def send(input: I): F[O] = {
-    clientOrApp match {
-      case Left(client) =>
-        client
-          .run(inputToRequest(input))
-          .use { response =>
-            outputFromResponse(response)
-          }
-      case Right(httpApp) =>
-        httpApp.run(inputToRequest(input)).flatMap(outputFromResponse)
-    }
+    client
+      .run(inputToRequest(input))
+      .use { response =>
+        outputFromResponse(response)
+      }
   }
 
   private val method: org.http4s.Method = toHttp4sMethod(httpEndpoint.method)

--- a/modules/http4s/test/src-jvm/smithy4s/http4s/Http4sDynamicPizzaClientSpec.scala
+++ b/modules/http4s/test/src-jvm/smithy4s/http4s/Http4sDynamicPizzaClientSpec.scala
@@ -19,9 +19,7 @@ package smithy4s.http4s
 import smithy4s.dynamic._
 import smithy4s.ShapeId
 import org.http4s.client.Client
-import org.http4s.implicits._
 import cats.implicits._
-
 import cats.effect.IO
 import cats.effect.Resource
 import org.http4s.HttpApp
@@ -49,7 +47,7 @@ class DynamicHttpProxy(client: Client[IO]) {
     dynamicServiceIO
       .flatMap { dsi =>
         SimpleRestJsonBuilder(dsi.service)
-          .client[IO](client, uri"http://localhost:8080")
+          .client[IO](client).either
           .liftTo[IO]
           .map { dynamicClient =>
             JsonIOProtocol

--- a/modules/http4s/test/src-jvm/smithy4s/http4s/Http4sDynamicPizzaClientSpec.scala
+++ b/modules/http4s/test/src-jvm/smithy4s/http4s/Http4sDynamicPizzaClientSpec.scala
@@ -47,7 +47,7 @@ class DynamicHttpProxy(client: Client[IO]) {
     dynamicServiceIO
       .flatMap { dsi =>
         SimpleRestJsonBuilder(dsi.service)
-          .client[IO](client).either
+          .client[IO](client).use
           .liftTo[IO]
           .map { dynamicClient =>
             JsonIOProtocol

--- a/modules/http4s/test/src-jvm/smithy4s/http4s/Http4sDynamicPizzaClientSpec.scala
+++ b/modules/http4s/test/src-jvm/smithy4s/http4s/Http4sDynamicPizzaClientSpec.scala
@@ -47,7 +47,8 @@ class DynamicHttpProxy(client: Client[IO]) {
     dynamicServiceIO
       .flatMap { dsi =>
         SimpleRestJsonBuilder(dsi.service)
-          .client[IO](client).use
+          .client[IO](client)
+          .use
           .liftTo[IO]
           .map { dynamicClient =>
             JsonIOProtocol

--- a/modules/http4s/test/src/smithy4s/http4s/Http4sPizzaClientSpec.scala
+++ b/modules/http4s/test/src/smithy4s/http4s/Http4sPizzaClientSpec.scala
@@ -27,7 +27,9 @@ object Http4sPizzaClientSpec extends smithy4s.tests.PizzaClientSpec {
     HttpApp[IO] => Resource[IO, PizzaAdminService[IO]],
     Int => Resource[IO, PizzaAdminService[IO]]
   ] = Left { httpApp =>
-    SimpleRestJsonBuilder(PizzaAdminService).client(Client.fromHttpApp(httpApp)).resource
+    SimpleRestJsonBuilder(PizzaAdminService)
+      .client(Client.fromHttpApp(httpApp))
+      .resource
   }
 
 }

--- a/modules/http4s/test/src/smithy4s/http4s/Http4sPizzaClientSpec.scala
+++ b/modules/http4s/test/src/smithy4s/http4s/Http4sPizzaClientSpec.scala
@@ -19,7 +19,7 @@ package smithy4s.http4s
 import cats.effect.IO
 import cats.effect.Resource
 import org.http4s.HttpApp
-import org.http4s.Uri
+import org.http4s.client.Client
 import smithy4s.example.PizzaAdminService
 
 object Http4sPizzaClientSpec extends smithy4s.tests.PizzaClientSpec {
@@ -27,8 +27,7 @@ object Http4sPizzaClientSpec extends smithy4s.tests.PizzaClientSpec {
     HttpApp[IO] => Resource[IO, PizzaAdminService[IO]],
     Int => Resource[IO, PizzaAdminService[IO]]
   ] = Left { httpApp =>
-    val uri = Uri.unsafeFromString("http://localhost:8080")
-    SimpleRestJsonBuilder(PizzaAdminService).clientResource(httpApp, uri)
+    SimpleRestJsonBuilder(PizzaAdminService).client(Client.fromHttpApp(httpApp)).resource
   }
 
 }

--- a/modules/http4s/test/src/smithy4s/http4s/RecursiveInputSpec.scala
+++ b/modules/http4s/test/src/smithy4s/http4s/RecursiveInputSpec.scala
@@ -19,8 +19,8 @@ package smithy4s.http4s
 import weaver._
 
 import org.http4s.HttpApp
+import org.http4s.client.Client
 import cats.effect.IO
-import org.http4s.Uri
 
 // This is a non-regression test for https://github.com/disneystreaming/smithy4s/issues/181
 object RecursiveInputSpec extends FunSuite {
@@ -28,9 +28,7 @@ object RecursiveInputSpec extends FunSuite {
   test("simpleRestJson works with recursive input operations") {
     val result =
       SimpleRestJsonBuilder(smithy4s.example.RecursiveInputService).client(
-        HttpApp.notFound[IO],
-        Uri.unsafeFromString("http://localhost")
-      )
+        Client.fromHttpApp(HttpApp.notFound[IO])).either
 
     expect(result.isRight)
   }

--- a/modules/http4s/test/src/smithy4s/http4s/RecursiveInputSpec.scala
+++ b/modules/http4s/test/src/smithy4s/http4s/RecursiveInputSpec.scala
@@ -27,8 +27,9 @@ object RecursiveInputSpec extends FunSuite {
 
   test("simpleRestJson works with recursive input operations") {
     val result =
-      SimpleRestJsonBuilder(smithy4s.example.RecursiveInputService).client(
-        Client.fromHttpApp(HttpApp.notFound[IO])).use
+      SimpleRestJsonBuilder(smithy4s.example.RecursiveInputService)
+        .client(Client.fromHttpApp(HttpApp.notFound[IO]))
+        .use
 
     expect(result.isRight)
   }

--- a/modules/http4s/test/src/smithy4s/http4s/RecursiveInputSpec.scala
+++ b/modules/http4s/test/src/smithy4s/http4s/RecursiveInputSpec.scala
@@ -28,7 +28,7 @@ object RecursiveInputSpec extends FunSuite {
   test("simpleRestJson works with recursive input operations") {
     val result =
       SimpleRestJsonBuilder(smithy4s.example.RecursiveInputService).client(
-        Client.fromHttpApp(HttpApp.notFound[IO])).either
+        Client.fromHttpApp(HttpApp.notFound[IO])).use
 
     expect(result.isRight)
   }


### PR DESCRIPTION
Ok so this is obviously not backwards compatible at all as it changes the interface that is exposed to users
I'm marking it draft to signal that this is more about a direction then a production ready PR
If we go ahead with this PR, we can keep the existing methods and mark deprecated , those methods will use the builder internally.
the benefits of this interface is that its fluent and achieves some code reuse.
Changes made

- I removed HttpApp from method args since its trivial for a user to wrap their HttpApp themselves and it really makes the underlying code more convoluted. We cannot run the conversion for them as we currently have a EffectCompat constraint on F while Client.fromHttpApp needs F[_]:Async. (@kubukoz says it doesnt really need it 🤷 ) .That said this does come with some implications to consider as this now blocks a user from utilizing an HttpApp where their F is doesnt have an instance of Async. I leave that for discussion about whether this is a serious problem
- I defaulted the URI to localhost:8080(though I can understand why this might be unacceptable)) to provide an initial valid state and not have to deal with mutation/effects as one might have to with standard builders. As a side effect this actually makes it nicer when testing as you get a standard localhost:8080 ..
- 