### PR TITLE
Add a guide module - show case CORS middleware

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,4 @@
+import sbt.internal.IvyConsole
 import org.scalajs.jsenv.nodejs.NodeJSEnv
 
 import java.io.File
@@ -668,6 +669,24 @@ lazy val example = projectMatrix
     genSmithyOpenapiOutput := (Compile / resourceDirectory).value
   )
   .jvmPlatform(List(Scala213), jvmDimSettings)
+  .settings(Smithy4sPlugin.doNotPublishArtifact)
+
+lazy val guides = projectMatrix
+  .in(file("modules/guides"))
+  .dependsOn(http4s)
+  .settings(
+    Compile / allowedNamespaces := Seq("smithy4s.guides.hello"),
+    smithySpecs := Seq(
+      (ThisBuild / baseDirectory).value / "modules" / "guides" / "smithy" / "hello.smithy"
+    ),
+    (Compile / sourceGenerators) := Seq(genSmithyScala(Compile).taskValue),
+    isCE3 := true,
+    libraryDependencies ++= Seq(
+      Dependencies.Http4s.emberServer.value,
+      Dependencies.Weaver.cats.value % Test
+    )
+  )
+  .jvmPlatform(Seq(Scala3), jvmDimSettings)
   .settings(Smithy4sPlugin.doNotPublishArtifact)
 
 /**

--- a/modules/guides/smithy/hello.smithy
+++ b/modules/guides/smithy/hello.smithy
@@ -1,0 +1,23 @@
+$version: "2"
+
+namespace smithy4s.guides.hello
+
+use smithy4s.api#simpleRestJson
+
+@simpleRestJson
+service HelloWorldService {
+  version: "1.0.0",
+  operations: [SayWorld]
+}
+
+
+@readonly
+@http(method: "GET", uri: "/hello", code: 200)
+operation SayWorld {
+  output: World
+}
+
+structure World {
+  message: String = "World !"
+}
+

--- a/modules/guides/src/smithy4s/guides/Cors.scala
+++ b/modules/guides/src/smithy4s/guides/Cors.scala
@@ -1,0 +1,57 @@
+/*
+ *  Copyright 2021-2022 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package smithy4s.guides
+
+import smithy4s.guides.hello._
+import cats.effect._
+import cats.implicits._
+import org.http4s.implicits._
+import org.http4s.ember.server._
+import org.http4s._
+import com.comcast.ip4s._
+import smithy4s.http4s.SimpleRestJsonBuilder
+import org.http4s.server.Middleware
+
+object HelloWorldImpl extends HelloWorldService[IO] {
+  def sayWorld(): IO[World] = World().pure[IO]
+}
+
+object Routes {
+  import org.http4s.server.middleware._
+
+  val customMiddleware = CORS.policy.withAllowOriginAll
+    .withAllowCredentials(false)
+    .apply(_: HttpRoutes[IO])
+
+  private val helloRoutes: Resource[IO, HttpRoutes[IO]] =
+    SimpleRestJsonBuilder.routes(HelloWorldImpl).resource
+
+  val all: Resource[IO, HttpRoutes[IO]] =
+    helloRoutes.map(r => customMiddleware(r))
+}
+
+object Main extends IOApp.Simple {
+  val run = Routes.all.flatMap { routes =>
+    EmberServerBuilder
+      .default[IO]
+      .withPort(port"9000")
+      .withHost(host"localhost")
+      .withHttpApp(routes.orNotFound)
+      .build
+  }.useForever
+
+}


### PR DESCRIPTION
The first guide shows how to setup an http4s app and add a middleware to deal with CORS.

Sending a request to the service returns:

```bash
$ curl -v -H 'Origin: http://mysite.com' 'http://localhost:9000/hello'
*   Trying 127.0.0.1:9000...
* Connected to localhost (127.0.0.1) port 9000 (#0)
> GET /hello HTTP/1.1
> Host: localhost:9000
> User-Agent: curl/7.79.1
> Accept: */*
> Origin: http://mysite.com
>
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< Date: Thu, 15 Sep 2022 20:45:50 GMT
< Connection: keep-alive
< Content-Length: 21
< Content-Type: application/json
< Access-Control-Allow-Origin: *
<
* Connection #0 to host localhost left intact
{"message":"World !"}⏎
```

So this is to serve as documentation. I'll open as a draft while I write documentation that refers to this complete example in the site. 