### PR TITLE
Add smithy4s models to upstream model validation

### DIFF
--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/multimodule-staged/bar/src/main/scala/Test.scala
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/multimodule-staged/bar/src/main/scala/Test.scala
@@ -1,0 +1,25 @@
+/*
+ *  Copyright 2021-2022 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package bar
+
+import foo._
+
+object BarTest {
+
+  def main(args: Array[String]): Unit = println(Bar(Some(Foo(Some(1)))))
+
+}

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/multimodule-staged/bar/src/main/smithy/bar.smithy
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/multimodule-staged/bar/src/main/smithy/bar.smithy
@@ -1,0 +1,10 @@
+$version: "2.0"
+
+namespace bar
+
+use foo#Foo
+
+// Checking that Foo can be found by virtue of the bar project depending on the foo project
+structure Bar {
+  foo: Foo
+}

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/multimodule-staged/build.sbt
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/multimodule-staged/build.sbt
@@ -1,0 +1,19 @@
+ThisBuild / scalaVersion := "2.13.8"
+ThisBuild / version := "0.0.1-SNAPSHOT"
+ThisBuild / organization := "foobar"
+
+lazy val foo = (project in file("foo"))
+  .enablePlugins(Smithy4sCodegenPlugin)
+  .settings(
+    libraryDependencies ++= Seq(
+      "com.disneystreaming.smithy4s" %% "smithy4s-core" % smithy4sVersion.value
+    )
+  )
+
+lazy val bar = (project in file("bar"))
+  .enablePlugins(Smithy4sCodegenPlugin)
+  .settings(
+    libraryDependencies ++= Seq(
+      "foobar" %% "foo" % version.value % Smithy4sCompile
+    )
+  )

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/multimodule-staged/foo/src/main/smithy/foo.smithy
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/multimodule-staged/foo/src/main/smithy/foo.smithy
@@ -1,0 +1,12 @@
+$version: "2.0"
+
+namespace foo
+
+use smithy4s.api#uuidFormat
+
+structure Foo {
+  a: Integer
+}
+
+@uuidFormat
+string MyUUID

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/multimodule-staged/project/build.properties
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/multimodule-staged/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.7.1

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/multimodule-staged/project/plugins.sbt
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/multimodule-staged/project/plugins.sbt
@@ -1,0 +1,9 @@
+sys.props.get("plugin.version") match {
+  case Some(x) =>
+    addSbtPlugin("com.disneystreaming.smithy4s" % "smithy4s-sbt-codegen" % x)
+  case _ =>
+    sys.error(
+      """|The system property 'plugin.version' is not defined.
+         |Specify this property using the scriptedLaunchOpts -D.""".stripMargin
+    )
+}

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/multimodule-staged/test
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/multimodule-staged/test
@@ -1,0 +1,8 @@
+# check if smithy4sCodegen works in multimodule contexts
+> foo/publishLocal
+> bar/compile
+$ exists bar/target/scala-2.13/src_managed/main/bar/Bar.scala
+$ absent bar/target/scala-2.13/src_managed/main/foo/Foo.scala
+
+# check if code can run, this can reveal runtime issues# such as initialization errors
+> bar/run

--- a/modules/codegen/src/smithy4s/codegen/ModelLoader.scala
+++ b/modules/codegen/src/smithy4s/codegen/ModelLoader.scala
@@ -59,6 +59,7 @@ object ModelLoader {
       val upstreamModel = Model
         .assembler()
         .discoverModels(upstreamClassLoader)
+        .addClasspathModels(currentClassLoader, false)
         // disabling cache to support snapshot-driven experimentation
         .putProperty(ModelAssembler.DISABLE_JAR_CACHE, true)
         .assemble()
@@ -165,14 +166,14 @@ object ModelLoader {
 
     def addClasspathModels(
         classLoader: ClassLoader,
-        flag: Boolean
+        discoverModels: Boolean
     ): ModelAssembler = {
       val smithy4sResources = List(
         "META-INF/smithy/smithy4s.smithy",
         "META-INF/smithy/smithy4s.meta.smithy"
       ).map(classLoader.getResource)
 
-      if (flag) assembler.discoverModels(classLoader)
+      if (discoverModels) assembler.discoverModels(classLoader)
       else addImports(smithy4sResources)
     }
   }


### PR DESCRIPTION
If users publish smithy4s generated code, we package the models in the artifacts for sharing with downstream projects. The problem has to do with Smithy4s not including its own models when loading upstream models, which do not necessarily depend on smithy4s-protocol.

This change adds the smithy4s-protocol model when loading upstream models, just in case.

Fixes https://github.com/disneystreaming/smithy4s/issues/420