### PR TITLE
Adds Service as class member to Client builder 

### DIFF
--- a/modules/http4s/src/smithy4s/http4s/SimpleProtocolBuilder.scala
+++ b/modules/http4s/src/smithy4s/http4s/SimpleProtocolBuilder.scala
@@ -91,7 +91,7 @@ abstract class SimpleProtocolBuilder[P](val codecs: CodecAPI)(implicit
       _
   ]: EffectCompat] private[http4s] (
       client: Client[F],
-      service: smithy4s.Service[Alg, Op],
+      val  service: smithy4s.Service[Alg, Op],
       uri: Uri = uri"http://localhost:8080"
   ) {
 

--- a/modules/http4s/src/smithy4s/http4s/SimpleProtocolBuilder.scala
+++ b/modules/http4s/src/smithy4s/http4s/SimpleProtocolBuilder.scala
@@ -91,7 +91,7 @@ abstract class SimpleProtocolBuilder[P](val codecs: CodecAPI)(implicit
       _
   ]: EffectCompat] private[http4s] (
       client: Client[F],
-      val  service: smithy4s.Service[Alg, Op],
+      val service: smithy4s.Service[Alg, Op],
       uri: Uri = uri"http://localhost:8080"
   ) {
 


### PR DESCRIPTION
Service is now a class member in the ClientBuilder
This allows extending the ClientBuilder and utilizing the service in the extension methods
