### PR TITLE
Fix codegen resource outputs for Smithy files in subdirectories

### DIFF
--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/multimodule/bar/src/main/scala/Test.scala
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/multimodule/bar/src/main/scala/Test.scala
@@ -20,6 +20,9 @@ import foo._
 
 object BarTest {
 
-  def main(args: Array[String]): Unit = println(Bar(Some(Foo(Some(1)))))
+  def main(args: Array[String]): Unit = {
+    println(Bar(Some(Foo(Some(1)))))
+    println(foodir.FooDir(Some(2)))
+  }
 
 }

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/multimodule/foo/src/main/smithy/foodir/foodir.smithy
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/multimodule/foo/src/main/smithy/foodir/foodir.smithy
@@ -1,0 +1,7 @@
+$version: "2.0"
+
+namespace foodir
+
+structure FooDir {
+  a: Integer
+}

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/multimodule/test
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/multimodule/test
@@ -2,7 +2,9 @@
 > compile
 $ exists bar/target/scala-2.13/src_managed/main/bar/Bar.scala
 $ absent bar/target/scala-2.13/src_managed/main/foo/Foo.scala
+$ absent bar/target/scala-2.13/src_managed/main/foodir/FooDir.scala
 $ exists foo/target/scala-2.13/src_managed/main/foo/Foo.scala
+$ exists foo/target/scala-2.13/src_managed/main/foodir/FooDir.scala
 
 # check if code can run, this can reveal runtime issues# such as initialization errors
 > bar/run

--- a/modules/codegen-plugin/src/smithy4s/codegen/Smithy4sCodegenPlugin.scala
+++ b/modules/codegen-plugin/src/smithy4s/codegen/Smithy4sCodegenPlugin.scala
@@ -121,7 +121,9 @@ object Smithy4sCodegenPlugin extends AutoPlugin {
 
   def cachedSmithyCodegen(conf: Configuration) = Def.task {
     val inputFiles =
-      Option((conf / smithy4sInputDir).value.listFiles()).getOrElse(Array.empty)
+      Option((conf / smithy4sInputDir).value)
+        .filter(_.exists())
+        .toList
     val outputPath = (conf / smithy4sOutputDir).value
     val resourceOutputPath = (conf / smithy4sResourceDir).value
     val allowedNamespaces =

--- a/modules/codegen/src/smithy4s/codegen/SmithyResources.scala
+++ b/modules/codegen/src/smithy4s/codegen/SmithyResources.scala
@@ -16,6 +16,8 @@
 
 package smithy4s.codegen
 
+import os.RelPath
+
 /**
   * This construct aims at adding metadata information to the classpath to let Smithy4s
   * know about code that may have been generated in upstream modules.
@@ -39,34 +41,38 @@ private[smithy4s] object SmithyResources {
                         |
                         |metadata smithy4sGenerated = [{smithy4sVersion: "$smithy4sVersion", namespaces: [$nsString]}]
                         |""".stripMargin
-    val localCopyBindings = localSmithyFiles.map { path =>
-      (path, smithyFolder / path.last)
-    }
-    val allSmithyFiles = trackingFile :: localCopyBindings.map(_._2)
 
     val metadataFile = smithyFolder / "manifest"
 
     val metadataFileContent =
-      allSmithyFiles.map(_.last).mkString(System.lineSeparator())
+      (trackingFile :: localSmithyFiles)
+        .flatMap {
+          case f if os.isDir(f) =>
+            os.walk(f).map(_.relativeTo(f / os.up))
+          case f => RelPath(f.last) :: Nil
+        }
 
     os.write.over(
       metadataFile,
-      metadataFileContent,
+      metadataFileContent.mkString(System.lineSeparator()),
       createFolders = true
     )
 
     os.write.over(trackingFile, content, createFolders = true)
 
-    localCopyBindings.foreach { case (from, to) =>
-      os.copy(
-        from,
-        to,
-        replaceExisting = true,
-        createFolders = true
-      )
-    }
+    localSmithyFiles
+      .foreach { path =>
+        os.copy(
+          from = path,
+          to = smithyFolder / path.last,
+          replaceExisting = true,
+          createFolders = true
+        )
+      }
 
-    val allProducedFiles = metadataFile :: allSmithyFiles
+    val allProducedFiles =
+      metadataFile :: metadataFileContent.map(_.resolveFrom(smithyFolder))
+
     allProducedFiles
   }
 

--- a/modules/codegen/src/smithy4s/codegen/SmithyResources.scala
+++ b/modules/codegen/src/smithy4s/codegen/SmithyResources.scala
@@ -48,7 +48,7 @@ private[smithy4s] object SmithyResources {
       (trackingFile :: localSmithyFiles)
         .flatMap {
           case f if os.isDir(f) =>
-            os.walk(f).map(_.relativeTo(f / os.up))
+            os.walk(f).filter(os.isFile(_)).map(_.relativeTo(f))
           case f => RelPath(f.last) :: Nil
         }
 
@@ -61,6 +61,10 @@ private[smithy4s] object SmithyResources {
     os.write.over(trackingFile, content, createFolders = true)
 
     localSmithyFiles
+      .flatMap {
+        case p if os.isDir(p) => os.list(p)
+        case p                => List(p)
+      }
       .foreach { path =>
         os.copy(
           from = path,

--- a/modules/mill-codegen-plugin/src/smithy4s/codegen/mill/Smithy4sModule.scala
+++ b/modules/mill-codegen-plugin/src/smithy4s/codegen/mill/Smithy4sModule.scala
@@ -74,7 +74,7 @@ trait Smithy4sModule extends ScalaModule {
   def smithy4sCodegen: T[(PathRef, PathRef)] = T {
 
     val specFiles = if (os.exists(smithy4sInputDir().path)) {
-      os.walk(smithy4sInputDir().path, skip = _.ext != "smithy")
+      os.list(smithy4sInputDir().path)
     } else Seq.empty
 
     val scalaOutput = smithy4sOutputDir().path

--- a/modules/mill-codegen-plugin/src/smithy4s/codegen/mill/Smithy4sModule.scala
+++ b/modules/mill-codegen-plugin/src/smithy4s/codegen/mill/Smithy4sModule.scala
@@ -73,9 +73,7 @@ trait Smithy4sModule extends ScalaModule {
 
   def smithy4sCodegen: T[(PathRef, PathRef)] = T {
 
-    val specFiles = if (os.exists(smithy4sInputDir().path)) {
-      os.list(smithy4sInputDir().path)
-    } else Seq.empty
+    val specFiles = List(smithy4sInputDir().path).filter(os.exists(_))
 
     val scalaOutput = smithy4sOutputDir().path
     val resourcesOutput = smithy4sResourceOutputDir().path

--- a/modules/mill-codegen-plugin/test/resources/multi-module/bar/src/Test.scala
+++ b/modules/mill-codegen-plugin/test/resources/multi-module/bar/src/Test.scala
@@ -20,6 +20,9 @@ import foo._
 
 object BarTest {
 
-  def main(args: Array[String]): Unit = println(Bar(Some(Foo(Some(1)))))
+  def main(args: Array[String]): Unit = {
+    println(Bar(Some(Foo(Some(1)))))
+    println(foodir.FooDir(Some(2)))
+  }
 
 }

--- a/modules/mill-codegen-plugin/test/resources/multi-module/foo/smithy/foodir/foodir.smithy
+++ b/modules/mill-codegen-plugin/test/resources/multi-module/foo/smithy/foodir/foodir.smithy
@@ -1,0 +1,7 @@
+$version: "2.0"
+
+namespace foodir
+
+structure FooDir {
+  a: Integer
+}

--- a/modules/mill-codegen-plugin/test/src/smithy4s/codegen/mill/Smithy4sModuleSpec.scala
+++ b/modules/mill-codegen-plugin/test/src/smithy4s/codegen/mill/Smithy4sModuleSpec.scala
@@ -90,10 +90,18 @@ class Smithy4sModuleSpec extends munit.FunSuite {
       fooEv.outPath / "smithy4sOutputDir.dest" / "scala" / "foo" / "Foo.scala",
       shouldExist = true
     )
+    checkFileExist(
+      fooEv.outPath / "smithy4sOutputDir.dest" / "scala" / "foodir" / "FooDir.scala",
+      shouldExist = true
+    )
 
     compileWorks(bar, barEv)
     checkFileExist(
       barEv.outPath / "smithy4sOutputDir.dest" / "scala" / "foo" / "Foo.scala",
+      shouldExist = false
+    )
+    checkFileExist(
+      barEv.outPath / "smithy4sOutputDir.dest" / "scala" / "foodir" / "FooDir.scala",
       shouldExist = false
     )
     checkFileExist(


### PR DESCRIPTION
In 0.16.2, it seems like putting a Smithy file in a module breaks `smithy4sCodegen` of downstream modules. This will (hopefully) demonstrate that downstream modules fail to run codegen when such a situation arises.

The error is:

```
software.amazon.smithy.model.loader.ModelImportException: Unable to open Smithy model import URL: jar:file:/tmp/sbt_b32e5aac/foo/target/scala-2.13/foo_2.13-0.1.0-SNAPSHOT.jar!/META-INF/smithy/foodir

caused by

java.io.FileNotFoundException: JAR entry META-INF/smithy/foodir not found in /tmp/sbt_b32e5aac/foo/target/scala-2.13/foo_2.13-0.1.0-SNAPSHOT.jar
```

You can also reproduce this issue by trying to compile [this](https://github.com/kubukoz/demos/tree/smithy4s-subdir).

The generated manifest for this file structure:

```
smithy
- dir
| - coredir.smithy
```

is:

```
smithy4s.tracking.smithy
dir
```