### PR TITLE
Remove stale generated resource directories

### DIFF
--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/multimodule/a.scala
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/multimodule/a.scala
@@ -1,0 +1,22 @@
+/*
+ *  Copyright 2021-2022 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+// this file will be copied to the foo module as part of the test
+package foo
+
+object a {
+  val x = "hello"
+}

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/multimodule/a.scala
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/multimodule/a.scala
@@ -17,6 +17,4 @@
 // this file will be copied to the foo module as part of the test
 package foo
 
-object a {
-  val x = "hello"
-}
+object a

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/multimodule/bar/src/main/smithy/subdir/sub.smithy
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/multimodule/bar/src/main/smithy/subdir/sub.smithy
@@ -1,0 +1,5 @@
+$version: "2.0"
+
+namespace subdir
+
+structure BarBar { }

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/multimodule/test
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/multimodule/test
@@ -6,3 +6,7 @@ $ exists foo/target/scala-2.13/src_managed/main/foo/Foo.scala
 
 # check if code can run, this can reveal runtime issues# such as initialization errors
 > bar/run
+
+# check if upstream changes result in successful rebuilds downstream
+$ copy-file a.scala foo/src/main/scala/a.scala
+> bar/run

--- a/modules/codegen/src/smithy4s/codegen/SmithyResources.scala
+++ b/modules/codegen/src/smithy4s/codegen/SmithyResources.scala
@@ -58,12 +58,7 @@ private[smithy4s] object SmithyResources {
     os.write.over(trackingFile, content, createFolders = true)
 
     localCopyBindings.foreach { case (from, to) =>
-      // Files will be overwritten by the copy below
-      // so we only need to remove directories
-      if (os.isDir(to) && os.exists(to))
-        os.remove.all(to)
-
-      os.copy(
+      os.copy.over(
         from,
         to,
         replaceExisting = true,

--- a/modules/codegen/src/smithy4s/codegen/SmithyResources.scala
+++ b/modules/codegen/src/smithy4s/codegen/SmithyResources.scala
@@ -58,6 +58,11 @@ private[smithy4s] object SmithyResources {
     os.write.over(trackingFile, content, createFolders = true)
 
     localCopyBindings.foreach { case (from, to) =>
+      // Files will be overwritten by the copy below
+      // so we only need to remove directories
+      if (os.isDir(to) && os.exists(to))
+        os.remove.all(to)
+
       os.copy(
         from,
         to,

--- a/modules/mill-codegen-plugin/test/resources/multi-module/bar/smithy/subdir/sub.smithy
+++ b/modules/mill-codegen-plugin/test/resources/multi-module/bar/smithy/subdir/sub.smithy
@@ -1,0 +1,5 @@
+$version: "2.0"
+
+namespace subdir
+
+structure BarBar { }

--- a/modules/mill-codegen-plugin/test/src/smithy4s/codegen/mill/Smithy4sModuleSpec.scala
+++ b/modules/mill-codegen-plugin/test/src/smithy4s/codegen/mill/Smithy4sModuleSpec.scala
@@ -104,7 +104,8 @@ class Smithy4sModuleSpec extends munit.FunSuite {
     os.write(
       foo.millSourcePath / "scala" / "foo" / "a.scala",
       """package foo
-        |object a""".stripMargin
+        |object a""".stripMargin,
+      createFolders = true
     )
     compileWorks(bar, barEv)
   }

--- a/modules/mill-codegen-plugin/test/src/smithy4s/codegen/mill/Smithy4sModuleSpec.scala
+++ b/modules/mill-codegen-plugin/test/src/smithy4s/codegen/mill/Smithy4sModuleSpec.scala
@@ -118,7 +118,6 @@ class Smithy4sModuleSpec extends munit.FunSuite {
       createFolders = true
     )
 
-    // for some reason this works on mill
     try compileWorks(bar, barEv)
     finally {
       val _ =

--- a/modules/mill-codegen-plugin/test/src/smithy4s/codegen/mill/Smithy4sModuleSpec.scala
+++ b/modules/mill-codegen-plugin/test/src/smithy4s/codegen/mill/Smithy4sModuleSpec.scala
@@ -100,6 +100,13 @@ class Smithy4sModuleSpec extends munit.FunSuite {
       barEv.outPath / "smithy4sOutputDir.dest" / "scala" / "bar" / "Bar.scala",
       shouldExist = true
     )
+
+    os.write(
+      foo.millSourcePath / "scala" / "foo" / "a.scala",
+      """package foo
+        |object a""".stripMargin
+    )
+    compileWorks(bar, barEv)
   }
 
   private def compileWorks(

--- a/modules/mill-codegen-plugin/test/src/smithy4s/codegen/mill/Smithy4sModuleSpec.scala
+++ b/modules/mill-codegen-plugin/test/src/smithy4s/codegen/mill/Smithy4sModuleSpec.scala
@@ -101,12 +101,13 @@ class Smithy4sModuleSpec extends munit.FunSuite {
       shouldExist = true
     )
 
-    os.write(
-      foo.millSourcePath / "scala" / "foo" / "a.scala",
+    os.write.over(
+      foo.millSourcePath / "src" / "scala" / "foo" / "a.scala",
       """package foo
         |object a""".stripMargin,
       createFolders = true
     )
+
     compileWorks(bar, barEv)
   }
 

--- a/modules/mill-codegen-plugin/test/src/smithy4s/codegen/mill/Smithy4sModuleSpec.scala
+++ b/modules/mill-codegen-plugin/test/src/smithy4s/codegen/mill/Smithy4sModuleSpec.scala
@@ -101,14 +101,23 @@ class Smithy4sModuleSpec extends munit.FunSuite {
       shouldExist = true
     )
 
-    os.write.over(
-      foo.millSourcePath / "src" / "scala" / "foo" / "a.scala",
+    val aScalaPath = foo.millSourcePath / "src" / "a.scala"
+
+    os.write(
+      aScalaPath,
       """package foo
-        |object a""".stripMargin,
+      |object a""".stripMargin,
       createFolders = true
     )
 
-    compileWorks(bar, barEv)
+    // for some reason this works on mill
+    try compileWorks(bar, barEv)
+    finally {
+      val _ =
+        // cleaning up, because the target path doesn't get cleared automatically on test re-runs
+        // (it's part of this test module's target path)
+        os.remove.all(aScalaPath)
+    }
   }
 
   private def compileWorks(


### PR DESCRIPTION
Closely related to #485, but can be resolved separately.

Might be worth a separate test to reduce the amount of moving parts in this one.

What happens here:

1. `bar` has a `.smithy` file in a subdirectory
2. `bar/smithy4sCodegen` runs
3. upstream changes (code changes or anything that forces `bar` to regenerate sources but apparently not things that directly impact `CodegenArgs`) happen
4. `bar/smithy4sCodegen` runs again: it fails because it's trying to overwrite files in `resources_managed` without removing them first