### PR TITLE
Codegen: Fix hashing for directories

### DIFF
--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/defaults/example-added.smithy
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/defaults/example-added.smithy
@@ -1,0 +1,3 @@
+namespace smithy4s.example
+
+structure Added {}

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/defaults/src/main/scala/Main.scala
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/defaults/src/main/scala/Main.scala
@@ -21,6 +21,7 @@ import smithy4s.dynamic.DynamicSchemaIndex
 
 object Main extends App {
   try {
+    println(smithy4s.example.Foo.IntCase(42))
     println(smithy.api.NonEmptyString("nope").value)
   } catch {
     case _: java.lang.ExceptionInInitializerError =>

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/defaults/test
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/defaults/test
@@ -6,3 +6,10 @@ $ exists target/scala-2.13/resource_managed/main/smithy4s.example.ObjectService.
 # check if code can run, this can reveal runtime issues
 # such as initialization errors
 > run
+$ copy-file example-added.smithy src/main/smithy/example-added.smithy
+> compile
+$ exists target/scala-2.13/src_managed/main/smithy4s/example/Added.scala
+
+# ensuring that removing existing files removes their outputs
+$ delete src/main/smithy/example.smithy
+-> compile

--- a/modules/mill-codegen-plugin/test/src/smithy4s/codegen/mill/Smithy4sModuleSpec.scala
+++ b/modules/mill-codegen-plugin/test/src/smithy4s/codegen/mill/Smithy4sModuleSpec.scala
@@ -32,7 +32,7 @@ class Smithy4sModuleSpec extends munit.FunSuite {
   private val coreDep =
     ivy"com.disneystreaming.smithy4s::smithy4s-core:${smithy4s.codegen.BuildInfo.version}"
 
-  test("basic codegen runs".only) {
+  test("basic codegen runs") {
     object foo extends testKit.BaseModule with Smithy4sModule {
       override def scalaVersion = "2.13.8"
       override def ivyDeps = Agg(coreDep)


### PR DESCRIPTION
Fixes a regression from #485: in the sbt plugin, we now always pass just the path to the `smithy` directory (the default input directory for specs), and it turns out that the hashing implementation for directories doesn't look at the contents.

This PR ensures that we hash directories according to their contents (recursively), and adds some tests (for sbt/mill) to ensure we don't have bad cache hits and actually regenerate stuff when needed.