### PR TITLE
Amends cache key in Cached schema visitor

### DIFF
--- a/modules/core/src/smithy4s/Bijection.scala
+++ b/modules/core/src/smithy4s/Bijection.scala
@@ -52,7 +52,7 @@ object Bijection {
   def apply[A, B](to: A => B, from: B => A): Bijection[A, B] =
     new Impl[A, B](to, from)
 
-  private class Impl[A, B](toFunction: A => B, fromFunction: B => A)
+  private case class Impl[A, B](toFunction: A => B, fromFunction: B => A)
       extends Bijection[A, B] {
     def to(a: A): B = toFunction(a)
     def from(b: B): A = fromFunction(b)

--- a/modules/core/src/smithy4s/Hints.scala
+++ b/modules/core/src/smithy4s/Hints.scala
@@ -67,6 +67,11 @@ object Hints {
     }
     override def toString(): String =
       s"Hints(${all.mkString(", ")})"
+
+    override def hashCode(): Int = toMap.hashCode()
+    override def equals(obj: Any): Boolean = {
+      obj.isInstanceOf[Impl] && obj.asInstanceOf[Impl].toMap == this.toMap
+    }
   }
 
   sealed trait Binding extends Product with Serializable {

--- a/modules/core/src/smithy4s/schema/HashVisitor.scala
+++ b/modules/core/src/smithy4s/schema/HashVisitor.scala
@@ -1,0 +1,115 @@
+package smithy4s.schema
+
+import smithy4s.Lazy
+
+import smithy4s.Bijection
+import smithy4s.Refinement
+
+import smithy4s.{Hints, ShapeId}
+
+private[schema] class HashVisitor() extends SchemaVisitor[Lambda[A => Unit]] {
+  private var result: Int = 1
+  private val prime: Int = 31
+  private val visitedLazy: java.util.HashSet[ShapeId] =
+    new java.util.HashSet[ShapeId]()
+
+  def getResult: Int = result
+
+  def primitive[P](shapeId: ShapeId, hints: Hints, tag: Primitive[P]): Unit = {
+    result = result * prime + 1
+    result = result * prime + shapeId.hashCode()
+    result = result * prime + hints.hashCode()
+    result = result * prime + tag.hashCode()
+  }
+
+  def collection[C[_], A](
+      shapeId: ShapeId,
+      hints: Hints,
+      tag: CollectionTag[C],
+      member: Schema[A]
+  ): Unit = {
+    result = result * prime + 2
+    result = result * prime + shapeId.hashCode()
+    result = result * prime + hints.hashCode()
+    result = result * prime + tag.hashCode()
+  }
+
+  def map[K, V](
+      shapeId: ShapeId,
+      hints: Hints,
+      key: Schema[K],
+      value: Schema[V]
+  ): Unit = {
+    result = result * prime + 3
+    result = result * prime + shapeId.hashCode()
+    result = result * prime + hints.hashCode()
+    this(key)
+    this(value)
+  }
+
+  def enumeration[E](
+      shapeId: ShapeId,
+      hints: Hints,
+      values: List[EnumValue[E]],
+      total: E => EnumValue[E]
+  ): Unit = {
+    result = result * prime + 4
+    result = result * prime + shapeId.hashCode()
+    result = result * prime + hints.hashCode()
+    for (v <- values) {
+      result = result * prime + v.hashCode()
+    }
+  }
+
+  def struct[S](
+      shapeId: ShapeId,
+      hints: Hints,
+      fields: Vector[SchemaField[S, _]],
+      make: IndexedSeq[Any] => S
+  ): Unit = {
+    result = result * prime + 5
+    result = result * prime + shapeId.hashCode()
+    result = result * prime + hints.hashCode()
+    def processField(field: SchemaField[S, _]): Unit = {
+      result = result * prime + field.label.hashCode()
+      this(field.instance)
+    }
+    fields.foreach(processField(_))
+  }
+
+  def union[U](
+      shapeId: ShapeId,
+      hints: Hints,
+      alternatives: Vector[SchemaAlt[U, _]],
+      dispatch: Alt.Dispatcher[Schema, U]
+  ): Unit = {
+    result = result * prime + 6
+    result = result * prime + shapeId.hashCode()
+    result = result * prime + hints.hashCode()
+    def processAlt(field: SchemaAlt[U, _]): Unit = {
+      result = result * prime + field.label.hashCode()
+      this(field.instance)
+    }
+    alternatives.foreach(processAlt(_))
+  }
+
+  def biject[A, B](schema: Schema[A], bijection: Bijection[A, B]): Unit = {
+    result = result * prime + 7
+    this(schema)
+  }
+
+  def refine[A, B](schema: Schema[A], refinement: Refinement[A, B]): Unit = {
+    result = result * prime + 8
+    this(schema)
+  }
+
+  def lazily[A](suspend: Lazy[Schema[A]]): Unit = {
+    result = result * prime + 9
+    val shapeId = suspend.value.shapeId
+    if (!visitedLazy.contains(suspend.value.shapeId)) {
+      visitedLazy.add(shapeId)
+      this(suspend.value)
+    }
+  }
+
+}

--- a/modules/core/src/smithy4s/schema/HashVisitor.scala
+++ b/modules/core/src/smithy4s/schema/HashVisitor.scala
@@ -7,7 +7,12 @@ import smithy4s.Refinement
 
 import smithy4s.{Hints, ShapeId}
 
-private[schema] class HashVisitor() extends SchemaVisitor[Lambda[A => Unit]] {
+private[schema] object HashVisitor {
+  type Imperative[A] = Unit
+}
+
+private[schema] class HashVisitor()
+    extends SchemaVisitor[HashVisitor.Imperative] {
   private var result: Int = 1
   private val prime: Int = 31
   private val visitedLazy: java.util.HashSet[ShapeId] =

--- a/modules/core/src/smithy4s/schema/HashVisitor.scala
+++ b/modules/core/src/smithy4s/schema/HashVisitor.scala
@@ -75,8 +75,10 @@ private[schema] class HashVisitor()
     result = result * prime + 5
     result = result * prime + shapeId.hashCode()
     result = result * prime + hints.hashCode()
+    result = result * prime + make.hashCode()
     def processField(field: SchemaField[S, _]): Unit = {
       result = result * prime + field.label.hashCode()
+      result = result * prime + field.get.hashCode()
       this(field.instance)
     }
     fields.foreach(processField(_))
@@ -91,20 +93,24 @@ private[schema] class HashVisitor()
     result = result * prime + 6
     result = result * prime + shapeId.hashCode()
     result = result * prime + hints.hashCode()
-    def processAlt(field: SchemaAlt[U, _]): Unit = {
-      result = result * prime + field.label.hashCode()
-      this(field.instance)
+    result = result * prime + dispatch.hashCode()
+    def processAlt(alt: SchemaAlt[U, _]): Unit = {
+      result = result * prime + alt.label.hashCode()
+      result = result * prime + alt.inject.hashCode()
+      this(alt.instance)
     }
     alternatives.foreach(processAlt(_))
   }
 
   def biject[A, B](schema: Schema[A], bijection: Bijection[A, B]): Unit = {
     result = result * prime + 7
+    result = result * prime + bijection.hashCode()
     this(schema)
   }
 
   def refine[A, B](schema: Schema[A], refinement: Refinement[A, B]): Unit = {
     result = result * prime + 8
+    result = result * prime + refinement.hashCode()
     this(schema)
   }
 

--- a/modules/core/src/smithy4s/schema/HashVisitor.scala
+++ b/modules/core/src/smithy4s/schema/HashVisitor.scala
@@ -1,3 +1,19 @@
+/*
+ *  Copyright 2021-2022 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 package smithy4s.schema
 
 import smithy4s.Lazy

--- a/modules/core/src/smithy4s/schema/Schema.scala
+++ b/modules/core/src/smithy4s/schema/Schema.scala
@@ -47,7 +47,6 @@ sealed trait Schema[A]{
 
   final def withId(namespace: String, name: String) : Schema[A] = withId(ShapeId(namespace, name))
 
-
   final def transformHintsLocally(f: Hints => Hints) : Schema[A] = this match {
     case PrimitiveSchema(shapeId, hints, tag) => PrimitiveSchema(shapeId, f(hints), tag)
     case s: CollectionSchema[c, a] => CollectionSchema(s.shapeId, f(s.hints), s.tag, s.member).asInstanceOf[Schema[A]]
@@ -78,6 +77,13 @@ sealed trait Schema[A]{
   }
 
   final def refined[B]: PartiallyAppliedRefinement[A, B] = new PartiallyAppliedRefinement[A, B](this)
+
+  private[schema] final def schemaHash : Int = {
+    val hashVisitor = new HashVisitor()
+    hashVisitor(this)
+    hashVisitor.getResult
+  }
+
 }
 
 object Schema {

--- a/modules/core/src/smithy4s/schema/SchemaVisitor.scala
+++ b/modules/core/src/smithy4s/schema/SchemaVisitor.scala
@@ -68,8 +68,8 @@ object SchemaVisitor {
 
     override def apply[A](schema: Schema[A]): F[A] = {
       // We're using a cache key that's the combination of the shape id, and
-      // an educated hashcode that leaves aside anything unlikely to be the same
-      // (typically, lambdas, which are only comparable using referential equality)
+      // an educated hashcode that leaves aside `Lazy`, which is unstable
+      // when transforming hints.
       //
       // There may be some extremely unlikely edge-cases.
       val key = (schema.shapeId, schema.schemaHash)

--- a/modules/core/src/smithy4s/schema/SchemaVisitor.scala
+++ b/modules/core/src/smithy4s/schema/SchemaVisitor.scala
@@ -67,7 +67,13 @@ object SchemaVisitor {
     private val cache: MMap[Any, Any] = MMap.empty
 
     override def apply[A](schema: Schema[A]): F[A] = {
-      cache.getOrElseUpdate(schema, super.apply(schema)).asInstanceOf[F[A]]
+      // We're using a cache key that's the combination of the shape id, and
+      // an educated hashcode that leaves aside anything unlikely to be the same
+      // (typically, lambdas, which are only comparable using referential equality)
+      //
+      // There may be some extremely unlikely edge-cases.
+      val key = (schema.shapeId, schema.schemaHash)
+      cache.getOrElseUpdate(key, super.apply(schema)).asInstanceOf[F[A]]
     }
   }
 

--- a/modules/core/test/src/smithy4s/HintsEqualitySpec.scala
+++ b/modules/core/test/src/smithy4s/HintsEqualitySpec.scala
@@ -1,3 +1,19 @@
+/*
+ *  Copyright 2021-2022 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 package smithy4s
 
 import munit._

--- a/modules/core/test/src/smithy4s/HintsEqualitySpec.scala
+++ b/modules/core/test/src/smithy4s/HintsEqualitySpec.scala
@@ -1,0 +1,14 @@
+package smithy4s
+
+import munit._
+
+class HintsEqualitySpec() extends FunSuite {
+
+  test("the Hints construct has an implemented equality method") {
+    def hints() = Hints(smithy.api.Deprecated())
+    val hints1 = hints()
+    val hints2 = hints()
+    assertEquals(hints1, hints2)
+  }
+
+}

--- a/modules/core/test/src/smithy4s/PatternSpec.scala
+++ b/modules/core/test/src/smithy4s/PatternSpec.scala
@@ -1,3 +1,19 @@
+/*
+ *  Copyright 2021-2022 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 package smithy4s
 import smithy4s.example._
 

--- a/modules/core/test/src/smithy4s/schema/SchemaHashSpec.scala
+++ b/modules/core/test/src/smithy4s/schema/SchemaHashSpec.scala
@@ -1,3 +1,19 @@
+/*
+ *  Copyright 2021-2022 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 package smithy4s.schema
 
 import munit._

--- a/modules/core/test/src/smithy4s/schema/SchemaHashSpec.scala
+++ b/modules/core/test/src/smithy4s/schema/SchemaHashSpec.scala
@@ -1,0 +1,85 @@
+package smithy4s.schema
+
+import munit._
+import smithy4s.Hints
+import Schema._
+
+class SchemaHashSpec() extends FunSuite {
+
+  def checkSchema[A](schema: Schema[A])(implicit loc: Location): Unit = {
+    def transform() =
+      schema.transformHintsTransitively(_ ++ Hints(smithy.api.Deprecated()))
+    val transformed1 = transform().schemaHash
+    val transformed2 = transform().schemaHash
+    assertNotEquals(transformed1, 1)
+    assertEquals(transformed1, transformed2)
+  }
+
+  val header = "schema hash equal through hints transformation: "
+
+  test(header + "primitive") {
+    checkSchema(int)
+  }
+
+  test(header + "collection") {
+    checkSchema(list(int))
+  }
+
+  test(header + "map") {
+    checkSchema(map(string, int))
+  }
+
+  test(header + "enum") {
+    sealed abstract class FooBar(val stringValue: String, val intValue: Int)
+        extends smithy4s.Enumeration.Value {
+      val name = stringValue
+      val value = stringValue
+      val hints = Hints.empty
+    }
+    case object Foo extends FooBar("foo", 0)
+    case object Bar extends FooBar("bar", 1)
+    val schema: Schema[FooBar] = enumeration[FooBar](List(Foo, Bar))
+    checkSchema(schema)
+  }
+
+  test(header + "struct") {
+    case class Foo(int: Int)
+    val schema = struct(int.required[Foo]("int", _.int))(Foo(_))
+    checkSchema(schema)
+  }
+
+  test(header + "union") {
+    type Foo = Either[Int, String]
+    val left = int.oneOf[Foo]("left", Left(_))
+    val right = string.oneOf[Foo]("right", Right(_))
+    val schema = union(left, right) {
+      case Left(int)     => left(int)
+      case Right(string) => right(string)
+    }
+
+    checkSchema(schema)
+  }
+
+  test(header + "lazy") {
+    case class Foo(foo: Option[Foo])
+    object Foo {
+      val schema: Schema[Foo] = recursive {
+        val foos = schema.optional[Foo]("foo", _.foo)
+        struct(foos)(Foo.apply)
+      }
+    }
+    checkSchema(Foo.schema)
+  }
+
+  test(header + "bijection") {
+    case class Foo(x: Int)
+    val schema: Schema[Foo] = bijection(int, Foo(_), _.x)
+    checkSchema(schema)
+  }
+
+  test(header + "surjection") {
+    val schema: Schema[Int] =
+      int.refined(smithy.api.Range(None, Option(BigDecimal(1))))
+    checkSchema(schema)
+  }
+}

--- a/modules/dynamic/src/smithy4s/dynamic/internals/DynamicLambdas.scala
+++ b/modules/dynamic/src/smithy4s/dynamic/internals/DynamicLambdas.scala
@@ -1,0 +1,46 @@
+package smithy4s.dynamic.internals
+
+import smithy4s.schema.Alt
+import smithy4s.schema.Schema
+
+/**
+  * A bunch of hash-code stable lambdas that are less likely to break memoization
+  * that may be able to SchemaVisitors.
+  */
+private[internals] object DynamicLambdas {
+  final case class Injector(index: Int) extends (DynData => DynAlt) {
+    def apply(data: DynData): DynAlt = (index, data)
+  }
+
+  final case class Accessor(index: Int) extends (DynStruct => DynData) {
+    def apply(data: DynStruct): DynData = data(index)
+  }
+
+  final case class OptionalAccessor(index: Int)
+      extends (DynStruct => Option[DynData]) {
+    def apply(data: DynStruct): Option[DynData] = Option(data(index))
+  }
+
+  final case object Constructor extends (IndexedSeq[DynData] => DynStruct) {
+    def apply(fields: IndexedSeq[Any]): DynStruct = {
+      val array = Array.ofDim[Any](fields.size)
+      var i = 0
+      fields.foreach {
+        case None        => i += 1 // leaving value to null
+        case Some(value) => (array(i) = value); i += 1
+        case other       => (array(i) = other); i += 1
+      }
+      array
+    }
+  }
+
+  final case class Dispatcher(alts: IndexedSeq[Alt[Schema, DynAlt, DynData]])
+      extends (DynAlt => Alt.SchemaAndValue[DynAlt, DynData]) {
+    def apply(dynAlt: DynAlt): Alt.SchemaAndValue[DynAlt, DynData] = {
+      val index = dynAlt._1
+      val data = dynAlt._2
+      alts(index).apply(data)
+    }
+  }
+
+}

--- a/modules/dynamic/src/smithy4s/dynamic/internals/DynamicLambdas.scala
+++ b/modules/dynamic/src/smithy4s/dynamic/internals/DynamicLambdas.scala
@@ -1,3 +1,19 @@
+/*
+ *  Copyright 2021-2022 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 package smithy4s.dynamic.internals
 
 import smithy4s.schema.Alt
@@ -21,7 +37,7 @@ private[internals] object DynamicLambdas {
     def apply(data: DynStruct): Option[DynData] = Option(data(index))
   }
 
-  final case object Constructor extends (IndexedSeq[DynData] => DynStruct) {
+  case object Constructor extends (IndexedSeq[DynData] => DynStruct) {
     def apply(fields: IndexedSeq[Any]): DynStruct = {
       val array = Array.ofDim[Any](fields.size)
       var i = 0
@@ -34,7 +50,7 @@ private[internals] object DynamicLambdas {
     }
   }
 
-  final case class Dispatcher(alts: IndexedSeq[Alt[Schema, DynAlt, DynData]])
+  case class Dispatcher(alts: IndexedSeq[Alt[Schema, DynAlt, DynData]])
       extends (DynAlt => Alt.SchemaAndValue[DynAlt, DynData]) {
     def apply(dynAlt: DynAlt): Alt.SchemaAndValue[DynAlt, DynData] = {
       val index = dynAlt._1

--- a/modules/dynamic/src/smithy4s/dynamic/internals/DynamicModelCompiler.scala
+++ b/modules/dynamic/src/smithy4s/dynamic/internals/DynamicModelCompiler.scala
@@ -27,6 +27,7 @@ import cats.syntax.all._
 import smithy4s.schema.EnumValue
 import smithy4s.schema.SchemaField
 import smithy4s.schema.Alt
+import DynamicLambdas._
 
 private[dynamic] object Compiler {
 
@@ -448,19 +449,6 @@ private[dynamic] object Compiler {
       serviceMap += id -> service
     }
 
-    // Creates a dynamic structure array, unpacking options
-    // when needed
-    private final def dynStruct(fields: IndexedSeq[Any]): DynStruct = {
-      val array = Array.ofDim[Any](fields.size)
-      var i = 0
-      fields.foreach {
-        case None        => i += 1 // leaving value to null
-        case Some(value) => (array(i) = value); i += 1
-        case other       => (array(i) = other); i += 1
-      }
-      array
-    }
-
     override def structureShape(id: ShapeId, shape: StructureShape): Unit =
       update(
         id,
@@ -476,10 +464,12 @@ private[dynamic] object Compiler {
                       .getOrElse(Map.empty)
                       .contains(IdRef("smithy.api#required"))
                   ) {
-                    lMemberSchema.map(_.required[DynStruct](label, _(index)))
+                    lMemberSchema.map(
+                      _.required[DynStruct](label, Accessor(index))
+                    )
                   } else {
                     lMemberSchema.map(
-                      _.optional[DynStruct](label, arr => Option(arr(index)))
+                      _.optional[DynStruct](label, OptionalAccessor(index))
                         .asInstanceOf[SchemaField[DynStruct, DynData]]
                     )
                   }
@@ -490,8 +480,8 @@ private[dynamic] object Compiler {
               .sequence
           }
           if (isRecursive(id)) {
-            Eval.later(recursive(struct(lFields.value)(dynStruct)))
-          } else lFields.map(fields => struct(fields)(dynStruct))
+            Eval.later(recursive(struct(lFields.value)(Constructor)))
+          } else lFields.map(fields => struct(fields)(Constructor))
         }
       )
 
@@ -505,7 +495,7 @@ private[dynamic] object Compiler {
                 .map { case ((label, mShape), index) =>
                   val memberHints = allHints(mShape.traits)
                   schema(mShape.target)
-                    .map(_.oneOf[DynAlt](label, (data: Any) => (index, data)))
+                    .map(_.oneOf[DynAlt](label, Injector(index)))
                     .map(_.addHints(memberHints))
                 }
                 .toVector
@@ -513,15 +503,11 @@ private[dynamic] object Compiler {
             if (isRecursive(id)) {
               Eval.later(recursive {
                 val alts = lAlts.value
-                union(alts) { case (index, data) =>
-                  alts(index).apply(data)
-                }
+                union(alts)(Dispatcher(alts))
               })
             } else
               lAlts.map { alts =>
-                union(alts) { case (index, data) =>
-                  alts(index).apply(data)
-                }
+                union(alts)(Dispatcher(alts))
               }
           }
         )


### PR DESCRIPTION
In order to reduce risk of memory leaks when people do not have stable references for the routers (ie `def` instead of `val`), this PR changes the cache key for the Cached schema visitor to avoid it being impacted by bits that are different when performing equality checks, in particular `Lazy`. 

This isn't a panacea, Schemas cannot be accurately compared for equality, for the sheer fact that two schemas might be semantically the same without being equal, due to the language limitation of not being able to compare thunks in Lazy.

Therefore, we mitigate the problem by providing a custom hashing function for schemas that applies a reasoned behaviour when encountering `Lazy`, and use that (conjointly with the ShapeId) as a key during memoization of schema compilation.

Additionally, this PR provides : 

* an implementation for the equals/hashcode methods of the Hints map
* a bunch of hash-code stable function constructs for the usecase of Dynamic. 

- [ ] Add a bunch of tests, in particular in the Dynamic usecase, to make sure that two dynamic schemas coming from the same model are not re-creating entries in the memoization map. 
