### PR TITLE
Apply hint mask transitively in json codecs

### DIFF
--- a/modules/http4s/src/smithy4s/http4s/SimpleRestJsonBuilder.scala
+++ b/modules/http4s/src/smithy4s/http4s/SimpleRestJsonBuilder.scala
@@ -22,6 +22,9 @@ import smithy4s.internals.InputOutput
 object SimpleRestJsonBuilder
     extends SimpleProtocolBuilder[smithy4s.api.SimpleRestJson](
       smithy4s.http.json.codecs(
-        smithy4s.api.SimpleRestJson.protocol.hintMask ++ HintMask(InputOutput)
+        smithy4s.api.SimpleRestJson.protocol.hintMask ++ HintMask(
+          InputOutput,
+          IntEnum
+        )
       )
     )

--- a/modules/json/src/smithy4s/http/json/JsonCodecAPI.scala
+++ b/modules/json/src/smithy4s/http/json/JsonCodecAPI.scala
@@ -37,7 +37,7 @@ abstract class JsonCodecAPI(
   def compileCodec[A](schema0: Schema[A]): JCodec[A] = {
     val schema =
       hintMask
-        .map(mask => schema0.transformHintsLocally(mask.apply))
+        .map(mask => schema0.transformHintsTransitively(mask.apply))
         .getOrElse(schema0)
     schema.compile(schemaVisitorJCodec)
   }

--- a/modules/json/test/src/smithy4s/http/json/JsonCodecApiTests.scala
+++ b/modules/json/test/src/smithy4s/http/json/JsonCodecApiTests.scala
@@ -1,0 +1,28 @@
+package smithy4s.http.json
+
+import munit.FunSuite
+import smithy.api.JsonName
+import smithy4s.schema.Schema
+import smithy4s.HintMask
+
+class JsonCodecApiTests extends FunSuite {
+
+  test(
+    "codecs with an empty hint mask should not be affected by format hints"
+  ) {
+    val schemaWithJsonName = Schema
+      .struct[String]
+      .apply(
+        Schema.string
+          .addHints(JsonName("b"))
+          .required[String]("a", identity)
+      )(identity)
+
+    val capi = codecs(HintMask.empty)
+
+    val codec = capi.compileCodec(schemaWithJsonName)
+    val encodedString = new String(capi.writeToArray(codec, "test"))
+
+    assertEquals(encodedString, """{"a":"test"}""")
+  }
+}


### PR DESCRIPTION
Previously, only top-level hints would be modified with the hint mask, so even if the mask was empty you could affect serialization with something like `@jsonName` or `@discriminated`.

This PR enables hint masks to work on all levels. This may possibly break existing behavior in users' code if they rely on the mask being applied only on the surface.

For such users, a workaround would be to use the `HintMask.allAllowed` mask in the codecs, but apply `.transformHintsLocally` with the old hint mask on the Schema directly.