### PR TITLE
Fix hint transformations and adds a test suite

### DIFF
--- a/modules/core/src/smithy4s/PolyFunction.scala
+++ b/modules/core/src/smithy4s/PolyFunction.scala
@@ -90,7 +90,7 @@ trait PolyFunction[F[_], G[_]] { self =>
         builder.result()
       }
       def apply[A](input: F[A]): G[A] = {
-        map(getKey(input)).asInstanceOf[G[A]]
+        map(getKey(Existential.wrap(input))).asInstanceOf[G[A]]
       }
     }
 }

--- a/modules/core/src/smithy4s/PolyFunction.scala
+++ b/modules/core/src/smithy4s/PolyFunction.scala
@@ -75,8 +75,6 @@ trait PolyFunction[F[_], G[_]] { self =>
       }
     }
 
-  type ConstK[H[_], C] = C
-
   private[smithy4s] final def unsafeCacheBy[K](
       allPossibleInputs: Vector[Existential[F]],
       getKey: Existential[F] => K

--- a/modules/core/src/smithy4s/capability/EncoderK.scala
+++ b/modules/core/src/smithy4s/capability/EncoderK.scala
@@ -34,4 +34,5 @@ object EncoderK {
       def apply[A](fa: A => B, a: A): B = fa(a)
       def absorb[A](f: A => B): A => B = f
     }
+
 }

--- a/modules/core/src/smithy4s/http/internals/ErrorCodeSchemaVisitor.scala
+++ b/modules/core/src/smithy4s/http/internals/ErrorCodeSchemaVisitor.scala
@@ -22,7 +22,7 @@ import smithy4s.schema._
 
 private[smithy4s] object ErrorCodeSchemaVisitor
     extends SchemaVisitor.Cached[HttpCode]
-    with SchemaVisitor.Default[HttpCode] {
+    with SchemaVisitor.Default[HttpCode] { compile =>
   def default[A]: A => Option[Int] = _ => None
 
   override def union[U](
@@ -30,15 +30,11 @@ private[smithy4s] object ErrorCodeSchemaVisitor
       hints: Hints,
       alternatives: Vector[SchemaAlt[U, _]],
       dispatcher: Alt.Dispatcher[Schema, U]
-  ): HttpCode[U] = { (s) =>
-    processAltWithValue(dispatcher.underlying(s))
-  }
-
-  def processAltWithValue[S, B](
-      withValue: Alt.WithValue[Schema, S, B]
-  ): Option[Int] = {
-    val httpCode = apply(withValue.alt.instance)
-    httpCode(withValue.value)
+  ): HttpCode[U] = {
+    dispatcher.compile(new Alt.Precompiler[Schema, HttpCode] {
+      def apply[A](label: String, instance: Schema[A]): HttpCode[A] =
+        compile(instance)
+    })
   }
 
   override def lazily[A](suspend: Lazy[Schema[A]]): HttpCode[A] =

--- a/modules/core/src/smithy4s/schema/Alt.scala
+++ b/modules/core/src/smithy4s/schema/Alt.scala
@@ -91,9 +91,10 @@ object Alt {
       ): G[U] = {
         val precompiledAlts =
           precompile.toPolyFunction
-            .unsafeCacheBy(
+            .unsafeCacheBy[String](
               alts.map(smithy4s.Existential.wrap(_)),
-              (alt: Alt[F, U, _]) => alt.label
+              (alt: Existential[Alt[F, U, *]]) =>
+                alt.asInstanceOf[Alt[F, U, _]].label
             )
 
         encoderK.absorb[U] { u =>

--- a/modules/core/src/smithy4s/schema/Schema.scala
+++ b/modules/core/src/smithy4s/schema/Schema.scala
@@ -64,9 +64,9 @@ sealed trait Schema[A]{
     case PrimitiveSchema(shapeId, hints, tag) => PrimitiveSchema(shapeId, f(hints), tag)
     case s: CollectionSchema[c, a] => CollectionSchema[c, a](s.shapeId, f(s.hints), s.tag, s.member.transformHintsTransitively(f)).asInstanceOf[Schema[A]]
     case s: MapSchema[k, v] => MapSchema(s.shapeId, f(s.hints), s.key.transformHintsTransitively(f), s.value.transformHintsTransitively(f)).asInstanceOf[Schema[A]]
-    case EnumerationSchema(shapeId, hints, values, total) => EnumerationSchema(shapeId, f(hints), values.map(_.transformHints(f)), total)
+    case EnumerationSchema(shapeId, hints, values, total) => EnumerationSchema(shapeId, f(hints), values.map(_.transformHints(f)), total andThen (_.transformHints(f)))
     case StructSchema(shapeId, hints, fields, make) => StructSchema(shapeId, f(hints), fields.map(_.mapK(Schema.transformHintsTransitivelyK(f))), make)
-    case UnionSchema(shapeId, hints, alternatives, dispatch) => UnionSchema(shapeId, f(hints), alternatives.map(_.mapK(Schema.transformHintsTransitivelyK(f))), dispatch)
+    case UnionSchema(shapeId, hints, alternatives, dispatch) => UnionSchema(shapeId, f(hints), alternatives.map(_.mapK(Schema.transformHintsTransitivelyK(f))), dispatch andThen (_.mapK(Schema.transformHintsTransitivelyK(f))))
     case BijectionSchema(schema, bijection) => BijectionSchema(schema.transformHintsTransitively(f), bijection)
     case RefinementSchema(schema, refinement) => RefinementSchema(schema.transformHintsTransitively(f), refinement)
     case LazySchema(suspend) => LazySchema(suspend.map(_.transformHintsTransitively(f)))

--- a/modules/core/test/src/smithy4s/PatternSpec.scala
+++ b/modules/core/test/src/smithy4s/PatternSpec.scala
@@ -1,3 +1,19 @@
+/*
+ *  Copyright 2021-2022 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 package smithy4s
 import smithy4s.example._
 

--- a/modules/core/test/src/smithy4s/schema/HintsTransformationSpec.scala
+++ b/modules/core/test/src/smithy4s/schema/HintsTransformationSpec.scala
@@ -1,3 +1,19 @@
+/*
+ *  Copyright 2021-2022 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 package smithy4s.schema
 
 import munit._

--- a/modules/core/test/src/smithy4s/schema/HintsTransformationSpec.scala
+++ b/modules/core/test/src/smithy4s/schema/HintsTransformationSpec.scala
@@ -1,0 +1,238 @@
+package smithy4s.schema
+
+import munit._
+import smithy4s.ShapeId
+import smithy4s.Hints
+import smithy4s.Lazy
+import smithy4s.Bijection
+import smithy4s.Refinement
+import smithy4s.ShapeTag
+import cats.syntax.all._
+import Schema._
+
+class HintsTransformationSpec() extends FunSuite {
+
+  def header(
+      tpe: String
+  ): String = "Transitive hint transformation is applied to all layers: " + tpe
+
+  test(header("primitive")) {
+    implicit val schema: Schema[Int] = Schema.int
+    checkSchema(1, 1)
+  }
+
+  test(header("list")) {
+    implicit val schema: Schema[List[Int]] = Schema.list(Schema.int)
+    // 3 primitives, 1 list
+    checkSchema(List(1, 2, 3), 4)
+  }
+
+  test(header("map")) {
+    implicit val schema: Schema[Map[Int, Int]] = map(int, int)
+    // 2 keys, 2 values, 1 map
+    checkSchema(Map(1 -> 1, 2 -> 2), 5)
+  }
+
+  test(header("enum")) {
+    sealed abstract class FooBar(val stringValue: String, val intValue: Int)
+        extends smithy4s.Enumeration.Value {
+      val name = stringValue
+      val value = stringValue
+      val hints = Hints.empty
+
+    }
+    case object Foo extends FooBar("foo", 0)
+    implicit val schema: Schema[FooBar] = enumeration[FooBar](List(Foo))
+    // 1 for the enum, 1 for the enum value
+    checkSchema(Foo: FooBar, 2)
+  }
+
+  test(header("struct")) {
+    case class Foo(x: Int, y: Option[Int])
+    implicit val schema = struct(
+      int.required[Foo]("x", _.x),
+      int.optional[Foo]("y", _.y)
+    )(Foo.apply)
+    // One for the case class, one for the x field
+    checkSchema(Foo(1, None), 2)
+    // One for the case class, one for the x field, one for the y field
+    checkSchema(Foo(1, Some(1)), 3)
+  }
+
+  test(header("struct")) {
+    case class Foo(x: Int, y: Option[Int])
+    implicit val schema: Schema[Foo] = struct(
+      int.required[Foo]("x", _.x),
+      int.optional[Foo]("y", _.y)
+    )(Foo.apply)
+    // One for the case class, one for the x field
+    checkSchema(Foo(1, None), 2)
+    // One for the case class, one for the x field, one for the y field
+    checkSchema(Foo(1, Some(1)), 3)
+  }
+
+  test(header("union")) {
+    type Foo = Either[Int, String]
+    val left = int.oneOf[Foo]("left", Left(_))
+    val right = string.oneOf[Foo]("right", Right(_))
+    implicit val schema: Schema[Foo] = union(left, right) {
+      case Left(int)     => left(int)
+      case Right(string) => right(string)
+    }
+
+    // One for the union, one for the union member
+    checkSchema(Left(1): Foo, 2)
+  }
+
+  test(header("bijection")) {
+    case class Foo(x: Int)
+    implicit val schema: Schema[Foo] = bijection(int, Foo(_), _.x)
+    checkSchema(Foo(1), 1)
+  }
+
+  test(header("bijection")) {
+    implicit val schema: Schema[Int] =
+      int.refined(smithy.api.Range(None, Option(BigDecimal(1))))
+    checkSchema(1, 1)
+  }
+
+  test(header("recursive")) {
+    case class Foo(foo: Option[Foo])
+    object Foo {
+      implicit val schema: Schema[Foo] = recursive {
+        val foos = schema.optional[Foo]("foo", _.foo)
+        struct(foos)(Foo.apply)
+      }
+    }
+    checkSchema(Foo(None), 1)
+    checkSchema(Foo(Some(Foo(None))), 2)
+    checkSchema(Foo(Some(Foo(Some(Foo(None))))), 3)
+  }
+
+  case class Mark()
+  object Mark extends ShapeTag.Companion[Mark] {
+    implicit val schema: Schema[Mark] =
+      Schema.constant(Mark()).withId(ShapeId("test", "Mark"))
+    def id: ShapeId = schema.shapeId
+  }
+
+  // We're testing that all layers have received a mark, by counting the marks
+  // when a runtime instance traverses the corresponding layers.
+  //
+  // It is important that we test against runtime values, to ensure that
+  // the transformation works correctly with unions (which is the trickiest)
+  def checkSchema[A: Schema](value: A, expected: Int)(implicit
+      loc: Location
+  ): Unit = {
+    val countLocal = implicitly[Schema[A]]
+      .transformHintsLocally(_ ++ Hints(Mark()))
+      .compile(CountVisitor)
+
+    val countTransitive = implicitly[Schema[A]]
+      .transformHintsTransitively(_ ++ Hints(Mark()))
+      .compile(CountVisitor)
+
+    val localMsg = "Unexpected count of marks after local transformation"
+    assertEquals(countLocal(value), 1, localMsg)
+    val transitiveMsg =
+      "Unexpected count of marks after transitive transformation"
+    assertEquals(countTransitive(value), expected, transitiveMsg)
+  }
+
+  private def count(hints: Hints): Int = if (hints.has[Mark]) 1 else 0
+
+  // Counts how much time an instance traverses "marked" datatypes
+  type Count[A] = A => Int
+  object CountVisitor extends SchemaVisitor[Count] { compile =>
+    def primitive[P](
+        shapeId: ShapeId,
+        hints: Hints,
+        tag: Primitive[P]
+    ): Count[P] = _ => count(hints)
+
+    def collection[C[_], A](
+        shapeId: ShapeId,
+        hints: Hints,
+        tag: CollectionTag[C],
+        member: Schema[A]
+    ): Count[C[A]] = {
+      val cMember = compile(member)
+      ca => {
+        count(hints) + tag.iterator(ca).toList.foldMap(cMember(_))
+      }
+    }
+
+    def map[K, V](
+        shapeId: ShapeId,
+        hints: Hints,
+        key: Schema[K],
+        value: Schema[V]
+    ): Count[Map[K, V]] = {
+      val ck = compile(key)
+      val cv = compile(value)
+      mkv => {
+        count(hints) + mkv.toList.foldMap { case (k, v) => ck(k) + cv(v) }
+      }
+    }
+
+    def enumeration[E](
+        shapeId: ShapeId,
+        hints: Hints,
+        values: List[EnumValue[E]],
+        total: E => EnumValue[E]
+    ): Count[E] = { e =>
+      count(hints) + count(total(e).hints)
+    }
+
+    def struct[S](
+        shapeId: ShapeId,
+        hints: Hints,
+        fields: Vector[SchemaField[S, _]],
+        make: IndexedSeq[Any] => S
+    ): Count[S] = {
+      def countField[AA](field: smithy4s.schema.Field[Schema, S, AA]) =
+        field.fold(new Field.Folder[Schema, S, S => Int] {
+          def onRequired[A](
+              label: String,
+              instance: Schema[A],
+              get: S => A
+          ): S => Int = s => compile(instance)(get(s))
+
+          def onOptional[A](
+              label: String,
+              instance: Schema[A],
+              get: S => Option[A]
+          ): S => Int = s => get(s).foldMap(compile(instance))
+        })
+      s => count(hints) + fields.foldMap(countField(_)(s))
+    }
+
+    def union[U](
+        shapeId: ShapeId,
+        hints: Hints,
+        alternatives: Vector[SchemaAlt[U, _]],
+        dispatch: Alt.Dispatcher[Schema, U]
+    ): Count[U] = {
+      val countU = dispatch.compile(new Alt.Precompiler[Schema, Count] {
+        def apply[A](label: String, instance: Schema[A]): Count[A] =
+          compile(instance)
+      })
+      u => countU(u) + count(hints)
+    }
+
+    def biject[A, B](schema: Schema[A], bijection: Bijection[A, B]): Count[B] =
+      compile(schema).compose(bijection.from)
+
+    def refine[A, B](
+        schema: Schema[A],
+        refinement: Refinement[A, B]
+    ): Count[B] = compile(schema).compose(refinement.from)
+
+    def lazily[A](suspend: Lazy[Schema[A]]): Count[A] = {
+      lazy val underlying = compile(suspend.value)
+      a => underlying(a)
+    }
+
+  }
+
+}

--- a/modules/http4s/src/smithy4s/http4s/internals/SmithyHttp4sServerEndpoint.scala
+++ b/modules/http4s/src/smithy4s/http4s/internals/SmithyHttp4sServerEndpoint.scala
@@ -21,14 +21,12 @@ package internals
 import cats.data.Kleisli
 import cats.syntax.all._
 import org.http4s.EntityEncoder
-import org.http4s.Header
 import org.http4s.Headers
 import org.http4s.Message
 import org.http4s.Method
 import org.http4s.Request
 import org.http4s.Response
 import org.http4s.Status
-import org.typelevel.ci.CIString
 import smithy4s.http.Metadata
 import smithy4s.http._
 import smithy4s.schema.Alt
@@ -163,51 +161,57 @@ private[smithy4s] class SmithyHttp4sServerEndpointImpl[F[_], Op[_, _, _, _, _], 
   private def successResponse(output: O): F[Response[F]] = {
     val outputMetadata = outputMetadataEncoder.encode(output)
     val outputHeaders = toHeaders(outputMetadata.headers)
+    val statusCode = outputMetadata.statusCode.getOrElse(httpEndpoint.code)
+    val httpStatus = status(statusCode)
 
-    putHeaders(
-      Response[F](
-        status(outputMetadata.statusCode.getOrElse(httpEndpoint.code))
-      ),
-      outputHeaders
-    )
+    putHeaders(Response[F](httpStatus), outputHeaders)
       .withEntity(output)
       .pure[F]
   }
 
-  private def errorResponse(throwable: Throwable): F[Response[F]] = {
-
+  def compileErrorable(errorable: Errorable[E]): E => Response[F] = {
     def errorHeaders(errorLabel: String, metadata: Metadata): Headers =
-      toHeaders(metadata.headers)
-        .put(
-          Header.Raw(CIString(errorTypeHeader), errorLabel)
-        )
-
-    def processAlternative[ErrorUnion, ErrorType](
-        altAndValue: Alt.SchemaAndValue[ErrorUnion, ErrorType]
-    ): Response[F] = {
-      val errorSchema = altAndValue.alt.instance
-      val errorValue = altAndValue.value
-      val errorCode =
-        http.HttpStatusCode.fromSchema(errorSchema).code(errorValue, 500)
-      implicit val errorCodec = codecs.compileEntityEncoder(errorSchema)
-      val metadataEncoder = Metadata.Encoder.fromSchema(errorSchema)
-      val metadata = metadataEncoder.encode(errorValue)
-      val headers = errorHeaders(altAndValue.alt.label, metadata)
-      val status =
-        Status.fromInt(errorCode).getOrElse(Status.InternalServerError)
-      Response(status, headers = headers).withEntity(errorValue)
-    }
-
-    throwable
-      .pure[F]
-      .flatMap {
-        case e: HttpContractError =>
-          Response[F](Status.BadRequest).withEntity(e).pure[F]
-        case endpoint.Error((errorable, e)) =>
-          processAlternative(errorable.error.dispatch(e)).pure[F]
-        case e: Throwable =>
-          F.raiseError(e)
+      toHeaders(metadata.headers).put(errorTypeHeader -> errorLabel)
+    val errorUnionSchema = errorable.error
+    val dispatcher =
+      Alt.Dispatcher(errorUnionSchema.alternatives, errorUnionSchema.dispatch)
+    type ErrorEncoder[Err] = Err => Response[F]
+    val precompiler = new Alt.Precompiler[Schema, ErrorEncoder] {
+      def apply[Err](
+          label: String,
+          errorSchema: Schema[Err]
+      ): ErrorEncoder[Err] = {
+        implicit val errorCodec = codecs.compileEntityEncoder(errorSchema)
+        val metadataEncoder = Metadata.Encoder.fromSchema(errorSchema)
+        errorValue => {
+          val errorCode =
+            http.HttpStatusCode.fromSchema(errorSchema).code(errorValue, 500)
+          val metadata = metadataEncoder.encode(errorValue)
+          val headers = errorHeaders(label, metadata)
+          val status =
+            Status.fromInt(errorCode).getOrElse(Status.InternalServerError)
+          Response(status, headers = headers).withEntity(errorValue)
+        }
       }
+    }
+    dispatcher.compile(precompiler)
+  }
+
+  val errorResponse: Throwable => F[Response[F]] = {
+    endpoint.errorable match {
+      case Some(errorable) =>
+        val processError: E => Response[F] = compileErrorable(errorable)
+        (_: Throwable) match {
+          case e: HttpContractError =>
+            Response[F](Status.BadRequest).withEntity(e).pure[F]
+          case endpoint.Error((_, e)) =>
+            F.pure(processError(e))
+          case e: Throwable =>
+            F.raiseError(e)
+        }
+      case None =>
+        F.raiseError(_)
+    }
   }
 
 }

--- a/modules/json/src/smithy4s/http/json/SchemaVisitorJCodec.scala
+++ b/modules/json/src/smithy4s/http/json/SchemaVisitorJCodec.scala
@@ -28,7 +28,6 @@ import smithy.api.JsonName
 import smithy.api.TimestampFormat
 import smithy4s.api.Discriminated
 import smithy4s.api.Untagged
-import smithy4s.capability.EncoderK
 import smithy4s.internals.DiscriminatedUnionMember
 import smithy4s.schema._
 import smithy4s.schema.Primitive._
@@ -759,11 +758,6 @@ private[smithy4s] class SchemaVisitorJCodec(maxArity: Int)
   }
 
   private type Writer[A] = A => JsonWriter => Unit
-  private implicit val encoderK: EncoderK[Writer, JsonWriter => Unit] =
-    new EncoderK[Writer, JsonWriter => Unit] {
-      def apply[A](fa: Writer[A], a: A): JsonWriter => Unit = fa(a)
-      def absorb[A](f: A => JsonWriter => Unit): Writer[A] = f
-    }
 
   private def taggedUnion[U](
       alternatives: Vector[Alt[Schema, U, _]]

--- a/modules/json/src/smithy4s/http/json/SchemaVisitorJCodec.scala
+++ b/modules/json/src/smithy4s/http/json/SchemaVisitorJCodec.scala
@@ -28,6 +28,7 @@ import smithy.api.JsonName
 import smithy.api.TimestampFormat
 import smithy4s.api.Discriminated
 import smithy4s.api.Untagged
+import smithy4s.capability.EncoderK
 import smithy4s.internals.DiscriminatedUnionMember
 import smithy4s.schema._
 import smithy4s.schema.Primitive._
@@ -757,23 +758,30 @@ private[smithy4s] class SchemaVisitorJCodec(maxArity: Int)
     def encodeKey(x: A, out: JsonWriter): Unit = underlying.encodeKey(x, out)
   }
 
-  private def taggedUnion[Z](
-      alternatives: Vector[Alt[Schema, Z, _]]
-  )(total: Z => Alt.WithValue[Schema, Z, _]): JCodec[Z] =
-    new JCodec[Z] {
+  private type Writer[A] = A => JsonWriter => Unit
+  private implicit val encoderK: EncoderK[Writer, JsonWriter => Unit] =
+    new EncoderK[Writer, JsonWriter => Unit] {
+      def apply[A](fa: Writer[A], a: A): JsonWriter => Unit = fa(a)
+      def absorb[A](f: A => JsonWriter => Unit): Writer[A] = f
+    }
+
+  private def taggedUnion[U](
+      alternatives: Vector[Alt[Schema, U, _]]
+  )(dispatch: Alt.Dispatcher[Schema, U]): JCodec[U] =
+    new JCodec[U] {
       val expecting: String = "tagged-union"
 
       override def canBeKey: Boolean = false
 
-      def jsonLabel[A](alt: Alt[Schema, Z, A]): String =
+      def jsonLabel[A](alt: Alt[Schema, U, A]): String =
         alt.hints.get(JsonName) match {
           case None    => alt.label
           case Some(x) => x.value
         }
 
       private[this] val handlerMap =
-        new util.HashMap[String, (Cursor, JsonReader) => Z] {
-          def handler[A](alt: Alt[Schema, Z, A]) = {
+        new util.HashMap[String, (Cursor, JsonReader) => U] {
+          def handler[A](alt: Alt[Schema, U, A]) = {
             val codec = apply(alt.instance)
             (cursor: Cursor, reader: JsonReader) =>
               alt.inject(cursor.decode(codec, reader))
@@ -782,7 +790,7 @@ private[smithy4s] class SchemaVisitorJCodec(maxArity: Int)
           alternatives.foreach(alt => put(jsonLabel(alt), handler(alt)))
         }
 
-      def decodeValue(cursor: Cursor, in: JsonReader): Z =
+      def decodeValue(cursor: Cursor, in: JsonReader): U =
         if (in.isNextToken('{')) {
           if (in.isNextToken('}'))
             in.decodeError("Expected a single key/value pair")
@@ -802,41 +810,44 @@ private[smithy4s] class SchemaVisitorJCodec(maxArity: Int)
           }
         } else in.decodeError("Expected JSON object")
 
-      private[this] val altCache =
-        new PolyFunction[Alt[Schema, Z, *], JCodec] {
-          def apply[A](fa: Alt[Schema, Z, A]): JCodec[A] =
-            self.apply(fa.instance)
-        }.unsafeCache((alternatives).map(alt => Existential.wrap(alt)))
+      val precompiler = new smithy4s.schema.Alt.Precompiler[Schema, Writer] {
+        def apply[A](label: String, instance: Schema[A]): Writer[A] = {
+          val jsonLabel =
+            instance.hints.get(JsonName).map(_.value).getOrElse(label)
+          val jcodecA = instance.compile(self)
+          a =>
+            out => {
+              out.writeObjectStart()
+              out.writeKey(jsonLabel)
+              jcodecA.encodeValue(a, out)
+              out.writeObjectEnd()
+            }
+        }
+      }
+      val writer = dispatch.compile(precompiler)
 
-      def encodeValue(z: Z, out: JsonWriter): Unit = {
-        def writeValue[A](awv: Alt.WithValue[Schema, Z, A]): Unit =
-          altCache(awv.alt).encodeValue(awv.value, out)
-
-        out.writeObjectStart()
-        val awv = total(z)
-        out.writeKey(jsonLabel(awv.alt))
-        writeValue(awv)
-        out.writeObjectEnd()
+      def encodeValue(u: U, out: JsonWriter): Unit = {
+        writer(u)(out)
       }
 
-      def decodeKey(in: JsonReader): Z =
+      def decodeKey(in: JsonReader): U =
         in.decodeError("Cannot use coproducts as keys")
 
-      def encodeKey(x: Z, out: JsonWriter): Unit =
+      def encodeKey(u: U, out: JsonWriter): Unit =
         out.encodeError("Cannot use coproducts as keys")
     }
 
-  private def untaggedUnion[Z](
-      alternatives: Vector[Alt[Schema, Z, _]]
-  )(total: Z => Alt.WithValue[Schema, Z, _]): JCodec[Z] = new JCodec[Z] {
+  private def untaggedUnion[U](
+      alternatives: Vector[Alt[Schema, U, _]]
+  )(dispatch: Alt.Dispatcher[Schema, U]): JCodec[U] = new JCodec[U] {
     def expecting: String = "untaggedUnion"
 
     override def canBeKey: Boolean = false
 
-    private[this] val handlerList: Array[(Cursor, JsonReader) => Z] = {
-      val res = Array.newBuilder[(Cursor, JsonReader) => Z]
+    private[this] val handlerList: Array[(Cursor, JsonReader) => U] = {
+      val res = Array.newBuilder[(Cursor, JsonReader) => U]
 
-      def handler[A](alt: Alt[Schema, Z, A]) = {
+      def handler[A](alt: Alt[Schema, U, A]) = {
         val codec = apply(alt.instance)
         (cursor: Cursor, reader: JsonReader) =>
           alt.inject(cursor.decode(codec, reader))
@@ -846,8 +857,8 @@ private[smithy4s] class SchemaVisitorJCodec(maxArity: Int)
       res.result()
     }
 
-    def decodeValue(cursor: Cursor, in: JsonReader): Z = {
-      var z: Z = null.asInstanceOf[Z]
+    def decodeValue(cursor: Cursor, in: JsonReader): U = {
+      var z: U = null.asInstanceOf[U]
       val len = handlerList.length
       var i = 0
       while (z == null && i < len) {
@@ -865,45 +876,45 @@ private[smithy4s] class SchemaVisitorJCodec(maxArity: Int)
       else cursor.payloadError(this, "Could not decode untagged union")
     }
 
-    private[this] val altCache =
-      new PolyFunction[Alt[Schema, Z, *], JCodec] {
-        def apply[A](fa: Alt[Schema, Z, A]): JCodec[A] = self.apply(fa.instance)
-      }.unsafeCache((alternatives).map(alt => Existential.wrap(alt)))
+    val precompiler = new smithy4s.schema.Alt.Precompiler[Schema, Writer] {
+      def apply[A](label: String, instance: Schema[A]): Writer[A] = {
+        val jcodecA = instance.compile(self)
+        a => out => jcodecA.encodeValue(a, out)
+      }
+    }
+    val writer = dispatch.compile(precompiler)
 
-    def encodeValue(z: Z, out: JsonWriter): Unit = {
-      def writeValue[A](awv: Alt.WithValue[Schema, Z, A]): Unit =
-        altCache(awv.alt).encodeValue(awv.value, out)
-
-      writeValue(total(z))
+    def encodeValue(u: U, out: JsonWriter): Unit = {
+      writer(u)(out)
     }
 
-    def decodeKey(in: JsonReader): Z =
+    def decodeKey(in: JsonReader): U =
       in.decodeError("Cannot use coproducts as keys")
 
-    def encodeKey(x: Z, out: JsonWriter): Unit =
+    def encodeKey(u: U, out: JsonWriter): Unit =
       out.encodeError("Cannot use coproducts as keys")
   }
 
-  private def discriminatedUnion[Z](
-      alternatives: Vector[Alt[Schema, Z, _]],
+  private def discriminatedUnion[U](
+      alternatives: Vector[Alt[Schema, U, _]],
       discriminated: Discriminated
-  )(total: Z => Alt.WithValue[Schema, Z, _]): JCodec[Z] =
-    new JCodec[Z] {
+  )(dispatch: Alt.Dispatcher[Schema, U]): JCodec[U] =
+    new JCodec[U] {
       def expecting: String = "discriminated-union"
 
       override def canBeKey: Boolean = false
 
-      def jsonLabel[A](alt: Alt[Schema, Z, A]): String =
+      def jsonLabel[A](alt: Alt[Schema, U, A]): String =
         alt.hints.get(JsonName) match {
           case None    => alt.label
           case Some(x) => x.value
         }
 
       private[this] val handlerMap =
-        new util.HashMap[String, (Cursor, JsonReader) => Z] {
+        new util.HashMap[String, (Cursor, JsonReader) => U] {
           def handler[A](
-              alt: Alt[Schema, Z, A]
-          ): (Cursor, JsonReader) => Z = {
+              alt: Alt[Schema, U, A]
+          ): (Cursor, JsonReader) => U = {
             val codec = apply(alt.instance)
             (cursor: Cursor, reader: JsonReader) =>
               alt.inject(cursor.decode(codec, reader))
@@ -912,7 +923,7 @@ private[smithy4s] class SchemaVisitorJCodec(maxArity: Int)
           alternatives.foreach(alt => put(jsonLabel(alt), handler(alt)))
         }
 
-      def decodeValue(cursor: Cursor, in: JsonReader): Z =
+      def decodeValue(cursor: Cursor, in: JsonReader): U =
         if (in.isNextToken('{')) {
           in.setMark()
           if (in.skipToKey(discriminated.value)) {
@@ -930,30 +941,28 @@ private[smithy4s] class SchemaVisitorJCodec(maxArity: Int)
             )
         } else in.decodeError("Expected JSON object")
 
-      private[this] val altCache =
-        new PolyFunction[Alt[Schema, Z, *], JCodec] {
-          def apply[A](fa: Alt[Schema, Z, A]): JCodec[A] = {
-            val label = jsonLabel(fa)
-            self.apply(
-              fa.instance
-                .addHints(
-                  Hints(DiscriminatedUnionMember(discriminated.value, label))
-                )
+      val precompiler = new smithy4s.schema.Alt.Precompiler[Schema, Writer] {
+        def apply[A](label: String, instance: Schema[A]): Writer[A] = {
+          val jsonLabel =
+            instance.hints.get(JsonName).map(_.value).getOrElse(label)
+          val jcodecA = instance
+            .addHints(
+              Hints(DiscriminatedUnionMember(discriminated.value, jsonLabel))
             )
-          }
-        }.unsafeCache((alternatives).map(alt => Existential.wrap(alt)))
+            .compile(self)
+          a => out => jcodecA.encodeValue(a, out)
+        }
+      }
+      val writer = dispatch.compile(precompiler)
 
-      def encodeValue(z: Z, out: JsonWriter): Unit = {
-        def writeValue[A](awv: Alt.WithValue[Schema, Z, A]): Unit =
-          altCache(awv.alt).encodeValue(awv.value, out)
-
-        writeValue(total(z))
+      def encodeValue(u: U, out: JsonWriter): Unit = {
+        writer(u)(out)
       }
 
-      def decodeKey(in: JsonReader): Z =
+      def decodeKey(in: JsonReader): U =
         in.decodeError("Cannot use coproducts as keys")
 
-      def encodeKey(x: Z, out: JsonWriter): Unit =
+      def encodeKey(x: U, out: JsonWriter): Unit =
         out.encodeError("Cannot use coproducts as keys")
     }
 
@@ -963,10 +972,9 @@ private[smithy4s] class SchemaVisitorJCodec(maxArity: Int)
       alternatives: Vector[SchemaAlt[U, _]],
       dispatch: Alt.Dispatcher[Schema, U]
   ): JCodec[U] = hints match {
-    case Untagged.hint(_) => untaggedUnion(alternatives)(dispatch.underlying)
-    case Discriminated.hint(d) =>
-      discriminatedUnion(alternatives, d)(dispatch.underlying)
-    case _ => taggedUnion(alternatives)(dispatch.underlying)
+    case Untagged.hint(_)      => untaggedUnion(alternatives)(dispatch)
+    case Discriminated.hint(d) => discriminatedUnion(alternatives, d)(dispatch)
+    case _                     => taggedUnion(alternatives)(dispatch)
   }
 
   override def enumeration[E](


### PR DESCRIPTION
The transitive hints transformation was not accurately propagating hints wherever it needed. 

Additionally, this fixes the union Dispatcher construct, by caching on the labels as opposed to the instance, which aren't stable wrt hint transformation. 

This fixes the bug that makes https://github.com/disneystreaming/smithy4s/pull/521 red