### PR TITLE
Removing hint transformation in union's "total" function ...

### DIFF
--- a/modules/core/src/smithy4s/schema/Schema.scala
+++ b/modules/core/src/smithy4s/schema/Schema.scala
@@ -66,7 +66,7 @@ sealed trait Schema[A]{
     case s: MapSchema[k, v] => MapSchema(s.shapeId, f(s.hints), s.key.transformHintsTransitively(f), s.value.transformHintsTransitively(f)).asInstanceOf[Schema[A]]
     case EnumerationSchema(shapeId, hints, values, total) => EnumerationSchema(shapeId, f(hints), values.map(_.transformHints(f)), total andThen (_.transformHints(f)))
     case StructSchema(shapeId, hints, fields, make) => StructSchema(shapeId, f(hints), fields.map(_.mapK(Schema.transformHintsTransitivelyK(f))), make)
-    case UnionSchema(shapeId, hints, alternatives, dispatch) => UnionSchema(shapeId, f(hints), alternatives.map(_.mapK(Schema.transformHintsTransitivelyK(f))), dispatch andThen (_.mapK(Schema.transformHintsTransitivelyK(f))))
+    case UnionSchema(shapeId, hints, alternatives, dispatch) => UnionSchema(shapeId, f(hints), alternatives.map(_.mapK(Schema.transformHintsTransitivelyK(f))), dispatch)
     case BijectionSchema(schema, bijection) => BijectionSchema(schema.transformHintsTransitively(f), bijection)
     case RefinementSchema(schema, refinement) => RefinementSchema(schema.transformHintsTransitively(f), refinement)
     case LazySchema(suspend) => LazySchema(suspend.map(_.transformHintsTransitively(f)))


### PR DESCRIPTION
... for performance reasons, as this happens on the "hot-path". 

It's fine to remove because, due to the `Dispatcher` mechanism, the alt values should not be queried, which means the hints that may be transformed should not be queried either (at that level, anyway). It's even discouraged to query it because the alt field is now deprecated. 