### PR TITLE
Render "Default" (aka Stub) classes

### DIFF
--- a/modules/codegen/src/smithy4s/codegen/CollisionAvoidance.scala
+++ b/modules/codegen/src/smithy4s/codegen/CollisionAvoidance.scala
@@ -281,6 +281,7 @@ object CollisionAvoidance {
     val struct_ = NameRef("smithy4s.schema.Schema", "struct")
     val bijection_ = NameRef("smithy4s.schema.Schema", "bijection")
     val Transformed_ = NameDef("Transformed")
+    val Default_ = NameDef("Default")
 
     // We reserve these keywords as they collide with types that the
     // users are bound to manipulate when using Smithy4s .

--- a/modules/codegen/src/smithy4s/codegen/Renderer.scala
+++ b/modules/codegen/src/smithy4s/codegen/Renderer.scala
@@ -170,7 +170,7 @@ private[codegen] class Renderer(compilationUnit: CompilationUnit) { self =>
         block(
           line"object ${NameRef(name)} extends $Service_.Provider[$nameGen, ${name}Operation]"
         )(
-          line"type Default[F[+_]] = $nameGen.Default[smithy4s.StubLift[F]#Stub]",
+          line"type $Default_[F[+_]] = $nameGen.Default[smithy4s.StubLift[F]#Stub]",
           line"def apply[F[_]](implicit F: ${NameRef(name)}[F]): F.type = F",
           line"def service: $Service_[$nameGen, ${name}Operation] = $nameGen",
           line"val id: $ShapeId_ = service.id"
@@ -259,7 +259,7 @@ private[codegen] class Renderer(compilationUnit: CompilationUnit) { self =>
         },
         newline,
         block(
-          line"class Default[P[-_, +_, +_, -_, +_]](default: => P[Any, Nothing, Nothing, Any, Nothing])"
+          line"class $Default_[P[-_, +_, +_, -_, +_]](default: => P[Any, Nothing, Nothing, Any, Nothing])"
         ) {
           ops.map { op =>
             line"def ${op.methodName}(${op.renderArgs}): P[${op.renderAlgParams(genNameRef.name)}] = default"

--- a/modules/codegen/src/smithy4s/codegen/Renderer.scala
+++ b/modules/codegen/src/smithy4s/codegen/Renderer.scala
@@ -170,6 +170,7 @@ private[codegen] class Renderer(compilationUnit: CompilationUnit) { self =>
         block(
           line"object ${NameRef(name)} extends $Service_.Provider[$nameGen, ${name}Operation]"
         )(
+          line"type Default[F[+_]] = $nameGen.Default[smithy4s.StubLift[F]#Stub]",
           line"def apply[F[_]](implicit F: ${NameRef(name)}[F]): F.type = F",
           line"def service: $Service_[$nameGen, ${name}Operation] = $nameGen",
           line"val id: $ShapeId_ = service.id"
@@ -254,6 +255,14 @@ private[codegen] class Renderer(compilationUnit: CompilationUnit) { self =>
               line"def ${op.methodName}(${op.renderArgs}) = ${op.name}(input)"
             case op =>
               line"def ${op.methodName}(${op.renderArgs}) = ${op.name}(${op.input}(${op.renderParams}))"
+          }
+        },
+        newline,
+        block(
+          line"class Default[P[-_, +_, +_, -_, +_]](default: => P[Any, Nothing, Nothing, Any, Nothing])"
+        ) {
+          ops.map { op =>
+            line"def ${op.methodName}(${op.renderArgs}): P[${op.renderAlgParams(genNameRef.name)}] = default"
           }
         },
         newline,

--- a/modules/core/src/smithy4s/package.scala
+++ b/modules/core/src/smithy4s/package.scala
@@ -29,6 +29,10 @@ package object smithy4s extends TypeAliases with ExistentialsPlatformCompat {
     type λ[I, E, O, SI, SO] = F[O]
   }
 
+  type StubLift[F[+_]] = {
+    type Stub[-I, +E, +O, -SI, +SO] = F[O]
+  }
+
   def checkProtocol[Alg[_[_, _, _, _, _]], Op[_, _, _, _, _]](
       service: Service[Alg, Op],
       protocolTag: ShapeTag[_]

--- a/modules/core/test/src/smithy4s/DefaultServiceSmokeSpec.scala
+++ b/modules/core/test/src/smithy4s/DefaultServiceSmokeSpec.scala
@@ -1,0 +1,30 @@
+/*
+ *  Copyright 2021-2022 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package smithy4s
+
+import munit._
+class DefaultServiceSmokeSpec() extends FunSuite {
+
+  test("Default stubs do compile") {
+    object stub extends smithy4s.example.Weather.Default[Option](None)
+    val expected: Option[smithy4s.example.GetCurrentTimeOutput] = None
+    // calling _.time to verify type inference
+    val result = stub.getCurrentTime().map(_.time)
+    expect.same(result, expected)
+  }
+
+}

--- a/modules/docs/src/01-overview/06-stubs.md
+++ b/modules/docs/src/01-overview/06-stubs.md
@@ -1,0 +1,28 @@
+---
+sidebar_label: Stubbed implementations
+title: Stubbed implementations
+---
+
+For various reasons, such as testing/mocking, you may want to instantiate a stub implementation of generated service interfaces. Smithy4s makes it easy, by generating a `Default` class in the companion object of each service.
+
+This class has a constructor parameter that require a value. This value is what is returned when invoking any of the methods
+
+```scala mdoc:silent
+import smithy4s.hello._
+import cats.effect._
+
+object StubbedHelloWorld extends HelloWorldService.Default[IO](IO.stub)
+```
+
+Obviously, the generated methods can be overridden.
+
+```scala mdoc:silent
+import smithy4s.hello._
+import cats.effect._
+
+object OverriddenHelloWorld extends HelloWorldService.Default[IO](IO.stub){
+  override def hello(name: String, town: Option[String]) : IO[Greeting] = IO.pure {
+    Greeting(s"Hello $name!")
+  }
+}
+```

--- a/modules/example/src/smithy4s/example/BrandService.scala
+++ b/modules/example/src/smithy4s/example/BrandService.scala
@@ -43,6 +43,10 @@ object BrandServiceGen extends Service[BrandServiceGen, BrandServiceOperation] {
     def addBrands(brands: Option[List[String]] = None) = AddBrands(AddBrandsInput(brands))
   }
 
+  class Default[P[-_, +_, +_, -_, +_]](default: => P[Any, Nothing, Nothing, Any, Nothing]) {
+    def addBrands(brands: Option[List[String]] = None): P[AddBrandsInput, Nothing, Unit, Nothing, Nothing] = default
+  }
+
   def transform[P[_, _, _, _, _]](transformation: Transformation[BrandServiceOperation, P]): BrandServiceGen[P] = reified.transform(transformation)
 
   def transform[P[_, _, _, _, _], P1[_, _, _, _, _]](alg: BrandServiceGen[P], transformation: Transformation[P, P1]): BrandServiceGen[P1] = alg.transform(transformation)

--- a/modules/example/src/smithy4s/example/FooService.scala
+++ b/modules/example/src/smithy4s/example/FooService.scala
@@ -43,6 +43,10 @@ object FooServiceGen extends Service[FooServiceGen, FooServiceOperation] {
     def getFoo() = GetFoo()
   }
 
+  class Default[P[-_, +_, +_, -_, +_]](default: => P[Any, Nothing, Nothing, Any, Nothing]) {
+    def getFoo(): P[Unit, Nothing, GetFooOutput, Nothing, Nothing] = default
+  }
+
   def transform[P[_, _, _, _, _]](transformation: Transformation[FooServiceOperation, P]): FooServiceGen[P] = reified.transform(transformation)
 
   def transform[P[_, _, _, _, _], P1[_, _, _, _, _]](alg: FooServiceGen[P], transformation: Transformation[P, P1]): FooServiceGen[P1] = alg.transform(transformation)

--- a/modules/example/src/smithy4s/example/NameCollision.scala
+++ b/modules/example/src/smithy4s/example/NameCollision.scala
@@ -48,6 +48,10 @@ object NameCollisionGen extends Service[NameCollisionGen, NameCollisionOperation
     def myOp() = MyOp()
   }
 
+  class Default[P[-_, +_, +_, -_, +_]](default: => P[Any, Nothing, Nothing, Any, Nothing]) {
+    def myOp(): P[Unit, NameCollisionGen.MyOpError, Unit, Nothing, Nothing] = default
+  }
+
   def transform[P[_, _, _, _, _]](transformation: Transformation[NameCollisionOperation, P]): NameCollisionGen[P] = reified.transform(transformation)
 
   def transform[P[_, _, _, _, _], P1[_, _, _, _, _]](alg: NameCollisionGen[P], transformation: Transformation[P, P1]): NameCollisionGen[P1] = alg.transform(transformation)

--- a/modules/example/src/smithy4s/example/ObjectService.scala
+++ b/modules/example/src/smithy4s/example/ObjectService.scala
@@ -55,6 +55,11 @@ object ObjectServiceGen extends Service[ObjectServiceGen, ObjectServiceOperation
     def getObject(key: ObjectKey, bucketName: BucketName) = GetObject(GetObjectInput(key, bucketName))
   }
 
+  class Default[P[-_, +_, +_, -_, +_]](default: => P[Any, Nothing, Nothing, Any, Nothing]) {
+    def putObject(key: ObjectKey, bucketName: BucketName, data: String, foo: Option[LowHigh] = None, someValue: Option[SomeValue] = None): P[PutObjectInput, ObjectServiceGen.PutObjectError, Unit, Nothing, Nothing] = default
+    def getObject(key: ObjectKey, bucketName: BucketName): P[GetObjectInput, ObjectServiceGen.GetObjectError, GetObjectOutput, Nothing, Nothing] = default
+  }
+
   def transform[P[_, _, _, _, _]](transformation: Transformation[ObjectServiceOperation, P]): ObjectServiceGen[P] = reified.transform(transformation)
 
   def transform[P[_, _, _, _, _], P1[_, _, _, _, _]](alg: ObjectServiceGen[P], transformation: Transformation[P, P1]): ObjectServiceGen[P1] = alg.transform(transformation)

--- a/modules/example/src/smithy4s/example/StreamedObjects.scala
+++ b/modules/example/src/smithy4s/example/StreamedObjects.scala
@@ -48,6 +48,11 @@ object StreamedObjectsGen extends Service[StreamedObjectsGen, StreamedObjectsOpe
     def getStreamedObject(key: String) = GetStreamedObject(GetStreamedObjectInput(key))
   }
 
+  class Default[P[-_, +_, +_, -_, +_]](default: => P[Any, Nothing, Nothing, Any, Nothing]) {
+    def putStreamedObject(key: String): P[PutStreamedObjectInput, Nothing, Unit, StreamedBlob, Nothing] = default
+    def getStreamedObject(key: String): P[GetStreamedObjectInput, Nothing, GetStreamedObjectOutput, Nothing, StreamedBlob] = default
+  }
+
   def transform[P[_, _, _, _, _]](transformation: Transformation[StreamedObjectsOperation, P]): StreamedObjectsGen[P] = reified.transform(transformation)
 
   def transform[P[_, _, _, _, _], P1[_, _, _, _, _]](alg: StreamedObjectsGen[P], transformation: Transformation[P, P1]): StreamedObjectsGen[P1] = alg.transform(transformation)

--- a/modules/example/src/smithy4s/example/collision/ReservedNameService.scala
+++ b/modules/example/src/smithy4s/example/collision/ReservedNameService.scala
@@ -60,6 +60,13 @@ object ReservedNameServiceGen extends Service[ReservedNameServiceGen, ReservedNa
     def option(value: Option[String] = None) = _Option(OptionInput(value))
   }
 
+  class Default[P[-_, +_, +_, -_, +_]](default: => P[Any, Nothing, Nothing, Any, Nothing]) {
+    def set(set: Set[String]): P[SetInput, Nothing, Unit, Nothing, Nothing] = default
+    def list(list: List[String]): P[ListInput, Nothing, Unit, Nothing, Nothing] = default
+    def map(value: Map[String,String]): P[MapInput, Nothing, Unit, Nothing, Nothing] = default
+    def option(value: Option[String] = None): P[OptionInput, Nothing, Unit, Nothing, Nothing] = default
+  }
+
   def transform[P[_, _, _, _, _]](transformation: Transformation[ReservedNameServiceOperation, P]): ReservedNameServiceGen[P] = reified.transform(transformation)
 
   def transform[P[_, _, _, _, _], P1[_, _, _, _, _]](alg: ReservedNameServiceGen[P], transformation: Transformation[P, P1]): ReservedNameServiceGen[P1] = alg.transform(transformation)

--- a/modules/example/src/smithy4s/example/collision/package.scala
+++ b/modules/example/src/smithy4s/example/collision/package.scala
@@ -3,6 +3,7 @@ package smithy4s.example
 package object collision {
   type ReservedNameService[F[_]] = smithy4s.Monadic[ReservedNameServiceGen, F]
   object ReservedNameService extends smithy4s.Service.Provider[ReservedNameServiceGen, ReservedNameServiceOperation] {
+    type Default[F[+_]] = ReservedNameServiceGen.Default[smithy4s.StubLift[F]#Stub]
     def apply[F[_]](implicit F: ReservedNameService[F]): F.type = F
     def service: smithy4s.Service[ReservedNameServiceGen, ReservedNameServiceOperation] = ReservedNameServiceGen
     val id: smithy4s.ShapeId = service.id

--- a/modules/example/src/smithy4s/example/imp/ImportService.scala
+++ b/modules/example/src/smithy4s/example/imp/ImportService.scala
@@ -52,6 +52,10 @@ object ImportServiceGen extends Service[ImportServiceGen, ImportServiceOperation
     def importOperation() = ImportOperation()
   }
 
+  class Default[P[-_, +_, +_, -_, +_]](default: => P[Any, Nothing, Nothing, Any, Nothing]) {
+    def importOperation(): P[Unit, ImportServiceGen.ImportOperationError, OpOutput, Nothing, Nothing] = default
+  }
+
   def transform[P[_, _, _, _, _]](transformation: Transformation[ImportServiceOperation, P]): ImportServiceGen[P] = reified.transform(transformation)
 
   def transform[P[_, _, _, _, _], P1[_, _, _, _, _]](alg: ImportServiceGen[P], transformation: Transformation[P, P1]): ImportServiceGen[P1] = alg.transform(transformation)

--- a/modules/example/src/smithy4s/example/imp/package.scala
+++ b/modules/example/src/smithy4s/example/imp/package.scala
@@ -3,6 +3,7 @@ package smithy4s.example
 package object imp {
   type ImportService[F[_]] = smithy4s.Monadic[ImportServiceGen, F]
   object ImportService extends smithy4s.Service.Provider[ImportServiceGen, ImportServiceOperation] {
+    type Default[F[+_]] = ImportServiceGen.Default[smithy4s.StubLift[F]#Stub]
     def apply[F[_]](implicit F: ImportService[F]): F.type = F
     def service: smithy4s.Service[ImportServiceGen, ImportServiceOperation] = ImportServiceGen
     val id: smithy4s.ShapeId = service.id

--- a/modules/example/src/smithy4s/example/package.scala
+++ b/modules/example/src/smithy4s/example/package.scala
@@ -3,30 +3,35 @@ package smithy4s
 package object example {
   type StreamedObjects[F[_]] = smithy4s.Monadic[StreamedObjectsGen, F]
   object StreamedObjects extends smithy4s.Service.Provider[StreamedObjectsGen, StreamedObjectsOperation] {
+    type Default[F[+_]] = StreamedObjectsGen.Default[smithy4s.StubLift[F]#Stub]
     def apply[F[_]](implicit F: StreamedObjects[F]): F.type = F
     def service: smithy4s.Service[StreamedObjectsGen, StreamedObjectsOperation] = StreamedObjectsGen
     val id: smithy4s.ShapeId = service.id
   }
   type FooService[F[_]] = smithy4s.Monadic[FooServiceGen, F]
   object FooService extends smithy4s.Service.Provider[FooServiceGen, FooServiceOperation] {
+    type Default[F[+_]] = FooServiceGen.Default[smithy4s.StubLift[F]#Stub]
     def apply[F[_]](implicit F: FooService[F]): F.type = F
     def service: smithy4s.Service[FooServiceGen, FooServiceOperation] = FooServiceGen
     val id: smithy4s.ShapeId = service.id
   }
   type BrandService[F[_]] = smithy4s.Monadic[BrandServiceGen, F]
   object BrandService extends smithy4s.Service.Provider[BrandServiceGen, BrandServiceOperation] {
+    type Default[F[+_]] = BrandServiceGen.Default[smithy4s.StubLift[F]#Stub]
     def apply[F[_]](implicit F: BrandService[F]): F.type = F
     def service: smithy4s.Service[BrandServiceGen, BrandServiceOperation] = BrandServiceGen
     val id: smithy4s.ShapeId = service.id
   }
   type ObjectService[F[_]] = smithy4s.Monadic[ObjectServiceGen, F]
   object ObjectService extends smithy4s.Service.Provider[ObjectServiceGen, ObjectServiceOperation] {
+    type Default[F[+_]] = ObjectServiceGen.Default[smithy4s.StubLift[F]#Stub]
     def apply[F[_]](implicit F: ObjectService[F]): F.type = F
     def service: smithy4s.Service[ObjectServiceGen, ObjectServiceOperation] = ObjectServiceGen
     val id: smithy4s.ShapeId = service.id
   }
   type NameCollision[F[_]] = smithy4s.Monadic[NameCollisionGen, F]
   object NameCollision extends smithy4s.Service.Provider[NameCollisionGen, NameCollisionOperation] {
+    type Default[F[+_]] = NameCollisionGen.Default[smithy4s.StubLift[F]#Stub]
     def apply[F[_]](implicit F: NameCollision[F]): F.type = F
     def service: smithy4s.Service[NameCollisionGen, NameCollisionOperation] = NameCollisionGen
     val id: smithy4s.ShapeId = service.id


### PR DESCRIPTION
Adds logic and the necessary typelevel black-magic to facilitate the creation of implementations where methods receive a default/stub implementations (which can be overridden)

- [x] documentation