### PR TITLE
Use a concurrent map on JVM for the compilation cache

### DIFF
--- a/modules/core/src/smithy4s/schema/CompilationCache.scala
+++ b/modules/core/src/smithy4s/schema/CompilationCache.scala
@@ -16,7 +16,7 @@
 
 package smithy4s
 package schema
-import scala.collection.mutable.{Map => MMap}
+import smithy4s.internals.maps.MMap
 
 trait CompilationCache[F[_]] {
   def getOrElseUpdate[A](schema: Schema[A], fetch: Schema[A] => F[A]): F[A]


### PR DESCRIPTION
When schema visitors are used as means to formulate typeclass instances, a global cache is used. It is risky to use non-thread-safe maps when that's the case. 

NB : I've not managed to trigger a bug, doesn't mean it wouldn't happen. 