### PR TITLE
Build http4s routers lazily

### DIFF
--- a/modules/http4s/src/smithy4s/http4s/SimpleProtocolBuilder.scala
+++ b/modules/http4s/src/smithy4s/http4s/SimpleProtocolBuilder.scala
@@ -103,7 +103,9 @@ abstract class SimpleProtocolBuilder[P](val codecs: CodecAPI)(implicit
 
     def use: Either[UnsupportedProtocolError, Monadic[Alg, F]] = {
       checkProtocol(service, protocolTag)
-        .as(
+        // Making sure the router is evaluated lazily, so that all the compilation inside it
+        // doesn't happen in case of a missing protocol
+        .map { _ =>
           new SmithyHttp4sReverseRouter[Alg, Op, F](
             uri,
             service,
@@ -111,7 +113,7 @@ abstract class SimpleProtocolBuilder[P](val codecs: CodecAPI)(implicit
             EntityCompiler
               .fromCodecAPI[F](codecs)
           )
-        )
+        }
         .map(service.transform[GenLift[F]#λ](_))
     }
   }
@@ -140,14 +142,17 @@ abstract class SimpleProtocolBuilder[P](val codecs: CodecAPI)(implicit
       new RouterBuilder(service, impl, fe)
 
     def make: Either[UnsupportedProtocolError, HttpRoutes[F]] =
-      checkProtocol(service, protocolTag).as {
-        new SmithyHttp4sRouter[Alg, Op, F](
-          service,
-          impl,
-          errorTransformation,
-          entityCompiler
-        ).routes
-      }
+      checkProtocol(service, protocolTag)
+        // Making sure the router is evaluated lazily, so that all the compilation inside it
+        // doesn't happen in case of a missing protocol
+        .map { _ =>
+          new SmithyHttp4sRouter[Alg, Op, F](
+            service,
+            impl,
+            errorTransformation,
+            entityCompiler
+          ).routes
+        }
 
     def resource: Resource[F, HttpRoutes[F]] =
       make.leftWiden[Throwable].liftTo[Resource[F, *]]

--- a/modules/http4s/test/src/smithy4s/http4s/ProtocolBuilderSpec.scala
+++ b/modules/http4s/test/src/smithy4s/http4s/ProtocolBuilderSpec.scala
@@ -1,0 +1,34 @@
+package smithy4s.http4s
+
+import cats.effect.IO
+import org.http4s.HttpApp
+import org.http4s.client.Client
+import smithy4s.example.PizzaAdminServiceGen
+import smithy4s.example.WeatherGen
+import weaver._
+
+object ProtocolBuilderSpec extends FunSuite {
+
+  private val fakeClient = Client.fromHttpApp(HttpApp.notFound[IO])
+
+  test(
+    "SimpleProtocolBuilder (client) fails when the protocol is not present"
+  ) {
+    val result = SimpleRestJsonBuilder(WeatherGen)
+      .client(fakeClient)
+      .use
+
+    assert(result.isLeft)
+  }
+
+  test(
+    "SimpleProtocolBuilder (client) succeeds when the protocol is present"
+  ) {
+    val result = SimpleRestJsonBuilder(PizzaAdminServiceGen)
+      .client(fakeClient)
+      .use
+
+    assert(result.isRight)
+  }
+
+}


### PR DESCRIPTION
Closes #501. The main issue would've been solved by #493, but even that PR doesn't address the eagerness problem of `as` - we shouldn't be building the whole router if it's not even going to be returned.