### PR TITLE
Catch PayloadErrors in complete decoding in CodecAPI

### DIFF
--- a/modules/aws/src/smithy4s/aws/internals/AwsUnaryEndpoint.scala
+++ b/modules/aws/src/smithy4s/aws/internals/AwsUnaryEndpoint.scala
@@ -115,7 +115,8 @@ private[aws] class AwsUnaryEndpoint[F[_], Op[_, _, _, _, _], I, E, O, SI, SO](
           metadataPartial <- metadataDecoder.decode(metadata).liftTo[F]
           bodyPartial <-
             codecAPI.decodeFromByteArrayPartial(codec, response.body).liftTo[F]
-        } yield metadataPartial.combine(bodyPartial)
+          decoded <- metadataPartial.combineCatch(bodyPartial).liftTo[F]
+        } yield decoded
     }
   }
 

--- a/modules/core/src/smithy4s/http/CodecAPI.scala
+++ b/modules/core/src/smithy4s/http/CodecAPI.scala
@@ -73,7 +73,9 @@ trait CodecAPI {
       codec: Codec[A],
       bytes: Array[Byte]
   ): Either[PayloadError, A] =
-    decodeFromByteArrayPartial(codec, bytes).map(_.complete(MMap.empty))
+    decodeFromByteArrayPartial(codec, bytes).flatMap(
+      _.completeCatch(MMap.empty)
+    )
 
   /**
     * Decodes partial data from a byte buffer, returning a function that is able
@@ -94,7 +96,9 @@ trait CodecAPI {
       codec: Codec[A],
       bytes: ByteBuffer
   ): Either[PayloadError, A] =
-    decodeFromByteBufferPartial(codec, bytes).map(_.complete(MMap.empty))
+    decodeFromByteBufferPartial(codec, bytes).flatMap(
+      _.completeCatch(MMap.empty)
+    )
 
   /**
     * Writes data to a byte array. Field values bound

--- a/modules/core/src/smithy4s/http/Partial.scala
+++ b/modules/core/src/smithy4s/http/Partial.scala
@@ -17,11 +17,19 @@
 package smithy4s.http
 
 import scala.collection.{Map => MMap}
+import scala.annotation.nowarn
 
 final class MetadataPartial[A] private[smithy4s] (
     private[smithy4s] val decoded: MMap[String, Any]
 ) {
+  @deprecated(
+    "0.16.8",
+    "This may throw a PayloadError. Use combineCatch instead."
+  )
   final def combine(body: BodyPartial[A]): A = body.complete(decoded)
+
+  final def combineCatch(body: BodyPartial[A]): Either[PayloadError, A] =
+    body.completeCatch(decoded)
 }
 object MetadataPartial {
   private[smithy4s] def apply[A](decoded: MMap[String, Any]) =
@@ -31,14 +39,24 @@ object MetadataPartial {
 final class BodyPartial[A] private[smithy4s] (
     private[smithy4s] val complete: MMap[String, Any] => A
 ) {
-  final def combine(metadata: MetadataPartial[A]): A = complete(
-    metadata.decoded
+  @deprecated(
+    "0.16.8",
+    "This may throw a PayloadError. Use combineCatch instead."
   )
+  @nowarn("msg=method combine in class MetadataPartial is deprecated")
+  final def combine(metadata: MetadataPartial[A]): A =
+    metadata.combine(this)
+
+  final def combineCatch(
+      metadata: MetadataPartial[A]
+  ): Either[PayloadError, A] =
+    metadata.combineCatch(this)
 
   final def map[B](f: A => B): BodyPartial[B] = new BodyPartial(
     complete andThen f
   )
 
+  @nowarn("msg=method combine in class BodyPartial is deprecated")
   private[smithy4s] def completeCatch(
       m: MMap[String, Any]
   ): Either[PayloadError, A] = try Right(complete(m))

--- a/modules/core/src/smithy4s/http/Partial.scala
+++ b/modules/core/src/smithy4s/http/Partial.scala
@@ -38,6 +38,13 @@ final class BodyPartial[A] private[smithy4s] (
   final def map[B](f: A => B): BodyPartial[B] = new BodyPartial(
     complete andThen f
   )
+
+  private[smithy4s] def completeCatch(
+      m: MMap[String, Any]
+  ): Either[PayloadError, A] = try Right(complete(m))
+  catch {
+    case p: PayloadError => Left(p)
+  }
 }
 object BodyPartial {
   def apply[A](complete: MMap[String, Any] => A): BodyPartial[A] =

--- a/modules/http4s/src/smithy4s/http4s/internals/SmithyHttp4sServerEndpoint.scala
+++ b/modules/http4s/src/smithy4s/http4s/internals/SmithyHttp4sServerEndpoint.scala
@@ -135,7 +135,8 @@ private[smithy4s] class SmithyHttp4sServerEndpointImpl[F[_], Op[_, _, _, _, _], 
           for {
             metadataPartial <- inputMetadataDecoder.decode(metadata).liftTo[F]
             bodyPartial <- request.as[BodyPartial[I]]
-          } yield metadataPartial.combine(bodyPartial)
+            decoded <- metadataPartial.combineCatch(bodyPartial).liftTo[F]
+          } yield decoded
         }
     }
   }

--- a/modules/json/test/src/smithy4s/http/json/JsonCodecApiTests.scala
+++ b/modules/json/test/src/smithy4s/http/json/JsonCodecApiTests.scala
@@ -25,4 +25,24 @@ class JsonCodecApiTests extends FunSuite {
 
     assertEquals(encodedString, """{"a":"test"}""")
   }
+
+  test(
+    "struct codec with a required field should return a Left when the field is missing"
+  ) {
+    val schemaWithRequiredField =
+      Schema
+        .struct[String]
+        .apply(
+          Schema.string
+            .required[String]("a", identity)
+        )(identity)
+
+    val capi = codecs(HintMask.empty)
+
+    val codec = capi.compileCodec(schemaWithRequiredField)
+
+    val decoded = capi.decodeFromByteArray(codec, """{}""".getBytes())
+
+    assert(decoded.isLeft)
+  }
 }


### PR DESCRIPTION
Closes #594. Targetting main because this can be released in a patch release.