### PR TITLE
Fix microsite, again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,9 +152,9 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Java and Scala
-        uses: olafurpg/setup-scala@v13
+        uses: coursier/setup-action@v1
         with:
-          java-version: temurin:1.17
+          jvm: temurin:1.17
 
       - name: Cache
         uses: coursier/cache-action@v6


### PR DESCRIPTION
For real this time. Follow-up to https://github.com/disneystreaming/smithy4s/pull/572.

We were still using setup-scala, which uses Jabba to get the JVM, and Jabba apparently doesn't know about Temurin at all.

Running this one manually here: https://github.com/disneystreaming/smithy4s/actions/runs/3439662770 (edit: gonna have to retry after the 0.16.8 publishing is done, because MiMa is failing)