### PR TITLE
Render deprecation hints

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -269,7 +269,13 @@ lazy val `aws-kernel` = projectMatrix
       "aws.protocols"
     ),
     Compile / sourceGenerators := Seq(genSmithyScala(Compile).taskValue),
-    Test / envVars ++= Map("TEST_VAR" -> "hello")
+    Test / envVars ++= Map("TEST_VAR" -> "hello"),
+    scalacOptions ++= Seq(
+      "-Wconf:msg=class AwsQuery in package aws.protocols is deprecated:silent",
+      "-Wconf:msg=class RestXml in package aws.protocols is deprecated:silent",
+      "-Wconf:msg=value noErrorWrapping in class RestXml is deprecated:silent",
+      "-Wconf:msg=class Ec2Query in package aws.protocols is deprecated:silent"
+    )
   )
   .jvmPlatform(latest2ScalaVersions, jvmDimSettings)
   .jsPlatform(

--- a/build.sbt
+++ b/build.sbt
@@ -725,6 +725,8 @@ lazy val complianceTests = projectMatrix
 /**
  * Example application using the custom REST-JSON protocol provided by
  * smithy4s.
+ *
+ * All Scala code in this module is generated!
  */
 lazy val example = projectMatrix
   .in(file("modules/example"))
@@ -742,6 +744,7 @@ lazy val example = projectMatrix
     ),
     smithySpecs := Seq(
       (ThisBuild / baseDirectory).value / "sampleSpecs" / "example.smithy",
+      (ThisBuild / baseDirectory).value / "sampleSpecs" / "deprecations.smithy",
       (ThisBuild / baseDirectory).value / "sampleSpecs" / "errors.smithy",
       (ThisBuild / baseDirectory).value / "sampleSpecs" / "streaming.smithy",
       (ThisBuild / baseDirectory).value / "sampleSpecs" / "operation.smithy",

--- a/build.sbt
+++ b/build.sbt
@@ -726,7 +726,7 @@ lazy val complianceTests = projectMatrix
  * Example application using the custom REST-JSON protocol provided by
  * smithy4s.
  *
- * All Scala code in this module is generated!
+ * (almost) all Scala code in this module is generated! The ones that aren't should have a note stating so.
  */
 lazy val example = projectMatrix
   .in(file("modules/example"))
@@ -769,7 +769,9 @@ lazy val example = projectMatrix
     ),
     genSmithyOutput := ((ThisBuild / baseDirectory).value / "modules" / "example" / "src"),
     genSmithyResourcesOutput := (Compile / resourceDirectory).value,
-    smithy4sSkip := List("resource")
+    smithy4sSkip := List("resource"),
+    // Ignore deprecation warnings here - it's all generated code, anyway.
+    scalacOptions += "-Wconf:cat=deprecation:silent"
   )
   .jvmPlatform(List(Scala213), jvmDimSettings)
   .settings(Smithy4sBuildPlugin.doNotPublishArtifact)

--- a/modules/codegen/src/smithy4s/codegen/IR.scala
+++ b/modules/codegen/src/smithy4s/codegen/IR.scala
@@ -95,13 +95,13 @@ case class Enumeration(
     shapeId: ShapeId,
     name: String,
     values: List[EnumValue],
-    hints: List[Hint] = Nil
+    hints: List[Hint]
 ) extends Decl
 case class EnumValue(
     value: String,
     intValue: Int,
     name: String,
-    hints: List[Hint] = Nil
+    hints: List[Hint]
 )
 
 case class Field(
@@ -245,6 +245,8 @@ object Hint {
   case class Constraint(tr: Type.Ref, native: Native) extends Hint
   case class Protocol(traits: List[Type.Ref]) extends Hint
   case class Default(typedNode: Fix[TypedNode]) extends Hint
+  case class Deprecated(message: Option[String], since: Option[String])
+      extends Hint
   // traits that get rendered generically
   case class Native(typedNode: Fix[TypedNode]) extends Hint
   case object IntEnum extends Hint

--- a/modules/codegen/src/smithy4s/codegen/Renderer.scala
+++ b/modules/codegen/src/smithy4s/codegen/Renderer.scala
@@ -745,13 +745,12 @@ private[codegen] class Renderer(compilationUnit: CompilationUnit) { self =>
       renderHintsVal(hints),
       newline,
       values.map { case e @ EnumValue(value, intValue, _, hints) =>
+        val valueName = NameRef(e.name)
+        val valueHints = line"$Hints_(${memberHints(e.hints)})"
+
         lines(
           deprecationAnnotation(hints),
-          line"""case object ${NameRef(
-            e.name
-          )} extends $name("$value", "${e.name}", $intValue, $Hints_(${memberHints(
-            e.hints
-          )}))"""
+          line"""case object $valueName extends $name("$value", "${e.name}", $intValue, $valueHints)"""
         )
       },
       newline,

--- a/modules/codegen/src/smithy4s/codegen/Renderer.scala
+++ b/modules/codegen/src/smithy4s/codegen/Renderer.scala
@@ -715,7 +715,7 @@ private[codegen] class Renderer(compilationUnit: CompilationUnit) { self =>
           )
         }
 
-        deprecationAnnotation(hints).appendUnlessEmpty(Line.space) +
+        deprecationAnnotation(hints).appendIf(_.nonEmpty)(Line.space) +
           line"$name: " + tpeAndDefault
     }
   }
@@ -731,12 +731,12 @@ private[codegen] class Renderer(compilationUnit: CompilationUnit) { self =>
   ): Lines = lines(
     deprecationAnnotation(hints),
     block(
-      line"sealed abstract class ${name.name}(_value: String, _name: String, _intValue: Int) extends $Enumeration_.Value"
+      line"sealed abstract class ${name.name}(_value: String, _name: String, _intValue: Int, _hints: $Hints_) extends $Enumeration_.Value"
     )(
       line"override val value: String = _value",
       line"override val name: String = _name",
       line"override val intValue: Int = _intValue",
-      line"override val hints: $Hints_ = $Hints_.empty",
+      line"override val hints: $Hints_ = _hints",
       line"@inline final def widen: $name = this"
     ),
     obj(name, ext = line"$Enumeration_[$name]", w = line"${shapeTag(name)}")(
@@ -749,7 +749,9 @@ private[codegen] class Renderer(compilationUnit: CompilationUnit) { self =>
           deprecationAnnotation(hints),
           line"""case object ${NameRef(
             e.name
-          )} extends $name("$value", "${e.name}", $intValue)"""
+          )} extends $name("$value", "${e.name}", $intValue, $Hints_(${memberHints(
+            e.hints
+          )}))"""
         )
       },
       newline,

--- a/modules/codegen/src/smithy4s/codegen/Renderer.scala
+++ b/modules/codegen/src/smithy4s/codegen/Renderer.scala
@@ -635,6 +635,8 @@ private[codegen] class Renderer(compilationUnit: CompilationUnit) { self =>
               newline,
               line"""val alt = schema.oneOf[$name]("$realName")"""
             )
+            // In case of union members that are inline structs (as opposed to structs being referenced and wrapped by a new class),
+            // we want to put a deprecation note (if it exists on the alt) on the struct - there's nowhere else to put it.
             renderProduct(
               // putting alt hints first should result in higher priority of these.
               // might need deduplication (although the Hints type will take care of it, just in case)

--- a/modules/codegen/src/smithy4s/codegen/Renderer.scala
+++ b/modules/codegen/src/smithy4s/codegen/Renderer.scala
@@ -129,7 +129,7 @@ private[codegen] class Renderer(compilationUnit: CompilationUnit) { self =>
     case union @ Union(shapeId, _, alts, recursive, hints) =>
       renderUnion(shapeId, union.nameRef, alts, recursive, hints)
     case ta @ TypeAlias(shapeId, _, tpe, _, recursive, hints) =>
-      renderTypeAlias(shapeId, ta.nameRef, tpe, recursive, hints)
+      renderNewtype(shapeId, ta.nameRef, tpe, recursive, hints)
     case enumeration @ Enumeration(shapeId, _, values, hints) =>
       renderEnum(shapeId, enumeration.nameRef, values, hints)
   }
@@ -762,8 +762,7 @@ private[codegen] class Renderer(compilationUnit: CompilationUnit) { self =>
     )
   )
 
-  // also known as newtypes
-  private def renderTypeAlias(
+  private def renderNewtype(
       shapeId: ShapeId,
       name: NameRef,
       tpe: Type,

--- a/modules/codegen/src/smithy4s/codegen/SmithyToIR.scala
+++ b/modules/codegen/src/smithy4s/codegen/SmithyToIR.scala
@@ -739,8 +739,8 @@ private[codegen] class SmithyToIR(model: Model, namespace: String) {
     val nonMetaTraits =
       traits
         .filterNot(_.toShapeId().getNamespace() == "smithy4s.meta")
-        // not sure about this
         .filterNot(_.toShapeId().getNamespace() == "smithy.synthetic")
+
     val nonConstraintNonMetaTraits = nonMetaTraits.collect {
       case t if ConstraintTrait.unapply(t).isEmpty => t
     }

--- a/modules/codegen/src/smithy4s/codegen/SmithyToIR.scala
+++ b/modules/codegen/src/smithy4s/codegen/SmithyToIR.scala
@@ -741,7 +741,7 @@ private[codegen] class SmithyToIR(model: Model, namespace: String) {
         // don't have shapes in the model - so we can't generate hints for them.
         .filterNot(_.toShapeId().getNamespace() == "smithy.synthetic")
         // enumValue can be derived from enum schemas anyway, so we're removing it from hints
-        .filterNot(_.toShapeId().toString() == "smithy.api#enumValue")
+        .filterNot(_.toShapeId() == EnumValueTrait.ID)
 
     val nonConstraintNonMetaTraits = nonMetaTraits.collect {
       case t if ConstraintTrait.unapply(t).isEmpty => t

--- a/modules/codegen/src/smithy4s/codegen/SmithyToIR.scala
+++ b/modules/codegen/src/smithy4s/codegen/SmithyToIR.scala
@@ -739,6 +739,8 @@ private[codegen] class SmithyToIR(model: Model, namespace: String) {
     val nonMetaTraits =
       traits
         .filterNot(_.toShapeId().getNamespace() == "smithy4s.meta")
+        // traits from the synthetic namespace, e.g. smithy.synthetic.enum
+        // don't have shapes in the model - so we can't generate hints for them.
         .filterNot(_.toShapeId().getNamespace() == "smithy.synthetic")
 
     val nonConstraintNonMetaTraits = nonMetaTraits.collect {

--- a/modules/codegen/src/smithy4s/codegen/SmithyToIR.scala
+++ b/modules/codegen/src/smithy4s/codegen/SmithyToIR.scala
@@ -273,7 +273,8 @@ private[codegen] class SmithyToIR(model: Model, namespace: String) {
                     value.getName().asScala,
                     value.getValue,
                     index
-                  )
+                  ),
+                  hints = Nil
                 )
               }
               .toList
@@ -287,10 +288,20 @@ private[codegen] class SmithyToIR(model: Model, namespace: String) {
           .asScala
           .zipWithIndex
           .map { case ((name, value), index) =>
-            EnumValue(value, index, name)
+            val member = shape.getMember(name).get()
+
+            // random note: any other traits that are allowed on enum values? cuz they don't generate hints.
+            // known: @deprecated, @documentation
+            EnumValue(value, index, name, hints(member))
           }
           .toList
-        Enumeration(shape.getId(), shape.name, values).some
+
+        Enumeration(
+          shape.getId(),
+          shape.name,
+          values,
+          hints = hints(shape)
+        ).some
       }
 
       override def intEnumShape(shape: IntEnumShape): Option[Decl] = {
@@ -298,7 +309,9 @@ private[codegen] class SmithyToIR(model: Model, namespace: String) {
           .getEnumValues()
           .asScala
           .map { case (name, value) =>
-            EnumValue(name, value, name)
+            val member = shape.getMember(name).get()
+
+            EnumValue(name, value, name, hints(member))
           }
           .toList
         Enumeration(
@@ -707,6 +720,8 @@ private[codegen] class SmithyToIR(model: Model, namespace: String) {
       Hint.Protocol(refs.toList)
     case _: PackedInputsTrait =>
       Hint.PackedInputs
+    case d: DeprecatedTrait =>
+      Hint.Deprecated(d.getMessage.asScala, d.getSince.asScala)
     case _: ErrorMessageTrait =>
       Hint.ErrorMessage
     case _: VectorTrait =>
@@ -722,7 +737,10 @@ private[codegen] class SmithyToIR(model: Model, namespace: String) {
 
   private def traitsToHints(traits: List[Trait]): List[Hint] = {
     val nonMetaTraits =
-      traits.filterNot(_.toShapeId().getNamespace() == "smithy4s.meta")
+      traits
+        .filterNot(_.toShapeId().getNamespace() == "smithy4s.meta")
+        // not sure about this
+        .filterNot(_.toShapeId().getNamespace() == "smithy.synthetic")
     val nonConstraintNonMetaTraits = nonMetaTraits.collect {
       case t if ConstraintTrait.unapply(t).isEmpty => t
     }

--- a/modules/codegen/src/smithy4s/codegen/SmithyToIR.scala
+++ b/modules/codegen/src/smithy4s/codegen/SmithyToIR.scala
@@ -290,8 +290,6 @@ private[codegen] class SmithyToIR(model: Model, namespace: String) {
           .map { case ((name, value), index) =>
             val member = shape.getMember(name).get()
 
-            // random note: any other traits that are allowed on enum values? cuz they don't generate hints.
-            // known: @deprecated, @documentation
             EnumValue(value, index, name, hints(member))
           }
           .toList
@@ -742,6 +740,8 @@ private[codegen] class SmithyToIR(model: Model, namespace: String) {
         // traits from the synthetic namespace, e.g. smithy.synthetic.enum
         // don't have shapes in the model - so we can't generate hints for them.
         .filterNot(_.toShapeId().getNamespace() == "smithy.synthetic")
+        // enumValue can be derived from enum schemas anyway, so we're removing it from hints
+        .filterNot(_.toShapeId().toString() == "smithy.api#enumValue")
 
     val nonConstraintNonMetaTraits = nonMetaTraits.collect {
       case t if ConstraintTrait.unapply(t).isEmpty => t

--- a/modules/codegen/src/smithy4s/codegen/ToLine.scala
+++ b/modules/codegen/src/smithy4s/codegen/ToLine.scala
@@ -124,6 +124,9 @@ case class Line(segments: Chain[LineSegment]) {
       Lines.empty
     }
   }
+
+  def appendUnlessEmpty(other: Line): Line =
+    if (nonEmpty) this + other else this
 }
 
 object Line {
@@ -150,6 +153,7 @@ object Line {
 
   val empty: Line = Line(Chain.empty)
   val comma: Line = Line(", ")
+  val space: Line = Line(" ")
   val dot: Line = Line(".")
   implicit val monoid: Monoid[Line] = Monoid.instance(empty, _ + _)
 

--- a/modules/codegen/src/smithy4s/codegen/ToLine.scala
+++ b/modules/codegen/src/smithy4s/codegen/ToLine.scala
@@ -125,8 +125,8 @@ case class Line(segments: Chain[LineSegment]) {
     }
   }
 
-  def appendUnlessEmpty(other: Line): Line =
-    if (nonEmpty) this + other else this
+  def appendIf(condition: this.type => Boolean)(other: Line): Line =
+    if (condition(this)) this + other else this
 }
 
 object Line {

--- a/modules/dynamic/src/smithy4s/dynamic/internals/DynamicModelCompiler.scala
+++ b/modules/dynamic/src/smithy4s/dynamic/internals/DynamicModelCompiler.scala
@@ -151,15 +151,16 @@ private[dynamic] object Compiler {
       )
     }
 
-    private def allHints(traits: Option[Map[IdRef, Document]]): Hints =
+    private def allHints(traits: Option[Map[IdRef, Document]]): Hints = {
+      val ignoredHints = List(IdRef("smithy.api#enumValue"))
+
       Hints.fromSeq {
-        traits
-          .getOrElse(Map.empty)
-          .collect { case (ValidIdRef(k), v) =>
+        (traits.getOrElse(Map.empty) -- ignoredHints).collect {
+          case (ValidIdRef(k), v) =>
             toHint(k, v)
-          }
-          .toSeq
+        }.toSeq
       }
+    }
 
     private def update[A](
         shapeId: ShapeId,

--- a/modules/dynamic/src/smithy4s/dynamic/internals/DynamicModelCompiler.scala
+++ b/modules/dynamic/src/smithy4s/dynamic/internals/DynamicModelCompiler.scala
@@ -236,7 +236,7 @@ private[dynamic] object Compiler {
           .flatMap { case (k, m) =>
             getTrait[smithy.api.EnumValue](m.traits).toList.map {
               _.value match {
-                case Document.DString(s) => (k, s)
+                case Document.DString(s) => (k, s, m.traits)
                 case v =>
                   throw new IllegalArgumentException(
                     s"enum value $k has a non-string value: $v"
@@ -245,13 +245,13 @@ private[dynamic] object Compiler {
             }
           }
           .zipWithIndex
-          .map { case ((name, stringValue), i) =>
+          .map { case ((name, stringValue, traits), i) =>
             EnumValue(
               stringValue = stringValue,
               intValue = i,
               value = i,
               name = name,
-              hints = Hints.empty
+              hints = allHints(traits)
             )
           }
 
@@ -269,7 +269,7 @@ private[dynamic] object Compiler {
             _.value match {
               case Document.DNumber(num) =>
                 // toInt is safe because Smithy validates the model at loading time
-                (k, num.toInt)
+                (k, num.toInt, m.traits)
               case v =>
                 throw new IllegalArgumentException(
                   s"intEnum value $k has a non-numeric value: $v"
@@ -277,13 +277,13 @@ private[dynamic] object Compiler {
             }
           }
         }
-        .map { case (name, intValue) =>
+        .map { case (name, intValue, traits) =>
           intValue -> EnumValue(
             stringValue = name,
             intValue = intValue,
             value = intValue,
             name = name,
-            hints = Hints.empty
+            hints = allHints(traits)
           )
         }
         .toMap

--- a/modules/dynamic/test/src-jvm/smithy4s/dynamic/EnumSpec.scala
+++ b/modules/dynamic/test/src-jvm/smithy4s/dynamic/EnumSpec.scala
@@ -57,6 +57,12 @@ class EnumSpec extends FunSuite {
 
       FIRE = 10
     }
+
+    @deprecated
+    enum EnumWithTraits {
+      @deprecated ICE,
+      FIRE
+    }
   """
 
   val compiled = Utils.compile(model)
@@ -137,14 +143,18 @@ class EnumSpec extends FunSuite {
           intValue = 0,
           value = 0,
           name = "FIRE",
-          hints = Hints.empty
+          hints = Hints(
+            enumValueHint("Fire")
+          )
         ),
         EnumValue(
           stringValue = "Ice",
           intValue = 1,
           value = 1,
           name = "ICE",
-          hints = Hints.empty
+          hints = Hints(
+            enumValueHint("Ice")
+          )
         )
       )
     )
@@ -159,14 +169,18 @@ class EnumSpec extends FunSuite {
           intValue = 10,
           value = 10,
           name = "FIRE",
-          hints = Hints.empty
+          hints = Hints(
+            enumValueHintInt(10)
+          )
         ),
         EnumValue(
           stringValue = "ICE",
           intValue = 42,
           value = 42,
           name = "ICE",
-          hints = Hints.empty
+          hints = Hints(
+            enumValueHintInt(42)
+          )
         )
       )
     )
@@ -214,5 +228,36 @@ class EnumSpec extends FunSuite {
 
       assertEquals(actual, Document.DNumber(ICE))
     }
+  }
+
+  private def enumValueHint(value: String) =
+    ShapeId("smithy.api", "enumValue") -> Document.fromString(value)
+
+  private def enumValueHintInt(value: Int) =
+    ShapeId("smithy.api", "enumValue") -> Document.fromInt(value)
+
+  test("Smithy 2.0 enum members get their hints compiled") {
+    assertEnum(
+      ShapeId("example", "EnumWithTraits"),
+      expectedValues = List(
+        EnumValue(
+          stringValue = "FIRE",
+          intValue = 0,
+          value = 0,
+          name = "FIRE",
+          hints = Hints(enumValueHint("FIRE"))
+        ),
+        EnumValue(
+          stringValue = "ICE",
+          intValue = 1,
+          value = 1,
+          name = "ICE",
+          hints = Hints(
+            enumValueHint("ICE"),
+            ShapeId("smithy.api", "deprecated") -> Document.obj()
+          )
+        )
+      )
+    )
   }
 }

--- a/modules/dynamic/test/src-jvm/smithy4s/dynamic/EnumSpec.scala
+++ b/modules/dynamic/test/src-jvm/smithy4s/dynamic/EnumSpec.scala
@@ -143,18 +143,14 @@ class EnumSpec extends FunSuite {
           intValue = 0,
           value = 0,
           name = "FIRE",
-          hints = Hints(
-            enumValueHint("Fire")
-          )
+          hints = Hints.empty
         ),
         EnumValue(
           stringValue = "Ice",
           intValue = 1,
           value = 1,
           name = "ICE",
-          hints = Hints(
-            enumValueHint("Ice")
-          )
+          hints = Hints.empty
         )
       )
     )
@@ -169,18 +165,14 @@ class EnumSpec extends FunSuite {
           intValue = 10,
           value = 10,
           name = "FIRE",
-          hints = Hints(
-            enumValueHintInt(10)
-          )
+          hints = Hints.empty
         ),
         EnumValue(
           stringValue = "ICE",
           intValue = 42,
           value = 42,
           name = "ICE",
-          hints = Hints(
-            enumValueHintInt(42)
-          )
+          hints = Hints.empty
         )
       )
     )
@@ -230,12 +222,6 @@ class EnumSpec extends FunSuite {
     }
   }
 
-  private def enumValueHint(value: String) =
-    ShapeId("smithy.api", "enumValue") -> Document.fromString(value)
-
-  private def enumValueHintInt(value: Int) =
-    ShapeId("smithy.api", "enumValue") -> Document.fromInt(value)
-
   test("Smithy 2.0 enum members get their hints compiled") {
     assertEnum(
       ShapeId("example", "EnumWithTraits"),
@@ -245,7 +231,7 @@ class EnumSpec extends FunSuite {
           intValue = 0,
           value = 0,
           name = "FIRE",
-          hints = Hints(enumValueHint("FIRE"))
+          hints = Hints.empty
         ),
         EnumValue(
           stringValue = "ICE",
@@ -253,7 +239,6 @@ class EnumSpec extends FunSuite {
           value = 1,
           name = "ICE",
           hints = Hints(
-            enumValueHint("ICE"),
             ShapeId("smithy.api", "deprecated") -> Document.obj()
           )
         )

--- a/modules/example/src/smithy4s/example/DeprecatedService.scala
+++ b/modules/example/src/smithy4s/example/DeprecatedService.scala
@@ -8,6 +8,7 @@ import smithy4s.kinds.FunctorAlgebra
 import smithy4s.ShapeId
 import smithy4s.Service
 import smithy4s.kinds.BiFunctorAlgebra
+import smithy4s.kinds.toPolyFunction5.const5
 import smithy4s.Hints
 import smithy4s.StreamingSchema
 
@@ -26,6 +27,9 @@ object DeprecatedServiceGen extends Service.Mixin[DeprecatedServiceGen, Deprecat
   def apply[F[_]](implicit F: FunctorAlgebra[DeprecatedServiceGen, F]): F.type = F
 
   type WithError[F[_, _]] = BiFunctorAlgebra[DeprecatedServiceGen, F]
+  object WithError {
+    type Default[F[+_, +_]] = Constant[smithy4s.kinds.stubs.Kind2[F]#toKind5]
+  }
 
   val id: ShapeId = ShapeId("smithy4s.example", "DeprecatedService")
 
@@ -53,6 +57,9 @@ object DeprecatedServiceGen extends Service.Mixin[DeprecatedServiceGen, Deprecat
   class Transformed[P[_, _, _, _, _], P1[_ ,_ ,_ ,_ ,_]](alg: DeprecatedServiceGen[P], f : PolyFunction5[P, P1]) extends DeprecatedServiceGen[P1] {
     def deprecatedOperation() = f[Unit, Nothing, Unit, Nothing, Nothing](alg.deprecatedOperation())
   }
+
+  class Constant[P[-_, +_, +_, +_, +_]](value: P[Any, Nothing, Nothing, Nothing, Nothing]) extends Transformed[DeprecatedServiceOperation, P](reified, const5(value))
+  type Default[F[+_]] = Constant[smithy4s.kinds.stubs.Kind1[F]#toKind5]
 
   def toPolyFunction[P[_, _, _, _, _]](impl : DeprecatedServiceGen[P]): PolyFunction5[DeprecatedServiceOperation, P] = new PolyFunction5[DeprecatedServiceOperation, P] {
     def apply[I, E, O, SI, SO](op : DeprecatedServiceOperation[I, E, O, SI, SO]) : P[I, E, O, SI, SO] = op match  {

--- a/modules/example/src/smithy4s/example/DeprecatedService.scala
+++ b/modules/example/src/smithy4s/example/DeprecatedService.scala
@@ -1,0 +1,74 @@
+package smithy4s.example
+
+import smithy4s.Schema
+import smithy4s.schema.Schema.unit
+import smithy4s.kinds.PolyFunction5
+import smithy4s.Transformation
+import smithy4s.kinds.FunctorAlgebra
+import smithy4s.ShapeId
+import smithy4s.Service
+import smithy4s.kinds.BiFunctorAlgebra
+import smithy4s.Hints
+import smithy4s.StreamingSchema
+
+trait DeprecatedServiceGen[F[_, _, _, _, _]] {
+  self =>
+
+  def deprecatedOperation() : F[Unit, Nothing, Unit, Nothing, Nothing]
+
+  def transform : Transformation.PartiallyApplied[DeprecatedServiceGen[F]] = new Transformation.PartiallyApplied[DeprecatedServiceGen[F]](this)
+}
+
+object DeprecatedServiceGen extends Service.Mixin[DeprecatedServiceGen, DeprecatedServiceOperation] {
+
+  def apply[F[_]](implicit F: FunctorAlgebra[DeprecatedServiceGen, F]): F.type = F
+
+  type WithError[F[_, _]] = BiFunctorAlgebra[DeprecatedServiceGen, F]
+
+  val id: ShapeId = ShapeId("smithy4s.example", "DeprecatedService")
+
+  val hints : Hints = Hints(
+    smithy.api.Deprecated(message = None, since = None),
+  )
+
+  val endpoints: List[DeprecatedServiceGen.Endpoint[_, _, _, _, _]] = List(
+    DeprecatedOperation,
+  )
+
+  val version: String = ""
+
+  def endpoint[I, E, O, SI, SO](op : DeprecatedServiceOperation[I, E, O, SI, SO]) = op match {
+    case DeprecatedOperation() => ((), DeprecatedOperation)
+  }
+
+  object reified extends DeprecatedServiceGen[DeprecatedServiceOperation] {
+    def deprecatedOperation() = DeprecatedOperation()
+  }
+
+  def mapK5[P[_, _, _, _, _], P1[_, _, _, _, _]](alg: DeprecatedServiceGen[P], f: PolyFunction5[P, P1]): DeprecatedServiceGen[P1] = new Transformed(alg, f)
+
+  def fromPolyFunction[P[_, _, _, _, _]](f: PolyFunction5[DeprecatedServiceOperation, P]): DeprecatedServiceGen[P] = new Transformed(reified, f)
+  class Transformed[P[_, _, _, _, _], P1[_ ,_ ,_ ,_ ,_]](alg: DeprecatedServiceGen[P], f : PolyFunction5[P, P1]) extends DeprecatedServiceGen[P1] {
+    def deprecatedOperation() = f[Unit, Nothing, Unit, Nothing, Nothing](alg.deprecatedOperation())
+  }
+
+  def toPolyFunction[P[_, _, _, _, _]](impl : DeprecatedServiceGen[P]): PolyFunction5[DeprecatedServiceOperation, P] = new PolyFunction5[DeprecatedServiceOperation, P] {
+    def apply[I, E, O, SI, SO](op : DeprecatedServiceOperation[I, E, O, SI, SO]) : P[I, E, O, SI, SO] = op match  {
+      case DeprecatedOperation() => impl.deprecatedOperation()
+    }
+  }
+  case class DeprecatedOperation() extends DeprecatedServiceOperation[Unit, Nothing, Unit, Nothing, Nothing]
+  object DeprecatedOperation extends DeprecatedServiceGen.Endpoint[Unit, Nothing, Unit, Nothing, Nothing] {
+    val id: ShapeId = ShapeId("smithy4s.example", "DeprecatedOperation")
+    val input: Schema[Unit] = unit.addHints(smithy4s.internals.InputOutput.Input.widen)
+    val output: Schema[Unit] = unit.addHints(smithy4s.internals.InputOutput.Output.widen)
+    val streamedInput : StreamingSchema[Nothing] = StreamingSchema.nothing
+    val streamedOutput : StreamingSchema[Nothing] = StreamingSchema.nothing
+    val hints : Hints = Hints(
+      smithy.api.Deprecated(message = None, since = None),
+    )
+    def wrap(input: Unit) = DeprecatedOperation()
+  }
+}
+
+sealed trait DeprecatedServiceOperation[Input, Err, Output, StreamedInput, StreamedOutput]

--- a/modules/example/src/smithy4s/example/DeprecatedService.scala
+++ b/modules/example/src/smithy4s/example/DeprecatedService.scala
@@ -11,9 +11,11 @@ import smithy4s.kinds.BiFunctorAlgebra
 import smithy4s.Hints
 import smithy4s.StreamingSchema
 
+@deprecated
 trait DeprecatedServiceGen[F[_, _, _, _, _]] {
   self =>
 
+  @deprecated
   def deprecatedOperation() : F[Unit, Nothing, Unit, Nothing, Nothing]
 
   def transform : Transformation.PartiallyApplied[DeprecatedServiceGen[F]] = new Transformation.PartiallyApplied[DeprecatedServiceGen[F]](this)

--- a/modules/example/src/smithy4s/example/DeprecatedString.scala
+++ b/modules/example/src/smithy4s/example/DeprecatedString.scala
@@ -7,6 +7,7 @@ import smithy4s.ShapeId
 import smithy4s.schema.Schema.bijection
 import smithy4s.Newtype
 
+@deprecated
 object DeprecatedString extends Newtype[String] {
   val id: ShapeId = ShapeId("smithy4s.example", "DeprecatedString")
   val hints : Hints = Hints(

--- a/modules/example/src/smithy4s/example/DeprecatedString.scala
+++ b/modules/example/src/smithy4s/example/DeprecatedString.scala
@@ -1,0 +1,17 @@
+package smithy4s.example
+
+import smithy4s.Schema
+import smithy4s.Hints
+import smithy4s.schema.Schema.string
+import smithy4s.ShapeId
+import smithy4s.schema.Schema.bijection
+import smithy4s.Newtype
+
+object DeprecatedString extends Newtype[String] {
+  val id: ShapeId = ShapeId("smithy4s.example", "DeprecatedString")
+  val hints : Hints = Hints(
+    smithy.api.Deprecated(message = None, since = None),
+  )
+  val underlyingSchema : Schema[String] = string.withId(id).addHints(hints)
+  implicit val schema : Schema[DeprecatedString] = bijection(underlyingSchema, asBijection)
+}

--- a/modules/example/src/smithy4s/example/DeprecatedStructure.scala
+++ b/modules/example/src/smithy4s/example/DeprecatedStructure.scala
@@ -1,0 +1,25 @@
+package smithy4s.example
+
+import smithy4s.Schema
+import smithy4s.Hints
+import smithy4s.schema.Schema.string
+import smithy4s.ShapeId
+import smithy4s.schema.Schema.struct
+import smithy4s.ShapeTag
+
+case class DeprecatedStructure(name: Option[String] = None, nameV2: Option[String] = None, strings: Option[List[String]] = None)
+object DeprecatedStructure extends ShapeTag.Companion[DeprecatedStructure] {
+  val id: ShapeId = ShapeId("smithy4s.example", "DeprecatedStructure")
+
+  val hints : Hints = Hints(
+    smithy.api.Deprecated(message = Some("A compelling reason"), since = Some("0.0.1")),
+  )
+
+  implicit val schema: Schema[DeprecatedStructure] = struct(
+    string.optional[DeprecatedStructure]("name", _.name).addHints(smithy.api.Deprecated(message = None, since = None)),
+    string.optional[DeprecatedStructure]("nameV2", _.nameV2),
+    Strings.underlyingSchema.optional[DeprecatedStructure]("strings", _.strings),
+  ){
+    DeprecatedStructure.apply
+  }.withId(id).addHints(hints)
+}

--- a/modules/example/src/smithy4s/example/DeprecatedStructure.scala
+++ b/modules/example/src/smithy4s/example/DeprecatedStructure.scala
@@ -7,7 +7,8 @@ import smithy4s.ShapeId
 import smithy4s.schema.Schema.struct
 import smithy4s.ShapeTag
 
-case class DeprecatedStructure(name: Option[String] = None, nameV2: Option[String] = None, strings: Option[List[String]] = None)
+@deprecated(message = "A compelling reason", since = "0.0.1")
+case class DeprecatedStructure(@deprecated name: Option[String] = None, nameV2: Option[String] = None, strings: Option[List[String]] = None)
 object DeprecatedStructure extends ShapeTag.Companion[DeprecatedStructure] {
   val id: ShapeId = ShapeId("smithy4s.example", "DeprecatedStructure")
 

--- a/modules/example/src/smithy4s/example/DeprecatedUnion.scala
+++ b/modules/example/src/smithy4s/example/DeprecatedUnion.scala
@@ -9,6 +9,7 @@ import smithy4s.schema.Schema.union
 import smithy4s.schema.Schema.constant
 import smithy4s.Hints
 
+@deprecated(message = "A compelling reason", since = "0.0.1")
 sealed trait DeprecatedUnion extends scala.Product with scala.Serializable {
   @inline final def widen: DeprecatedUnion = this
 }
@@ -19,8 +20,10 @@ object DeprecatedUnion extends ShapeTag.Companion[DeprecatedUnion] {
     smithy.api.Deprecated(message = Some("A compelling reason"), since = Some("0.0.1")),
   )
 
+  @deprecated
   case class SCase(s: String) extends DeprecatedUnion
   case class S_V2Case(s_V2: String) extends DeprecatedUnion
+  @deprecated
   case class DeprecatedUnionProductCase() extends DeprecatedUnion
   object DeprecatedUnionProductCase extends ShapeTag.Companion[DeprecatedUnionProductCase] {
     val id: ShapeId = ShapeId("smithy4s.example", "DeprecatedUnionProductCase")
@@ -33,11 +36,14 @@ object DeprecatedUnion extends ShapeTag.Companion[DeprecatedUnion] {
 
     val alt = schema.oneOf[DeprecatedUnion]("p")
   }
+  @deprecated
   case class UnionProductCaseDeprecatedAtCallSite() extends DeprecatedUnion
   object UnionProductCaseDeprecatedAtCallSite extends ShapeTag.Companion[UnionProductCaseDeprecatedAtCallSite] {
     val id: ShapeId = ShapeId("smithy4s.example", "UnionProductCaseDeprecatedAtCallSite")
 
-    val hints : Hints = Hints.empty
+    val hints : Hints = Hints(
+      smithy.api.Deprecated(message = None, since = None),
+    )
 
     implicit val schema: Schema[UnionProductCaseDeprecatedAtCallSite] = constant(UnionProductCaseDeprecatedAtCallSite()).withId(id).addHints(hints)
 

--- a/modules/example/src/smithy4s/example/DeprecatedUnion.scala
+++ b/modules/example/src/smithy4s/example/DeprecatedUnion.scala
@@ -1,0 +1,71 @@
+package smithy4s.example
+
+import smithy4s.Schema
+import smithy4s.schema.Schema.string
+import smithy4s.ShapeId
+import smithy4s.ShapeTag
+import smithy4s.schema.Schema.bijection
+import smithy4s.schema.Schema.union
+import smithy4s.schema.Schema.constant
+import smithy4s.Hints
+
+sealed trait DeprecatedUnion extends scala.Product with scala.Serializable {
+  @inline final def widen: DeprecatedUnion = this
+}
+object DeprecatedUnion extends ShapeTag.Companion[DeprecatedUnion] {
+  val id: ShapeId = ShapeId("smithy4s.example", "DeprecatedUnion")
+
+  val hints : Hints = Hints(
+    smithy.api.Deprecated(message = Some("A compelling reason"), since = Some("0.0.1")),
+  )
+
+  case class SCase(s: String) extends DeprecatedUnion
+  case class S_V2Case(s_V2: String) extends DeprecatedUnion
+  case class DeprecatedUnionProductCase() extends DeprecatedUnion
+  object DeprecatedUnionProductCase extends ShapeTag.Companion[DeprecatedUnionProductCase] {
+    val id: ShapeId = ShapeId("smithy4s.example", "DeprecatedUnionProductCase")
+
+    val hints : Hints = Hints(
+      smithy.api.Deprecated(message = None, since = None),
+    )
+
+    implicit val schema: Schema[DeprecatedUnionProductCase] = constant(DeprecatedUnionProductCase()).withId(id).addHints(hints)
+
+    val alt = schema.oneOf[DeprecatedUnion]("p")
+  }
+  case class UnionProductCaseDeprecatedAtCallSite() extends DeprecatedUnion
+  object UnionProductCaseDeprecatedAtCallSite extends ShapeTag.Companion[UnionProductCaseDeprecatedAtCallSite] {
+    val id: ShapeId = ShapeId("smithy4s.example", "UnionProductCaseDeprecatedAtCallSite")
+
+    val hints : Hints = Hints.empty
+
+    implicit val schema: Schema[UnionProductCaseDeprecatedAtCallSite] = constant(UnionProductCaseDeprecatedAtCallSite()).withId(id).addHints(hints)
+
+    val alt = schema.oneOf[DeprecatedUnion]("p2")
+  }
+
+  object SCase {
+    val hints : Hints = Hints(
+      smithy.api.Deprecated(message = None, since = None),
+    )
+    val schema: Schema[SCase] = bijection(string.addHints(hints), SCase(_), _.s)
+    val alt = schema.oneOf[DeprecatedUnion]("s")
+  }
+  object S_V2Case {
+    val hints : Hints = Hints.empty
+    val schema: Schema[S_V2Case] = bijection(string.addHints(hints), S_V2Case(_), _.s_V2)
+    val alt = schema.oneOf[DeprecatedUnion]("s_V2")
+  }
+
+  implicit val schema: Schema[DeprecatedUnion] = union(
+    SCase.alt,
+    S_V2Case.alt,
+    DeprecatedUnionProductCase.alt,
+    UnionProductCaseDeprecatedAtCallSite.alt,
+  ){
+    case c : SCase => SCase.alt(c)
+    case c : S_V2Case => S_V2Case.alt(c)
+    case c : DeprecatedUnionProductCase => DeprecatedUnionProductCase.alt(c)
+    case c : UnionProductCaseDeprecatedAtCallSite => UnionProductCaseDeprecatedAtCallSite.alt(c)
+  }.withId(id).addHints(hints)
+}

--- a/modules/example/src/smithy4s/example/EnumWithDeprecations.scala
+++ b/modules/example/src/smithy4s/example/EnumWithDeprecations.scala
@@ -8,11 +8,11 @@ import smithy4s.ShapeTag
 import smithy4s.schema.Schema.enumeration
 
 @deprecated
-sealed abstract class EnumWithDeprecations(_value: String, _name: String, _intValue: Int) extends Enumeration.Value {
+sealed abstract class EnumWithDeprecations(_value: String, _name: String, _intValue: Int, _hints: Hints) extends Enumeration.Value {
   override val value: String = _value
   override val name: String = _name
   override val intValue: Int = _intValue
-  override val hints: Hints = Hints.empty
+  override val hints: Hints = _hints
   @inline final def widen: EnumWithDeprecations = this
 }
 object EnumWithDeprecations extends Enumeration[EnumWithDeprecations] with ShapeTag.Companion[EnumWithDeprecations] {
@@ -24,8 +24,8 @@ object EnumWithDeprecations extends Enumeration[EnumWithDeprecations] with Shape
   )
 
   @deprecated
-  case object OLD extends EnumWithDeprecations("OLD", "OLD", 0)
-  case object NEW extends EnumWithDeprecations("NEW", "NEW", 1)
+  case object OLD extends EnumWithDeprecations("OLD", "OLD", 0, Hints(smithy.api.Deprecated(message = None, since = None), smithy.api.EnumValue(smithy4s.Document.fromString("OLD"))))
+  case object NEW extends EnumWithDeprecations("NEW", "NEW", 1, Hints(smithy.api.EnumValue(smithy4s.Document.fromString("NEW"))))
 
   val values: List[EnumWithDeprecations] = List(
     OLD,

--- a/modules/example/src/smithy4s/example/EnumWithDeprecations.scala
+++ b/modules/example/src/smithy4s/example/EnumWithDeprecations.scala
@@ -7,6 +7,7 @@ import smithy4s.ShapeId
 import smithy4s.ShapeTag
 import smithy4s.schema.Schema.enumeration
 
+@deprecated
 sealed abstract class EnumWithDeprecations(_value: String, _name: String, _intValue: Int) extends Enumeration.Value {
   override val value: String = _value
   override val name: String = _name
@@ -17,8 +18,12 @@ sealed abstract class EnumWithDeprecations(_value: String, _name: String, _intVa
 object EnumWithDeprecations extends Enumeration[EnumWithDeprecations] with ShapeTag.Companion[EnumWithDeprecations] {
   val id: ShapeId = ShapeId("smithy4s.example", "EnumWithDeprecations")
 
-  val hints : Hints = Hints.empty
+  val hints : Hints = Hints(
+    smithy.api.Documentation("some docs here"),
+    smithy.api.Deprecated(message = None, since = None),
+  )
 
+  @deprecated
   case object OLD extends EnumWithDeprecations("OLD", "OLD", 0)
   case object NEW extends EnumWithDeprecations("NEW", "NEW", 1)
 

--- a/modules/example/src/smithy4s/example/EnumWithDeprecations.scala
+++ b/modules/example/src/smithy4s/example/EnumWithDeprecations.scala
@@ -1,0 +1,30 @@
+package smithy4s.example
+
+import smithy4s.Schema
+import smithy4s.Enumeration
+import smithy4s.Hints
+import smithy4s.ShapeId
+import smithy4s.ShapeTag
+import smithy4s.schema.Schema.enumeration
+
+sealed abstract class EnumWithDeprecations(_value: String, _name: String, _intValue: Int) extends Enumeration.Value {
+  override val value: String = _value
+  override val name: String = _name
+  override val intValue: Int = _intValue
+  override val hints: Hints = Hints.empty
+  @inline final def widen: EnumWithDeprecations = this
+}
+object EnumWithDeprecations extends Enumeration[EnumWithDeprecations] with ShapeTag.Companion[EnumWithDeprecations] {
+  val id: ShapeId = ShapeId("smithy4s.example", "EnumWithDeprecations")
+
+  val hints : Hints = Hints.empty
+
+  case object OLD extends EnumWithDeprecations("OLD", "OLD", 0)
+  case object NEW extends EnumWithDeprecations("NEW", "NEW", 1)
+
+  val values: List[EnumWithDeprecations] = List(
+    OLD,
+    NEW,
+  )
+  implicit val schema: Schema[EnumWithDeprecations] = enumeration(values).withId(id).addHints(hints)
+}

--- a/modules/example/src/smithy4s/example/EnumWithDeprecations.scala
+++ b/modules/example/src/smithy4s/example/EnumWithDeprecations.scala
@@ -24,8 +24,8 @@ object EnumWithDeprecations extends Enumeration[EnumWithDeprecations] with Shape
   )
 
   @deprecated
-  case object OLD extends EnumWithDeprecations("OLD", "OLD", 0, Hints(smithy.api.Deprecated(message = None, since = None), smithy.api.EnumValue(smithy4s.Document.fromString("OLD"))))
-  case object NEW extends EnumWithDeprecations("NEW", "NEW", 1, Hints(smithy.api.EnumValue(smithy4s.Document.fromString("NEW"))))
+  case object OLD extends EnumWithDeprecations("OLD", "OLD", 0, Hints(smithy.api.Deprecated(message = None, since = None)))
+  case object NEW extends EnumWithDeprecations("NEW", "NEW", 1, Hints())
 
   val values: List[EnumWithDeprecations] = List(
     OLD,

--- a/modules/example/src/smithy4s/example/FaceCard.scala
+++ b/modules/example/src/smithy4s/example/FaceCard.scala
@@ -23,11 +23,11 @@ object FaceCard extends Enumeration[FaceCard] with ShapeTag.Companion[FaceCard] 
     IntEnum(),
   )
 
-  case object JACK extends FaceCard("JACK", "JACK", 1, Hints(smithy.api.EnumValue(smithy4s.Document.fromDouble(1.0))))
-  case object QUEEN extends FaceCard("QUEEN", "QUEEN", 2, Hints(smithy.api.EnumValue(smithy4s.Document.fromDouble(2.0))))
-  case object KING extends FaceCard("KING", "KING", 3, Hints(smithy.api.EnumValue(smithy4s.Document.fromDouble(3.0))))
-  case object ACE extends FaceCard("ACE", "ACE", 4, Hints(smithy.api.EnumValue(smithy4s.Document.fromDouble(4.0))))
-  case object JOKER extends FaceCard("JOKER", "JOKER", 5, Hints(smithy.api.EnumValue(smithy4s.Document.fromDouble(5.0))))
+  case object JACK extends FaceCard("JACK", "JACK", 1, Hints())
+  case object QUEEN extends FaceCard("QUEEN", "QUEEN", 2, Hints())
+  case object KING extends FaceCard("KING", "KING", 3, Hints())
+  case object ACE extends FaceCard("ACE", "ACE", 4, Hints())
+  case object JOKER extends FaceCard("JOKER", "JOKER", 5, Hints())
 
   val values: List[FaceCard] = List(
     JACK,

--- a/modules/example/src/smithy4s/example/FaceCard.scala
+++ b/modules/example/src/smithy4s/example/FaceCard.scala
@@ -8,11 +8,11 @@ import smithy4s.ShapeId
 import smithy4s.ShapeTag
 import smithy4s.schema.Schema.enumeration
 
-sealed abstract class FaceCard(_value: String, _name: String, _intValue: Int) extends Enumeration.Value {
+sealed abstract class FaceCard(_value: String, _name: String, _intValue: Int, _hints: Hints) extends Enumeration.Value {
   override val value: String = _value
   override val name: String = _name
   override val intValue: Int = _intValue
-  override val hints: Hints = Hints.empty
+  override val hints: Hints = _hints
   @inline final def widen: FaceCard = this
 }
 object FaceCard extends Enumeration[FaceCard] with ShapeTag.Companion[FaceCard] {
@@ -23,11 +23,11 @@ object FaceCard extends Enumeration[FaceCard] with ShapeTag.Companion[FaceCard] 
     IntEnum(),
   )
 
-  case object JACK extends FaceCard("JACK", "JACK", 1)
-  case object QUEEN extends FaceCard("QUEEN", "QUEEN", 2)
-  case object KING extends FaceCard("KING", "KING", 3)
-  case object ACE extends FaceCard("ACE", "ACE", 4)
-  case object JOKER extends FaceCard("JOKER", "JOKER", 5)
+  case object JACK extends FaceCard("JACK", "JACK", 1, Hints(smithy.api.EnumValue(smithy4s.Document.fromDouble(1.0))))
+  case object QUEEN extends FaceCard("QUEEN", "QUEEN", 2, Hints(smithy.api.EnumValue(smithy4s.Document.fromDouble(2.0))))
+  case object KING extends FaceCard("KING", "KING", 3, Hints(smithy.api.EnumValue(smithy4s.Document.fromDouble(3.0))))
+  case object ACE extends FaceCard("ACE", "ACE", 4, Hints(smithy.api.EnumValue(smithy4s.Document.fromDouble(4.0))))
+  case object JOKER extends FaceCard("JOKER", "JOKER", 5, Hints(smithy.api.EnumValue(smithy4s.Document.fromDouble(5.0))))
 
   val values: List[FaceCard] = List(
     JACK,

--- a/modules/example/src/smithy4s/example/Launcher.scala
+++ b/modules/example/src/smithy4s/example/Launcher.scala
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+//  This file is NOT generated!
 package smithy4s.example
 
 import cats.effect._

--- a/modules/example/src/smithy4s/example/Letters.scala
+++ b/modules/example/src/smithy4s/example/Letters.scala
@@ -7,11 +7,11 @@ import smithy4s.ShapeId
 import smithy4s.ShapeTag
 import smithy4s.schema.Schema.enumeration
 
-sealed abstract class Letters(_value: String, _name: String, _intValue: Int) extends Enumeration.Value {
+sealed abstract class Letters(_value: String, _name: String, _intValue: Int, _hints: Hints) extends Enumeration.Value {
   override val value: String = _value
   override val name: String = _name
   override val intValue: Int = _intValue
-  override val hints: Hints = Hints.empty
+  override val hints: Hints = _hints
   @inline final def widen: Letters = this
 }
 object Letters extends Enumeration[Letters] with ShapeTag.Companion[Letters] {
@@ -19,9 +19,9 @@ object Letters extends Enumeration[Letters] with ShapeTag.Companion[Letters] {
 
   val hints : Hints = Hints.empty
 
-  case object A extends Letters("a", "A", 0)
-  case object B extends Letters("b", "B", 1)
-  case object C extends Letters("c", "C", 2)
+  case object A extends Letters("a", "A", 0, Hints(smithy.api.EnumValue(smithy4s.Document.fromString("a"))))
+  case object B extends Letters("b", "B", 1, Hints(smithy.api.EnumValue(smithy4s.Document.fromString("b"))))
+  case object C extends Letters("c", "C", 2, Hints(smithy.api.EnumValue(smithy4s.Document.fromString("c"))))
 
   val values: List[Letters] = List(
     A,

--- a/modules/example/src/smithy4s/example/Letters.scala
+++ b/modules/example/src/smithy4s/example/Letters.scala
@@ -19,9 +19,9 @@ object Letters extends Enumeration[Letters] with ShapeTag.Companion[Letters] {
 
   val hints : Hints = Hints.empty
 
-  case object A extends Letters("a", "A", 0, Hints(smithy.api.EnumValue(smithy4s.Document.fromString("a"))))
-  case object B extends Letters("b", "B", 1, Hints(smithy.api.EnumValue(smithy4s.Document.fromString("b"))))
-  case object C extends Letters("c", "C", 2, Hints(smithy.api.EnumValue(smithy4s.Document.fromString("c"))))
+  case object A extends Letters("a", "A", 0, Hints())
+  case object B extends Letters("b", "B", 1, Hints())
+  case object C extends Letters("c", "C", 2, Hints())
 
   val values: List[Letters] = List(
     A,

--- a/modules/example/src/smithy4s/example/LowHigh.scala
+++ b/modules/example/src/smithy4s/example/LowHigh.scala
@@ -7,11 +7,11 @@ import smithy4s.ShapeId
 import smithy4s.ShapeTag
 import smithy4s.schema.Schema.enumeration
 
-sealed abstract class LowHigh(_value: String, _name: String, _intValue: Int) extends Enumeration.Value {
+sealed abstract class LowHigh(_value: String, _name: String, _intValue: Int, _hints: Hints) extends Enumeration.Value {
   override val value: String = _value
   override val name: String = _name
   override val intValue: Int = _intValue
-  override val hints: Hints = Hints.empty
+  override val hints: Hints = _hints
   @inline final def widen: LowHigh = this
 }
 object LowHigh extends Enumeration[LowHigh] with ShapeTag.Companion[LowHigh] {
@@ -21,8 +21,8 @@ object LowHigh extends Enumeration[LowHigh] with ShapeTag.Companion[LowHigh] {
     smithy.api.Enum(List(smithy.api.EnumDefinition(value = smithy.api.NonEmptyString("Low"), name = Some(smithy.api.EnumConstantBodyName("LOW")), documentation = None, tags = None, deprecated = None), smithy.api.EnumDefinition(value = smithy.api.NonEmptyString("High"), name = Some(smithy.api.EnumConstantBodyName("HIGH")), documentation = None, tags = None, deprecated = None))),
   )
 
-  case object LOW extends LowHigh("Low", "LOW", 0)
-  case object HIGH extends LowHigh("High", "HIGH", 1)
+  case object LOW extends LowHigh("Low", "LOW", 0, Hints())
+  case object HIGH extends LowHigh("High", "HIGH", 1, Hints())
 
   val values: List[LowHigh] = List(
     LOW,

--- a/modules/example/src/smithy4s/example/Strings.scala
+++ b/modules/example/src/smithy4s/example/Strings.scala
@@ -8,6 +8,7 @@ import smithy4s.ShapeId
 import smithy4s.schema.Schema.bijection
 import smithy4s.Newtype
 
+@deprecated
 object Strings extends Newtype[List[String]] {
   val id: ShapeId = ShapeId("smithy4s.example", "Strings")
   val hints : Hints = Hints(

--- a/modules/example/src/smithy4s/example/Strings.scala
+++ b/modules/example/src/smithy4s/example/Strings.scala
@@ -1,0 +1,18 @@
+package smithy4s.example
+
+import smithy4s.Schema
+import smithy4s.schema.Schema.list
+import smithy4s.Hints
+import smithy4s.schema.Schema.string
+import smithy4s.ShapeId
+import smithy4s.schema.Schema.bijection
+import smithy4s.Newtype
+
+object Strings extends Newtype[List[String]] {
+  val id: ShapeId = ShapeId("smithy4s.example", "Strings")
+  val hints : Hints = Hints(
+    smithy.api.Deprecated(message = None, since = None),
+  )
+  val underlyingSchema : Schema[List[String]] = list(string).withId(id).addHints(hints)
+  implicit val schema : Schema[Strings] = bijection(underlyingSchema, asBijection)
+}

--- a/modules/example/src/smithy4s/example/SwitchState.scala
+++ b/modules/example/src/smithy4s/example/SwitchState.scala
@@ -19,8 +19,8 @@ object SwitchState extends Enumeration[SwitchState] with ShapeTag.Companion[Swit
 
   val hints : Hints = Hints.empty
 
-  case object ON extends SwitchState("ON", "ON", 0, Hints(smithy.api.EnumValue(smithy4s.Document.fromString("ON"))))
-  case object OFF extends SwitchState("OFF", "OFF", 1, Hints(smithy.api.EnumValue(smithy4s.Document.fromString("OFF"))))
+  case object ON extends SwitchState("ON", "ON", 0, Hints())
+  case object OFF extends SwitchState("OFF", "OFF", 1, Hints())
 
   val values: List[SwitchState] = List(
     ON,

--- a/modules/example/src/smithy4s/example/SwitchState.scala
+++ b/modules/example/src/smithy4s/example/SwitchState.scala
@@ -7,11 +7,11 @@ import smithy4s.ShapeId
 import smithy4s.ShapeTag
 import smithy4s.schema.Schema.enumeration
 
-sealed abstract class SwitchState(_value: String, _name: String, _intValue: Int) extends Enumeration.Value {
+sealed abstract class SwitchState(_value: String, _name: String, _intValue: Int, _hints: Hints) extends Enumeration.Value {
   override val value: String = _value
   override val name: String = _name
   override val intValue: Int = _intValue
-  override val hints: Hints = Hints.empty
+  override val hints: Hints = _hints
   @inline final def widen: SwitchState = this
 }
 object SwitchState extends Enumeration[SwitchState] with ShapeTag.Companion[SwitchState] {
@@ -19,8 +19,8 @@ object SwitchState extends Enumeration[SwitchState] with ShapeTag.Companion[Swit
 
   val hints : Hints = Hints.empty
 
-  case object ON extends SwitchState("ON", "ON", 0)
-  case object OFF extends SwitchState("OFF", "OFF", 1)
+  case object ON extends SwitchState("ON", "ON", 0, Hints(smithy.api.EnumValue(smithy4s.Document.fromString("ON"))))
+  case object OFF extends SwitchState("OFF", "OFF", 1, Hints(smithy.api.EnumValue(smithy4s.Document.fromString("OFF"))))
 
   val values: List[SwitchState] = List(
     ON,

--- a/modules/example/src/smithy4s/example/package.scala
+++ b/modules/example/src/smithy4s/example/package.scala
@@ -11,6 +11,7 @@ package object example {
   val ObjectService = ObjectServiceGen
   type NameCollision[F[_]] = smithy4s.kinds.FunctorAlgebra[NameCollisionGen, F]
   val NameCollision = NameCollisionGen
+  @deprecated
   type DeprecatedService[F[_]] = smithy4s.kinds.FunctorAlgebra[DeprecatedServiceGen, F]
   val DeprecatedService = DeprecatedServiceGen
 
@@ -27,8 +28,10 @@ package object example {
   type DogName = smithy4s.example.DogName.Type
   type SomeVector = smithy4s.example.SomeVector.Type
   type FancyList = smithy4s.example.FancyList.Type
+  @deprecated
   type Strings = smithy4s.example.Strings.Type
   type PersonAge = smithy4s.example.PersonAge.Type
+  @deprecated
   type DeprecatedString = smithy4s.example.DeprecatedString.Type
   type ObjectSize = smithy4s.example.ObjectSize.Type
   type SomeIndexSeq = smithy4s.example.SomeIndexSeq.Type

--- a/modules/example/src/smithy4s/example/package.scala
+++ b/modules/example/src/smithy4s/example/package.scala
@@ -11,6 +11,8 @@ package object example {
   val ObjectService = ObjectServiceGen
   type NameCollision[F[_]] = smithy4s.kinds.FunctorAlgebra[NameCollisionGen, F]
   val NameCollision = NameCollisionGen
+  type DeprecatedService[F[_]] = smithy4s.kinds.FunctorAlgebra[DeprecatedServiceGen, F]
+  val DeprecatedService = DeprecatedServiceGen
 
   type StreamedBlob = smithy4s.example.StreamedBlob.Type
   type SomeValue = smithy4s.example.SomeValue.Type
@@ -25,7 +27,9 @@ package object example {
   type DogName = smithy4s.example.DogName.Type
   type SomeVector = smithy4s.example.SomeVector.Type
   type FancyList = smithy4s.example.FancyList.Type
+  type Strings = smithy4s.example.Strings.Type
   type PersonAge = smithy4s.example.PersonAge.Type
+  type DeprecatedString = smithy4s.example.DeprecatedString.Type
   type ObjectSize = smithy4s.example.ObjectSize.Type
   type SomeIndexSeq = smithy4s.example.SomeIndexSeq.Type
   type StringList = smithy4s.example.StringList.Type

--- a/project/Smithy4sBuildPlugin.scala
+++ b/project/Smithy4sBuildPlugin.scala
@@ -107,7 +107,9 @@ object Smithy4sBuildPlugin extends AutoPlugin {
     semanticdbVersion := scalafixSemanticdb.revision,
     testFrameworks += new TestFramework("weaver.framework.CatsEffect"),
     Test / fork := virtualAxes.?.value.forall(_.contains(VirtualAxis.jvm)),
-    Test / javaOptions += s"-Duser.dir=${sys.props("user.dir")}"
+    Test / javaOptions += s"-Duser.dir=${sys.props("user.dir")}",
+    // Ignores warnings in code using the deprecated Enum trait.
+    scalacOptions += "-Wconf:msg=object Enum in package api is deprecated:silent"
   ) ++ publishSettings ++ loggingSettings ++ compilerPlugins ++ headerSettings
 
   lazy val compilerPlugins = Seq(

--- a/project/Smithy4sBuildPlugin.scala
+++ b/project/Smithy4sBuildPlugin.scala
@@ -111,7 +111,10 @@ object Smithy4sBuildPlugin extends AutoPlugin {
     // Ignores warnings in code using the deprecated Enum trait.
     scalacOptions ++= Seq(
       "-Wconf:msg=object Enum in package api is deprecated:silent",
-      "-Wconf:msg=type Enum in package api is deprecated:silent"
+      "-Wconf:msg=type Enum in package api is deprecated:silent",
+      // for Scala 3
+      "-Wconf:msg=object Enum in package smithy.api is deprecated:silent",
+      "-Wconf:msg=type Enum in package smithy.api is deprecated:silent"
     )
   ) ++ publishSettings ++ loggingSettings ++ compilerPlugins ++ headerSettings
 

--- a/project/Smithy4sBuildPlugin.scala
+++ b/project/Smithy4sBuildPlugin.scala
@@ -109,7 +109,10 @@ object Smithy4sBuildPlugin extends AutoPlugin {
     Test / fork := virtualAxes.?.value.forall(_.contains(VirtualAxis.jvm)),
     Test / javaOptions += s"-Duser.dir=${sys.props("user.dir")}",
     // Ignores warnings in code using the deprecated Enum trait.
-    scalacOptions += "-Wconf:msg=object Enum in package api is deprecated:silent"
+    scalacOptions ++= Seq(
+      "-Wconf:msg=object Enum in package api is deprecated:silent",
+      "-Wconf:msg=type Enum in package api is deprecated:silent"
+    )
   ) ++ publishSettings ++ loggingSettings ++ compilerPlugins ++ headerSettings
 
   lazy val compilerPlugins = Seq(

--- a/sampleSpecs/deprecations.smithy
+++ b/sampleSpecs/deprecations.smithy
@@ -1,0 +1,50 @@
+$version: "2"
+namespace smithy4s.example
+use smithy4s.meta#adtMember
+
+@deprecated(message: "A compelling reason", since: "0.0.1")
+structure DeprecatedStructure {
+  @deprecated name: String,
+  nameV2: String,
+  strings: Strings
+}
+
+@deprecated
+list Strings {
+  member: String
+}
+
+@deprecated(message: "A compelling reason", since: "0.0.1")
+union DeprecatedUnion {
+  @deprecated s: String,
+  s_V2: String,
+  p: DeprecatedUnionProductCase,
+  @deprecated
+  p2: UnionProductCaseDeprecatedAtCallSite
+}
+
+@adtMember(DeprecatedUnion)
+@deprecated
+structure DeprecatedUnionProductCase {}
+
+@adtMember(DeprecatedUnion)
+structure UnionProductCaseDeprecatedAtCallSite {}
+
+@deprecated
+string DeprecatedString
+
+@deprecated service DeprecatedService {
+  operations: [DeprecatedOperation]
+}
+
+@deprecated
+operation DeprecatedOperation {}
+
+@deprecated
+@documentation("some docs here")
+enum EnumWithDeprecations {
+  @deprecated
+  OLD,
+  NEW
+}
+


### PR DESCRIPTION
Made a separate commit for the actual implementation so that you can see how it affects the deprecated shapes:

[files in `modules/example` of this commit](https://github.com/disneystreaming/smithy4s/pull/599/commits/d5b5a818c078bfd29da959cc0772c130ccd55b84#diff-f6f31a8e21b138548e86cdaeadb003dd61d64575ca94b9a8ad5baa265f248556)

I think this doesn't have to go into 0.17 as it wouldn't make breaking changes.

Edit: about the above, I think this might be source breaking in a way (people might have fatal warnings on). Let's stick it into 0.17.

Solves the deprecation part of #256 