### PR TITLE
Delete .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-*.smithy linguist-language=Kotlin


### PR DESCRIPTION
remove .gitattributes as no longer necessary due to Linguist integrating the Smity language