### PR TITLE
Implement HttpProtocolCompliance w/o IO

### DIFF
--- a/modules/compliance-tests/src-ce2/smithy4s/compliancetests/Compat.scala
+++ b/modules/compliance-tests/src-ce2/smithy4s/compliancetests/Compat.scala
@@ -16,16 +16,19 @@
 
 package smithy4s.compliancetests
 
-import cats.effect.IO
+import cats.effect._
 import cats.effect.concurrent.Deferred
-import cats.effect.ContextShift
-import cats.effect.Timer
-import cats.effect.Concurrent
+import cats.effect.implicits._
+import cats.Monad
+import scala.concurrent.duration.FiniteDuration
 
 private[compliancetests] class CompatEffect[F[_]](implicit
-    val F: Concurrent[F]
-) {
+    val _Concurrent: Concurrent[F],
+    val _Time: Timer[F],
+    val _Monad: Monad[F]
+) extends CompatUtils[F] {
   def deferred[A]: F[Deferred[F, A]] = Deferred[F, A]
+  def timeout[A](f: F[A], delay: FiniteDuration): F[A] = f.timeout(delay)
 
   val utf8Encode: fs2.Pipe[F, String, Byte] = fs2.text.utf8Encode[F]
   val utf8Decode: fs2.Pipe[F, Byte, String] = fs2.text.utf8Decode[F]

--- a/modules/compliance-tests/src-ce2/smithy4s/compliancetests/Compat.scala
+++ b/modules/compliance-tests/src-ce2/smithy4s/compliancetests/Compat.scala
@@ -18,18 +18,19 @@ package smithy4s.compliancetests
 
 import cats.effect._
 import cats.effect.concurrent.Deferred
-import cats.effect.implicits._
-import cats.Monad
 import scala.concurrent.duration.FiniteDuration
 
 private[compliancetests] class CompatEffect[F[_]](implicit
     val _Concurrent: Concurrent[F],
-    val _Time: Timer[F],
-    val _Monad: Monad[F]
+    val _Timer: Timer[F]
 ) extends CompatUtils[F] {
+  // CE2 Deferred is in a cats.effect.concurrent.Deferred
   def deferred[A]: F[Deferred[F, A]] = Deferred[F, A]
-  def timeout[A](f: F[A], delay: FiniteDuration): F[A] = f.timeout(delay)
+  // CE2 timeout is on Concurrent
+  def timeout[A](f: F[A], delay: FiniteDuration): F[A] =
+    Concurrent.timeout[F, A](f, delay)
 
+  // utf8 encode/decode under fs2.text
   val utf8Encode: fs2.Pipe[F, String, Byte] = fs2.text.utf8Encode[F]
   val utf8Decode: fs2.Pipe[F, Byte, String] = fs2.text.utf8Decode[F]
 }

--- a/modules/compliance-tests/src-ce3/smithy4s/compliancetests/Compat.scala
+++ b/modules/compliance-tests/src-ce3/smithy4s/compliancetests/Compat.scala
@@ -18,19 +18,20 @@ package smithy4s.compliancetests
 
 import cats.effect.Async
 import cats.effect.Deferred
-import cats.Monad
 import com.comcast.ip4s.Host
 import com.comcast.ip4s.Port
 import scala.concurrent.duration.FiniteDuration
 
 private[compliancetests] class CompatEffect[F[_]](implicit
-    val _Async: Async[F],
-    val _Monad: Monad[F]
+    val _Async: Async[F]
 ) extends CompatUtils[F] {
+  // CE3 Deferred is in a cats.effect.Deferred
   def deferred[A]: F[Deferred[F, A]] = Deferred[F, A]
+  // CE3 timeout is on Async
   def timeout[A](f: F[A], delay: FiniteDuration): F[A] =
     _Async.timeout(f, delay)
 
+  // utf8 encode/decode under fs2.text.utf8
   val utf8Encode: fs2.Pipe[F, String, Byte] = fs2.text.utf8.encode[F]
   val utf8Decode: fs2.Pipe[F, Byte, String] = fs2.text.utf8.decode[F]
 }

--- a/modules/compliance-tests/src-ce3/smithy4s/compliancetests/Compat.scala
+++ b/modules/compliance-tests/src-ce3/smithy4s/compliancetests/Compat.scala
@@ -16,13 +16,20 @@
 
 package smithy4s.compliancetests
 
+import cats.effect.Async
 import cats.effect.Deferred
+import cats.Monad
 import com.comcast.ip4s.Host
 import com.comcast.ip4s.Port
-import cats.effect.Async
+import scala.concurrent.duration.FiniteDuration
 
-private[compliancetests] class CompatEffect[F[_]](implicit val F: Async[F]) {
+private[compliancetests] class CompatEffect[F[_]](implicit
+    val _Async: Async[F],
+    val _Monad: Monad[F]
+) extends CompatUtils[F] {
   def deferred[A]: F[Deferred[F, A]] = Deferred[F, A]
+  def timeout[A](f: F[A], delay: FiniteDuration): F[A] =
+    _Async.timeout(f, delay)
 
   val utf8Encode: fs2.Pipe[F, String, Byte] = fs2.text.utf8.encode[F]
   val utf8Decode: fs2.Pipe[F, Byte, String] = fs2.text.utf8.decode[F]

--- a/modules/compliance-tests/src/smithy4s/compliancetests/CompatUtils.scala
+++ b/modules/compliance-tests/src/smithy4s/compliancetests/CompatUtils.scala
@@ -20,7 +20,11 @@ import cats.Monoid
 import cats.MonadError
 import cats.Monad
 
-abstract class CompatUtils[F[_]: MonadError[*[_], Throwable]] {
+private object CompatUtils {
+  type ME[F[_]] = MonadError[F, Throwable]
+}
+
+abstract class CompatUtils[F[_]: CompatUtils.ME] {
   def raiseError[A](err: Throwable): F[A] =
     MonadError[F, Throwable].raiseError(err)
 

--- a/modules/compliance-tests/src/smithy4s/compliancetests/CompatUtils.scala
+++ b/modules/compliance-tests/src/smithy4s/compliancetests/CompatUtils.scala
@@ -1,3 +1,19 @@
+/*
+ *  Copyright 2021-2022 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 package smithy4s.compliancetests
 
 import cats.Monoid

--- a/modules/compliance-tests/src/smithy4s/compliancetests/CompatUtils.scala
+++ b/modules/compliance-tests/src/smithy4s/compliancetests/CompatUtils.scala
@@ -1,0 +1,18 @@
+package smithy4s.compliancetests
+
+import cats.Monoid
+import cats.MonadError
+import cats.Monad
+
+abstract class CompatUtils[F[_]: MonadError[*[_], Throwable]] {
+  def raiseError[A](err: Throwable): F[A] =
+    MonadError[F, Throwable].raiseError(err)
+
+  implicit def monoid[A: Monoid]: Monoid[F[A]] = new Monoid[F[A]] {
+    override def combine(x: F[A], y: F[A]): F[A] =
+      Monad[F].flatMap(x)(xa =>
+        Monad[F].map(y)(ya => Monoid[A].combine(xa, ya))
+      )
+    override def empty: F[A] = Monad[F].pure(Monoid[A].empty)
+  }
+}

--- a/modules/compliance-tests/src/smithy4s/compliancetests/CompatUtils.scala
+++ b/modules/compliance-tests/src/smithy4s/compliancetests/CompatUtils.scala
@@ -17,22 +17,12 @@
 package smithy4s.compliancetests
 
 import cats.Monoid
-import cats.MonadError
-import cats.Monad
+import cats.MonadThrow
+import cats.Applicative
 
-private object CompatUtils {
-  type ME[F[_]] = MonadError[F, Throwable]
-}
-
-abstract class CompatUtils[F[_]: CompatUtils.ME] {
+abstract class CompatUtils[F[_]: MonadThrow] {
   def raiseError[A](err: Throwable): F[A] =
-    MonadError[F, Throwable].raiseError(err)
+    MonadThrow[F].raiseError(err)
 
-  implicit def monoid[A: Monoid]: Monoid[F[A]] = new Monoid[F[A]] {
-    override def combine(x: F[A], y: F[A]): F[A] =
-      Monad[F].flatMap(x)(xa =>
-        Monad[F].map(y)(ya => Monoid[A].combine(xa, ya))
-      )
-    override def empty: F[A] = Monad[F].pure(Monoid[A].empty)
-  }
+  implicit def monoid[A: Monoid]: Monoid[F[A]] = Applicative.monoid[F, A]
 }

--- a/modules/compliance-tests/src/smithy4s/compliancetests/ComplianceTest.scala
+++ b/modules/compliance-tests/src/smithy4s/compliancetests/ComplianceTest.scala
@@ -1,3 +1,19 @@
+/*
+ *  Copyright 2021-2022 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 package smithy4s.compliancetests
 
 import ComplianceTest.ComplianceResult

--- a/modules/compliance-tests/src/smithy4s/compliancetests/HttpProtocolCompliance.scala
+++ b/modules/compliance-tests/src/smithy4s/compliancetests/HttpProtocolCompliance.scala
@@ -1,3 +1,19 @@
+/*
+ *  Copyright 2021-2022 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 package smithy4s.compliancetests
 
 import smithy4s.Service

--- a/modules/compliance-tests/src/smithy4s/compliancetests/HttpProtocolCompliance.scala
+++ b/modules/compliance-tests/src/smithy4s/compliancetests/HttpProtocolCompliance.scala
@@ -1,7 +1,6 @@
 package smithy4s.compliancetests
 
 import smithy4s.Service
-import cats.effect.IO
 
 /**
   * A construct allowing for running http protocol compliance tests against the implementation of a given protocol.
@@ -13,28 +12,28 @@ import cats.effect.IO
   */
 object HttpProtocolCompliance {
 
-  def clientTests[Alg[_[_, _, _, _, _]]](
-      reverseRouter: ReverseRouter[IO],
+  def clientTests[F[_], Alg[_[_, _, _, _, _]]](
+      reverseRouter: ReverseRouter[F],
       serviceProvider: Service.Provider[Alg]
-  )(implicit ce: CompatEffect[IO]): List[ComplianceTest[IO]] =
-    new internals.ClientHttpComplianceTestCase[Alg](
+  )(implicit ce: CompatEffect[F]): List[ComplianceTest[F]] =
+    new internals.ClientHttpComplianceTestCase[F, Alg](
       reverseRouter,
       serviceProvider
     ).allClientTests()
 
-  def serverTests[Alg[_[_, _, _, _, _]]](
-      router: Router[IO],
+  def serverTests[F[_], Alg[_[_, _, _, _, _]]](
+      router: Router[F],
       serviceProvider: Service.Provider[Alg]
-  )(implicit ce: CompatEffect[IO]): List[ComplianceTest[IO]] =
-    new internals.ServerHttpComplianceTestCase[Alg](
+  )(implicit ce: CompatEffect[F]): List[ComplianceTest[F]] =
+    new internals.ServerHttpComplianceTestCase[F, Alg](
       router,
       serviceProvider
     ).allServerTests()
 
-  def clientAndServerTests[Alg[_[_, _, _, _, _]]](
-      router: Router[IO] with ReverseRouter[IO],
+  def clientAndServerTests[F[_], Alg[_[_, _, _, _, _]]](
+      router: Router[F] with ReverseRouter[F],
       serviceProvider: Service.Provider[Alg]
-  )(implicit ce: CompatEffect[IO]): List[ComplianceTest[IO]] =
+  )(implicit ce: CompatEffect[F]): List[ComplianceTest[F]] =
     clientTests(router, serviceProvider) ++ serverTests(router, serviceProvider)
 
 }

--- a/modules/compliance-tests/src/smithy4s/compliancetests/ReverseRouter.scala
+++ b/modules/compliance-tests/src/smithy4s/compliancetests/ReverseRouter.scala
@@ -1,3 +1,19 @@
+/*
+ *  Copyright 2021-2022 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 package smithy4s.compliancetests
 
 import smithy4s.Service

--- a/modules/compliance-tests/src/smithy4s/compliancetests/Router.scala
+++ b/modules/compliance-tests/src/smithy4s/compliancetests/Router.scala
@@ -1,3 +1,19 @@
+/*
+ *  Copyright 2021-2022 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 package smithy4s.compliancetests
 
 import smithy4s.Service

--- a/modules/docs/markdown/03-protocols/05-compliance-tests.md
+++ b/modules/docs/markdown/03-protocols/05-compliance-tests.md
@@ -61,44 +61,39 @@ import org.http4s.client.Client
 import smithy4s.compliancetests._
 import smithy4s.example.test._
 import smithy4s.http4s._
+import smithy4s.kinds._
 import smithy4s.Service
 ```
 
 Then, you can create and instance of `ClientHttpComplianceTestCase` and/or `ServerHttpComplianceTestCase` while selecting the protocol to use and the service to test:
 
 ```scala mdoc:silent
-val clientTestGenerator = new ClientHttpComplianceTestCase[
-    alloy.SimpleRestJson,
-    HelloServiceGen,
-  ](
-    alloy.SimpleRestJson(),
-    HelloService
-  ) {
-    import org.http4s.implicits._
-    private val baseUri = uri"http://localhost/"
-    def getClient(app: HttpApp[IO]): Resource[IO, HelloService[IO]] =
-      SimpleRestJsonBuilder(HelloService)
+object SimpleRestJsonIntegration extends Router[IO] with ReverseRouter[IO] {
+    type Protocol = alloy.SimpleRestJson
+    val protocolTag = alloy.SimpleRestJson
+
+    def codecs = SimpleRestJsonBuilder.codecs
+
+    def routes[Alg[_[_, _, _, _, _]]](
+        impl: FunctorAlgebra[Alg, IO]
+    )(implicit service: Service[Alg]): Resource[IO, HttpRoutes[IO]] =
+      SimpleRestJsonBuilder(service).routes(impl).resource
+
+    def reverseRoutes[Alg[_[_, _, _, _, _]]](app: HttpApp[IO])(implicit
+        service: Service[Alg]
+    ): Resource[IO, FunctorAlgebra[Alg, IO]] = {
+      import org.http4s.implicits._
+      val baseUri = uri"http://localhost/"
+
+      SimpleRestJsonBuilder(service)
         .client(Client.fromHttpApp(app))
         .uri(baseUri)
         .resource
-    def codecs = SimpleRestJsonBuilder.codecs
+    }
   }
 
-val serverTestGenerator = new ServerHttpComplianceTestCase[
-    alloy.SimpleRestJson,
-    HelloServiceGen,
-  ](
-    alloy.SimpleRestJson(),
-    HelloService
-  ) {
-    def getServer[Alg2[_[_, _, _, _, _]]](
-      impl: smithy4s.kinds.FunctorAlgebra[Alg2, IO]
-  )(implicit s: Service[Alg2]): Resource[IO, HttpRoutes[IO]] =
-      SimpleRestJsonBuilder(s).routes(impl).resource
-    def codecs = SimpleRestJsonBuilder.codecs
-  }
-
-val tests: List[ComplianceTest[IO]] = clientTestGenerator.allClientTests() ++ serverTestGenerator.allServerTests()
+val tests: List[ComplianceTest[IO]] = HttpProtocolCompliance
+    .clientAndServerTests(SimpleRestJsonIntegration, HelloWorldService)
 ```
 
 Now, you can iterate over the test cases and do what you want. This is where you would hook in the test framework of your choice, but in the following example, we're just going to print the result:

--- a/sampleSpecs/test.smithy
+++ b/sampleSpecs/test.smithy
@@ -106,7 +106,7 @@ operation TestPath {
     }
 }
 
-// The following shapes are used
+// The following shapes are used by the documentation
 @simpleRestJson
 service HelloWorldService {
   version: "1.0.0",


### PR DESCRIPTION
This branch targets `refine-compliance-tests-dx` and I assumed it was based on `series/0.17` so I merged that in. 
The only relevant commit in that PR is: https://github.com/disneystreaming/smithy4s/commit/ee22af5a51e1744a19a172f6e923b31a5f2173f9