### PR TITLE
Fail CLI if all input are empty

### DIFF
--- a/modules/codegen-cli/src/smithy4s/codegen/cli/CodegenCommand.scala
+++ b/modules/codegen-cli/src/smithy4s/codegen/cli/CodegenCommand.scala
@@ -125,6 +125,21 @@ object CodegenCommand {
             localJars.getOrElse(List.empty)
           )
       }
+      .mapValidated { cmd =>
+        if (
+          cmd.specs.isEmpty && cmd.dependencies.isEmpty && cmd.localJars.isEmpty
+        ) {
+          Validated.invalidNel(
+            List(
+              "No input for the Smithy model. Consider pointing to a folder or a Smithy file.",
+              "You can also use `--dependencies` to import from maven coordinates",
+              "or use `--localJars` to point to a JAR on your file system."
+            ).mkString(" ")
+          )
+        } else {
+          Validated.valid(cmd)
+        }
+      }
 
   val command = Command(
     "generate",


### PR DESCRIPTION
References: https://github.com/disneystreaming/smithy4s/issues/571

The CLI fails with a non-zero exit code and prints the help along with an error message, it looks like this:

```
No input for the Smithy model. Consider pointing to a folder or a Smithy file. You can also use `--dependencies` to import from maven coordinates or use `--localJars` to point to a JAR on your file system.

Usage: smithy4s generate [--output <path>] [--resource-output <path>] [--skip <string>]... [--discover-models] [--allowed-ns <string,string,...>] [--excluded-ns <string,string,...>] [--repositories <string,string,...>] [--dependencies <string,string,...>] [--transformers <string,string,...>] [--localJars <path,path,...>] [<path>...]

Generates scala code and openapi-specs from smithy specs

Options and flags:
    --help
        Display this help text.
    --output <path>, -o <path>
        Path where scala code should be generated. Defaults to pwd
    --resource-output <path>
        Path where non-scala files should be generated. Defaults to pwd
    --skip <string>
        Indicates that some files types should be skipped during generation
    --discover-models
        Indicates whether the model assembler should try to discover models in the classpath
    --allowed-ns <string,string,...>
        Comma-delimited list of namespaces that should not be processed. If unset, all namespaces are processed (except stdlib ones)
    --excluded-ns <string,string,...>
        Comma-delimited list of namespaces that should not be processed. If unset, all namespaces are processed (except stdlib ones)
    --repositories <string,string,...>
        Comma-delimited list of repositories to look in for resolving any provided dependencies
    --dependencies <string,string,...>
        Comma-delimited list of dependencies containing smithy files
    --transformers <string,string,...>
        Comma-delimited list of transformer names to apply to smithy files
    --localJars <path,path,...>
        Comma-delimited list of local JAR files containing smithy files
```