### PR TITLE
Add a message when no files are generated

### DIFF
--- a/modules/codegen-cli/src/smithy4s/codegen/cli/Main.scala
+++ b/modules/codegen-cli/src/smithy4s/codegen/cli/Main.scala
@@ -42,7 +42,19 @@ object Main {
         .parse(args.toList)
         .map {
           case Smithy4sCommand.Generate(args) =>
-            Codegen.processSpecs(args).foreach(out.println)
+            val res = Codegen.processSpecs(args)
+            if (res.isEmpty) {
+              // Printing to stderr because we print generated files path to stdout
+              Console.err.println(
+                List(
+                  "Nothing was generated. Make sure your targetting Smithy files or folders",
+                  "that include Smithy definitions. Otherwise, you can also use",
+                  "--dependencies to pull external JARs or use --local-jars to use",
+                  "JARs located on your file system."
+                ).mkString(" ")
+              )
+            }
+            res.foreach(out.println)
 
           case Smithy4sCommand.DumpModel(args) =>
             out.println(DumpModel.run(args))

--- a/modules/codegen-cli/src/smithy4s/codegen/cli/Options.scala
+++ b/modules/codegen-cli/src/smithy4s/codegen/cli/Options.scala
@@ -91,7 +91,7 @@ object Options {
   val localJarsOpt: Opts[Option[List[os.Path]]] =
     Opts
       .option[List[os.Path]](
-        "localJars",
+        "local-jars",
         "Comma-delimited list of local JAR files containing smithy files"
       )
       .orNone

--- a/modules/codegen-cli/test/src/smithy4s/codegen/cli/CommandParsingSpec.scala
+++ b/modules/codegen-cli/test/src/smithy4s/codegen/cli/CommandParsingSpec.scala
@@ -66,7 +66,7 @@ object CommandParsingSpec extends FunSuite {
         "dep1,dep2",
         "--transformers",
         "t1,t2",
-        "--localJars",
+        "--local-jars",
         "lib1.jar,lib2.jar"
       )
     )
@@ -127,7 +127,7 @@ object CommandParsingSpec extends FunSuite {
         "dep1,dep2",
         "--transformers",
         "t1,t2",
-        "--localJars",
+        "--local-jars",
         "lib1.jar,lib2.jar"
       )
     )

--- a/modules/codegen-plugin/src/smithy4s/codegen/JsonConverters.scala
+++ b/modules/codegen-plugin/src/smithy4s/codegen/JsonConverters.scala
@@ -76,7 +76,7 @@ private[smithy4s] object JsonConverters {
         ("repositories", ca.repositories) :*:
         ("dependencies", ca.dependencies) :*:
         ("transformers", ca.transformers) :*:
-        ("localJars", ca.localJars) :*:
+        ("local-jars", ca.localJars) :*:
         LNil
     },
     {

--- a/modules/codegen-plugin/src/smithy4s/codegen/JsonConverters.scala
+++ b/modules/codegen-plugin/src/smithy4s/codegen/JsonConverters.scala
@@ -76,7 +76,7 @@ private[smithy4s] object JsonConverters {
         ("repositories", ca.repositories) :*:
         ("dependencies", ca.dependencies) :*:
         ("transformers", ca.transformers) :*:
-        ("local-jars", ca.localJars) :*:
+        ("localJars", ca.localJars) :*:
         LNil
     },
     {

--- a/modules/codegen/src/smithy4s/codegen/Codegen.scala
+++ b/modules/codegen/src/smithy4s/codegen/Codegen.scala
@@ -46,7 +46,9 @@ object Codegen { self =>
         scalaFile
       }
       val generatedNamespaces = codegenResult.map(_._2.namespace).distinct
-      val resources = if (!args.skipResources) {
+      val skipResource =
+        args.skipResources || (args.specs.isEmpty && generatedNamespaces.isEmpty)
+      val resources = if (!skipResource) {
         SmithyResources.produce(
           args.resourceOutput,
           args.specs,


### PR DESCRIPTION
References #571 

Also, took the initiative to rename `--localJars` to `--local-jars` so that all flags remain in the same style.

Looks like this:

```
./smithy4s-gen-test generate # built with `cs bootstrap`
Nothing was generated. Make sure your targetting Smithy files or folders that include Smithy definitions. Otherwise, you can also use --dependencies to pull external JARs or use --local-jars to use JARs located on your file system.
```