### PR TITLE
smithy4sInputDirs more conservative default

### DIFF
--- a/modules/codegen-plugin/src/smithy4s/codegen/Smithy4sCodegenPlugin.scala
+++ b/modules/codegen-plugin/src/smithy4s/codegen/Smithy4sCodegenPlugin.scala
@@ -97,8 +97,9 @@ object Smithy4sCodegenPlugin extends AutoPlugin {
 
   // Use this with any configuration to enable the codegen in it.
   def defaultSettings(config: Configuration) = Seq(
-    config / smithy4sInputDirs := (config / unmanagedSourceDirectories).value
-      .map(_.getParentFile() / "smithy"),
+    config / smithy4sInputDirs := Seq(
+      (config / sourceDirectory).value / "smithy"
+    ),
     config / smithy4sOutputDir := (config / sourceManaged).value,
     config / smithy4sResourceDir := (config / resourceManaged).value,
     config / smithy4sCodegen := cachedSmithyCodegen(config).value,


### PR DESCRIPTION
Restores the previous default since `unmanagedSourceDirectories` is not what the average user would need and it causes some unexpected behavior depending on the build setup (as seen on some test projects).