### PR TITLE
Allow credentials in coursier Fetch in the model loader

### DIFF
--- a/modules/codegen/src/smithy4s/codegen/ModelLoader.scala
+++ b/modules/codegen/src/smithy4s/codegen/ModelLoader.scala
@@ -17,6 +17,7 @@
 package smithy4s.codegen
 
 import coursier._
+import coursier.cache.FileCache
 import coursier.parse.DependencyParser
 import coursier.parse.RepositoryParser
 import software.amazon.smithy.build.ProjectionTransformer
@@ -145,7 +146,9 @@ object ModelLoader {
     }
     val resolvedDeps: Seq[java.io.File] =
       if (deps.nonEmpty) {
-        val fetch = Fetch().addRepositories(repos: _*).addDependencies(deps: _*)
+        val fetch = Fetch(FileCache())
+          .addRepositories(repos: _*)
+          .addDependencies(deps: _*)
         fetch.run()
       } else {
         Seq.empty


### PR DESCRIPTION
`Fetch()` uses the default cache, which is `FileCache().noCredentials`. I have no clue why that's the default, given `FileCache()` itself doesn't disable creds.

This enables the use of global credentials / environment variables / Java system properties.

Not easily testable without publishing something that requires credentials, so I'll trust in my manual testing.