### PR TITLE
Fix a NPE when calling getAttributes on a null manifest

### DIFF
--- a/modules/codegen-plugin/src/smithy4s/codegen/Smithy4sCodegenPlugin.scala
+++ b/modules/codegen-plugin/src/smithy4s/codegen/Smithy4sCodegenPlugin.scala
@@ -17,7 +17,6 @@
 package smithy4s.codegen
 
 import sbt.Keys._
-import java.util.jar.JarFile
 import sbt.util.CacheImplicits._
 import sbt.{fileJsonFormatter => _, _}
 import JsonConverters._
@@ -255,18 +254,18 @@ object Smithy4sCodegenPlugin extends AutoPlugin {
   private lazy val simple = raw"([^:]*):([^:]*):([^:]*)".r
   private lazy val cross = raw"([^:]*)::([^:]*):([^:]*)".r
   private def extract(jarFile: java.io.File): Seq[ModuleID] = {
-    val jar = new JarFile(jarFile)
-    Option(
-      jar.getManifest().getMainAttributes().getValue(SMITHY4S_DEPENDENCIES)
-    ).toList.flatMap { listString =>
-      listString
-        .split(",")
-        .collect {
-          case cross(org, art, version)  => org %% art % version
-          case simple(org, art, version) => org % art % version
-        }
-        .toList
-    }
+    JarUtils
+      .extractJarManifestAttribute(jarFile, SMITHY4S_DEPENDENCIES)
+      .toList
+      .flatMap { listString =>
+        listString
+          .split(",")
+          .collect {
+            case cross(org, art, version)  => org %% art % version
+            case simple(org, art, version) => org % art % version
+          }
+          .toList
+      }
   }
 
   def cachedSmithyCodegen(conf: Configuration) = Def.task {

--- a/modules/codegen-plugin/src/smithy4s/codegen/Smithy4sCodegenPlugin.scala
+++ b/modules/codegen-plugin/src/smithy4s/codegen/Smithy4sCodegenPlugin.scala
@@ -255,16 +255,10 @@ object Smithy4sCodegenPlugin extends AutoPlugin {
   private lazy val cross = raw"([^:]*)::([^:]*):([^:]*)".r
   private def extract(jarFile: java.io.File): Seq[ModuleID] = {
     JarUtils
-      .extractJarManifestAttribute(jarFile, SMITHY4S_DEPENDENCIES)
-      .toList
-      .flatMap { listString =>
-        listString
-          .split(",")
-          .collect {
-            case cross(org, art, version)  => org %% art % version
-            case simple(org, art, version) => org % art % version
-          }
-          .toList
+      .extractSmithy4sDependencies(jarFile)
+      .collect {
+        case cross(org, art, version)  => org %% art % version
+        case simple(org, art, version) => org % art % version
       }
   }
 

--- a/modules/codegen/src/smithy4s/codegen/JarUtils.scala
+++ b/modules/codegen/src/smithy4s/codegen/JarUtils.scala
@@ -1,0 +1,29 @@
+/*
+ *  Copyright 2021-2022 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package smithy4s.codegen
+
+import java.util.jar.JarFile
+import java.io.File
+
+object JarUtils {
+  def extractJarManifestAttribute(path: File, key: String): Option[String] = {
+    val jarFile = new JarFile(path)
+    Option(jarFile.getManifest()).flatMap(m =>
+      Option(m.getMainAttributes().getValue(key))
+    )
+  }
+}

--- a/modules/codegen/src/smithy4s/codegen/JarUtils.scala
+++ b/modules/codegen/src/smithy4s/codegen/JarUtils.scala
@@ -26,4 +26,11 @@ object JarUtils {
       Option(m.getMainAttributes().getValue(key))
     )
   }
+
+  def extractSmithy4sDependencies(path: File): List[String] = {
+    extractJarManifestAttribute(path, SMITHY4S_DEPENDENCIES).toList.flatMap {
+      str =>
+        str.split(',').toList
+    }
+  }
 }

--- a/modules/http4s/src/smithy4s/http4s/package.scala
+++ b/modules/http4s/src/smithy4s/http4s/package.scala
@@ -32,7 +32,8 @@ package object http4s extends Compat.Package {
       private[this] val serviceProvider: smithy4s.Service.Provider[Alg]
   ) {
     @deprecated(
-      "this extension method is deprecated ,Use smithy4s.http4s.SimpleRestJsonBuilder"
+      "this extension method is deprecated. Use smithy4s.http4s.SimpleRestJsonBuilder",
+      since = "0.17.0"
     )
     def simpleRestJson: SimpleRestJsonBuilder.ServiceBuilder[Alg] =
       SimpleRestJsonBuilder(serviceProvider)

--- a/modules/http4s/src/smithy4s/http4s/package.scala
+++ b/modules/http4s/src/smithy4s/http4s/package.scala
@@ -28,18 +28,6 @@ import cats.implicits._
 
 package object http4s extends Compat.Package {
 
-  implicit final class ServiceOps[Alg[_[_, _, _, _, _]]](
-      private[this] val serviceProvider: smithy4s.Service.Provider[Alg]
-  ) {
-    @deprecated(
-      "this extension method is deprecated. Use smithy4s.http4s.SimpleRestJsonBuilder",
-      since = "0.17.0"
-    )
-    def simpleRestJson: SimpleRestJsonBuilder.ServiceBuilder[Alg] =
-      SimpleRestJsonBuilder(serviceProvider)
-
-  }
-
   private[smithy4s] def toHttp4sMethod(
       method: SmithyMethod
   ): Either[ParseFailure, Http4sMethod] =

--- a/modules/mill-codegen-plugin/src/smithy4s/codegen/mill/Smithy4sModule.scala
+++ b/modules/mill-codegen-plugin/src/smithy4s/codegen/mill/Smithy4sModule.scala
@@ -113,11 +113,8 @@ trait Smithy4sModule extends ScalaModule {
   def smithy4sExternalCodegenIvyDeps: T[Agg[Dep]] = T {
     resolveDeps(transitiveIvyDeps)().flatMap { pathRef =>
       val deps = JarUtils
-        .extractJarManifestAttribute(pathRef.path.toIO, SMITHY4S_DEPENDENCIES)
-        .toList
-        .flatMap { listString =>
-          listString.split(",").toList.map(dep => ivy"$dep")
-        }
+        .extractSmithy4sDependencies(pathRef.path.toIO)
+        .map(dep => ivy"$dep")
       Agg.from(deps)
     }
   }

--- a/modules/mill-codegen-plugin/src/smithy4s/codegen/mill/Smithy4sModule.scala
+++ b/modules/mill-codegen-plugin/src/smithy4s/codegen/mill/Smithy4sModule.scala
@@ -21,14 +21,18 @@ import mill._
 import mill.api.PathRef
 import mill.define.Sources
 import mill.scalalib._
-import smithy4s.codegen.{CodegenArgs, Codegen => Smithy4s, FileType}
-import smithy4s.codegen.BuildInfo
-import smithy4s.codegen.SMITHY4S_DEPENDENCIES
+import smithy4s.codegen.{
+  CodegenArgs,
+  Codegen => Smithy4s,
+  FileType,
+  BuildInfo,
+  JarUtils,
+  SMITHY4S_DEPENDENCIES
+}
 import mill.modules.Jvm
 import mill.scalalib.CrossVersion.Binary
 import mill.scalalib.CrossVersion.Constant
 import mill.scalalib.CrossVersion.Full
-import java.util.jar.JarFile
 
 trait Smithy4sModule extends ScalaModule {
 
@@ -108,15 +112,12 @@ trait Smithy4sModule extends ScalaModule {
 
   def smithy4sExternalCodegenIvyDeps: T[Agg[Dep]] = T {
     resolveDeps(transitiveIvyDeps)().flatMap { pathRef =>
-      val jarFile = new JarFile(pathRef.path.toIO)
-      val deps = Option(
-        jarFile
-          .getManifest()
-          .getMainAttributes()
-          .getValue(SMITHY4S_DEPENDENCIES)
-      ).toList.flatMap { listString =>
-        listString.split(",").toList.map(dep => ivy"$dep")
-      }
+      val deps = JarUtils
+        .extractJarManifestAttribute(pathRef.path.toIO, SMITHY4S_DEPENDENCIES)
+        .toList
+        .flatMap { listString =>
+          listString.split(",").toList.map(dep => ivy"$dep")
+        }
       Agg.from(deps)
     }
   }


### PR DESCRIPTION
Stack:

```
sbt "clean; compile"
[info] welcome to sbt 1.7.2 (Eclipse Adoptium Java 17.0.2)
[info] loading settings for project global-plugins from revolver.sbt ...
[info] loading global plugins from /Users/David.Francoeur/.sbt/1.0/plugins
[info] loading settings for project http-payload-build-build-build from metals.sbt ...
[info] loading project definition from /Users/David.Francoeur/workspace/dev/trash/http-payload/project/project/project
[info] loading settings for project http-payload-build-build from metals.sbt ...
[info] loading project definition from /Users/David.Francoeur/workspace/dev/trash/http-payload/project/project
[success] Generated .bloop/http-payload-build-build.json
[success] Total time: 0 s, completed Nov. 23, 2022, 9:13:15 p.m.
[info] loading settings for project http-payload-build from metals.sbt,plugins.sbt ...
[info] loading project definition from /Users/David.Francoeur/workspace/dev/trash/http-payload/project
[success] Generated .bloop/http-payload-build.json
[success] Total time: 0 s, completed Nov. 23, 2022, 9:13:16 p.m.
[info] loading settings for project root from build.sbt ...
[info] set current project to http-payload (in build file:/Users/David.Francoeur/workspace/dev/trash/http-payload/)
[success] Total time: 0 s, completed Nov. 23, 2022, 9:13:17 p.m.
[error] java.lang.NullPointerException: Cannot invoke "java.util.jar.Manifest.getMainAttributes()" because the return value of "java.util.jar.JarFile.getManifest()" is null
[error]         at smithy4s.codegen.Smithy4sCodegenPlugin$.extract(Smithy4sCodegenPlugin.scala:260)
[error]         at smithy4s.codegen.Smithy4sCodegenPlugin$.$anonfun$smithy4sFetchUpstreamCodegenDependencies$3(Smithy4sCodegenPlugin.scala:229)
[error]         at scala.collection.immutable.List.flatMap(List.scala:366)
[error]         at smithy4s.codegen.Smithy4sCodegenPlugin$.$anonfun$smithy4sFetchUpstreamCodegenDependencies$1(Smithy4sCodegenPlugin.scala:229)
```