### PR TITLE
Unifies resolution before codegen

### DIFF
--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/custom-settings/test
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/custom-settings/test
@@ -1,4 +1,5 @@
 # check if smithy4sCodegen works
+> show p1/smithy4sAllExternalDependencies
 > p1/compile
 $ exists p1/smithy_output/aws/iam/ActionPermissionDescription.scala
 $ exists p1/smithy_output/smithy4s/example/ObjectService.scala

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/multimodule-aws/test
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/multimodule-aws/test
@@ -1,4 +1,5 @@
 # check if smithy4sCodegen works with libraries that were built with Smithy4s
+> show bar/smithy4sAllExternalDependencies
 > compile
 $ exists foo/target/scala-2.13/src_managed/main/foo/Lambda.scala
 $ absent bar/target/scala-2.13/src_managed/main/foo/Lambda.scala

--- a/modules/codegen-plugin/src/smithy4s/codegen/Smithy4sCodegenPlugin.scala
+++ b/modules/codegen-plugin/src/smithy4s/codegen/Smithy4sCodegenPlugin.scala
@@ -68,7 +68,7 @@ object Smithy4sCodegenPlugin extends AutoPlugin {
           "List of explicitly defined libraries for external dependencies that should be added to the classpath used by Smithy4s during code-generation",
           "The smithy files and smithy validators contained by these jars are included in the Smithy4s code-generation process",
           "Namespaces that were used for code generation in these dependencies will be excluded from code generation in this project.",
-          "By default, this includes the library dependencies of annotated with the `Smithy4s` configuration of the current project and its upstreams"
+          "By default, this includes the library dependencies annotated with the `Smithy4s` configuration of the current project and its upstreams"
         ).mkString(" ")
       )
 

--- a/modules/codegen-plugin/src/smithy4s/codegen/Smithy4sCodegenPlugin.scala
+++ b/modules/codegen-plugin/src/smithy4s/codegen/Smithy4sCodegenPlugin.scala
@@ -95,7 +95,7 @@ object Smithy4sCodegenPlugin extends AutoPlugin {
     val smithy4sAllExternalDependencies =
       taskKey[Seq[ModuleID]](
         List(
-          "Exhaustive list external dependencies that should be added to the classpath used by Smithy4s during code-generation",
+          "Exhaustive list of external dependencies that should be added to the classpath used by Smithy4s during code-generation",
           "The smithy files and smithy validators contained by these jars are included in the Smithy4s code-generation process",
           "Namespaces that were used for code generation in these dependencies will be excluded from code generation in this project."
         ).mkString(" ")

--- a/modules/mill-codegen-plugin/src/smithy4s/codegen/mill/Smithy4sModule.scala
+++ b/modules/mill-codegen-plugin/src/smithy4s/codegen/mill/Smithy4sModule.scala
@@ -107,10 +107,7 @@ trait Smithy4sModule extends ScalaModule {
       .flatten
   }
 
-  private def smithy4sResolvedIvyDeps: T[Agg[PathRef]] =
-    resolveDeps(smithy4sTransitiveIvyDeps)
-
-  def smithy4sExternalCodegenIvyDeps: T[Agg[Dep]] = T {
+  def smithy4sExternallyTrackedIvyDeps: T[Agg[Dep]] = T {
     resolveDeps(transitiveIvyDeps)().flatMap { pathRef =>
       val deps = JarUtils
         .extractSmithy4sDependencies(pathRef.path.toIO)
@@ -119,14 +116,19 @@ trait Smithy4sModule extends ScalaModule {
     }
   }
 
-  private def smithy4sResolvedExternalCodegenIvyDeps: T[Agg[PathRef]] =
-    resolveDeps(smithy4sExternalCodegenIvyDeps)
+  def smithy4sAllExternalDependencies: T[Agg[Dep]] = T {
+    transitiveIvyDeps() ++
+      smithy4sTransitiveIvyDeps() ++
+      smithy4sExternallyTrackedIvyDeps()
+  }
+
+  def smithy4sResolvedAllExternalDependencies: T[Agg[PathRef]] = T {
+    resolveDeps(smithy4sAllExternalDependencies)()
+  }
 
   def smithy4sAllDependenciesAsJars: T[Agg[PathRef]] = T {
-    resolvedIvyDeps() ++
-      smithy4sInternalDependenciesAsJars() ++
-      smithy4sResolvedIvyDeps() ++
-      smithy4sResolvedExternalCodegenIvyDeps()
+    smithy4sInternalDependenciesAsJars() ++
+      smithy4sResolvedAllExternalDependencies()
   }
 
   def smithy4sCodegen: T[(PathRef, PathRef)] = T {


### PR DESCRIPTION
Unifies resolution (via the build tool's resolver) to ensure that there are no conflict resolved jars that are passed to the code-generator. This is done by gather all ModuleIDs before re-running the resolver, in order for it to perform the necessary eviction.

Thus, we only concatenate the jars that come from dependency resolution with the internal jars (which should hardly ever conflict).

Fixes https://github.com/disneystreaming/smithy4s/issues/644 

- [x] SBT 
- [x] Mill 
