### PR TITLE
Remove the Service.Provider construct

### DIFF
--- a/modules/aws-http4s/src/smithy4s/aws/http4s/package.scala
+++ b/modules/aws-http4s/src/smithy4s/aws/http4s/package.scala
@@ -24,7 +24,7 @@ import org.http4s.client.Client
 package object http4s {
 
   implicit final class ServiceOps[Alg[_[_, _, _, _, _]]](
-      private[this] val serviceProvider: smithy4s.Service.Provider[Alg]
+      private[this] val service: smithy4s.Service[Alg]
   ) {
 
     def awsClient[F[_]: Temporal](
@@ -32,7 +32,7 @@ package object http4s {
         awsRegion: AwsRegion
     ): Resource[F, AwsClient[Alg, F]] = for {
       env <- AwsEnvironment.default(AwsHttp4sBackend(client), awsRegion)
-      awsClient <- AwsClient(serviceProvider.service, env)
+      awsClient <- AwsClient(service, env)
     } yield awsClient
 
   }

--- a/modules/compliance-tests/src/smithy4s/compliancetests/HttpProtocolCompliance.scala
+++ b/modules/compliance-tests/src/smithy4s/compliancetests/HttpProtocolCompliance.scala
@@ -30,26 +30,26 @@ object HttpProtocolCompliance {
 
   def clientTests[F[_], Alg[_[_, _, _, _, _]]](
       reverseRouter: ReverseRouter[F],
-      serviceProvider: Service.Provider[Alg]
+      service: Service[Alg]
   )(implicit ce: CompatEffect[F]): List[ComplianceTest[F]] =
     new internals.ClientHttpComplianceTestCase[F, Alg](
       reverseRouter,
-      serviceProvider
+      service
     ).allClientTests()
 
   def serverTests[F[_], Alg[_[_, _, _, _, _]]](
       router: Router[F],
-      serviceProvider: Service.Provider[Alg]
+      service: Service[Alg]
   )(implicit ce: CompatEffect[F]): List[ComplianceTest[F]] =
     new internals.ServerHttpComplianceTestCase[F, Alg](
       router,
-      serviceProvider
+      service
     ).allServerTests()
 
   def clientAndServerTests[F[_], Alg[_[_, _, _, _, _]]](
       router: Router[F] with ReverseRouter[F],
-      serviceProvider: Service.Provider[Alg]
+      service: Service[Alg]
   )(implicit ce: CompatEffect[F]): List[ComplianceTest[F]] =
-    clientTests(router, serviceProvider) ++ serverTests(router, serviceProvider)
+    clientTests(router, service) ++ serverTests(router, service)
 
 }

--- a/modules/compliance-tests/src/smithy4s/compliancetests/internals/ClientHttpComplianceTestCase.scala
+++ b/modules/compliance-tests/src/smithy4s/compliancetests/internals/ClientHttpComplianceTestCase.scala
@@ -44,14 +44,13 @@ private[compliancetests] class ClientHttpComplianceTestCase[
     Alg[_[_, _, _, _, _]]
 ](
     reverseRouter: ReverseRouter[F],
-    serviceProvider: Service.Provider[Alg]
+    serviceInstance: Service[Alg]
 )(implicit ce: CompatEffect[F]) {
   import ce._
   import org.http4s.implicits._
   import reverseRouter._
   private val baseUri = uri"http://localhost/"
-  private[compliancetests] implicit val service: Service[Alg] =
-    serviceProvider.service
+  private[compliancetests] implicit val service: Service[Alg] = serviceInstance
 
   private def matchRequest(
       request: Request[F],

--- a/modules/compliance-tests/src/smithy4s/compliancetests/internals/ServerHttpComplianceTestCase.scala
+++ b/modules/compliance-tests/src/smithy4s/compliancetests/internals/ServerHttpComplianceTestCase.scala
@@ -37,14 +37,14 @@ private[compliancetests] class ServerHttpComplianceTestCase[
     Alg[_[_, _, _, _, _]]
 ](
     router: Router[F],
-    serviceProvider: Service.Provider[Alg]
+    serviceInstance: Service[Alg]
 )(implicit
     ce: CompatEffect[F]
 ) {
   import ce._
   import org.http4s.implicits._
   import router._
-  private[compliancetests] val originalService = serviceProvider.service
+  private[compliancetests] val originalService: Service[Alg] = serviceInstance
   private val baseUri = uri"http://localhost/"
 
   private def makeRequest(

--- a/modules/core/src/smithy4s/Service.scala
+++ b/modules/core/src/smithy4s/Service.scala
@@ -34,7 +34,7 @@ import kinds._
   *   around makes it drastically easier to implement logic generically, without involving
   *   metaprogramming.
   */
-trait Service[Alg[_[_, _, _, _, _]]] extends FunctorK5[Alg] with Service.Provider[Alg] {
+trait Service[Alg[_[_, _, _, _, _]]] extends FunctorK5[Alg] with HasId {
   type Operation[I, E, O, SI, SO]
   type Endpoint[I, E, O, SI, SO] = smithy4s.Endpoint[Operation, I, E, O, SI, SO]
   type Interpreter[F[_, _, _, _, _]] = PolyFunction5[Operation, F]
@@ -63,10 +63,6 @@ object Service {
   def apply[Alg[_[_, _, _, _, _]]](implicit ev: Service[Alg]): ev.type = ev
 
   type Aux[Alg[_[_, _, _, _, _]], Op[_, _, _, _, _]] = Service[Alg]{ type Operation[I, E, O, SI, SO] = Op[I, E, O, SI, SO] }
-
-  trait Provider[Alg[_[_, _, _, _, _]]] extends HasId {
-    def service: Service[Alg]
-  }
 
   trait Mixin[Alg[_[_, _, _, _, _]], Op[_, _, _, _, _]] extends Service[Alg]{
     implicit val serviceInstance: Service[Alg] = this

--- a/modules/http4s/src/smithy4s/http4s/SimpleProtocolBuilder.scala
+++ b/modules/http4s/src/smithy4s/http4s/SimpleProtocolBuilder.scala
@@ -36,8 +36,8 @@ abstract class SimpleProtocolBuilder[P](val codecs: CodecAPI)(implicit
 ) {
 
   def apply[Alg[_[_, _, _, _, _]]](
-      serviceProvider: smithy4s.Service.Provider[Alg]
-  ): ServiceBuilder[Alg] = new ServiceBuilder(serviceProvider.service)
+      service: smithy4s.Service[Alg]
+  ): ServiceBuilder[Alg] = new ServiceBuilder(service)
 
   def routes[Alg[_[_, _, _, _, _]], F[_]](
       impl: FunctorAlgebra[Alg, F]

--- a/modules/test-utils/src/smithy4s/tests/JsonProtocolF.scala
+++ b/modules/test-utils/src/smithy4s/tests/JsonProtocolF.scala
@@ -32,15 +32,15 @@ import smithy4s.kinds._
 class JsonProtocolF[F[_]](implicit F: MonadThrow[F]) {
 
   def dummy[Alg[_[_, _, _, _, _]]](
-      service: Service.Provider[Alg]
+      service: Service[Alg]
   ): Document => F[Document] = {
-    implicit val S: Service[Alg] = service.service
+    implicit val S: Service[Alg] = service
     toJsonF[Alg, S.Operation](DummyService[F].create[Alg])
   }
 
   def redactingProxy[Alg[_[_, _, _, _, _]]](
       jsonF: Document => F[Document],
-      service: Service.Provider[Alg]
+      service: Service[Alg]
   ): Document => F[Document] = {
     implicit val S: Service[Alg] = service.service
     toJsonF[Alg, S.Operation](


### PR DESCRIPTION
I *think* the displacement of `Op` from parameter to member may have helped the tooling, and this is no longer needed 