### PR TITLE
add pprint library to compliance tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -737,7 +737,7 @@ lazy val complianceTests = projectMatrix
         Dependencies.Http4s.circe.value,
         Dependencies.Http4s.client.value,
         Dependencies.Weaver.cats.value % Test,
-        "com.lihaoyi" %% "pprint" % "0.8.1"
+        Dependencies.Pprint.core.value
       )
     },
     Test / smithySpecs := Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -835,7 +835,7 @@ lazy val benchmark = projectMatrix
   )
   .settings(
     libraryDependencies ++= Seq(
-      Dependencies.Circe.generic
+      Dependencies.Circe.generic.value
     ),
     smithySpecs := Seq(
       (ThisBuild / baseDirectory).value / "sampleSpecs" / "benchmark.smithy"

--- a/build.sbt
+++ b/build.sbt
@@ -32,7 +32,7 @@ Global / licenses := Seq(
 sonatypeCredentialHost := "s01.oss.sonatype.org"
 
 ThisBuild / version := {
-  if (!sys.env.contains("CI")) "dev-SNAPSHOT1"
+  if (!sys.env.contains("CI")) "dev-SNAPSHOT"
   else (ThisBuild / version).value
 }
 

--- a/build.sbt
+++ b/build.sbt
@@ -32,7 +32,7 @@ Global / licenses := Seq(
 sonatypeCredentialHost := "s01.oss.sonatype.org"
 
 ThisBuild / version := {
-  if (!sys.env.contains("CI")) "dev-SNAPSHOT"
+  if (!sys.env.contains("CI")) "dev-SNAPSHOT1"
   else (ThisBuild / version).value
 }
 
@@ -735,7 +735,8 @@ lazy val complianceTests = projectMatrix
       ce3 ++ Seq(
         Dependencies.Http4s.circe.value,
         Dependencies.Http4s.client.value,
-        Dependencies.Weaver.cats.value % Test
+        Dependencies.Weaver.cats.value % Test,
+        "com.lihaoyi" %% "pprint" % "0.8.1"
       )
     },
     Test / smithySpecs := Seq(

--- a/modules/compliance-tests/src/smithy4s/compliancetests/internals/Assertions.scala
+++ b/modules/compliance-tests/src/smithy4s/compliancetests/internals/Assertions.scala
@@ -31,7 +31,9 @@ private[internals] object assert {
     if (expected == actual) {
       success
     } else {
-      fail(s"Actual value: $actual was not equal to $expected.")
+      fail(
+        s"Actual value: ${pprint.apply(actual)} was not equal to ${pprint.apply(expected)}."
+      )
     }
   }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -63,6 +63,11 @@ object Dependencies {
     val mainTestkit = "com.lihaoyi" %% "mill-main-testkit" % millVersion % Test
   }
 
+  object Pprint{
+    val pprintVersion = "0.8.1"
+    val core = Def.setting("com.lihaoyi" %%% "pprint" % pprintVersion)
+  }
+
 
   /*
    * we override the version to use the fix included in

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -42,12 +42,6 @@ object Dependencies {
     val generic =  Def.setting("io.circe" %%% "circe-generic" % circeVersion)
   }
 
-  object Circe {
-    val circeVersion = "0.14.1"
-    val parser = "io.circe" %% "circe-parser" % circeVersion
-    val generic = "io.circe" %% "circe-generic" % circeVersion
-  }
-
   object Decline {
     val declineVersion = "2.4.0"
 


### PR DESCRIPTION
If we are ok adding another library, Pprint is helpfult to present as clear evidence as possible of inequality between values when using the Compliance tests