### PR TITLE
Compliance tests jsonfix

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -733,7 +733,7 @@ lazy val complianceTests = projectMatrix
         if (isCE3.value) Seq(Dependencies.CatsEffect3.value)
         else Seq.empty
       ce3 ++ Seq(
-       Dependencies.Circe.parser,
+       Dependencies.Circe.parser.value,
         Dependencies.Http4s.circe.value,
         Dependencies.Http4s.client.value,
         Dependencies.Weaver.cats.value % Test
@@ -833,7 +833,7 @@ lazy val benchmark = projectMatrix
   )
   .settings(
     libraryDependencies ++= Seq(
-      Dependencies.Circe.generic
+      Dependencies.Circe.generic.value
     ),
     smithySpecs := Seq(
       (ThisBuild / baseDirectory).value / "sampleSpecs" / "benchmark.smithy"

--- a/build.sbt
+++ b/build.sbt
@@ -733,6 +733,7 @@ lazy val complianceTests = projectMatrix
         if (isCE3.value) Seq(Dependencies.CatsEffect3.value)
         else Seq.empty
       ce3 ++ Seq(
+       Dependencies.Circe.parser,
         Dependencies.Http4s.circe.value,
         Dependencies.Http4s.client.value,
         Dependencies.Weaver.cats.value % Test
@@ -832,7 +833,7 @@ lazy val benchmark = projectMatrix
   )
   .settings(
     libraryDependencies ++= Seq(
-      Dependencies.Circe.generic.value
+      Dependencies.Circe.generic
     ),
     smithySpecs := Seq(
       (ThisBuild / baseDirectory).value / "sampleSpecs" / "benchmark.smithy"

--- a/modules/compliance-tests/src/smithy4s/compliancetests/internals/Assertions.scala
+++ b/modules/compliance-tests/src/smithy4s/compliancetests/internals/Assertions.scala
@@ -19,19 +19,45 @@ package internals
 
 import cats.implicits._
 import ComplianceTest._
+import io.circe.parser._
 import org.http4s.Headers
 import org.typelevel.ci.CIString
-import smithy.test.{HttpResponseTestCase, HttpRequestTestCase}
+import smithy.test.{HttpRequestTestCase, HttpResponseTestCase}
 
 private[internals] object assert {
   def success: ComplianceResult = Right(())
   def fail(msg: String): ComplianceResult = Left(msg)
+
+  private def isJson(bodyMediaType: Option[String]) =
+    bodyMediaType.exists(_.equalsIgnoreCase("application/json"))
+
+  private def jsonEql(a: String, b: String): ComplianceResult = {
+    (parse(a), parse(b)) match {
+      case (Right(a), Right(b)) if a == b => success
+      case (Left(a), Left(b))   => fail(s"Both JSONs are invalid: $a, $b")
+      case (Left(a), _)         => fail(s"First JSON is invalid: $a")
+      case (_, Left(b))         => fail(s"Second JSON is invalid: $b")
+      case (Right(a), Right(b)) => fail(s"JSONs are not equal: $a, $b")
+    }
+  }
 
   def eql[A](expected: A, actual: A): ComplianceResult = {
     if (expected == actual) {
       success
     } else {
       fail(s"Actual value: $actual was not equal to $expected.")
+    }
+  }
+
+  def bodyEql[A](
+      expected: A,
+      actual: A,
+      bodyMediaType: Option[String]
+  ): ComplianceResult = {
+    if (isJson(bodyMediaType)) {
+      jsonEql(expected.toString, actual.toString)
+    } else {
+      eql(expected, actual)
     }
   }
 

--- a/modules/compliance-tests/src/smithy4s/compliancetests/internals/Assertions.scala
+++ b/modules/compliance-tests/src/smithy4s/compliancetests/internals/Assertions.scala
@@ -49,13 +49,13 @@ private[internals] object assert {
     }
   }
 
-  def bodyEql[A](
-      expected: A,
-      actual: A,
+  def bodyEql(
+      expected: String,
+      actual: String,
       bodyMediaType: Option[String]
   ): ComplianceResult = {
     if (isJson(bodyMediaType)) {
-      jsonEql(expected.toString, actual.toString)
+      jsonEql(expected, actual)
     } else {
       eql(expected, actual)
     }

--- a/modules/compliance-tests/src/smithy4s/compliancetests/internals/ClientHttpComplianceTestCase.scala
+++ b/modules/compliance-tests/src/smithy4s/compliancetests/internals/ClientHttpComplianceTestCase.scala
@@ -237,10 +237,9 @@ private[compliancetests] class ClientHttpComplianceTestCase[
                     .toPolyFunction[R](client)
                     .apply(endpoint.wrap(dummyInput))
                   res.map { output =>
-                    assert.bodyEql(
+                    assert.eql(
                       expectedOutput,
-                      output,
-                      testCase.bodyMediaType
+                      output
                     )
                   }
                 }

--- a/modules/compliance-tests/src/smithy4s/compliancetests/internals/ClientHttpComplianceTestCase.scala
+++ b/modules/compliance-tests/src/smithy4s/compliancetests/internals/ClientHttpComplianceTestCase.scala
@@ -56,10 +56,12 @@ private[compliancetests] class ClientHttpComplianceTestCase[
       request: Request[F],
       testCase: HttpRequestTestCase
   ): F[ComplianceResult] = {
+
     val bodyAssert = testCase.body
       .map { expectedBody =>
         request.bodyText.compile.string.map { responseBody =>
-          assert.eql(expectedBody, responseBody)
+          assert.bodyEql(responseBody, expectedBody, testCase.bodyMediaType)
+
         }
       }
       .getOrElse(assert.success.pure[F])
@@ -234,7 +236,13 @@ private[compliancetests] class ClientHttpComplianceTestCase[
                   val res: F[O] = service
                     .toPolyFunction[R](client)
                     .apply(endpoint.wrap(dummyInput))
-                  res.map { output => assert.eql(expectedOutput, output) }
+                  res.map { output =>
+                    assert.bodyEql(
+                      expectedOutput,
+                      output,
+                      testCase.bodyMediaType
+                    )
+                  }
                 }
             }
           }

--- a/modules/compliance-tests/src/smithy4s/compliancetests/internals/ServerHttpComplianceTestCase.scala
+++ b/modules/compliance-tests/src/smithy4s/compliancetests/internals/ServerHttpComplianceTestCase.scala
@@ -207,7 +207,9 @@ private[compliancetests] class ServerHttpComplianceTestCase[
               }
               .map { case ((actualBody, status), headers) =>
                 val bodyAssert = testCase.body
-                  .map(body => assert.eql(body, actualBody))
+                  .map(body =>
+                    assert.bodyEql(body, actualBody, testCase.bodyMediaType)
+                  )
                 val assertions =
                   bodyAssert.toList :+
                     assert.testCase.checkHeaders(testCase, headers) :+

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -36,6 +36,12 @@ object Dependencies {
       Def.setting("org.typelevel" %%% "cats-core" % "2.8.0")
   }
 
+  object Circe {
+    val circeVersion = "0.14.1"
+    val parser = "io.circe" %% "circe-parser" % circeVersion
+    val generic = "io.circe" %% "circe-generic" % circeVersion
+  }
+
   object Decline {
     val declineVersion = "2.4.0"
 
@@ -57,10 +63,6 @@ object Dependencies {
     val mainTestkit = "com.lihaoyi" %% "mill-main-testkit" % millVersion % Test
   }
 
-  val Circe = new {
-    val generic: Def.Initialize[ModuleID] =
-      Def.setting("io.circe" %%% "circe-generic" % "0.14.3")
-  }
 
   /*
    * we override the version to use the fix included in

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -37,9 +37,9 @@ object Dependencies {
   }
 
   object Circe {
-    val circeVersion = "0.14.1"
-    val parser = "io.circe" %% "circe-parser" % circeVersion
-    val generic = "io.circe" %% "circe-generic" % circeVersion
+    val circeVersion = "0.14.3"
+    val parser =  Def.setting("io.circe" %%% "circe-parser" % circeVersion)
+    val generic =  Def.setting("io.circe" %%% "circe-generic" % circeVersion)
   }
 
   object Decline {


### PR DESCRIPTION
adds dependency on circe for the Compliance tests module
detects when content type is json and the comparison is between 2 strings parse them first using a json parser to remove insignificant characters 