### PR TITLE
Pass scalaModuleInfo to dynamic resolution invocation

### DIFF
--- a/modules/codegen-plugin/src/smithy4s/codegen/Smithy4sCodegenPlugin.scala
+++ b/modules/codegen-plugin/src/smithy4s/codegen/Smithy4sCodegenPlugin.scala
@@ -241,10 +241,11 @@ object Smithy4sCodegenPlugin extends AutoPlugin {
         val depRes = (update / dependencyResolution).value
         val updc = (update / updateConfiguration).value
         val uwconfig = (update / unresolvedWarningConfiguration).value
+        val smInfo = (update / scalaModuleInfo).value
         val modDescr = depRes.moduleDescriptor(
           syntheticModule,
           ids.toVector,
-          None
+          smInfo
         )
 
         depRes


### PR DESCRIPTION
The absence of this information seems to trigger (hard to reproduce) edge-cases. 