### PR TITLE
fix for timestamp format issue for aws tests

### DIFF
--- a/modules/compliance-tests/src/smithy4s/compliancetests/internals/ClientHttpComplianceTestCase.scala
+++ b/modules/compliance-tests/src/smithy4s/compliancetests/internals/ClientHttpComplianceTestCase.scala
@@ -107,7 +107,8 @@ private[compliancetests] class ClientHttpComplianceTestCase[
   ): ComplianceTest[F] = {
     type R[I_, E_, O_, SE_, SO_] = F[O_]
 
-    val inputFromDocument = Document.Decoder.fromSchema(endpoint.input)
+    val revisedSchema = mapAllTimestampsToEpoch(endpoint.input)
+    val inputFromDocument = Document.Decoder.fromSchema(revisedSchema)
     ComplianceTest[F](
       name = endpoint.id.toString + "(client|request): " + testCase.id,
       run = {
@@ -164,11 +165,11 @@ private[compliancetests] class ClientHttpComplianceTestCase[
     ComplianceTest[F](
       name = endpoint.id.toString + "(client|response): " + testCase.id,
       run = {
-
+        val revisedSchema = mapAllTimestampsToEpoch(endpoint.output)
         val buildResult: Either[Document => F[Throwable], Document => F[O]] = {
           errorSchema
             .toLeft {
-              val outputDecoder = Document.Decoder.fromSchema(endpoint.output)
+              val outputDecoder = Document.Decoder.fromSchema(revisedSchema)
               (doc: Document) =>
                 outputDecoder
                   .decode(doc)

--- a/modules/compliance-tests/src/smithy4s/compliancetests/internals/ServerHttpComplianceTestCase.scala
+++ b/modules/compliance-tests/src/smithy4s/compliancetests/internals/ServerHttpComplianceTestCase.scala
@@ -103,7 +103,8 @@ private[compliancetests] class ServerHttpComplianceTestCase[
       testCase: HttpRequestTestCase
   ): ComplianceTest[F] = {
 
-    val inputFromDocument = Document.Decoder.fromSchema(endpoint.input)
+    val revisedSchema = mapAllTimestampsToEpoch(endpoint.input)
+    val inputFromDocument = Document.Decoder.fromSchema(revisedSchema)
     ComplianceTest[F](
       name = endpoint.id.toString + "(server|request): " + testCase.id,
       run = {
@@ -157,7 +158,9 @@ private[compliancetests] class ServerHttpComplianceTestCase[
         val buildResult: Either[Document => F[Throwable], Document => F[O]] = {
           errorSchema
             .toLeft {
-              val outputDecoder = Document.Decoder.fromSchema(endpoint.output)
+              val outputDecoder = Document.Decoder.fromSchema(
+                mapAllTimestampsToEpoch(endpoint.output)
+              )
               (doc: Document) =>
                 outputDecoder
                   .decode(doc)

--- a/modules/compliance-tests/src/smithy4s/compliancetests/internals/package.scala
+++ b/modules/compliance-tests/src/smithy4s/compliancetests/internals/package.scala
@@ -1,0 +1,32 @@
+/*
+ *  Copyright 2021-2022 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package smithy4s.compliancetests
+
+import smithy4s.Hints
+import smithy4s.schema.Schema
+
+package object internals {
+
+  // Due to AWS's usage of integer as the canonical representation of a Timestamp in smithy , we need to provide the decoder with instructions to use a Long instead.
+  // therefore the timestamp type is switched to type epochSeconds: Long
+  // This is just a workaround thats limited to testing scenarios
+  def mapAllTimestampsToEpoch[A](schema: Schema[A]): Schema[A] = {
+    schema.transformHintsTransitively(h =>
+      h.++(Hints(smithy.api.TimestampFormat.EPOCH_SECONDS.widen))
+    )
+  }
+}


### PR DESCRIPTION
maps transitively the Hints on a schema and adds a Epoch timestamp format hint