### PR TITLE
Various codegen fixes and improvements 

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -733,7 +733,7 @@ lazy val complianceTests = projectMatrix
         if (isCE3.value) Seq(Dependencies.CatsEffect3.value)
         else Seq.empty
       ce3 ++ Seq(
-       Dependencies.Circe.parser.value,
+        Dependencies.Circe.parser.value,
         Dependencies.Http4s.circe.value,
         Dependencies.Http4s.client.value,
         Dependencies.Weaver.cats.value % Test,
@@ -784,7 +784,8 @@ lazy val example = projectMatrix
       (ThisBuild / baseDirectory).value / "sampleSpecs" / "namecollision.smithy",
       (ThisBuild / baseDirectory).value / "sampleSpecs" / "mixins.smithy",
       (ThisBuild / baseDirectory).value / "sampleSpecs" / "defaults.smithy",
-      (ThisBuild / baseDirectory).value / "sampleSpecs" / "quoted_string.smithy"
+      (ThisBuild / baseDirectory).value / "sampleSpecs" / "quoted_string.smithy",
+      (ThisBuild / baseDirectory).value / "sampleSpecs" / "numeric.smithy"
     ),
     Compile / resourceDirectory := (ThisBuild / baseDirectory).value / "modules" / "example" / "resources",
     isCE3 := true,

--- a/modules/codegen/src/smithy4s/codegen/internals/Renderer.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/Renderer.scala
@@ -1003,7 +1003,7 @@ private[internals] class Renderer(compilationUnit: CompilationUnit) { self =>
           def nullNode(x: NullNode): Line =
             line"smithy4s.Document.nullDoc"
           def numberNode(x: NumberNode): Line =
-            line"smithy4s.Document.fromDouble(${x.getValue.doubleValue()})"
+            line"smithy4s.Document.fromDouble(${x.getValue.doubleValue()}d)"
           def objectNode(x: ObjectNode): Line = {
             val members = x.getMembers.asScala.map { member =>
               val key = s""""${member._1.getValue()}""""

--- a/modules/codegen/src/smithy4s/codegen/internals/Renderer.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/Renderer.scala
@@ -72,19 +72,18 @@ private[internals] object Renderer {
         .filter(_._2.size > 1)
         .keySet
 
-      val allImports: List[String] = renderResult.list
-        .flatMap { line =>
-          line.segments.toList.collect {
-            case nameRef @ NameRef(pkg, _, _)
-                if pkg.nonEmpty && !nameCollisions.contains(
-                  nameRef.getNamePrefix
-                )
-                  && !nameRef.isAutoImported &&
-                  !pkg.mkString(".").equalsIgnoreCase(unit.namespace) =>
-              nameRef.show
-            case Import(value) => value
-          }
+      val allImports: List[String] = renderResult.list.flatMap { line =>
+        line.segments.toList.collect {
+          case nameRef @ NameRef(pkg, _, _)
+              if pkg.nonEmpty && !nameCollisions.contains(
+                nameRef.getNamePrefix
+              )
+                && !nameRef.isAutoImported &&
+                !pkg.mkString(".").equalsIgnoreCase(unit.namespace) =>
+            nameRef.show
+          case Import(value) => value
         }
+      }
 
       val code: List[String] = renderResult.list
         .map { line =>
@@ -990,9 +989,9 @@ private[internals] class Renderer(compilationUnit: CompilationUnit) { self =>
         (bd: BigDecimal) => line"scala.math.BigDecimal($bd)"
       case Primitive.BigInteger => (bi: BigInt) => line"scala.math.BigInt($bi)"
       case Primitive.Unit       => _ => line"()"
-      case Primitive.Double     => t => line"${t.toString}"
-      case Primitive.Float      => t => line"${t.toString}"
-      case Primitive.Long       => t => line"${t.toString}"
+      case Primitive.Double     => t => line"${t.toString}d"
+      case Primitive.Float      => t => line"${t.toString}f"
+      case Primitive.Long       => t => line"${t.toString}L"
       case Primitive.Int        => t => line"${t.toString}"
       case Primitive.Short      => t => line"${t.toString}"
       case Primitive.Bool       => t => line"${t.toString}"

--- a/modules/codegen/src/smithy4s/codegen/internals/Renderer.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/Renderer.scala
@@ -98,7 +98,7 @@ private[internals] object Renderer {
         }
 
       val allLines: List[String] = List(p, "") ++
-        allImports.toSet.map("import " + _) ++
+        allImports.distinct.sorted.map("import " + _) ++
         List("") ++ code
 
       val content = allLines.mkString(System.lineSeparator())

--- a/modules/codegen/test/src/smithy4s/codegen/internals/DefaultRenderModeSpec.scala
+++ b/modules/codegen/test/src/smithy4s/codegen/internals/DefaultRenderModeSpec.scala
@@ -36,12 +36,12 @@ final class DefaultRenderModeSpec extends munit.FunSuite {
     val scalaCode =
       """|package foo
          |
-         |import smithy4s.Schema
          |import smithy4s.Hints
-         |import smithy4s.schema.Schema.string
+         |import smithy4s.Schema
          |import smithy4s.ShapeId
-         |import smithy4s.schema.Schema.struct
          |import smithy4s.ShapeTag
+         |import smithy4s.schema.Schema.string
+         |import smithy4s.schema.Schema.struct
          |
          |case class Test(one: Option[String], two: String, three: String)
          |object Test extends ShapeTag.Companion[Test] {
@@ -79,12 +79,12 @@ final class DefaultRenderModeSpec extends munit.FunSuite {
     val scalaCode =
       """|package foo
          |
-         |import smithy4s.Schema
          |import smithy4s.Hints
-         |import smithy4s.schema.Schema.string
+         |import smithy4s.Schema
          |import smithy4s.ShapeId
-         |import smithy4s.schema.Schema.struct
          |import smithy4s.ShapeTag
+         |import smithy4s.schema.Schema.string
+         |import smithy4s.schema.Schema.struct
          |
          |case class Test(two: String, three: String, one: Option[String] = None)
          |object Test extends ShapeTag.Companion[Test] {
@@ -122,12 +122,12 @@ final class DefaultRenderModeSpec extends munit.FunSuite {
     val scalaCode =
       """|package foo
          |
-         |import smithy4s.Schema
          |import smithy4s.Hints
-         |import smithy4s.schema.Schema.string
+         |import smithy4s.Schema
          |import smithy4s.ShapeId
-         |import smithy4s.schema.Schema.struct
          |import smithy4s.ShapeTag
+         |import smithy4s.schema.Schema.string
+         |import smithy4s.schema.Schema.struct
          |
          |case class Test(three: String, two: String = "test", one: Option[String] = None)
          |object Test extends ShapeTag.Companion[Test] {

--- a/modules/example/src/smithy4s/example/AString.scala
+++ b/modules/example/src/smithy4s/example/AString.scala
@@ -1,11 +1,11 @@
 package smithy4s.example
 
-import smithy4s.Schema
 import smithy4s.Hints
-import smithy4s.schema.Schema.string
+import smithy4s.Newtype
+import smithy4s.Schema
 import smithy4s.ShapeId
 import smithy4s.schema.Schema.bijection
-import smithy4s.Newtype
+import smithy4s.schema.Schema.string
 
 object AString extends Newtype[String] {
   val id: ShapeId = ShapeId("smithy4s.example", "AString")

--- a/modules/example/src/smithy4s/example/AStructure.scala
+++ b/modules/example/src/smithy4s/example/AStructure.scala
@@ -1,10 +1,10 @@
 package smithy4s.example
 
-import smithy4s.Schema
 import smithy4s.Hints
+import smithy4s.Schema
 import smithy4s.ShapeId
-import smithy4s.schema.Schema.struct
 import smithy4s.ShapeTag
+import smithy4s.schema.Schema.struct
 
 case class AStructure(astring: AString = smithy4s.example.AString("\"Hello World\" with \"quotes\""))
 object AStructure extends ShapeTag.Companion[AStructure] {

--- a/modules/example/src/smithy4s/example/AddBrandsInput.scala
+++ b/modules/example/src/smithy4s/example/AddBrandsInput.scala
@@ -1,11 +1,11 @@
 package smithy4s.example
 
-import smithy4s.Schema
 import smithy4s.Hints
+import smithy4s.Schema
 import smithy4s.ShapeId
+import smithy4s.ShapeTag
 import smithy4s.example.common.BrandList
 import smithy4s.schema.Schema.struct
-import smithy4s.ShapeTag
 
 case class AddBrandsInput(brands: Option[List[String]] = None)
 object AddBrandsInput extends ShapeTag.Companion[AddBrandsInput] {

--- a/modules/example/src/smithy4s/example/Age.scala
+++ b/modules/example/src/smithy4s/example/Age.scala
@@ -1,12 +1,12 @@
 package smithy4s.example
 
-import smithy4s.schema.Schema.int
 import smithy4s.Hints
-import smithy4s.ShapeId
-import smithy4s.schema.Schema.bijection
 import smithy4s.Newtype
-import smithy4s.example.refined.Age.provider._
 import smithy4s.Schema
+import smithy4s.ShapeId
+import smithy4s.example.refined.Age.provider._
+import smithy4s.schema.Schema.bijection
+import smithy4s.schema.Schema.int
 
 object Age extends Newtype[smithy4s.example.refined.Age] {
   val id: ShapeId = ShapeId("smithy4s.example", "Age")

--- a/modules/example/src/smithy4s/example/Age.scala
+++ b/modules/example/src/smithy4s/example/Age.scala
@@ -11,7 +11,7 @@ import smithy4s.schema.Schema.int
 object Age extends Newtype[smithy4s.example.refined.Age] {
   val id: ShapeId = ShapeId("smithy4s.example", "Age")
   val hints : Hints = Hints(
-    smithy.api.Default(smithy4s.Document.fromDouble(0.0)),
+    smithy.api.Default(smithy4s.Document.fromDouble(0.0d)),
   )
   val underlyingSchema : Schema[smithy4s.example.refined.Age] = int.refined[smithy4s.example.refined.Age](smithy4s.example.AgeFormat()).withId(id).addHints(hints)
   implicit val schema : Schema[Age] = bijection(underlyingSchema, asBijection)

--- a/modules/example/src/smithy4s/example/AgeFormat.scala
+++ b/modules/example/src/smithy4s/example/AgeFormat.scala
@@ -1,10 +1,10 @@
 package smithy4s.example
 
+import smithy4s.Hints
 import smithy4s.Schema
 import smithy4s.ShapeId
 import smithy4s.ShapeTag
 import smithy4s.schema.Schema.constant
-import smithy4s.Hints
 
 case class AgeFormat()
 object AgeFormat extends ShapeTag.Companion[AgeFormat] {

--- a/modules/example/src/smithy4s/example/ArbitraryData.scala
+++ b/modules/example/src/smithy4s/example/ArbitraryData.scala
@@ -1,13 +1,13 @@
 package smithy4s.example
 
-import smithy4s.Schema
-import smithy4s.Hints
-import smithy4s.ShapeId
-import smithy4s.schema.Schema.recursive
-import smithy4s.schema.Schema.bijection
 import smithy4s.Document
+import smithy4s.Hints
 import smithy4s.Newtype
+import smithy4s.Schema
+import smithy4s.ShapeId
+import smithy4s.schema.Schema.bijection
 import smithy4s.schema.Schema.document
+import smithy4s.schema.Schema.recursive
 
 object ArbitraryData extends Newtype[Document] {
   val id: ShapeId = ShapeId("smithy4s.example", "arbitraryData")

--- a/modules/example/src/smithy4s/example/ArbitraryDataTest.scala
+++ b/modules/example/src/smithy4s/example/ArbitraryDataTest.scala
@@ -1,10 +1,10 @@
 package smithy4s.example
 
+import smithy4s.Hints
 import smithy4s.Schema
 import smithy4s.ShapeId
 import smithy4s.ShapeTag
 import smithy4s.schema.Schema.constant
-import smithy4s.Hints
 
 case class ArbitraryDataTest()
 object ArbitraryDataTest extends ShapeTag.Companion[ArbitraryDataTest] {

--- a/modules/example/src/smithy4s/example/ArbitraryDataTest.scala
+++ b/modules/example/src/smithy4s/example/ArbitraryDataTest.scala
@@ -11,7 +11,7 @@ object ArbitraryDataTest extends ShapeTag.Companion[ArbitraryDataTest] {
   val id: ShapeId = ShapeId("smithy4s.example", "ArbitraryDataTest")
 
   val hints : Hints = Hints(
-    smithy4s.example.ArbitraryData(smithy4s.Document.obj("str" -> smithy4s.Document.fromString("hello"), "int" -> smithy4s.Document.fromDouble(1.0), "bool" -> smithy4s.Document.fromBoolean(true), "arr" -> smithy4s.Document.array(smithy4s.Document.fromString("one"), smithy4s.Document.fromString("two"), smithy4s.Document.fromString("three")), "obj" -> smithy4s.Document.obj("str" -> smithy4s.Document.fromString("s"), "i" -> smithy4s.Document.fromDouble(1.0)))),
+    smithy4s.example.ArbitraryData(smithy4s.Document.obj("str" -> smithy4s.Document.fromString("hello"), "int" -> smithy4s.Document.fromDouble(1.0d), "bool" -> smithy4s.Document.fromBoolean(true), "arr" -> smithy4s.Document.array(smithy4s.Document.fromString("one"), smithy4s.Document.fromString("two"), smithy4s.Document.fromString("three")), "obj" -> smithy4s.Document.obj("str" -> smithy4s.Document.fromString("s"), "i" -> smithy4s.Document.fromDouble(1.0d)))),
   )
 
   implicit val schema: Schema[ArbitraryDataTest] = constant(ArbitraryDataTest()).withId(id).addHints(hints)

--- a/modules/example/src/smithy4s/example/BrandService.scala
+++ b/modules/example/src/smithy4s/example/BrandService.scala
@@ -1,15 +1,15 @@
 package smithy4s.example
 
-import smithy4s.Schema
-import smithy4s.schema.Schema.unit
-import smithy4s.kinds.PolyFunction5
-import smithy4s.Transformation
-import smithy4s.Service
-import smithy4s.kinds.toPolyFunction5.const5
-import smithy4s.Hints
-import smithy4s.StreamingSchema
-import smithy4s.ShapeId
 import smithy4s.Endpoint
+import smithy4s.Hints
+import smithy4s.Schema
+import smithy4s.Service
+import smithy4s.ShapeId
+import smithy4s.StreamingSchema
+import smithy4s.Transformation
+import smithy4s.kinds.PolyFunction5
+import smithy4s.kinds.toPolyFunction5.const5
+import smithy4s.schema.Schema.unit
 
 trait BrandServiceGen[F[_, _, _, _, _]] {
   self =>

--- a/modules/example/src/smithy4s/example/BucketName.scala
+++ b/modules/example/src/smithy4s/example/BucketName.scala
@@ -1,11 +1,11 @@
 package smithy4s.example
 
-import smithy4s.Schema
 import smithy4s.Hints
-import smithy4s.schema.Schema.string
+import smithy4s.Newtype
+import smithy4s.Schema
 import smithy4s.ShapeId
 import smithy4s.schema.Schema.bijection
-import smithy4s.Newtype
+import smithy4s.schema.Schema.string
 
 object BucketName extends Newtype[String] {
   val id: ShapeId = ShapeId("smithy4s.example", "BucketName")

--- a/modules/example/src/smithy4s/example/Candy.scala
+++ b/modules/example/src/smithy4s/example/Candy.scala
@@ -1,11 +1,11 @@
 package smithy4s.example
 
-import smithy4s.Schema
 import smithy4s.Hints
-import smithy4s.schema.Schema.string
+import smithy4s.Schema
 import smithy4s.ShapeId
-import smithy4s.schema.Schema.struct
 import smithy4s.ShapeTag
+import smithy4s.schema.Schema.string
+import smithy4s.schema.Schema.struct
 
 case class Candy(name: Option[String] = None)
 object Candy extends ShapeTag.Companion[Candy] {

--- a/modules/example/src/smithy4s/example/DefaultInMixinUsageTest.scala
+++ b/modules/example/src/smithy4s/example/DefaultInMixinUsageTest.scala
@@ -1,11 +1,11 @@
 package smithy4s.example
 
-import smithy4s.Schema
 import smithy4s.Hints
-import smithy4s.schema.Schema.string
+import smithy4s.Schema
 import smithy4s.ShapeId
-import smithy4s.schema.Schema.struct
 import smithy4s.ShapeTag
+import smithy4s.schema.Schema.string
+import smithy4s.schema.Schema.struct
 
 case class DefaultInMixinUsageTest(one: String = "test") extends DefaultInMixinTest
 object DefaultInMixinUsageTest extends ShapeTag.Companion[DefaultInMixinUsageTest] {

--- a/modules/example/src/smithy4s/example/DefaultOrderingTest.scala
+++ b/modules/example/src/smithy4s/example/DefaultOrderingTest.scala
@@ -16,7 +16,7 @@ object DefaultOrderingTest extends ShapeTag.Companion[DefaultOrderingTest] {
 
   implicit val schema: Schema[DefaultOrderingTest] = struct(
     string.required[DefaultOrderingTest]("three", _.three).addHints(smithy.api.Required()),
-    int.required[DefaultOrderingTest]("one", _.one).addHints(smithy.api.Default(smithy4s.Document.fromDouble(1.0))),
+    int.required[DefaultOrderingTest]("one", _.one).addHints(smithy.api.Default(smithy4s.Document.fromDouble(1.0d))),
     string.optional[DefaultOrderingTest]("two", _.two),
   ){
     DefaultOrderingTest.apply

--- a/modules/example/src/smithy4s/example/DefaultOrderingTest.scala
+++ b/modules/example/src/smithy4s/example/DefaultOrderingTest.scala
@@ -1,12 +1,12 @@
 package smithy4s.example
 
-import smithy4s.Schema
-import smithy4s.schema.Schema.int
 import smithy4s.Hints
-import smithy4s.schema.Schema.string
+import smithy4s.Schema
 import smithy4s.ShapeId
-import smithy4s.schema.Schema.struct
 import smithy4s.ShapeTag
+import smithy4s.schema.Schema.int
+import smithy4s.schema.Schema.string
+import smithy4s.schema.Schema.struct
 
 case class DefaultOrderingTest(three: String, one: Int = 1, two: Option[String] = None)
 object DefaultOrderingTest extends ShapeTag.Companion[DefaultOrderingTest] {

--- a/modules/example/src/smithy4s/example/DefaultTest.scala
+++ b/modules/example/src/smithy4s/example/DefaultTest.scala
@@ -15,7 +15,7 @@ object DefaultTest extends ShapeTag.Companion[DefaultTest] {
   val hints : Hints = Hints.empty
 
   implicit val schema: Schema[DefaultTest] = struct(
-    int.required[DefaultTest]("one", _.one).addHints(smithy.api.Default(smithy4s.Document.fromDouble(1.0))),
+    int.required[DefaultTest]("one", _.one).addHints(smithy.api.Default(smithy4s.Document.fromDouble(1.0d))),
     string.required[DefaultTest]("two", _.two).addHints(smithy.api.Default(smithy4s.Document.fromString("test"))),
     StringList.underlyingSchema.required[DefaultTest]("three", _.three).addHints(smithy.api.Default(smithy4s.Document.array())),
   ){

--- a/modules/example/src/smithy4s/example/DefaultTest.scala
+++ b/modules/example/src/smithy4s/example/DefaultTest.scala
@@ -1,12 +1,12 @@
 package smithy4s.example
 
-import smithy4s.Schema
-import smithy4s.schema.Schema.int
 import smithy4s.Hints
-import smithy4s.schema.Schema.string
+import smithy4s.Schema
 import smithy4s.ShapeId
-import smithy4s.schema.Schema.struct
 import smithy4s.ShapeTag
+import smithy4s.schema.Schema.int
+import smithy4s.schema.Schema.string
+import smithy4s.schema.Schema.struct
 
 case class DefaultTest(one: Int = 1, two: String = "test", three: List[String] = List())
 object DefaultTest extends ShapeTag.Companion[DefaultTest] {

--- a/modules/example/src/smithy4s/example/DeprecatedService.scala
+++ b/modules/example/src/smithy4s/example/DeprecatedService.scala
@@ -4,11 +4,12 @@ import smithy4s.Schema
 import smithy4s.schema.Schema.unit
 import smithy4s.kinds.PolyFunction5
 import smithy4s.Transformation
-import smithy4s.ShapeId
 import smithy4s.Service
 import smithy4s.kinds.toPolyFunction5.const5
 import smithy4s.Hints
 import smithy4s.StreamingSchema
+import smithy4s.ShapeId
+import smithy4s.Endpoint
 
 @deprecated
 trait DeprecatedServiceGen[F[_, _, _, _, _]] {
@@ -41,9 +42,7 @@ object DeprecatedServiceGen extends Service.Mixin[DeprecatedServiceGen, Deprecat
 
   val version: String = ""
 
-  def endpoint[I, E, O, SI, SO](op : DeprecatedServiceOperation[I, E, O, SI, SO]) = op match {
-    case DeprecatedOperation() => ((), DeprecatedOperation)
-  }
+  def endpoint[I, E, O, SI, SO](op : DeprecatedServiceOperation[I, E, O, SI, SO]) = op.endpoint
 
   object reified extends DeprecatedServiceGen[DeprecatedServiceOperation] {
     def deprecatedOperation() = DeprecatedOperation()
@@ -60,11 +59,12 @@ object DeprecatedServiceGen extends Service.Mixin[DeprecatedServiceGen, Deprecat
   type Default[F[+_]] = Constant[smithy4s.kinds.stubs.Kind1[F]#toKind5]
 
   def toPolyFunction[P[_, _, _, _, _]](impl : DeprecatedServiceGen[P]): PolyFunction5[DeprecatedServiceOperation, P] = new PolyFunction5[DeprecatedServiceOperation, P] {
-    def apply[I, E, O, SI, SO](op : DeprecatedServiceOperation[I, E, O, SI, SO]) : P[I, E, O, SI, SO] = op match  {
-      case DeprecatedOperation() => impl.deprecatedOperation()
-    }
+    def apply[I, E, O, SI, SO](op : DeprecatedServiceOperation[I, E, O, SI, SO]) : P[I, E, O, SI, SO] = op.run(impl) 
   }
-  case class DeprecatedOperation() extends DeprecatedServiceOperation[Unit, Nothing, Unit, Nothing, Nothing]
+  case class DeprecatedOperation() extends DeprecatedServiceOperation[Unit, Nothing, Unit, Nothing, Nothing] {
+    def run[F[_, _, _, _, _]](impl: DeprecatedServiceGen[F]): F[Unit, Nothing, Unit, Nothing, Nothing] = impl.deprecatedOperation()
+    def endpoint: (Unit, Endpoint[Unit, Nothing, Unit, Nothing, Nothing]) = ((), DeprecatedOperation)
+  }
   object DeprecatedOperation extends DeprecatedServiceGen.Endpoint[Unit, Nothing, Unit, Nothing, Nothing] {
     val id: ShapeId = ShapeId("smithy4s.example", "DeprecatedOperation")
     val input: Schema[Unit] = unit.addHints(smithy4s.internals.InputOutput.Input.widen)
@@ -78,4 +78,7 @@ object DeprecatedServiceGen extends Service.Mixin[DeprecatedServiceGen, Deprecat
   }
 }
 
-sealed trait DeprecatedServiceOperation[Input, Err, Output, StreamedInput, StreamedOutput]
+sealed trait DeprecatedServiceOperation[Input, Err, Output, StreamedInput, StreamedOutput] {
+  def run[F[_, _, _, _, _]](impl: DeprecatedServiceGen[F]): F[Input, Err, Output, StreamedInput, StreamedOutput]
+  def endpoint: (Input, Endpoint[DeprecatedServiceOperation, Input, Err, Output, StreamedInput, StreamedOutput])
+}

--- a/modules/example/src/smithy4s/example/DeprecatedService.scala
+++ b/modules/example/src/smithy4s/example/DeprecatedService.scala
@@ -1,15 +1,15 @@
 package smithy4s.example
 
-import smithy4s.Schema
-import smithy4s.schema.Schema.unit
-import smithy4s.kinds.PolyFunction5
-import smithy4s.Transformation
-import smithy4s.Service
-import smithy4s.kinds.toPolyFunction5.const5
-import smithy4s.Hints
-import smithy4s.StreamingSchema
-import smithy4s.ShapeId
 import smithy4s.Endpoint
+import smithy4s.Hints
+import smithy4s.Schema
+import smithy4s.Service
+import smithy4s.ShapeId
+import smithy4s.StreamingSchema
+import smithy4s.Transformation
+import smithy4s.kinds.PolyFunction5
+import smithy4s.kinds.toPolyFunction5.const5
+import smithy4s.schema.Schema.unit
 
 @deprecated
 trait DeprecatedServiceGen[F[_, _, _, _, _]] {

--- a/modules/example/src/smithy4s/example/DeprecatedString.scala
+++ b/modules/example/src/smithy4s/example/DeprecatedString.scala
@@ -1,11 +1,11 @@
 package smithy4s.example
 
-import smithy4s.Schema
 import smithy4s.Hints
-import smithy4s.schema.Schema.string
+import smithy4s.Newtype
+import smithy4s.Schema
 import smithy4s.ShapeId
 import smithy4s.schema.Schema.bijection
-import smithy4s.Newtype
+import smithy4s.schema.Schema.string
 
 @deprecated
 object DeprecatedString extends Newtype[String] {

--- a/modules/example/src/smithy4s/example/DeprecatedStructure.scala
+++ b/modules/example/src/smithy4s/example/DeprecatedStructure.scala
@@ -1,11 +1,11 @@
 package smithy4s.example
 
-import smithy4s.Schema
 import smithy4s.Hints
-import smithy4s.schema.Schema.string
+import smithy4s.Schema
 import smithy4s.ShapeId
-import smithy4s.schema.Schema.struct
 import smithy4s.ShapeTag
+import smithy4s.schema.Schema.string
+import smithy4s.schema.Schema.struct
 
 @deprecated(message = "A compelling reason", since = "0.0.1")
 case class DeprecatedStructure(@deprecated name: Option[String] = None, nameV2: Option[String] = None, strings: Option[List[String]] = None)

--- a/modules/example/src/smithy4s/example/DeprecatedUnion.scala
+++ b/modules/example/src/smithy4s/example/DeprecatedUnion.scala
@@ -1,13 +1,13 @@
 package smithy4s.example
 
+import smithy4s.Hints
 import smithy4s.Schema
-import smithy4s.schema.Schema.string
 import smithy4s.ShapeId
 import smithy4s.ShapeTag
 import smithy4s.schema.Schema.bijection
-import smithy4s.schema.Schema.union
 import smithy4s.schema.Schema.constant
-import smithy4s.Hints
+import smithy4s.schema.Schema.string
+import smithy4s.schema.Schema.union
 
 @deprecated(message = "A compelling reason", since = "0.0.1")
 sealed trait DeprecatedUnion extends scala.Product with scala.Serializable {

--- a/modules/example/src/smithy4s/example/DogName.scala
+++ b/modules/example/src/smithy4s/example/DogName.scala
@@ -1,11 +1,11 @@
 package smithy4s.example
 
-import smithy4s.Schema
 import smithy4s.Hints
-import smithy4s.ShapeId
-import smithy4s.schema.Schema.bijection
 import smithy4s.Newtype
+import smithy4s.Schema
+import smithy4s.ShapeId
 import smithy4s.example.refined.Name
+import smithy4s.schema.Schema.bijection
 import smithy4s.schema.Schema.string
 
 object DogName extends Newtype[Name] {

--- a/modules/example/src/smithy4s/example/EnumWithDeprecations.scala
+++ b/modules/example/src/smithy4s/example/EnumWithDeprecations.scala
@@ -1,8 +1,8 @@
 package smithy4s.example
 
-import smithy4s.Schema
 import smithy4s.Enumeration
 import smithy4s.Hints
+import smithy4s.Schema
 import smithy4s.ShapeId
 import smithy4s.ShapeTag
 import smithy4s.schema.Schema.enumeration

--- a/modules/example/src/smithy4s/example/FaceCard.scala
+++ b/modules/example/src/smithy4s/example/FaceCard.scala
@@ -1,9 +1,9 @@
 package smithy4s.example
 
-import smithy4s.IntEnum
-import smithy4s.Schema
 import smithy4s.Enumeration
 import smithy4s.Hints
+import smithy4s.IntEnum
+import smithy4s.Schema
 import smithy4s.ShapeId
 import smithy4s.ShapeTag
 import smithy4s.schema.Schema.enumeration

--- a/modules/example/src/smithy4s/example/FancyList.scala
+++ b/modules/example/src/smithy4s/example/FancyList.scala
@@ -1,12 +1,12 @@
 package smithy4s.example
 
-import smithy4s.Schema
-import smithy4s.schema.Schema.list
 import smithy4s.Hints
-import smithy4s.schema.Schema.string
+import smithy4s.Newtype
+import smithy4s.Schema
 import smithy4s.ShapeId
 import smithy4s.schema.Schema.bijection
-import smithy4s.Newtype
+import smithy4s.schema.Schema.list
+import smithy4s.schema.Schema.string
 
 object FancyList extends Newtype[smithy4s.example.refined.FancyList] {
   val id: ShapeId = ShapeId("smithy4s.example", "FancyList")

--- a/modules/example/src/smithy4s/example/FancyListFormat.scala
+++ b/modules/example/src/smithy4s/example/FancyListFormat.scala
@@ -1,10 +1,10 @@
 package smithy4s.example
 
+import smithy4s.Hints
 import smithy4s.Schema
 import smithy4s.ShapeId
 import smithy4s.ShapeTag
 import smithy4s.schema.Schema.constant
-import smithy4s.Hints
 
 case class FancyListFormat()
 object FancyListFormat extends ShapeTag.Companion[FancyListFormat] {

--- a/modules/example/src/smithy4s/example/Foo.scala
+++ b/modules/example/src/smithy4s/example/Foo.scala
@@ -1,14 +1,14 @@
 package smithy4s.example
 
-import smithy4s.Schema
-import smithy4s.schema.Schema.int
 import smithy4s.Hints
-import smithy4s.schema.Schema.string
+import smithy4s.Schema
 import smithy4s.ShapeId
 import smithy4s.ShapeTag
-import smithy4s.schema.Schema.bijection
-import smithy4s.schema.Schema.bigint
 import smithy4s.schema.Schema.bigdecimal
+import smithy4s.schema.Schema.bigint
+import smithy4s.schema.Schema.bijection
+import smithy4s.schema.Schema.int
+import smithy4s.schema.Schema.string
 import smithy4s.schema.Schema.union
 
 sealed trait Foo extends scala.Product with scala.Serializable {

--- a/modules/example/src/smithy4s/example/FooService.scala
+++ b/modules/example/src/smithy4s/example/FooService.scala
@@ -1,15 +1,15 @@
 package smithy4s.example
 
-import smithy4s.Schema
-import smithy4s.schema.Schema.unit
-import smithy4s.kinds.PolyFunction5
-import smithy4s.Transformation
-import smithy4s.Service
-import smithy4s.kinds.toPolyFunction5.const5
-import smithy4s.Hints
-import smithy4s.StreamingSchema
-import smithy4s.ShapeId
 import smithy4s.Endpoint
+import smithy4s.Hints
+import smithy4s.Schema
+import smithy4s.Service
+import smithy4s.ShapeId
+import smithy4s.StreamingSchema
+import smithy4s.Transformation
+import smithy4s.kinds.PolyFunction5
+import smithy4s.kinds.toPolyFunction5.const5
+import smithy4s.schema.Schema.unit
 
 trait FooServiceGen[F[_, _, _, _, _]] {
   self =>

--- a/modules/example/src/smithy4s/example/FooService.scala
+++ b/modules/example/src/smithy4s/example/FooService.scala
@@ -4,11 +4,12 @@ import smithy4s.Schema
 import smithy4s.schema.Schema.unit
 import smithy4s.kinds.PolyFunction5
 import smithy4s.Transformation
-import smithy4s.ShapeId
 import smithy4s.Service
 import smithy4s.kinds.toPolyFunction5.const5
 import smithy4s.Hints
 import smithy4s.StreamingSchema
+import smithy4s.ShapeId
+import smithy4s.Endpoint
 
 trait FooServiceGen[F[_, _, _, _, _]] {
   self =>
@@ -37,9 +38,7 @@ object FooServiceGen extends Service.Mixin[FooServiceGen, FooServiceOperation] {
 
   val version: String = "1.0.0"
 
-  def endpoint[I, E, O, SI, SO](op : FooServiceOperation[I, E, O, SI, SO]) = op match {
-    case GetFoo() => ((), GetFoo)
-  }
+  def endpoint[I, E, O, SI, SO](op : FooServiceOperation[I, E, O, SI, SO]) = op.endpoint
 
   object reified extends FooServiceGen[FooServiceOperation] {
     def getFoo() = GetFoo()
@@ -56,11 +55,12 @@ object FooServiceGen extends Service.Mixin[FooServiceGen, FooServiceOperation] {
   type Default[F[+_]] = Constant[smithy4s.kinds.stubs.Kind1[F]#toKind5]
 
   def toPolyFunction[P[_, _, _, _, _]](impl : FooServiceGen[P]): PolyFunction5[FooServiceOperation, P] = new PolyFunction5[FooServiceOperation, P] {
-    def apply[I, E, O, SI, SO](op : FooServiceOperation[I, E, O, SI, SO]) : P[I, E, O, SI, SO] = op match  {
-      case GetFoo() => impl.getFoo()
-    }
+    def apply[I, E, O, SI, SO](op : FooServiceOperation[I, E, O, SI, SO]) : P[I, E, O, SI, SO] = op.run(impl) 
   }
-  case class GetFoo() extends FooServiceOperation[Unit, Nothing, GetFooOutput, Nothing, Nothing]
+  case class GetFoo() extends FooServiceOperation[Unit, Nothing, GetFooOutput, Nothing, Nothing] {
+    def run[F[_, _, _, _, _]](impl: FooServiceGen[F]): F[Unit, Nothing, GetFooOutput, Nothing, Nothing] = impl.getFoo()
+    def endpoint: (Unit, Endpoint[Unit, Nothing, GetFooOutput, Nothing, Nothing]) = ((), GetFoo)
+  }
   object GetFoo extends FooServiceGen.Endpoint[Unit, Nothing, GetFooOutput, Nothing, Nothing] {
     val id: ShapeId = ShapeId("smithy4s.example", "GetFoo")
     val input: Schema[Unit] = unit.addHints(smithy4s.internals.InputOutput.Input.widen)
@@ -75,4 +75,7 @@ object FooServiceGen extends Service.Mixin[FooServiceGen, FooServiceOperation] {
   }
 }
 
-sealed trait FooServiceOperation[Input, Err, Output, StreamedInput, StreamedOutput]
+sealed trait FooServiceOperation[Input, Err, Output, StreamedInput, StreamedOutput] {
+  def run[F[_, _, _, _, _]](impl: FooServiceGen[F]): F[Input, Err, Output, StreamedInput, StreamedOutput]
+  def endpoint: (Input, Endpoint[FooServiceOperation, Input, Err, Output, StreamedInput, StreamedOutput])
+}

--- a/modules/example/src/smithy4s/example/GetFooOutput.scala
+++ b/modules/example/src/smithy4s/example/GetFooOutput.scala
@@ -1,10 +1,10 @@
 package smithy4s.example
 
-import smithy4s.Schema
 import smithy4s.Hints
+import smithy4s.Schema
 import smithy4s.ShapeId
-import smithy4s.schema.Schema.struct
 import smithy4s.ShapeTag
+import smithy4s.schema.Schema.struct
 
 case class GetFooOutput(foo: Option[Foo] = None)
 object GetFooOutput extends ShapeTag.Companion[GetFooOutput] {

--- a/modules/example/src/smithy4s/example/GetObjectInput.scala
+++ b/modules/example/src/smithy4s/example/GetObjectInput.scala
@@ -1,10 +1,10 @@
 package smithy4s.example
 
-import smithy4s.Schema
 import smithy4s.Hints
+import smithy4s.Schema
 import smithy4s.ShapeId
-import smithy4s.schema.Schema.struct
 import smithy4s.ShapeTag
+import smithy4s.schema.Schema.struct
 
 case class GetObjectInput(key: ObjectKey, bucketName: BucketName)
 object GetObjectInput extends ShapeTag.Companion[GetObjectInput] {

--- a/modules/example/src/smithy4s/example/GetObjectOutput.scala
+++ b/modules/example/src/smithy4s/example/GetObjectOutput.scala
@@ -1,11 +1,11 @@
 package smithy4s.example
 
-import smithy4s.Schema
 import smithy4s.Hints
-import smithy4s.schema.Schema.string
+import smithy4s.Schema
 import smithy4s.ShapeId
-import smithy4s.schema.Schema.struct
 import smithy4s.ShapeTag
+import smithy4s.schema.Schema.string
+import smithy4s.schema.Schema.struct
 
 case class GetObjectOutput(size: ObjectSize = smithy4s.example.ObjectSize(0), data: Option[String] = None)
 object GetObjectOutput extends ShapeTag.Companion[GetObjectOutput] {

--- a/modules/example/src/smithy4s/example/GetObjectOutput.scala
+++ b/modules/example/src/smithy4s/example/GetObjectOutput.scala
@@ -14,7 +14,7 @@ object GetObjectOutput extends ShapeTag.Companion[GetObjectOutput] {
   val hints : Hints = Hints.empty
 
   implicit val schema: Schema[GetObjectOutput] = struct(
-    ObjectSize.schema.required[GetObjectOutput]("size", _.size).addHints(smithy.api.Default(smithy4s.Document.fromDouble(0.0)), smithy.api.Required(), smithy.api.HttpHeader("X-Size")),
+    ObjectSize.schema.required[GetObjectOutput]("size", _.size).addHints(smithy.api.Default(smithy4s.Document.fromDouble(0.0d)), smithy.api.Required(), smithy.api.HttpHeader("X-Size")),
     string.optional[GetObjectOutput]("data", _.data).addHints(smithy.api.HttpPayload()),
   ){
     GetObjectOutput.apply

--- a/modules/example/src/smithy4s/example/GetStreamedObjectInput.scala
+++ b/modules/example/src/smithy4s/example/GetStreamedObjectInput.scala
@@ -1,11 +1,11 @@
 package smithy4s.example
 
-import smithy4s.Schema
 import smithy4s.Hints
-import smithy4s.schema.Schema.string
+import smithy4s.Schema
 import smithy4s.ShapeId
-import smithy4s.schema.Schema.struct
 import smithy4s.ShapeTag
+import smithy4s.schema.Schema.string
+import smithy4s.schema.Schema.struct
 
 case class GetStreamedObjectInput(key: String)
 object GetStreamedObjectInput extends ShapeTag.Companion[GetStreamedObjectInput] {

--- a/modules/example/src/smithy4s/example/GetStreamedObjectOutput.scala
+++ b/modules/example/src/smithy4s/example/GetStreamedObjectOutput.scala
@@ -1,10 +1,10 @@
 package smithy4s.example
 
+import smithy4s.Hints
 import smithy4s.Schema
 import smithy4s.ShapeId
 import smithy4s.ShapeTag
 import smithy4s.schema.Schema.constant
-import smithy4s.Hints
 
 case class GetStreamedObjectOutput()
 object GetStreamedObjectOutput extends ShapeTag.Companion[GetStreamedObjectOutput] {

--- a/modules/example/src/smithy4s/example/Letters.scala
+++ b/modules/example/src/smithy4s/example/Letters.scala
@@ -1,8 +1,8 @@
 package smithy4s.example
 
-import smithy4s.Schema
 import smithy4s.Enumeration
 import smithy4s.Hints
+import smithy4s.Schema
 import smithy4s.ShapeId
 import smithy4s.ShapeTag
 import smithy4s.schema.Schema.enumeration

--- a/modules/example/src/smithy4s/example/LowHigh.scala
+++ b/modules/example/src/smithy4s/example/LowHigh.scala
@@ -1,8 +1,8 @@
 package smithy4s.example
 
-import smithy4s.Schema
 import smithy4s.Enumeration
 import smithy4s.Hints
+import smithy4s.Schema
 import smithy4s.ShapeId
 import smithy4s.ShapeTag
 import smithy4s.schema.Schema.enumeration

--- a/modules/example/src/smithy4s/example/MixinErrorExample.scala
+++ b/modules/example/src/smithy4s/example/MixinErrorExample.scala
@@ -1,14 +1,14 @@
 package smithy4s.example
 
-import smithy4s.Schema
-import smithy4s.schema.Schema.int
 import smithy4s.Hints
-import smithy4s.schema.Schema.string
-import smithy4s.schema.Schema.boolean
+import smithy4s.Schema
 import smithy4s.ShapeId
-import smithy4s.schema.Schema.struct
 import smithy4s.ShapeTag
+import smithy4s.schema.Schema.boolean
+import smithy4s.schema.Schema.int
 import smithy4s.schema.Schema.long
+import smithy4s.schema.Schema.string
+import smithy4s.schema.Schema.struct
 
 case class MixinErrorExample(a: Option[String] = None, b: Option[Int] = None, c: Option[Long] = None, d: Option[Boolean] = None) extends Throwable with CommonFieldsOne with CommonFieldsTwo {
 }

--- a/modules/example/src/smithy4s/example/MixinExample.scala
+++ b/modules/example/src/smithy4s/example/MixinExample.scala
@@ -1,14 +1,14 @@
 package smithy4s.example
 
-import smithy4s.Schema
-import smithy4s.schema.Schema.int
 import smithy4s.Hints
-import smithy4s.schema.Schema.string
-import smithy4s.schema.Schema.boolean
+import smithy4s.Schema
 import smithy4s.ShapeId
-import smithy4s.schema.Schema.struct
 import smithy4s.ShapeTag
+import smithy4s.schema.Schema.boolean
+import smithy4s.schema.Schema.int
 import smithy4s.schema.Schema.long
+import smithy4s.schema.Schema.string
+import smithy4s.schema.Schema.struct
 
 case class MixinExample(a: Option[String] = None, b: Option[Int] = None, c: Option[Long] = None, d: Option[Boolean] = None) extends CommonFieldsOne with CommonFieldsTwo
 object MixinExample extends ShapeTag.Companion[MixinExample] {

--- a/modules/example/src/smithy4s/example/MixinOptionalMemberDefaultAdded.scala
+++ b/modules/example/src/smithy4s/example/MixinOptionalMemberDefaultAdded.scala
@@ -1,11 +1,11 @@
 package smithy4s.example
 
-import smithy4s.Schema
 import smithy4s.Hints
-import smithy4s.schema.Schema.string
+import smithy4s.Schema
 import smithy4s.ShapeId
-import smithy4s.schema.Schema.struct
 import smithy4s.ShapeTag
+import smithy4s.schema.Schema.string
+import smithy4s.schema.Schema.struct
 
 case class MixinOptionalMemberDefaultAdded(a: String = "test")
 object MixinOptionalMemberDefaultAdded extends ShapeTag.Companion[MixinOptionalMemberDefaultAdded] {

--- a/modules/example/src/smithy4s/example/MixinOptionalMemberOverride.scala
+++ b/modules/example/src/smithy4s/example/MixinOptionalMemberOverride.scala
@@ -1,11 +1,11 @@
 package smithy4s.example
 
-import smithy4s.Schema
 import smithy4s.Hints
-import smithy4s.schema.Schema.string
+import smithy4s.Schema
 import smithy4s.ShapeId
-import smithy4s.schema.Schema.struct
 import smithy4s.ShapeTag
+import smithy4s.schema.Schema.string
+import smithy4s.schema.Schema.struct
 
 case class MixinOptionalMemberOverride(a: String)
 object MixinOptionalMemberOverride extends ShapeTag.Companion[MixinOptionalMemberOverride] {

--- a/modules/example/src/smithy4s/example/MyOpError.scala
+++ b/modules/example/src/smithy4s/example/MyOpError.scala
@@ -1,10 +1,10 @@
 package smithy4s.example
 
+import smithy4s.Hints
 import smithy4s.Schema
 import smithy4s.ShapeId
 import smithy4s.ShapeTag
 import smithy4s.schema.Schema.constant
-import smithy4s.Hints
 
 case class MyOpError() extends Throwable {
 }

--- a/modules/example/src/smithy4s/example/Name.scala
+++ b/modules/example/src/smithy4s/example/Name.scala
@@ -1,11 +1,11 @@
 package smithy4s.example
 
-import smithy4s.Schema
 import smithy4s.Hints
-import smithy4s.schema.Schema.string
+import smithy4s.Newtype
+import smithy4s.Schema
 import smithy4s.ShapeId
 import smithy4s.schema.Schema.bijection
-import smithy4s.Newtype
+import smithy4s.schema.Schema.string
 
 object Name extends Newtype[smithy4s.example.refined.Name] {
   val id: ShapeId = ShapeId("smithy4s.example", "Name")

--- a/modules/example/src/smithy4s/example/NameCollision.scala
+++ b/modules/example/src/smithy4s/example/NameCollision.scala
@@ -1,20 +1,20 @@
 package smithy4s.example
 
+import smithy4s.Endpoint
 import smithy4s.Errorable
+import smithy4s.Hints
 import smithy4s.Schema
-import smithy4s.schema.Schema.unit
-import smithy4s.kinds.PolyFunction5
-import smithy4s.Transformation
 import smithy4s.Service
+import smithy4s.ShapeId
 import smithy4s.ShapeTag
+import smithy4s.StreamingSchema
+import smithy4s.Transformation
+import smithy4s.kinds.PolyFunction5
+import smithy4s.kinds.toPolyFunction5.const5
+import smithy4s.schema.Schema.UnionSchema
 import smithy4s.schema.Schema.bijection
 import smithy4s.schema.Schema.union
-import smithy4s.schema.Schema.UnionSchema
-import smithy4s.kinds.toPolyFunction5.const5
-import smithy4s.Hints
-import smithy4s.StreamingSchema
-import smithy4s.ShapeId
-import smithy4s.Endpoint
+import smithy4s.schema.Schema.unit
 
 trait NameCollisionGen[F[_, _, _, _, _]] {
   self =>

--- a/modules/example/src/smithy4s/example/NameFormat.scala
+++ b/modules/example/src/smithy4s/example/NameFormat.scala
@@ -1,10 +1,10 @@
 package smithy4s.example
 
+import smithy4s.Hints
 import smithy4s.Schema
 import smithy4s.ShapeId
 import smithy4s.ShapeTag
 import smithy4s.schema.Schema.constant
-import smithy4s.Hints
 
 case class NameFormat()
 object NameFormat extends ShapeTag.Companion[NameFormat] {

--- a/modules/example/src/smithy4s/example/NoMoreSpace.scala
+++ b/modules/example/src/smithy4s/example/NoMoreSpace.scala
@@ -1,11 +1,11 @@
 package smithy4s.example
 
-import smithy4s.Schema
 import smithy4s.Hints
-import smithy4s.schema.Schema.string
+import smithy4s.Schema
 import smithy4s.ShapeId
-import smithy4s.schema.Schema.struct
 import smithy4s.ShapeTag
+import smithy4s.schema.Schema.string
+import smithy4s.schema.Schema.struct
 
 case class NoMoreSpace(message: String, foo: Option[Foo] = None) extends Throwable {
   override def getMessage(): String = message

--- a/modules/example/src/smithy4s/example/NonEmptyCandies.scala
+++ b/modules/example/src/smithy4s/example/NonEmptyCandies.scala
@@ -1,12 +1,12 @@
 package smithy4s.example
 
-import smithy4s.Schema
-import smithy4s.example.refined.NonEmptyList
-import smithy4s.schema.Schema.list
 import smithy4s.Hints
-import smithy4s.ShapeId
-import smithy4s.schema.Schema.bijection
 import smithy4s.Newtype
+import smithy4s.Schema
+import smithy4s.ShapeId
+import smithy4s.example.refined.NonEmptyList
+import smithy4s.schema.Schema.bijection
+import smithy4s.schema.Schema.list
 
 object NonEmptyCandies extends Newtype[NonEmptyList[Candy]] {
   val id: ShapeId = ShapeId("smithy4s.example", "NonEmptyCandies")

--- a/modules/example/src/smithy4s/example/NonEmptyListFormat.scala
+++ b/modules/example/src/smithy4s/example/NonEmptyListFormat.scala
@@ -1,10 +1,10 @@
 package smithy4s.example
 
+import smithy4s.Hints
 import smithy4s.Schema
 import smithy4s.ShapeId
 import smithy4s.ShapeTag
 import smithy4s.schema.Schema.constant
-import smithy4s.Hints
 
 case class NonEmptyListFormat()
 object NonEmptyListFormat extends ShapeTag.Companion[NonEmptyListFormat] {

--- a/modules/example/src/smithy4s/example/NonEmptyMapFormat.scala
+++ b/modules/example/src/smithy4s/example/NonEmptyMapFormat.scala
@@ -1,10 +1,10 @@
 package smithy4s.example
 
+import smithy4s.Hints
 import smithy4s.Schema
 import smithy4s.ShapeId
 import smithy4s.ShapeTag
 import smithy4s.schema.Schema.constant
-import smithy4s.Hints
 
 case class NonEmptyMapFormat()
 object NonEmptyMapFormat extends ShapeTag.Companion[NonEmptyMapFormat] {

--- a/modules/example/src/smithy4s/example/NonEmptyMapNumbers.scala
+++ b/modules/example/src/smithy4s/example/NonEmptyMapNumbers.scala
@@ -1,14 +1,14 @@
 package smithy4s.example
 
-import smithy4s.Schema
-import smithy4s.schema.Schema.int
 import smithy4s.Hints
-import smithy4s.example.refined.NonEmptyMap
-import smithy4s.schema.Schema.string
-import smithy4s.ShapeId
-import smithy4s.schema.Schema.map
-import smithy4s.schema.Schema.bijection
 import smithy4s.Newtype
+import smithy4s.Schema
+import smithy4s.ShapeId
+import smithy4s.example.refined.NonEmptyMap
+import smithy4s.schema.Schema.bijection
+import smithy4s.schema.Schema.int
+import smithy4s.schema.Schema.map
+import smithy4s.schema.Schema.string
 
 object NonEmptyMapNumbers extends Newtype[NonEmptyMap[String, Int]] {
   val id: ShapeId = ShapeId("smithy4s.example", "NonEmptyMapNumbers")

--- a/modules/example/src/smithy4s/example/NonEmptyNames.scala
+++ b/modules/example/src/smithy4s/example/NonEmptyNames.scala
@@ -1,12 +1,12 @@
 package smithy4s.example
 
-import smithy4s.Schema
-import smithy4s.example.refined.NonEmptyList
-import smithy4s.schema.Schema.list
 import smithy4s.Hints
-import smithy4s.ShapeId
-import smithy4s.schema.Schema.bijection
 import smithy4s.Newtype
+import smithy4s.Schema
+import smithy4s.ShapeId
+import smithy4s.example.refined.NonEmptyList
+import smithy4s.schema.Schema.bijection
+import smithy4s.schema.Schema.list
 
 object NonEmptyNames extends Newtype[NonEmptyList[Name]] {
   val id: ShapeId = ShapeId("smithy4s.example", "NonEmptyNames")

--- a/modules/example/src/smithy4s/example/NonEmptyStrings.scala
+++ b/modules/example/src/smithy4s/example/NonEmptyStrings.scala
@@ -1,13 +1,13 @@
 package smithy4s.example
 
-import smithy4s.Schema
-import smithy4s.example.refined.NonEmptyList
-import smithy4s.schema.Schema.list
 import smithy4s.Hints
-import smithy4s.schema.Schema.string
-import smithy4s.ShapeId
-import smithy4s.schema.Schema.bijection
 import smithy4s.Newtype
+import smithy4s.Schema
+import smithy4s.ShapeId
+import smithy4s.example.refined.NonEmptyList
+import smithy4s.schema.Schema.bijection
+import smithy4s.schema.Schema.list
+import smithy4s.schema.Schema.string
 
 object NonEmptyStrings extends Newtype[NonEmptyList[String]] {
   val id: ShapeId = ShapeId("smithy4s.example", "NonEmptyStrings")

--- a/modules/example/src/smithy4s/example/Numeric.scala
+++ b/modules/example/src/smithy4s/example/Numeric.scala
@@ -1,17 +1,17 @@
 package smithy4s.example
 
-import smithy4s.Schema
-import smithy4s.schema.Schema.int
 import smithy4s.Hints
-import smithy4s.schema.Schema.struct
-import smithy4s.schema.Schema.double
-import smithy4s.schema.Schema.bigint
-import smithy4s.schema.Schema.bigdecimal
-import smithy4s.schema.Schema.long
+import smithy4s.Schema
 import smithy4s.ShapeId
-import smithy4s.schema.Schema.float
 import smithy4s.ShapeTag
+import smithy4s.schema.Schema.bigdecimal
+import smithy4s.schema.Schema.bigint
+import smithy4s.schema.Schema.double
+import smithy4s.schema.Schema.float
+import smithy4s.schema.Schema.int
+import smithy4s.schema.Schema.long
 import smithy4s.schema.Schema.short
+import smithy4s.schema.Schema.struct
 
 case class Numeric(i: Option[Int] = None, f: Option[Float] = None, d: Option[Double] = None, s: Option[Short] = None, l: Option[Long] = None, bi: Option[BigInt] = None, bd: Option[BigDecimal] = None)
 object Numeric extends ShapeTag.Companion[Numeric] {

--- a/modules/example/src/smithy4s/example/Numeric.scala
+++ b/modules/example/src/smithy4s/example/Numeric.scala
@@ -13,20 +13,20 @@ import smithy4s.schema.Schema.long
 import smithy4s.schema.Schema.short
 import smithy4s.schema.Schema.struct
 
-case class Numeric(i: Option[Int] = None, f: Option[Float] = None, d: Option[Double] = None, s: Option[Short] = None, l: Option[Long] = None, bi: Option[BigInt] = None, bd: Option[BigDecimal] = None)
+case class Numeric(i: Int = 1, f: Float = 1.0f, d: Double = 1.0d, s: Short = 1, l: Long = 1L, bi: BigInt = scala.math.BigInt(1), bd: BigDecimal = scala.math.BigDecimal(1.0))
 object Numeric extends ShapeTag.Companion[Numeric] {
   val id: ShapeId = ShapeId("smithy4s.example", "Numeric")
 
   val hints : Hints = Hints.empty
 
   implicit val schema: Schema[Numeric] = struct(
-    int.optional[Numeric]("i", _.i),
-    float.optional[Numeric]("f", _.f),
-    double.optional[Numeric]("d", _.d),
-    short.optional[Numeric]("s", _.s),
-    long.optional[Numeric]("l", _.l),
-    bigint.optional[Numeric]("bi", _.bi),
-    bigdecimal.optional[Numeric]("bd", _.bd),
+    int.required[Numeric]("i", _.i).addHints(smithy.api.Default(smithy4s.Document.fromDouble(1.0))),
+    float.required[Numeric]("f", _.f).addHints(smithy.api.Default(smithy4s.Document.fromDouble(1.0))),
+    double.required[Numeric]("d", _.d).addHints(smithy.api.Default(smithy4s.Document.fromDouble(1.0))),
+    short.required[Numeric]("s", _.s).addHints(smithy.api.Default(smithy4s.Document.fromDouble(1.0))),
+    long.required[Numeric]("l", _.l).addHints(smithy.api.Default(smithy4s.Document.fromDouble(1.0))),
+    bigint.required[Numeric]("bi", _.bi).addHints(smithy.api.Default(smithy4s.Document.fromDouble(1.0))),
+    bigdecimal.required[Numeric]("bd", _.bd).addHints(smithy.api.Default(smithy4s.Document.fromDouble(1.0))),
   ){
     Numeric.apply
   }.withId(id).addHints(hints)

--- a/modules/example/src/smithy4s/example/Numeric.scala
+++ b/modules/example/src/smithy4s/example/Numeric.scala
@@ -20,13 +20,13 @@ object Numeric extends ShapeTag.Companion[Numeric] {
   val hints : Hints = Hints.empty
 
   implicit val schema: Schema[Numeric] = struct(
-    int.required[Numeric]("i", _.i).addHints(smithy.api.Default(smithy4s.Document.fromDouble(1.0))),
-    float.required[Numeric]("f", _.f).addHints(smithy.api.Default(smithy4s.Document.fromDouble(1.0))),
-    double.required[Numeric]("d", _.d).addHints(smithy.api.Default(smithy4s.Document.fromDouble(1.0))),
-    short.required[Numeric]("s", _.s).addHints(smithy.api.Default(smithy4s.Document.fromDouble(1.0))),
-    long.required[Numeric]("l", _.l).addHints(smithy.api.Default(smithy4s.Document.fromDouble(1.0))),
-    bigint.required[Numeric]("bi", _.bi).addHints(smithy.api.Default(smithy4s.Document.fromDouble(1.0))),
-    bigdecimal.required[Numeric]("bd", _.bd).addHints(smithy.api.Default(smithy4s.Document.fromDouble(1.0))),
+    int.required[Numeric]("i", _.i).addHints(smithy.api.Default(smithy4s.Document.fromDouble(1.0d))),
+    float.required[Numeric]("f", _.f).addHints(smithy.api.Default(smithy4s.Document.fromDouble(1.0d))),
+    double.required[Numeric]("d", _.d).addHints(smithy.api.Default(smithy4s.Document.fromDouble(1.0d))),
+    short.required[Numeric]("s", _.s).addHints(smithy.api.Default(smithy4s.Document.fromDouble(1.0d))),
+    long.required[Numeric]("l", _.l).addHints(smithy.api.Default(smithy4s.Document.fromDouble(1.0d))),
+    bigint.required[Numeric]("bi", _.bi).addHints(smithy.api.Default(smithy4s.Document.fromDouble(1.0d))),
+    bigdecimal.required[Numeric]("bd", _.bd).addHints(smithy.api.Default(smithy4s.Document.fromDouble(1.0d))),
   ){
     Numeric.apply
   }.withId(id).addHints(hints)

--- a/modules/example/src/smithy4s/example/Numeric.scala
+++ b/modules/example/src/smithy4s/example/Numeric.scala
@@ -1,0 +1,33 @@
+package smithy4s.example
+
+import smithy4s.Schema
+import smithy4s.schema.Schema.int
+import smithy4s.Hints
+import smithy4s.schema.Schema.struct
+import smithy4s.schema.Schema.double
+import smithy4s.schema.Schema.bigint
+import smithy4s.schema.Schema.bigdecimal
+import smithy4s.schema.Schema.long
+import smithy4s.ShapeId
+import smithy4s.schema.Schema.float
+import smithy4s.ShapeTag
+import smithy4s.schema.Schema.short
+
+case class Numeric(i: Option[Int] = None, f: Option[Float] = None, d: Option[Double] = None, s: Option[Short] = None, l: Option[Long] = None, bi: Option[BigInt] = None, bd: Option[BigDecimal] = None)
+object Numeric extends ShapeTag.Companion[Numeric] {
+  val id: ShapeId = ShapeId("smithy4s.example", "Numeric")
+
+  val hints : Hints = Hints.empty
+
+  implicit val schema: Schema[Numeric] = struct(
+    int.optional[Numeric]("i", _.i),
+    float.optional[Numeric]("f", _.f),
+    double.optional[Numeric]("d", _.d),
+    short.optional[Numeric]("s", _.s),
+    long.optional[Numeric]("l", _.l),
+    bigint.optional[Numeric]("bi", _.bi),
+    bigdecimal.optional[Numeric]("bd", _.bd),
+  ){
+    Numeric.apply
+  }.withId(id).addHints(hints)
+}

--- a/modules/example/src/smithy4s/example/ObjectKey.scala
+++ b/modules/example/src/smithy4s/example/ObjectKey.scala
@@ -1,12 +1,12 @@
 package smithy4s.example
 
-import smithy4s.Schema
-import smithy4s.Hints
-import smithy4s.ShapeId
-import smithy4s.schema.Schema.uuid
-import smithy4s.schema.Schema.bijection
 import java.util.UUID
+import smithy4s.Hints
 import smithy4s.Newtype
+import smithy4s.Schema
+import smithy4s.ShapeId
+import smithy4s.schema.Schema.bijection
+import smithy4s.schema.Schema.uuid
 
 object ObjectKey extends Newtype[UUID] {
   val id: ShapeId = ShapeId("smithy4s.example", "ObjectKey")

--- a/modules/example/src/smithy4s/example/ObjectService.scala
+++ b/modules/example/src/smithy4s/example/ObjectService.scala
@@ -1,20 +1,20 @@
 package smithy4s.example
 
+import smithy4s.Endpoint
 import smithy4s.Errorable
+import smithy4s.Hints
 import smithy4s.Schema
-import smithy4s.schema.Schema.unit
-import smithy4s.kinds.PolyFunction5
-import smithy4s.Transformation
 import smithy4s.Service
+import smithy4s.ShapeId
 import smithy4s.ShapeTag
+import smithy4s.StreamingSchema
+import smithy4s.Transformation
+import smithy4s.kinds.PolyFunction5
+import smithy4s.kinds.toPolyFunction5.const5
+import smithy4s.schema.Schema.UnionSchema
 import smithy4s.schema.Schema.bijection
 import smithy4s.schema.Schema.union
-import smithy4s.schema.Schema.UnionSchema
-import smithy4s.kinds.toPolyFunction5.const5
-import smithy4s.Hints
-import smithy4s.StreamingSchema
-import smithy4s.ShapeId
-import smithy4s.Endpoint
+import smithy4s.schema.Schema.unit
 
 trait ObjectServiceGen[F[_, _, _, _, _]] {
   self =>

--- a/modules/example/src/smithy4s/example/ObjectSize.scala
+++ b/modules/example/src/smithy4s/example/ObjectSize.scala
@@ -1,11 +1,11 @@
 package smithy4s.example
 
-import smithy4s.Schema
-import smithy4s.schema.Schema.int
 import smithy4s.Hints
+import smithy4s.Newtype
+import smithy4s.Schema
 import smithy4s.ShapeId
 import smithy4s.schema.Schema.bijection
-import smithy4s.Newtype
+import smithy4s.schema.Schema.int
 
 object ObjectSize extends Newtype[Int] {
   val id: ShapeId = ShapeId("smithy4s.example", "ObjectSize")

--- a/modules/example/src/smithy4s/example/ObjectSize.scala
+++ b/modules/example/src/smithy4s/example/ObjectSize.scala
@@ -10,7 +10,7 @@ import smithy4s.schema.Schema.int
 object ObjectSize extends Newtype[Int] {
   val id: ShapeId = ShapeId("smithy4s.example", "ObjectSize")
   val hints : Hints = Hints(
-    smithy.api.Default(smithy4s.Document.fromDouble(0.0)),
+    smithy.api.Default(smithy4s.Document.fromDouble(0.0d)),
   )
   val underlyingSchema : Schema[Int] = int.withId(id).addHints(hints)
   implicit val schema : Schema[ObjectSize] = bijection(underlyingSchema, asBijection)

--- a/modules/example/src/smithy4s/example/OrderNumber.scala
+++ b/modules/example/src/smithy4s/example/OrderNumber.scala
@@ -1,11 +1,11 @@
 package smithy4s.example
 
-import smithy4s.Schema
-import smithy4s.schema.Schema.int
 import smithy4s.Hints
+import smithy4s.Newtype
+import smithy4s.Schema
 import smithy4s.ShapeId
 import smithy4s.schema.Schema.bijection
-import smithy4s.Newtype
+import smithy4s.schema.Schema.int
 
 object OrderNumber extends Newtype[Int] {
   val id: ShapeId = ShapeId("smithy4s.example", "OrderNumber")

--- a/modules/example/src/smithy4s/example/OrderNumber.scala
+++ b/modules/example/src/smithy4s/example/OrderNumber.scala
@@ -10,7 +10,7 @@ import smithy4s.schema.Schema.int
 object OrderNumber extends Newtype[Int] {
   val id: ShapeId = ShapeId("smithy4s.example", "OrderNumber")
   val hints : Hints = Hints(
-    smithy.api.Default(smithy4s.Document.fromDouble(0.0)),
+    smithy.api.Default(smithy4s.Document.fromDouble(0.0d)),
   )
   val underlyingSchema : Schema[Int] = int.withId(id).addHints(hints)
   implicit val schema : Schema[OrderNumber] = bijection(underlyingSchema, asBijection)

--- a/modules/example/src/smithy4s/example/OrderType.scala
+++ b/modules/example/src/smithy4s/example/OrderType.scala
@@ -1,12 +1,12 @@
 package smithy4s.example
 
-import smithy4s.Schema
 import smithy4s.Hints
-import smithy4s.schema.Schema.string
+import smithy4s.Schema
 import smithy4s.ShapeId
-import smithy4s.schema.Schema.struct
 import smithy4s.ShapeTag
 import smithy4s.schema.Schema.bijection
+import smithy4s.schema.Schema.string
+import smithy4s.schema.Schema.struct
 import smithy4s.schema.Schema.union
 
 sealed trait OrderType extends scala.Product with scala.Serializable {

--- a/modules/example/src/smithy4s/example/OrderType.scala
+++ b/modules/example/src/smithy4s/example/OrderType.scala
@@ -25,7 +25,7 @@ object OrderType extends ShapeTag.Companion[OrderType] {
     val hints : Hints = Hints.empty
 
     val schema: Schema[InStoreOrder] = struct(
-      OrderNumber.schema.required[InStoreOrder]("id", _.id).addHints(smithy.api.Default(smithy4s.Document.fromDouble(0.0)), smithy.api.Required()),
+      OrderNumber.schema.required[InStoreOrder]("id", _.id).addHints(smithy.api.Default(smithy4s.Document.fromDouble(0.0d)), smithy.api.Required()),
       string.optional[InStoreOrder]("locationId", _.locationId),
     ){
       InStoreOrder.apply

--- a/modules/example/src/smithy4s/example/PersonAge.scala
+++ b/modules/example/src/smithy4s/example/PersonAge.scala
@@ -12,7 +12,7 @@ import smithy4s.schema.Schema.int
 object PersonAge extends Newtype[Age] {
   val id: ShapeId = ShapeId("smithy4s.example", "PersonAge")
   val hints : Hints = Hints(
-    smithy.api.Default(smithy4s.Document.fromDouble(0.0)),
+    smithy.api.Default(smithy4s.Document.fromDouble(0.0d)),
   )
   val underlyingSchema : Schema[Age] = int.refined[Age](smithy4s.example.AgeFormat()).withId(id).addHints(hints)
   implicit val schema : Schema[PersonAge] = bijection(underlyingSchema, asBijection)

--- a/modules/example/src/smithy4s/example/PersonAge.scala
+++ b/modules/example/src/smithy4s/example/PersonAge.scala
@@ -1,13 +1,13 @@
 package smithy4s.example
 
-import smithy4s.schema.Schema.int
 import smithy4s.Hints
-import smithy4s.ShapeId
-import smithy4s.schema.Schema.bijection
-import smithy4s.example.refined.Age
 import smithy4s.Newtype
-import smithy4s.example.refined.Age.provider._
 import smithy4s.Schema
+import smithy4s.ShapeId
+import smithy4s.example.refined.Age
+import smithy4s.example.refined.Age.provider._
+import smithy4s.schema.Schema.bijection
+import smithy4s.schema.Schema.int
 
 object PersonAge extends Newtype[Age] {
   val id: ShapeId = ShapeId("smithy4s.example", "PersonAge")

--- a/modules/example/src/smithy4s/example/PutObjectInput.scala
+++ b/modules/example/src/smithy4s/example/PutObjectInput.scala
@@ -1,11 +1,11 @@
 package smithy4s.example
 
-import smithy4s.Schema
 import smithy4s.Hints
-import smithy4s.schema.Schema.string
+import smithy4s.Schema
 import smithy4s.ShapeId
-import smithy4s.schema.Schema.struct
 import smithy4s.ShapeTag
+import smithy4s.schema.Schema.string
+import smithy4s.schema.Schema.struct
 
 case class PutObjectInput(key: ObjectKey, bucketName: BucketName, data: String, foo: Option[LowHigh] = None, someValue: Option[SomeValue] = None)
 object PutObjectInput extends ShapeTag.Companion[PutObjectInput] {

--- a/modules/example/src/smithy4s/example/PutStreamedObjectInput.scala
+++ b/modules/example/src/smithy4s/example/PutStreamedObjectInput.scala
@@ -1,11 +1,11 @@
 package smithy4s.example
 
-import smithy4s.Schema
 import smithy4s.Hints
-import smithy4s.schema.Schema.string
+import smithy4s.Schema
 import smithy4s.ShapeId
-import smithy4s.schema.Schema.struct
 import smithy4s.ShapeTag
+import smithy4s.schema.Schema.string
+import smithy4s.schema.Schema.struct
 
 case class PutStreamedObjectInput(key: String)
 object PutStreamedObjectInput extends ShapeTag.Companion[PutStreamedObjectInput] {

--- a/modules/example/src/smithy4s/example/ServerError.scala
+++ b/modules/example/src/smithy4s/example/ServerError.scala
@@ -1,11 +1,11 @@
 package smithy4s.example
 
-import smithy4s.Schema
 import smithy4s.Hints
-import smithy4s.schema.Schema.string
+import smithy4s.Schema
 import smithy4s.ShapeId
-import smithy4s.schema.Schema.struct
 import smithy4s.ShapeTag
+import smithy4s.schema.Schema.string
+import smithy4s.schema.Schema.struct
 
 case class ServerError(message: Option[String] = None) extends Throwable {
   override def getMessage(): String = message.orNull

--- a/modules/example/src/smithy4s/example/ServerErrorCustomMessage.scala
+++ b/modules/example/src/smithy4s/example/ServerErrorCustomMessage.scala
@@ -1,11 +1,11 @@
 package smithy4s.example
 
-import smithy4s.Schema
 import smithy4s.Hints
-import smithy4s.schema.Schema.string
+import smithy4s.Schema
 import smithy4s.ShapeId
-import smithy4s.schema.Schema.struct
 import smithy4s.ShapeTag
+import smithy4s.schema.Schema.string
+import smithy4s.schema.Schema.struct
 
 case class ServerErrorCustomMessage(messageField: Option[String] = None) extends Throwable {
   override def getMessage(): String = messageField.orNull

--- a/modules/example/src/smithy4s/example/SomeIndexSeq.scala
+++ b/modules/example/src/smithy4s/example/SomeIndexSeq.scala
@@ -1,12 +1,12 @@
 package smithy4s.example
 
-import smithy4s.Schema
 import smithy4s.Hints
-import smithy4s.schema.Schema.string
-import smithy4s.ShapeId
-import smithy4s.schema.Schema.indexedSeq
-import smithy4s.schema.Schema.bijection
 import smithy4s.Newtype
+import smithy4s.Schema
+import smithy4s.ShapeId
+import smithy4s.schema.Schema.bijection
+import smithy4s.schema.Schema.indexedSeq
+import smithy4s.schema.Schema.string
 
 object SomeIndexSeq extends Newtype[IndexedSeq[String]] {
   val id: ShapeId = ShapeId("smithy4s.example", "SomeIndexSeq")

--- a/modules/example/src/smithy4s/example/SomeValue.scala
+++ b/modules/example/src/smithy4s/example/SomeValue.scala
@@ -1,11 +1,11 @@
 package smithy4s.example
 
-import smithy4s.Schema
 import smithy4s.Hints
-import smithy4s.schema.Schema.string
+import smithy4s.Newtype
+import smithy4s.Schema
 import smithy4s.ShapeId
 import smithy4s.schema.Schema.bijection
-import smithy4s.Newtype
+import smithy4s.schema.Schema.string
 
 object SomeValue extends Newtype[String] {
   val id: ShapeId = ShapeId("smithy4s.example", "SomeValue")

--- a/modules/example/src/smithy4s/example/SomeVector.scala
+++ b/modules/example/src/smithy4s/example/SomeVector.scala
@@ -1,12 +1,12 @@
 package smithy4s.example
 
-import smithy4s.Schema
 import smithy4s.Hints
-import smithy4s.schema.Schema.string
+import smithy4s.Newtype
+import smithy4s.Schema
 import smithy4s.ShapeId
 import smithy4s.schema.Schema.bijection
+import smithy4s.schema.Schema.string
 import smithy4s.schema.Schema.vector
-import smithy4s.Newtype
 
 object SomeVector extends Newtype[Vector[String]] {
   val id: ShapeId = ShapeId("smithy4s.example", "SomeVector")

--- a/modules/example/src/smithy4s/example/StreamedBlob.scala
+++ b/modules/example/src/smithy4s/example/StreamedBlob.scala
@@ -1,10 +1,10 @@
 package smithy4s.example
 
-import smithy4s.Schema
 import smithy4s.Hints
+import smithy4s.Newtype
+import smithy4s.Schema
 import smithy4s.ShapeId
 import smithy4s.schema.Schema.bijection
-import smithy4s.Newtype
 import smithy4s.schema.Schema.byte
 
 object StreamedBlob extends Newtype[Byte] {

--- a/modules/example/src/smithy4s/example/StreamedObjects.scala
+++ b/modules/example/src/smithy4s/example/StreamedObjects.scala
@@ -1,15 +1,15 @@
 package smithy4s.example
 
-import smithy4s.Schema
-import smithy4s.schema.Schema.unit
-import smithy4s.kinds.PolyFunction5
-import smithy4s.Transformation
-import smithy4s.Service
-import smithy4s.kinds.toPolyFunction5.const5
-import smithy4s.Hints
-import smithy4s.StreamingSchema
-import smithy4s.ShapeId
 import smithy4s.Endpoint
+import smithy4s.Hints
+import smithy4s.Schema
+import smithy4s.Service
+import smithy4s.ShapeId
+import smithy4s.StreamingSchema
+import smithy4s.Transformation
+import smithy4s.kinds.PolyFunction5
+import smithy4s.kinds.toPolyFunction5.const5
+import smithy4s.schema.Schema.unit
 
 trait StreamedObjectsGen[F[_, _, _, _, _]] {
   self =>

--- a/modules/example/src/smithy4s/example/StreamedObjects.scala
+++ b/modules/example/src/smithy4s/example/StreamedObjects.scala
@@ -4,11 +4,12 @@ import smithy4s.Schema
 import smithy4s.schema.Schema.unit
 import smithy4s.kinds.PolyFunction5
 import smithy4s.Transformation
-import smithy4s.ShapeId
 import smithy4s.Service
 import smithy4s.kinds.toPolyFunction5.const5
 import smithy4s.Hints
 import smithy4s.StreamingSchema
+import smithy4s.ShapeId
+import smithy4s.Endpoint
 
 trait StreamedObjectsGen[F[_, _, _, _, _]] {
   self =>
@@ -39,10 +40,7 @@ object StreamedObjectsGen extends Service.Mixin[StreamedObjectsGen, StreamedObje
 
   val version: String = "1.0.0"
 
-  def endpoint[I, E, O, SI, SO](op : StreamedObjectsOperation[I, E, O, SI, SO]) = op match {
-    case PutStreamedObject(input) => (input, PutStreamedObject)
-    case GetStreamedObject(input) => (input, GetStreamedObject)
-  }
+  def endpoint[I, E, O, SI, SO](op : StreamedObjectsOperation[I, E, O, SI, SO]) = op.endpoint
 
   object reified extends StreamedObjectsGen[StreamedObjectsOperation] {
     def putStreamedObject(key: String) = PutStreamedObject(PutStreamedObjectInput(key))
@@ -61,12 +59,12 @@ object StreamedObjectsGen extends Service.Mixin[StreamedObjectsGen, StreamedObje
   type Default[F[+_]] = Constant[smithy4s.kinds.stubs.Kind1[F]#toKind5]
 
   def toPolyFunction[P[_, _, _, _, _]](impl : StreamedObjectsGen[P]): PolyFunction5[StreamedObjectsOperation, P] = new PolyFunction5[StreamedObjectsOperation, P] {
-    def apply[I, E, O, SI, SO](op : StreamedObjectsOperation[I, E, O, SI, SO]) : P[I, E, O, SI, SO] = op match  {
-      case PutStreamedObject(PutStreamedObjectInput(key)) => impl.putStreamedObject(key)
-      case GetStreamedObject(GetStreamedObjectInput(key)) => impl.getStreamedObject(key)
-    }
+    def apply[I, E, O, SI, SO](op : StreamedObjectsOperation[I, E, O, SI, SO]) : P[I, E, O, SI, SO] = op.run(impl) 
   }
-  case class PutStreamedObject(input: PutStreamedObjectInput) extends StreamedObjectsOperation[PutStreamedObjectInput, Nothing, Unit, StreamedBlob, Nothing]
+  case class PutStreamedObject(input: PutStreamedObjectInput) extends StreamedObjectsOperation[PutStreamedObjectInput, Nothing, Unit, StreamedBlob, Nothing] {
+    def run[F[_, _, _, _, _]](impl: StreamedObjectsGen[F]): F[PutStreamedObjectInput, Nothing, Unit, StreamedBlob, Nothing] = impl.putStreamedObject(input.key)
+    def endpoint: (PutStreamedObjectInput, Endpoint[PutStreamedObjectInput, Nothing, Unit, StreamedBlob, Nothing]) = (input, PutStreamedObject)
+  }
   object PutStreamedObject extends StreamedObjectsGen.Endpoint[PutStreamedObjectInput, Nothing, Unit, StreamedBlob, Nothing] {
     val id: ShapeId = ShapeId("smithy4s.example", "PutStreamedObject")
     val input: Schema[PutStreamedObjectInput] = PutStreamedObjectInput.schema.addHints(smithy4s.internals.InputOutput.Input.widen)
@@ -76,7 +74,10 @@ object StreamedObjectsGen extends Service.Mixin[StreamedObjectsGen, StreamedObje
     val hints : Hints = Hints.empty
     def wrap(input: PutStreamedObjectInput) = PutStreamedObject(input)
   }
-  case class GetStreamedObject(input: GetStreamedObjectInput) extends StreamedObjectsOperation[GetStreamedObjectInput, Nothing, GetStreamedObjectOutput, Nothing, StreamedBlob]
+  case class GetStreamedObject(input: GetStreamedObjectInput) extends StreamedObjectsOperation[GetStreamedObjectInput, Nothing, GetStreamedObjectOutput, Nothing, StreamedBlob] {
+    def run[F[_, _, _, _, _]](impl: StreamedObjectsGen[F]): F[GetStreamedObjectInput, Nothing, GetStreamedObjectOutput, Nothing, StreamedBlob] = impl.getStreamedObject(input.key)
+    def endpoint: (GetStreamedObjectInput, Endpoint[GetStreamedObjectInput, Nothing, GetStreamedObjectOutput, Nothing, StreamedBlob]) = (input, GetStreamedObject)
+  }
   object GetStreamedObject extends StreamedObjectsGen.Endpoint[GetStreamedObjectInput, Nothing, GetStreamedObjectOutput, Nothing, StreamedBlob] {
     val id: ShapeId = ShapeId("smithy4s.example", "GetStreamedObject")
     val input: Schema[GetStreamedObjectInput] = GetStreamedObjectInput.schema.addHints(smithy4s.internals.InputOutput.Input.widen)
@@ -88,4 +89,7 @@ object StreamedObjectsGen extends Service.Mixin[StreamedObjectsGen, StreamedObje
   }
 }
 
-sealed trait StreamedObjectsOperation[Input, Err, Output, StreamedInput, StreamedOutput]
+sealed trait StreamedObjectsOperation[Input, Err, Output, StreamedInput, StreamedOutput] {
+  def run[F[_, _, _, _, _]](impl: StreamedObjectsGen[F]): F[Input, Err, Output, StreamedInput, StreamedOutput]
+  def endpoint: (Input, Endpoint[StreamedObjectsOperation, Input, Err, Output, StreamedInput, StreamedOutput])
+}

--- a/modules/example/src/smithy4s/example/StringList.scala
+++ b/modules/example/src/smithy4s/example/StringList.scala
@@ -1,12 +1,12 @@
 package smithy4s.example
 
-import smithy4s.Schema
-import smithy4s.schema.Schema.list
 import smithy4s.Hints
-import smithy4s.schema.Schema.string
+import smithy4s.Newtype
+import smithy4s.Schema
 import smithy4s.ShapeId
 import smithy4s.schema.Schema.bijection
-import smithy4s.Newtype
+import smithy4s.schema.Schema.list
+import smithy4s.schema.Schema.string
 
 object StringList extends Newtype[List[String]] {
   val id: ShapeId = ShapeId("smithy4s.example", "StringList")

--- a/modules/example/src/smithy4s/example/Strings.scala
+++ b/modules/example/src/smithy4s/example/Strings.scala
@@ -1,12 +1,12 @@
 package smithy4s.example
 
-import smithy4s.Schema
-import smithy4s.schema.Schema.list
 import smithy4s.Hints
-import smithy4s.schema.Schema.string
+import smithy4s.Newtype
+import smithy4s.Schema
 import smithy4s.ShapeId
 import smithy4s.schema.Schema.bijection
-import smithy4s.Newtype
+import smithy4s.schema.Schema.list
+import smithy4s.schema.Schema.string
 
 @deprecated
 object Strings extends Newtype[List[String]] {

--- a/modules/example/src/smithy4s/example/StructureWithRefinedTypes.scala
+++ b/modules/example/src/smithy4s/example/StructureWithRefinedTypes.scala
@@ -1,10 +1,10 @@
 package smithy4s.example
 
-import smithy4s.Schema
 import smithy4s.Hints
+import smithy4s.Schema
 import smithy4s.ShapeId
-import smithy4s.schema.Schema.struct
 import smithy4s.ShapeTag
+import smithy4s.schema.Schema.struct
 
 case class StructureWithRefinedTypes(age: Age, personAge: PersonAge, fancyList: Option[smithy4s.example.FancyList] = None, unwrappedFancyList: Option[smithy4s.example.refined.FancyList] = None, name: Option[smithy4s.example.Name] = None, dogName: Option[smithy4s.example.refined.Name] = None)
 object StructureWithRefinedTypes extends ShapeTag.Companion[StructureWithRefinedTypes] {

--- a/modules/example/src/smithy4s/example/StructureWithRefinedTypes.scala
+++ b/modules/example/src/smithy4s/example/StructureWithRefinedTypes.scala
@@ -13,8 +13,8 @@ object StructureWithRefinedTypes extends ShapeTag.Companion[StructureWithRefined
   val hints : Hints = Hints.empty
 
   implicit val schema: Schema[StructureWithRefinedTypes] = struct(
-    Age.schema.required[StructureWithRefinedTypes]("age", _.age).addHints(smithy.api.Default(smithy4s.Document.fromDouble(0.0))),
-    PersonAge.schema.required[StructureWithRefinedTypes]("personAge", _.personAge).addHints(smithy.api.Default(smithy4s.Document.fromDouble(0.0))),
+    Age.schema.required[StructureWithRefinedTypes]("age", _.age).addHints(smithy.api.Default(smithy4s.Document.fromDouble(0.0d))),
+    PersonAge.schema.required[StructureWithRefinedTypes]("personAge", _.personAge).addHints(smithy.api.Default(smithy4s.Document.fromDouble(0.0d))),
     smithy4s.example.FancyList.schema.optional[StructureWithRefinedTypes]("fancyList", _.fancyList),
     UnwrappedFancyList.underlyingSchema.optional[StructureWithRefinedTypes]("unwrappedFancyList", _.unwrappedFancyList),
     smithy4s.example.Name.schema.optional[StructureWithRefinedTypes]("name", _.name),

--- a/modules/example/src/smithy4s/example/SwitchState.scala
+++ b/modules/example/src/smithy4s/example/SwitchState.scala
@@ -1,8 +1,8 @@
 package smithy4s.example
 
-import smithy4s.Schema
 import smithy4s.Enumeration
 import smithy4s.Hints
+import smithy4s.Schema
 import smithy4s.ShapeId
 import smithy4s.ShapeTag
 import smithy4s.schema.Schema.enumeration

--- a/modules/example/src/smithy4s/example/TestEmptyMixin.scala
+++ b/modules/example/src/smithy4s/example/TestEmptyMixin.scala
@@ -1,11 +1,11 @@
 package smithy4s.example
 
-import smithy4s.Schema
 import smithy4s.Hints
+import smithy4s.Schema
 import smithy4s.ShapeId
-import smithy4s.schema.Schema.struct
 import smithy4s.ShapeTag
 import smithy4s.schema.Schema.long
+import smithy4s.schema.Schema.struct
 
 case class TestEmptyMixin(a: Option[Long] = None) extends EmptyMixin
 object TestEmptyMixin extends ShapeTag.Companion[TestEmptyMixin] {

--- a/modules/example/src/smithy4s/example/TestMixinAdt.scala
+++ b/modules/example/src/smithy4s/example/TestMixinAdt.scala
@@ -1,12 +1,12 @@
 package smithy4s.example
 
-import smithy4s.Schema
-import smithy4s.schema.Schema.int
 import smithy4s.Hints
-import smithy4s.schema.Schema.string
+import smithy4s.Schema
 import smithy4s.ShapeId
-import smithy4s.schema.Schema.struct
 import smithy4s.ShapeTag
+import smithy4s.schema.Schema.int
+import smithy4s.schema.Schema.string
+import smithy4s.schema.Schema.struct
 import smithy4s.schema.Schema.union
 
 sealed trait TestMixinAdt extends scala.Product with scala.Serializable {

--- a/modules/example/src/smithy4s/example/TestString.scala
+++ b/modules/example/src/smithy4s/example/TestString.scala
@@ -1,11 +1,11 @@
 package smithy4s.example
 
-import smithy4s.Schema
 import smithy4s.Hints
-import smithy4s.schema.Schema.string
+import smithy4s.Newtype
+import smithy4s.Schema
 import smithy4s.ShapeId
 import smithy4s.schema.Schema.bijection
-import smithy4s.Newtype
+import smithy4s.schema.Schema.string
 
 object TestString extends Newtype[String] {
   val id: ShapeId = ShapeId("smithy4s.example", "TestString")

--- a/modules/example/src/smithy4s/example/TestTrait.scala
+++ b/modules/example/src/smithy4s/example/TestTrait.scala
@@ -1,11 +1,11 @@
 package smithy4s.example
 
-import smithy4s.Schema
 import smithy4s.Hints
+import smithy4s.Schema
 import smithy4s.ShapeId
-import smithy4s.schema.Schema.struct
-import smithy4s.schema.Schema.recursive
 import smithy4s.ShapeTag
+import smithy4s.schema.Schema.recursive
+import smithy4s.schema.Schema.struct
 
 case class TestTrait(orderType: Option[OrderType] = None)
 object TestTrait extends ShapeTag.Companion[TestTrait] {

--- a/modules/example/src/smithy4s/example/UnionWithRefinedTypes.scala
+++ b/modules/example/src/smithy4s/example/UnionWithRefinedTypes.scala
@@ -1,10 +1,10 @@
 package smithy4s.example
 
-import smithy4s.Schema
 import smithy4s.Hints
-import smithy4s.example.refined.Name
+import smithy4s.Schema
 import smithy4s.ShapeId
 import smithy4s.ShapeTag
+import smithy4s.example.refined.Name
 import smithy4s.schema.Schema.bijection
 import smithy4s.schema.Schema.union
 

--- a/modules/example/src/smithy4s/example/UnwrappedFancyList.scala
+++ b/modules/example/src/smithy4s/example/UnwrappedFancyList.scala
@@ -1,13 +1,13 @@
 package smithy4s.example
 
-import smithy4s.Schema
-import smithy4s.example.refined.FancyList
-import smithy4s.schema.Schema.list
 import smithy4s.Hints
-import smithy4s.schema.Schema.string
-import smithy4s.ShapeId
-import smithy4s.schema.Schema.bijection
 import smithy4s.Newtype
+import smithy4s.Schema
+import smithy4s.ShapeId
+import smithy4s.example.refined.FancyList
+import smithy4s.schema.Schema.bijection
+import smithy4s.schema.Schema.list
+import smithy4s.schema.Schema.string
 
 object UnwrappedFancyList extends Newtype[FancyList] {
   val id: ShapeId = ShapeId("smithy4s.example", "UnwrappedFancyList")

--- a/modules/example/src/smithy4s/example/collision/ListInput.scala
+++ b/modules/example/src/smithy4s/example/collision/ListInput.scala
@@ -1,10 +1,10 @@
 package smithy4s.example.collision
 
-import smithy4s.Schema
 import smithy4s.Hints
+import smithy4s.Schema
 import smithy4s.ShapeId
-import smithy4s.schema.Schema.struct
 import smithy4s.ShapeTag
+import smithy4s.schema.Schema.struct
 
 case class ListInput(list: List[String])
 object ListInput extends ShapeTag.Companion[ListInput] {

--- a/modules/example/src/smithy4s/example/collision/MapInput.scala
+++ b/modules/example/src/smithy4s/example/collision/MapInput.scala
@@ -1,10 +1,10 @@
 package smithy4s.example.collision
 
-import smithy4s.Schema
 import smithy4s.Hints
+import smithy4s.Schema
 import smithy4s.ShapeId
-import smithy4s.schema.Schema.struct
 import smithy4s.ShapeTag
+import smithy4s.schema.Schema.struct
 
 case class MapInput(value: Map[String, String])
 object MapInput extends ShapeTag.Companion[MapInput] {

--- a/modules/example/src/smithy4s/example/collision/MyList.scala
+++ b/modules/example/src/smithy4s/example/collision/MyList.scala
@@ -1,12 +1,12 @@
 package smithy4s.example.collision
 
-import smithy4s.Schema
-import smithy4s.schema.Schema.list
 import smithy4s.Hints
-import smithy4s.schema.Schema.string
+import smithy4s.Newtype
+import smithy4s.Schema
 import smithy4s.ShapeId
 import smithy4s.schema.Schema.bijection
-import smithy4s.Newtype
+import smithy4s.schema.Schema.list
+import smithy4s.schema.Schema.string
 
 object MyList extends Newtype[List[String]] {
   val id: ShapeId = ShapeId("smithy4s.example.collision", "MyList")

--- a/modules/example/src/smithy4s/example/collision/MyMap.scala
+++ b/modules/example/src/smithy4s/example/collision/MyMap.scala
@@ -1,12 +1,12 @@
 package smithy4s.example.collision
 
-import smithy4s.Schema
 import smithy4s.Hints
-import smithy4s.schema.Schema.string
-import smithy4s.ShapeId
-import smithy4s.schema.Schema.map
-import smithy4s.schema.Schema.bijection
 import smithy4s.Newtype
+import smithy4s.Schema
+import smithy4s.ShapeId
+import smithy4s.schema.Schema.bijection
+import smithy4s.schema.Schema.map
+import smithy4s.schema.Schema.string
 
 object MyMap extends Newtype[Map[String, String]] {
   val id: ShapeId = ShapeId("smithy4s.example.collision", "MyMap")

--- a/modules/example/src/smithy4s/example/collision/MySet.scala
+++ b/modules/example/src/smithy4s/example/collision/MySet.scala
@@ -1,12 +1,12 @@
 package smithy4s.example.collision
 
-import smithy4s.Schema
-import smithy4s.schema.Schema.set
 import smithy4s.Hints
-import smithy4s.schema.Schema.string
+import smithy4s.Newtype
+import smithy4s.Schema
 import smithy4s.ShapeId
 import smithy4s.schema.Schema.bijection
-import smithy4s.Newtype
+import smithy4s.schema.Schema.set
+import smithy4s.schema.Schema.string
 
 object MySet extends Newtype[Set[String]] {
   val id: ShapeId = ShapeId("smithy4s.example.collision", "MySet")

--- a/modules/example/src/smithy4s/example/collision/OptionInput.scala
+++ b/modules/example/src/smithy4s/example/collision/OptionInput.scala
@@ -1,11 +1,11 @@
 package smithy4s.example.collision
 
-import smithy4s.Schema
 import smithy4s.Hints
-import smithy4s.schema.Schema.string
+import smithy4s.Schema
 import smithy4s.ShapeId
-import smithy4s.schema.Schema.struct
 import smithy4s.ShapeTag
+import smithy4s.schema.Schema.string
+import smithy4s.schema.Schema.struct
 
 case class OptionInput(value: Option[String] = None)
 object OptionInput extends ShapeTag.Companion[OptionInput] {

--- a/modules/example/src/smithy4s/example/collision/ReservedNameService.scala
+++ b/modules/example/src/smithy4s/example/collision/ReservedNameService.scala
@@ -1,15 +1,15 @@
 package smithy4s.example.collision
 
-import smithy4s.Schema
-import smithy4s.schema.Schema.unit
-import smithy4s.kinds.PolyFunction5
-import smithy4s.Transformation
-import smithy4s.Service
-import smithy4s.kinds.toPolyFunction5.const5
-import smithy4s.Hints
-import smithy4s.StreamingSchema
-import smithy4s.ShapeId
 import smithy4s.Endpoint
+import smithy4s.Hints
+import smithy4s.Schema
+import smithy4s.Service
+import smithy4s.ShapeId
+import smithy4s.StreamingSchema
+import smithy4s.Transformation
+import smithy4s.kinds.PolyFunction5
+import smithy4s.kinds.toPolyFunction5.const5
+import smithy4s.schema.Schema.unit
 
 trait ReservedNameServiceGen[F[_, _, _, _, _]] {
   self =>

--- a/modules/example/src/smithy4s/example/collision/ReservedNameService.scala
+++ b/modules/example/src/smithy4s/example/collision/ReservedNameService.scala
@@ -4,11 +4,12 @@ import smithy4s.Schema
 import smithy4s.schema.Schema.unit
 import smithy4s.kinds.PolyFunction5
 import smithy4s.Transformation
-import smithy4s.ShapeId
 import smithy4s.Service
 import smithy4s.kinds.toPolyFunction5.const5
 import smithy4s.Hints
 import smithy4s.StreamingSchema
+import smithy4s.ShapeId
+import smithy4s.Endpoint
 
 trait ReservedNameServiceGen[F[_, _, _, _, _]] {
   self =>
@@ -45,12 +46,7 @@ object ReservedNameServiceGen extends Service.Mixin[ReservedNameServiceGen, Rese
 
   val version: String = "1.0.0"
 
-  def endpoint[I, E, O, SI, SO](op : ReservedNameServiceOperation[I, E, O, SI, SO]) = op match {
-    case _Set(input) => (input, _Set)
-    case _List(input) => (input, _List)
-    case _Map(input) => (input, _Map)
-    case _Option(input) => (input, _Option)
-  }
+  def endpoint[I, E, O, SI, SO](op : ReservedNameServiceOperation[I, E, O, SI, SO]) = op.endpoint
 
   object reified extends ReservedNameServiceGen[ReservedNameServiceOperation] {
     def set(set: Set[String]) = _Set(SetInput(set))
@@ -73,14 +69,12 @@ object ReservedNameServiceGen extends Service.Mixin[ReservedNameServiceGen, Rese
   type Default[F[+_]] = Constant[smithy4s.kinds.stubs.Kind1[F]#toKind5]
 
   def toPolyFunction[P[_, _, _, _, _]](impl : ReservedNameServiceGen[P]): PolyFunction5[ReservedNameServiceOperation, P] = new PolyFunction5[ReservedNameServiceOperation, P] {
-    def apply[I, E, O, SI, SO](op : ReservedNameServiceOperation[I, E, O, SI, SO]) : P[I, E, O, SI, SO] = op match  {
-      case _Set(SetInput(set)) => impl.set(set)
-      case _List(ListInput(list)) => impl.list(list)
-      case _Map(MapInput(value)) => impl.map(value)
-      case _Option(OptionInput(value)) => impl.option(value)
-    }
+    def apply[I, E, O, SI, SO](op : ReservedNameServiceOperation[I, E, O, SI, SO]) : P[I, E, O, SI, SO] = op.run(impl) 
   }
-  case class _Set(input: SetInput) extends ReservedNameServiceOperation[SetInput, Nothing, Unit, Nothing, Nothing]
+  case class _Set(input: SetInput) extends ReservedNameServiceOperation[SetInput, Nothing, Unit, Nothing, Nothing] {
+    def run[F[_, _, _, _, _]](impl: ReservedNameServiceGen[F]): F[SetInput, Nothing, Unit, Nothing, Nothing] = impl.set(input.set)
+    def endpoint: (SetInput, Endpoint[SetInput, Nothing, Unit, Nothing, Nothing]) = (input, _Set)
+  }
   object _Set extends ReservedNameServiceGen.Endpoint[SetInput, Nothing, Unit, Nothing, Nothing] {
     val id: ShapeId = ShapeId("smithy4s.example.collision", "Set")
     val input: Schema[SetInput] = SetInput.schema.addHints(smithy4s.internals.InputOutput.Input.widen)
@@ -92,7 +86,10 @@ object ReservedNameServiceGen extends Service.Mixin[ReservedNameServiceGen, Rese
     )
     def wrap(input: SetInput) = _Set(input)
   }
-  case class _List(input: ListInput) extends ReservedNameServiceOperation[ListInput, Nothing, Unit, Nothing, Nothing]
+  case class _List(input: ListInput) extends ReservedNameServiceOperation[ListInput, Nothing, Unit, Nothing, Nothing] {
+    def run[F[_, _, _, _, _]](impl: ReservedNameServiceGen[F]): F[ListInput, Nothing, Unit, Nothing, Nothing] = impl.list(input.list)
+    def endpoint: (ListInput, Endpoint[ListInput, Nothing, Unit, Nothing, Nothing]) = (input, _List)
+  }
   object _List extends ReservedNameServiceGen.Endpoint[ListInput, Nothing, Unit, Nothing, Nothing] {
     val id: ShapeId = ShapeId("smithy4s.example.collision", "List")
     val input: Schema[ListInput] = ListInput.schema.addHints(smithy4s.internals.InputOutput.Input.widen)
@@ -104,7 +101,10 @@ object ReservedNameServiceGen extends Service.Mixin[ReservedNameServiceGen, Rese
     )
     def wrap(input: ListInput) = _List(input)
   }
-  case class _Map(input: MapInput) extends ReservedNameServiceOperation[MapInput, Nothing, Unit, Nothing, Nothing]
+  case class _Map(input: MapInput) extends ReservedNameServiceOperation[MapInput, Nothing, Unit, Nothing, Nothing] {
+    def run[F[_, _, _, _, _]](impl: ReservedNameServiceGen[F]): F[MapInput, Nothing, Unit, Nothing, Nothing] = impl.map(input.value)
+    def endpoint: (MapInput, Endpoint[MapInput, Nothing, Unit, Nothing, Nothing]) = (input, _Map)
+  }
   object _Map extends ReservedNameServiceGen.Endpoint[MapInput, Nothing, Unit, Nothing, Nothing] {
     val id: ShapeId = ShapeId("smithy4s.example.collision", "Map")
     val input: Schema[MapInput] = MapInput.schema.addHints(smithy4s.internals.InputOutput.Input.widen)
@@ -116,7 +116,10 @@ object ReservedNameServiceGen extends Service.Mixin[ReservedNameServiceGen, Rese
     )
     def wrap(input: MapInput) = _Map(input)
   }
-  case class _Option(input: OptionInput) extends ReservedNameServiceOperation[OptionInput, Nothing, Unit, Nothing, Nothing]
+  case class _Option(input: OptionInput) extends ReservedNameServiceOperation[OptionInput, Nothing, Unit, Nothing, Nothing] {
+    def run[F[_, _, _, _, _]](impl: ReservedNameServiceGen[F]): F[OptionInput, Nothing, Unit, Nothing, Nothing] = impl.option(input.value)
+    def endpoint: (OptionInput, Endpoint[OptionInput, Nothing, Unit, Nothing, Nothing]) = (input, _Option)
+  }
   object _Option extends ReservedNameServiceGen.Endpoint[OptionInput, Nothing, Unit, Nothing, Nothing] {
     val id: ShapeId = ShapeId("smithy4s.example.collision", "Option")
     val input: Schema[OptionInput] = OptionInput.schema.addHints(smithy4s.internals.InputOutput.Input.widen)
@@ -130,4 +133,7 @@ object ReservedNameServiceGen extends Service.Mixin[ReservedNameServiceGen, Rese
   }
 }
 
-sealed trait ReservedNameServiceOperation[Input, Err, Output, StreamedInput, StreamedOutput]
+sealed trait ReservedNameServiceOperation[Input, Err, Output, StreamedInput, StreamedOutput] {
+  def run[F[_, _, _, _, _]](impl: ReservedNameServiceGen[F]): F[Input, Err, Output, StreamedInput, StreamedOutput]
+  def endpoint: (Input, Endpoint[ReservedNameServiceOperation, Input, Err, Output, StreamedInput, StreamedOutput])
+}

--- a/modules/example/src/smithy4s/example/collision/SetInput.scala
+++ b/modules/example/src/smithy4s/example/collision/SetInput.scala
@@ -1,10 +1,10 @@
 package smithy4s.example.collision
 
-import smithy4s.Schema
 import smithy4s.Hints
+import smithy4s.Schema
 import smithy4s.ShapeId
-import smithy4s.schema.Schema.struct
 import smithy4s.ShapeTag
+import smithy4s.schema.Schema.struct
 
 case class SetInput(set: Set[String])
 object SetInput extends ShapeTag.Companion[SetInput] {

--- a/modules/example/src/smithy4s/example/common/BrandList.scala
+++ b/modules/example/src/smithy4s/example/common/BrandList.scala
@@ -1,12 +1,12 @@
 package smithy4s.example.common
 
-import smithy4s.Schema
-import smithy4s.schema.Schema.list
 import smithy4s.Hints
-import smithy4s.schema.Schema.string
+import smithy4s.Newtype
+import smithy4s.Schema
 import smithy4s.ShapeId
 import smithy4s.schema.Schema.bijection
-import smithy4s.Newtype
+import smithy4s.schema.Schema.list
+import smithy4s.schema.Schema.string
 
 object BrandList extends Newtype[List[String]] {
   val id: ShapeId = ShapeId("smithy4s.example.common", "BrandList")

--- a/modules/example/src/smithy4s/example/error/NotFoundError.scala
+++ b/modules/example/src/smithy4s/example/error/NotFoundError.scala
@@ -1,11 +1,11 @@
 package smithy4s.example.error
 
-import smithy4s.Schema
 import smithy4s.Hints
-import smithy4s.schema.Schema.string
+import smithy4s.Schema
 import smithy4s.ShapeId
-import smithy4s.schema.Schema.struct
 import smithy4s.ShapeTag
+import smithy4s.schema.Schema.string
+import smithy4s.schema.Schema.struct
 
 case class NotFoundError(error: Option[String] = None) extends Throwable {
 }

--- a/modules/example/src/smithy4s/example/imp/ImportService.scala
+++ b/modules/example/src/smithy4s/example/imp/ImportService.scala
@@ -1,22 +1,22 @@
 package smithy4s.example.imp
 
-import smithy4s.Errorable
-import smithy4s.example.import_test.OpOutput
-import smithy4s.Schema
-import smithy4s.schema.Schema.unit
-import smithy4s.kinds.PolyFunction5
-import smithy4s.Transformation
-import smithy4s.Service
-import smithy4s.ShapeTag
-import smithy4s.schema.Schema.bijection
-import smithy4s.example.error.NotFoundError
-import smithy4s.schema.Schema.union
-import smithy4s.schema.Schema.UnionSchema
-import smithy4s.kinds.toPolyFunction5.const5
-import smithy4s.Hints
-import smithy4s.StreamingSchema
-import smithy4s.ShapeId
 import smithy4s.Endpoint
+import smithy4s.Errorable
+import smithy4s.Hints
+import smithy4s.Schema
+import smithy4s.Service
+import smithy4s.ShapeId
+import smithy4s.ShapeTag
+import smithy4s.StreamingSchema
+import smithy4s.Transformation
+import smithy4s.example.error.NotFoundError
+import smithy4s.example.import_test.OpOutput
+import smithy4s.kinds.PolyFunction5
+import smithy4s.kinds.toPolyFunction5.const5
+import smithy4s.schema.Schema.UnionSchema
+import smithy4s.schema.Schema.bijection
+import smithy4s.schema.Schema.union
+import smithy4s.schema.Schema.unit
 
 trait ImportServiceGen[F[_, _, _, _, _]] {
   self =>

--- a/modules/example/src/smithy4s/example/import_test/OpOutput.scala
+++ b/modules/example/src/smithy4s/example/import_test/OpOutput.scala
@@ -1,11 +1,11 @@
 package smithy4s.example.import_test
 
-import smithy4s.Schema
 import smithy4s.Hints
-import smithy4s.schema.Schema.string
+import smithy4s.Schema
 import smithy4s.ShapeId
-import smithy4s.schema.Schema.struct
 import smithy4s.ShapeTag
+import smithy4s.schema.Schema.string
+import smithy4s.schema.Schema.struct
 
 case class OpOutput(output: String)
 object OpOutput extends ShapeTag.Companion[OpOutput] {

--- a/sampleSpecs/numeric.smithy
+++ b/sampleSpecs/numeric.smithy
@@ -1,0 +1,11 @@
+namespace smithy4s.example
+
+structure Numeric {
+    i: Integer,
+    f: Float,
+    d: Double
+    s: Short,
+    l: Long,
+    bi: BigInteger,
+    bd: BigDecimal
+}

--- a/sampleSpecs/numeric.smithy
+++ b/sampleSpecs/numeric.smithy
@@ -1,11 +1,13 @@
+$version: "2"
+
 namespace smithy4s.example
 
 structure Numeric {
-    i: Integer,
-    f: Float,
-    d: Double
-    s: Short,
-    l: Long,
-    bi: BigInteger,
-    bd: BigDecimal
+    i: Integer = 1,
+    f: Float = 1.0,
+    d: Double = 1.0
+    s: Short = 1,
+    l: Long = 1,
+    bi: BigInteger = 1,
+    bd: BigDecimal = 1
 }


### PR DESCRIPTION
1. Add precision suffixes to generated number literals, which appears to help Scala Native (`val x: Float = 1.0` doesn't play well with SN, you need to write `1.0f) 
2. Reworks the way that some functions of `smithy4s.Service` are implemented in the generated code, in order to avoid a "method too large" compilation error which appears to happen with services that have lots of operations. Instead of pat-mats, we use methods generated in the `Operation` associated to the service. 
3. Sorts the imports before rendering them. This is purely aesthetics but it looks much better. 