### PR TITLE
Hiding internal default fields

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -371,7 +371,7 @@ lazy val codegen = projectMatrix
       "smithyOrg" -> Dependencies.Smithy.org,
       "smithyVersion" -> Dependencies.Smithy.version,
       "alloyOrg" -> Dependencies.Alloy.org,
-      "alloyVersion" -> Dependencies.Alloy.version
+      "alloyVersion" -> Dependencies.Alloy.alloyVersion
     ),
     buildInfoPackage := "smithy4s.codegen",
     libraryDependencies ++= Seq(

--- a/modules/http4s/src/smithy4s/http4s/SimpleRestJsonBuilder.scala
+++ b/modules/http4s/src/smithy4s/http4s/SimpleRestJsonBuilder.scala
@@ -17,6 +17,8 @@
 package smithy4s
 package http4s
 
+import smithy.api.Default
+import smithy.api.Internal
 import smithy4s.internals.InputOutput
 
 object SimpleRestJsonBuilder extends SimpleRestJsonBuilder(1024)
@@ -26,7 +28,9 @@ class SimpleRestJsonBuilder(maxArity: Int)
       smithy4s.http.json.codecs(
         alloy.SimpleRestJson.protocol.hintMask ++ HintMask(
           InputOutput,
-          IntEnum
+          IntEnum,
+          Default,
+          Internal
         ),
         maxArity
       )

--- a/modules/json/src/smithy4s/http/json/SchemaVisitorJCodec.scala
+++ b/modules/json/src/smithy4s/http/json/SchemaVisitorJCodec.scala
@@ -23,7 +23,9 @@ import java.util
 
 import com.github.plokhotnyuk.jsoniter_scala.core.JsonReader
 import com.github.plokhotnyuk.jsoniter_scala.core.JsonWriter
+import smithy.api.Default
 import smithy.api.HttpPayload
+import smithy.api.Internal
 import smithy.api.JsonName
 import smithy.api.TimestampFormat
 import alloy.Discriminated
@@ -1094,7 +1096,12 @@ private[smithy4s] class SchemaVisitorJCodec(
       ): (Z, JsonWriter) => Unit = {
         val codec = apply(instance)
         val jLabel = jsonLabel(field)
-        if (jLabel.forall(JsonWriter.isNonEscapedAscii)) {
+        val hasDefault = instance.hints.has[Default]
+        val hasInternal = instance.hints.has[Internal]
+        if (hasInternal && hasDefault) { (_, _) =>
+          // we hide the field
+          ()
+        } else if (jLabel.forall(JsonWriter.isNonEscapedAscii)) {
           (z: Z, out: JsonWriter) =>
             {
               out.writeNonEscapedAsciiKey(jLabel)

--- a/modules/tests/src/smithy4s/tests/PizzaAdminServiceImpl.scala
+++ b/modules/tests/src/smithy4s/tests/PizzaAdminServiceImpl.scala
@@ -117,4 +117,6 @@ class PizzaAdminServiceImpl(ref: Compat.Ref[IO, State])
       body: EchoBody,
       queryParam: Option[String]
   ): IO[Unit] = IO.unit
+
+  def renderDefaults(): IO[GetDefault] = GetDefault().pure[IO]
 }

--- a/modules/tests/src/smithy4s/tests/PizzaSpec.scala
+++ b/modules/tests/src/smithy4s/tests/PizzaSpec.scala
@@ -356,6 +356,24 @@ abstract class PizzaSpec
     }
   }
 
+  routerTest("render default tests") { (client, uri, log) =>
+    for {
+      res <- client.send[Json](GET(uri / "get-defaults"), log)
+    } yield {
+      val (code, _, body) = res
+      val expectedBody = Json.obj(
+        "someString" -> Json.fromString("value"),
+        "someInt" -> Json.fromInt(1),
+        "someDouble" -> Json.fromDoubleOrNull(1.0d),
+        "someList" -> Json.arr(),
+        "someMap" -> Json.obj(),
+        "someBoolean" -> Json.fromBoolean(true)
+      )
+      expect.all(code == 200) &&
+      expect.same(body, expectedBody)
+    }
+  }
+
   private def headerTest(name: String)(requestHeaderNames: String*) =
     routerTest(name) { (client, uri, log) =>
       for {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -26,9 +26,9 @@ object Dependencies {
 
   val Alloy = new {
     val org = "com.disneystreaming.alloy"
-    val version = "0.1.2"
-    val core = org % "alloy-core" % version
-    val openapi = org %% "alloy-openapi" % version
+    val alloyVersion = "0.1.5"
+    val core = org % "alloy-core" % alloyVersion
+    val openapi = org %% "alloy-openapi" % alloyVersion
   }
 
   val Cats = new {

--- a/sampleSpecs/pizza.smithy
+++ b/sampleSpecs/pizza.smithy
@@ -7,7 +7,7 @@ use alloy#simpleRestJson
 @simpleRestJson
 service PizzaAdminService {
   version: "1.0.0",
-  operations: [AddMenuItem, GetMenu, Version, Health, HeaderEndpoint, RoundTrip, GetEnum, GetIntEnum, CustomCode, Book, Echo]
+  operations: [AddMenuItem, GetMenu, Version, Health, HeaderEndpoint, RoundTrip, GetEnum, GetIntEnum, CustomCode, Book, Echo, RenderDefaults]
 }
 
 @http(method: "POST", uri: "/restaurant/{restaurant}/menu/item", code: 201)
@@ -335,4 +335,30 @@ operation Echo {
 structure EchoBody {
   @length(min: 10)
   data: String
+}
+
+@readonly
+@http(method: "GET", uri: "/get-defaults", code: 200)
+operation RenderDefaults {
+  output: GetDefault
+}
+
+list AList {
+  member: String
+}
+
+map AMap {
+  key: String
+  value: Integer
+}
+
+structure GetDefault {
+  someString: String = "value"
+  someInt: Integer = 1
+  someDouble: Double = 1.0
+  someList: AList = [] //must be empty
+  someMap: AMap = {} //must be empty
+  someBoolean: Boolean = true
+  @internal
+  someOtherInternalString: String = "secret"
 }

--- a/smithy-build.json
+++ b/smithy-build.json
@@ -1,10 +1,7 @@
 {
-  "imports": [
-    "./sampleSpecs",
-    "./modules/protocol/resources"
-  ],
+  "imports": ["./sampleSpecs", "./modules/protocol/resources"],
   "mavenDependencies": [
     "software.amazon.smithy:smithy-protocol-test-traits:1.26.0",
-    "com.disneystreaming.alloy:alloy-core:0.1.2"
+    "com.disneystreaming.alloy:alloy-core:0.1.5"
   ]
 }


### PR DESCRIPTION
After reading this: https://smithy.io/2.0/spec/type-refinement-traits.html#default-value-serialization

I noticed that we were rendering the defaults when we _should not_. I open as draft because:

1. I believe this also affects the client and I'm not sure it should
2. I think `Internal` and `Default` should come from the alloy `protocolDefinition` rather than added here in the `HintMask`