### PR TITLE
Add resource operations to generated service

### DIFF
--- a/modules/core/test/src/smithy4s/ServiceWithResourcesSmokeSpec.scala
+++ b/modules/core/test/src/smithy4s/ServiceWithResourcesSmokeSpec.scala
@@ -1,0 +1,30 @@
+/*
+ *  Copyright 2021-2022 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package smithy4s
+
+import munit._
+
+class ServiceWithResourcesSmokeSpec() extends FunSuite {
+
+  test(
+    "Services that have resources in their smithy spec have the operations held by the resources"
+  ) {
+    val library = new smithy4s.example.Library.Default[Option](None)
+    expect.eql(library.getBook(), None)
+  }
+
+}

--- a/modules/core/test/src/smithy4s/TransformationSpec.scala
+++ b/modules/core/test/src/smithy4s/TransformationSpec.scala
@@ -23,8 +23,8 @@ import scala.util.{Failure, Success, Try}
 class TransformationSpec() extends FunSuite {
 
   test("transform method can be called with poly functions") {
-    object stub extends Weather[Option] {
-      def getCurrentTime(): Option[GetCurrentTimeOutput] = None
+    object stub extends Weather.Default[Option](None) {
+      override def getCurrentTime(): Option[GetCurrentTimeOutput] = None
     }
 
     case object Empty extends Throwable

--- a/sampleSpecs/misc.smithy
+++ b/sampleSpecs/misc.smithy
@@ -112,3 +112,15 @@ structure RangeCheck {
 // face with sunglasses emoji
 @pattern("^\\uD83D\\uDE0E$")
 string UnicodeRegexString
+
+service Library {
+  resources: [Book]
+}
+
+resource Book {
+  read: GetBook
+}
+
+@readonly
+operation GetBook {
+}


### PR DESCRIPTION
When rendering a service, the resource operations are now gathered and added as if they were defined directly on a service.