### PR TITLE
fix path segment parsing when suffixed with query

### DIFF
--- a/modules/core/src/smithy4s/http/HttpEndpoint.scala
+++ b/modules/core/src/smithy4s/http/HttpEndpoint.scala
@@ -27,8 +27,8 @@ trait HttpEndpoint[I] {
   // Returns a path template as a list of segments, which can be constant strings or placeholders.
   def path: List[PathSegment]
 
-  // Returns a map of static query parameters that are found in the uri of Http hint, there cannot be multiple of the same key !.
-  def staticQueryParams: Map[String, String]
+  // Returns a map of static query parameters that are found in the uri of Http hint.
+  def staticQueryParams: Map[String, Seq[String]]
   def method: HttpMethod
   def code: Int
 
@@ -69,7 +69,7 @@ object HttpEndpoint {
     } yield {
       new HttpEndpoint[I] {
         def path(input: I): List[String] = encoder.encode(input)
-        val staticQueryParams: Map[String, String] = queryParams
+        val staticQueryParams: Map[String, Seq[String]] = queryParams
         val path: List[PathSegment] = httpPath.toList
         val method: HttpMethod = httpMethod
         val code: Int = http.code

--- a/modules/core/src/smithy4s/http/HttpEndpoint.scala
+++ b/modules/core/src/smithy4s/http/HttpEndpoint.scala
@@ -69,7 +69,7 @@ object HttpEndpoint {
     } yield {
       new HttpEndpoint[I] {
         def path(input: I): List[String] = encoder.encode(input)
-        val staticQueryParams: Map[String,String] = queryParams
+        val staticQueryParams: Map[String, String] = queryParams
         val path: List[PathSegment] = httpPath.toList
         val method: HttpMethod = httpMethod
         val code: Int = http.code

--- a/modules/core/src/smithy4s/http/internals/package.scala
+++ b/modules/core/src/smithy4s/http/internals/package.scala
@@ -67,17 +67,17 @@ package object internals {
 
   private[http] def staticQueryParams(
       uri: String
-  ): Map[String, String] = {
+  ): Map[String, Seq[String]] = {
     uri.split("\\?", 2) match {
       case Array(_) => Map.empty
       case Array(_, query) =>
-        query.split("&").toList.foldLeft(Map.empty[String, String]) {
+        query.split("&").toList.foldLeft(Map.empty[String, Seq[String]]) {
           case (acc, param) =>
             val (k, v) = param.split("=", 2) match {
               case Array(key)        => (key, "")
               case Array(key, value) => (key, value)
             }
-            acc.updated(k, v)
+            acc.updated(k, acc.getOrElse(k, Seq.empty) :+ v)
         }
     }
   }

--- a/modules/core/src/smithy4s/http/internals/package.scala
+++ b/modules/core/src/smithy4s/http/internals/package.scala
@@ -57,12 +57,12 @@ package object internals {
   ): Option[Vector[PathSegment]] = {
     str
       .split('?')
-      .headOption
-      .flatMap(
-        _.split('/').toVector
-          .filterNot(_.isEmpty())
-          .traverse(fromToString(_))
-      )
+      .head
+      .split('/')
+      .toVector
+      .filterNot(_.isEmpty())
+      .traverse(fromToString(_))
+
   }
 
   private[http] def staticQueryParams(
@@ -83,16 +83,11 @@ package object internals {
   }
 
   private def fromToString(str: String): Option[PathSegment] = {
-    Option(str).filter(_.nonEmpty).map { str =>
-      {
-        // handle query params in path
-        if (str.startsWith("{") && str.endsWith("+}"))
-          PathSegment.greedy(str.substring(1, str.length() - 2))
-        else if (str.startsWith("{") && str.endsWith("}"))
-          PathSegment.label(str.substring(1, str.length() - 1))
-        else PathSegment.static(str)
-      }
-    }
+    if (str == null || str.isEmpty) None
+    else if (str.startsWith("{") && str.endsWith("+}"))
+      Some(PathSegment.greedy(str.substring(1, str.length() - 2)))
+    else if (str.startsWith("{") && str.endsWith("}"))
+      Some(PathSegment.label(str.substring(1, str.length() - 1)))
+    else Some(PathSegment.static(str))
   }
-
 }

--- a/modules/core/src/smithy4s/http/internals/package.scala
+++ b/modules/core/src/smithy4s/http/internals/package.scala
@@ -63,12 +63,17 @@ package object internals {
   }
 
   private def fromToString(str: String): Option[PathSegment] = {
-    if (str.isEmpty()) None
-    else if (str.startsWith("{") && str.endsWith("+}"))
-      Some(PathSegment.greedy(str.substring(1, str.length() - 2)))
-    else if (str.startsWith("{") && str.endsWith("}"))
-      Some(PathSegment.label(str.substring(1, str.length() - 1)))
-    else Some(PathSegment.static(str))
+    Option(str).map { str =>
+      {
+        // handle query params in path
+        val sanitized = str.split('?').head
+        if (sanitized.startsWith("{") && sanitized.endsWith("+}"))
+          PathSegment.greedy(sanitized.substring(1, sanitized.length() - 2))
+        else if (sanitized.startsWith("{") && sanitized.endsWith("}"))
+          PathSegment.label(sanitized.substring(1, sanitized.length() - 1))
+        else PathSegment.static(sanitized)
+      }
+    }
   }
 
 }

--- a/modules/core/src/smithy4s/http/internals/package.scala
+++ b/modules/core/src/smithy4s/http/internals/package.scala
@@ -63,7 +63,7 @@ package object internals {
   }
 
   private def fromToString(str: String): Option[PathSegment] = {
-    Option(str).map { str =>
+    Option(str).filter(_.nonEmpty).map { str =>
       {
         // handle query params in path
         val sanitized = str.split('?').head

--- a/modules/core/test/src/smithy4s/http/internals/PathSpec.scala
+++ b/modules/core/test/src/smithy4s/http/internals/PathSpec.scala
@@ -46,7 +46,7 @@ class PathSpec() extends munit.FunSuite {
   }
 
   test("Parse path pattern into path segments") {
-    val result = pathSegments("/{head}/foo/{tail+}?hello=world")
+    val result = pathSegments("/{head}/foo/{tail+}")
     expect(
       result == Option(
         Vector(
@@ -57,7 +57,18 @@ class PathSpec() extends munit.FunSuite {
       )
     )
   }
-
+  test("Parse path pattern from path that has query param into path segments") {
+    val result = pathSegments("/{head}/foo/{tail+}?hello=world&hi")
+    expect(
+      result == Option(
+        Vector(
+          PathSegment.label("head"),
+          PathSegment.static("foo"),
+          PathSegment.greedy("tail")
+        )
+      )
+    )
+  }
   test("Write PathParams for DummyPath") {
     val result = HttpEndpoint
       .cast(

--- a/modules/core/test/src/smithy4s/http/internals/PathSpec.scala
+++ b/modules/core/test/src/smithy4s/http/internals/PathSpec.scala
@@ -69,6 +69,35 @@ class PathSpec() extends munit.FunSuite {
       )
     )
   }
+  test("parse static query params from DummyPath") {
+    val httpEndpoint = HttpEndpoint
+      .cast(
+        DummyPath
+      )
+      .toOption
+      .get
+
+    val sqp = httpEndpoint.staticQueryParams
+    val path = httpEndpoint.path
+
+    val expectedQueryMap = Map("value" -> "foo", "baz" -> "bar")
+    expect(sqp == expectedQueryMap)
+    expect(
+      path ==
+        List(
+          PathSegment.static("dummy-path"),
+          PathSegment.label("str"),
+          PathSegment.label("int"),
+          PathSegment.label("ts1"),
+          PathSegment.label("ts2"),
+          PathSegment.label("ts3"),
+          PathSegment.label("ts4"),
+          PathSegment.label("b"),
+          PathSegment.label("ie")
+        )
+    )
+  }
+
   test("Write PathParams for DummyPath") {
     val result = HttpEndpoint
       .cast(

--- a/modules/core/test/src/smithy4s/http/internals/PathSpec.scala
+++ b/modules/core/test/src/smithy4s/http/internals/PathSpec.scala
@@ -80,7 +80,7 @@ class PathSpec() extends munit.FunSuite {
     val sqp = httpEndpoint.staticQueryParams
     val path = httpEndpoint.path
 
-    val expectedQueryMap = Map("value" -> "foo", "baz" -> "bar")
+    val expectedQueryMap = Map("value" -> Seq("foo"), "baz" -> Seq("bar"))
     expect(sqp == expectedQueryMap)
     expect(
       path ==

--- a/modules/core/test/src/smithy4s/http/internals/PathSpec.scala
+++ b/modules/core/test/src/smithy4s/http/internals/PathSpec.scala
@@ -46,7 +46,7 @@ class PathSpec() extends munit.FunSuite {
   }
 
   test("Parse path pattern into path segments") {
-    val result = pathSegments("/{head}/foo/{tail+}")
+    val result = pathSegments("/{head}/foo/{tail+}?hello=world")
     expect(
       result == Option(
         Vector(

--- a/modules/http4s/src/smithy4s/http4s/internals/SmithyHttp4sClientEndpoint.scala
+++ b/modules/http4s/src/smithy4s/http4s/internals/SmithyHttp4sClientEndpoint.scala
@@ -118,7 +118,7 @@ private[http4s] class SmithyHttp4sClientEndpointImpl[F[_], Op[_, _, _, _, _], I,
     val uri = baseUri
       .copy(path = baseUri.path.addSegments(path.map(Uri.Path.Segment(_))))
       .withQueryParams(staticQueries)
-      .withMultiValueQueryParams( metadata.query)
+      .withMultiValueQueryParams(metadata.query)
     val headers = toHeaders(metadata.headers)
     val baseRequest = Request[F](method, uri, headers = headers)
     if (inputHasBody) {

--- a/modules/http4s/src/smithy4s/http4s/internals/SmithyHttp4sClientEndpoint.scala
+++ b/modules/http4s/src/smithy4s/http4s/internals/SmithyHttp4sClientEndpoint.scala
@@ -114,9 +114,11 @@ private[http4s] class SmithyHttp4sClientEndpointImpl[F[_], Op[_, _, _, _, _], I,
   def inputToRequest(input: I): Request[F] = {
     val metadata = inputMetadataEncoder.encode(input)
     val path = httpEndpoint.path(input)
+    val staticQueries = httpEndpoint.staticQueryParams
     val uri = baseUri
       .copy(path = baseUri.path.addSegments(path.map(Uri.Path.Segment(_))))
-      .withMultiValueQueryParams(metadata.query)
+      .withQueryParams(staticQueries)
+      .withMultiValueQueryParams( metadata.query)
     val headers = toHeaders(metadata.headers)
     val baseRequest = Request[F](method, uri, headers = headers)
     if (inputHasBody) {

--- a/modules/http4s/src/smithy4s/http4s/internals/SmithyHttp4sClientEndpoint.scala
+++ b/modules/http4s/src/smithy4s/http4s/internals/SmithyHttp4sClientEndpoint.scala
@@ -117,8 +117,7 @@ private[http4s] class SmithyHttp4sClientEndpointImpl[F[_], Op[_, _, _, _, _], I,
     val staticQueries = httpEndpoint.staticQueryParams
     val uri = baseUri
       .copy(path = baseUri.path.addSegments(path.map(Uri.Path.Segment(_))))
-      .withQueryParams(staticQueries)
-      .withMultiValueQueryParams(metadata.query)
+      .withMultiValueQueryParams(staticQueries ++ metadata.query)
     val headers = toHeaders(metadata.headers)
     val baseRequest = Request[F](method, uri, headers = headers)
     if (inputHasBody) {

--- a/sampleSpecs/metadata.smithy
+++ b/sampleSpecs/metadata.smithy
@@ -15,7 +15,7 @@ operation Dummy {
   input: Queries
 }
 
-@http(method: "GET", uri: "/dummy-path/{str}/{int}/{ts1}/{ts2}/{ts3}/{ts4}/{b}/{ie}")
+@http(method: "GET", uri: "/dummy-path/{str}/{int}/{ts1}/{ts2}/{ts3}/{ts4}/{b}/{ie}?value=foo&baz=bar")
 @readonly
 operation DummyPath {
   input: PathParams


### PR DESCRIPTION
In the scenario of a constant query (and perhaps some other cases) parsing of path segments fail.
`http://yourhost/my/uri/{foo}?hello=world` should parse a label foo, which it currently does not 