### PR TITLE
DO NOT MERGE - bug in httpQueryParams trait reproduction

### DIFF
--- a/sampleSpecs/test.smithy
+++ b/sampleSpecs/test.smithy
@@ -8,7 +8,7 @@ use alloy#simpleRestJson
 
 @simpleRestJson
 service HelloService {
-    operations: [SayHello, Listen, TestPath]
+    operations: [SayHello, Listen, TestPath,QueryPrecedence]
 }
 
 @http(method: "POST", uri: "/")
@@ -193,4 +193,64 @@ structure ErrorDetails {
     date: Timestamp
     @required
     location: String
+}
+
+apply QueryPrecedence @httpRequestTests([
+    {
+        id: "QueryPrecedence",
+        documentation: "Prefer named query parameters when serializing",
+        protocol: simpleRestJson,
+        method: "POST",
+        uri: "/Precedence",
+        body: "",
+        queryParams: [
+            "bar=named",
+            "qux=alsoFromMap"
+        ],
+        params: {
+            foo: "named",
+            baz: {
+                bar: "fromMap",
+                qux: "alsoFromMap"
+            }
+        },
+        appliesTo: "client",
+    },
+    {
+        id: "RestJsonServersPutAllQueryParamsInMap",
+        documentation: "Servers put all query params in map",
+        protocol: simpleRestJson,
+        method: "POST",
+        uri: "/Precedence",
+        body: "",
+        queryParams: [
+            "bar=named",
+            "qux=fromMap"
+        ],
+        params: {
+            foo: "named",
+            baz: {
+                bar: "named",
+                qux: "fromMap"
+            }
+        },
+        appliesTo: "server",
+    }
+])
+@http(method: "POST", uri: "/Precedence")
+operation QueryPrecedence {
+    input: QueryParamsInput
+}
+
+structure QueryParamsInput {
+    @httpQuery("bar")
+    foo: String
+
+    @httpQueryParams
+    baz: StringMap
+}
+
+map StringMap {
+    key: String,
+    value: String,
 }


### PR DESCRIPTION
This PR just adds additional smithy to the compliance tests module test.smithy to showcase reproduction of bug when httpQuery trait and httpQueryParams trait overlap
see serialization rules here 
https://smithy.io/2.0/spec/http-bindings.html#httpqueryparams-trait