### PR TITLE
extract query parameter embedded in url

### DIFF
--- a/modules/http4s/src/smithy4s/http4s/internals/SmithyHttp4sClientEndpoint.scala
+++ b/modules/http4s/src/smithy4s/http4s/internals/SmithyHttp4sClientEndpoint.scala
@@ -114,12 +114,7 @@ private[http4s] class SmithyHttp4sClientEndpointImpl[F[_], Op[_, _, _, _, _], I,
   def inputToRequest(input: I): Request[F] = {
     val metadata = inputMetadataEncoder.encode(input)
     val path = httpEndpoint.path(input)
-    val (extractedPath, queries) =
-      path.lastOption
-        .fold((path, Map.empty[String, Seq[String]])) { segment =>
-          val (last, queries) = splitQueryAndPath(segment)
-          (path.dropRight(1) :+ last, queries)
-        }
+    val (extractedPath, queries) = splitPathSegmentsAndQueryParams(path)
     val uri = baseUri
       .copy(path =
         baseUri.path.addSegments(extractedPath.map(Uri.Path.Segment(_)))

--- a/modules/http4s/src/smithy4s/http4s/package.scala
+++ b/modules/http4s/src/smithy4s/http4s/package.scala
@@ -60,7 +60,16 @@ package object http4s extends Compat.Package {
       (CaseInsensitive(k.toString), v.map(_.value))
     }
 
-  private[smithy4s] def splitQueryAndPath(
+  private[smithy4s] def splitPathSegmentsAndQueryParams(
+      path: List[String]
+  ): (List[String], Map[String, Seq[String]]) = {
+    path.lastOption
+      .fold((path, Map.empty[String, Seq[String]])) { segment =>
+        val (last, queries) = splitPathAndQuery(segment)
+        (path.dropRight(1) :+ last, queries)
+      }
+  }
+  private def splitPathAndQuery(
       segment: String
   ): (String, Map[String, Seq[String]]) = {
     segment.split("\\?", 2) match {

--- a/modules/http4s/src/smithy4s/http4s/package.scala
+++ b/modules/http4s/src/smithy4s/http4s/package.scala
@@ -62,27 +62,27 @@ package object http4s extends Compat.Package {
 
   private[smithy4s] def splitPathSegmentsAndQueryParams(
       path: List[String]
-  ): (List[String], Map[String, Seq[String]]) = {
+  ): (List[String], Map[String, List[String]]) = {
     path.lastOption
-      .fold((path, Map.empty[String, Seq[String]])) { segment =>
+      .fold((path, Map.empty[String, List[String]])) { segment =>
         val (last, queries) = splitPathAndQuery(segment)
         (path.dropRight(1) :+ last, queries)
       }
   }
   private def splitPathAndQuery(
       segment: String
-  ): (String, Map[String, Seq[String]]) = {
+  ): (String, Map[String, List[String]]) = {
     segment.split("\\?", 2) match {
       case Array(path) => (path, Map.empty)
       case Array(path, query) =>
         val params =
-          query.split("&").toList.foldLeft(Map.empty[String, Seq[String]]) {
+          query.split("&").toList.foldLeft(Map.empty[String, List[String]]) {
             case (acc, param) =>
               val (k, v) = param.split("=", 2) match {
                 case Array(key, value) => (key, value)
                 case Array(key)        => (key, "")
               }
-              acc.updated(k, acc.getOrElse(k, Seq.empty) :+ v)
+              acc.updated(k, acc.getOrElse(k, List.empty) :+ v)
           }
         (path, params)
     }

--- a/modules/http4s/src/smithy4s/http4s/package.scala
+++ b/modules/http4s/src/smithy4s/http4s/package.scala
@@ -60,4 +60,22 @@ package object http4s extends Compat.Package {
       (CaseInsensitive(k.toString), v.map(_.value))
     }
 
+  private[smithy4s] def splitQueryAndPath(
+      segment: String
+  ): (String, Map[String, Seq[String]]) = {
+    segment.split("\\?", 2) match {
+      case Array(path) => (path, Map.empty)
+      case Array(path, query) =>
+        val params =
+          query.split("&").toList.foldLeft(Map.empty[String, Seq[String]]) {
+            case (acc, param) =>
+              val (k, v) = param.split("=", 2) match {
+                case Array(key, value) => (key, value)
+                case Array(key)        => (key, "")
+              }
+              acc.updated(k, acc.getOrElse(k, Seq.empty) :+ v)
+          }
+        (path, params)
+    }
+  }
 }

--- a/modules/http4s/test/src/smithy4s/http4s/Http4sUtilsSpec.scala
+++ b/modules/http4s/test/src/smithy4s/http4s/Http4sUtilsSpec.scala
@@ -1,0 +1,54 @@
+/*
+ *  Copyright 2021-2022 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package smithy4s
+package http4s
+
+import weaver.FunSuite
+
+object Http4sUtilsSpec extends FunSuite {
+
+  test(
+    "Path segments with a query string param should properly partitioned into a tuple of path and query params"
+  ) {
+    val segments = List("foo", "bar", "baz?qux=quz")
+    val (path, queries) = splitPathSegmentsAndQueryParams(segments)
+    expect.eql(List("foo", "bar", "baz"), path) && expect.eql(
+      Map("qux" -> List("quz")),
+      queries
+    )
+  }
+  test(
+    "Path segments with a query string param WITHOUT A VALUE should properly partitioned into a tuple of path and query params"
+  ) {
+    val segments = List("foo", "bar", "baz?qux=")
+    val (path, queries) = splitPathSegmentsAndQueryParams(segments)
+    expect.eql(List("foo", "bar", "baz"), path) && expect.eql(
+      Map("qux" -> List("")),
+      queries
+    )
+  }
+  test(
+    "Path segments with a query string param WITHOUT AN EQUAL SIGN OR VALUE should properly partitioned into a tuple of path and query params"
+  ) {
+    val segments = List("foo", "bar", "baz?qux")
+    val (path, queries) = splitPathSegmentsAndQueryParams(segments)
+    expect.eql(List("foo", "bar", "baz"), path) && expect.eql(
+      Map("qux" -> List("")),
+      queries
+    )
+  }
+}


### PR DESCRIPTION
this pr adds a method to split a constant query from the last path segment and add to list of existing query params gathered by the metadata
I did not add tests , as I am working on moving theses types of tests over to utilize compliance tests module
fixes #690 