### PR TITLE
Add scalacOptions for sourcemapping github paths

### DIFF
--- a/project/Smithy4sBuildPlugin.scala
+++ b/project/Smithy4sBuildPlugin.scala
@@ -394,8 +394,8 @@ object Smithy4sBuildPlugin extends AutoPlugin {
     scalacOptions ++= {
       // Map the sourcemaps to github paths instead of local directories
       val flag =
-        if (scalaVersion.value.startsWith("3")) "-scalajs-mapSourceURI:"
-        else "-P:scalajs:mapSourceURI:"
+        if (scalaVersion.value.startsWith("3")) "-scalajs-mapSourceURI"
+        else "-P:scalajs:mapSourceURI"
       val localSourcesPath = baseDirectory.value.toURI
       val headCommit = git.gitHeadCommit.value.get
       scmInfo.value.map { info =>


### PR DESCRIPTION
Hopefully fixes https://github.com/disneystreaming/smithy4s/issues/705

Code is an amalgamation of https://github.com/typelevel/sbt-typelevel/blob/4da726ca021ea2c6459e8286d9ec49ab7c79a883/github/src/main/scala/org/typelevel/sbt/TypelevelScalaJSGitHubPlugin.scala#L34 and https://github.com/raquo/Laminar/blob/739cc0dbab319c685f28be30a1592b7d04347842/build.sbt#L76

Feedback is very much welcome, the code could be a lot simpler like the code from Laminar.