### PR TITLE
[compliance tests] addresses timeouts on the server side 

### DIFF
--- a/modules/compliance-tests/src/smithy4s/compliancetests/internals/IntendedShortCircuit.scala
+++ b/modules/compliance-tests/src/smithy4s/compliancetests/internals/IntendedShortCircuit.scala
@@ -1,4 +1,21 @@
-package smithy4s.compliancetests.internals
+/*
+ *  Copyright 2021-2022 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package smithy4s.compliancetests
+package internals
 
 private[compliancetests] case class IntendedShortCircuit()
     extends scala.util.control.NoStackTrace

--- a/modules/compliance-tests/src/smithy4s/compliancetests/internals/IntendedShortCircuit.scala
+++ b/modules/compliance-tests/src/smithy4s/compliancetests/internals/IntendedShortCircuit.scala
@@ -1,0 +1,4 @@
+package smithy4s.compliancetests.internals
+
+private[compliancetests] case class IntendedShortCircuit()
+    extends scala.util.control.NoStackTrace

--- a/modules/compliance-tests/src/smithy4s/compliancetests/internals/ServerHttpComplianceTestCase.scala
+++ b/modules/compliance-tests/src/smithy4s/compliancetests/internals/ServerHttpComplianceTestCase.scala
@@ -102,7 +102,7 @@ private[compliancetests] class ServerHttpComplianceTestCase[
 
                   if (endpointInternal.id == endpoint.id)
                     inputDeferred.complete(in.asInstanceOf[I]) *>
-                      raiseError(new NotImplementedError)
+                      raiseError(new IntendedShortCircuit)
                   else raiseError(new Throwable("Wrong endpoint called"))
                 }
               }
@@ -112,7 +112,7 @@ private[compliancetests] class ServerHttpComplianceTestCase[
             .use { server =>
               server.orNotFound
                 .run(makeRequest(baseUri, testCase))
-                .attemptNarrow[NotImplementedError]
+                .attemptNarrow[IntendedShortCircuit]
                 .flatMap {
                   case Left(_) =>
                     ce.timeout(inputDeferred.get, 1.second).flatMap {

--- a/modules/compliance-tests/src/smithy4s/compliancetests/internals/ServerHttpComplianceTestCase.scala
+++ b/modules/compliance-tests/src/smithy4s/compliancetests/internals/ServerHttpComplianceTestCase.scala
@@ -127,7 +127,7 @@ private[compliancetests] class ServerHttpComplianceTestCase[
                   case Right(response) =>
                     response.body.compile.toVector.map { message =>
                       assert.fail(
-                        s"Expected a NotImplementedError, but got a response with status ${response.status} and message ${message
+                        s"Expected a IntendedShortCircuit error, but got a response with status ${response.status} and message ${message
                           .map(_.toChar)
                           .mkString}"
                       )


### PR DESCRIPTION
which are caused by payload or metadata decoding errors which are translated into an http4s response and deferred.complete is never called.
This causes the real error to remain hidden