### PR TITLE
codegen cli should use a non-zero exit code when failing

### DIFF
--- a/modules/codegen-cli/src/smithy4s/codegen/cli/Main.scala
+++ b/modules/codegen-cli/src/smithy4s/codegen/cli/Main.scala
@@ -64,7 +64,9 @@ object Main {
         }
         .merge
     } catch {
-      case e: Throwable => e.printStackTrace(System.err)
+      case e: Throwable =>
+        e.printStackTrace(System.err)
+        System.exit(1)
     } finally {
       System.setErr(out)
     }


### PR DESCRIPTION
when troubleshooting a problem with @yisraelU I found this issue.

Basically, because of a chicken-n-egg problem, we implement code generation for Smithy specifications, within this sbt build, as sourceGenerator. The implementation shells out to an external `java` process. The implementation uses `lineStream` which should throw if the process fails.

Without this change, process returns 0, so no exception is thrown, even though the `processSpecs` method has thrown. This is tricky, because `sbt` does not see that an issue was raised, and just assume no files were generated. It then proceeds with the rest of the compilation but fails, because of missing class definition.

With this change, the _sourceGenerator_ responsible for codegeneration fails, and thus sbt does not proceed with compilation.

Before:

```
> Test / compile
software.amazon.smithy.openapi.OpenApiException: The `httpPrefixHeaders` trait is not supported by OpenAPI and was found on `aws.protocoltests.restjson#HttpPrefixHeadersInResponseOutput$prefixHeaders`
        at software.amazon.smithy.openapi.fromsmithy.mappers.CheckForPrefixHeaders.check(CheckForPrefixHeaders.java:78)
        at software.amazon.smithy.openapi.fromsmithy.mappers.CheckForPrefixHeaders.checkForResponseHeaders(CheckForPrefixHeaders.java:66)
  | => hat software.amazon.smithy.openapi.fromsmithy.mappers.CheckForPrefixHeaders.lambda$before$1(CheckForPrefixHeaders.java:56)
        at java.base/java.util.HashMap$KeySpliterator.forEachRemaining(HashMap.java:1707)
        at java.base/java.util.stream.ReferencePipeline$Head.forEach(ReferencePipeline.java:762)
        at software.amazon.smithy.openapi.fromsmithy.mappers.CheckForPrefixHeaders.before(CheckForPrefixHeaders.java:54)
        at software.amazon.smithy.openapi.fromsmithy.OpenApiMapper$1.before(OpenApiMapper.java:416)
        at software.amazon.smithy.openapi.fromsmithy.OpenApiConverter.convertWithEnvironment(OpenApiConverter.java:311)
        at software.amazon.smithy.openapi.fromsmithy.OpenApiConverter.convert(OpenApiConverter.java:144)
        at alloy.openapi.package$.$anonfun$convert$6(package.scala:85)
        at scala.collection.StrictOptimizedIterableOps.map(StrictOptimizedIterableOps.scala:100)
        at scala.collection.StrictOptimizedIterableOps.map$(StrictOptimizedIterableOps.scala:87)
        at scala.collection.immutable.Set$Set1.map(Set.scala:156)
        at alloy.openapi.package$.$anonfun$convert$4(package.scala:80)
        at scala.collection.immutable.List.flatMap(List.scala:293)
        at alloy.openapi.package$.convert(package.scala:77)
        at smithy4s.codegen.internals.CodegenImpl$.processSpecs(CodegenImpl.scala:67)
        at smithy4s.codegen.Codegen$.processSpecs(Codegen.scala:23)
        at smithy4s.codegen.cli.Main$.$anonfun$main$1(Main.scala:45)
        at smithy4s.codegen.cli.Main$.$anonfun$main$1$adapted(Main.scala:43)
        at scala.util.Either.map(Either.scala:382)
        at smithy4s.codegen.cli.Main$.main(Main.scala:43)
        at smithy4s.codegen.cli.Main.main(Main.scala)
[info] [http4s] compiling 12 Scala sources to /Users/David.Francoeur/workspace/dev/smithy4s/modules/http4s/target/ce3-jvm-2.13/classes ...
[info] [http4s] compiling 7 Scala sources to /Users/David.Francoeur/workspace/dev/smithy4s/modules/http4s/target/ce3-jvm-2.13/test-classes ...
[error] [http4s] /Users/David.Francoeur/workspace/dev/smithy4s/modules/http4s/test/src/smithy4s/http4s/EndpointSpecificMiddlewareSpec.scala:21:17: object hello is not a member of package smithy4s
[error] [http4s] import smithy4s.hello._
[error] [http4s]                 ^
// ==================== MULTIPLE COMPILATION ISSUES ==================== //
[error] [http4s] /Users/David.Francoeur/workspace/dev/smithy4s/modules/http4s/test/src/smithy4s/http4s/EndpointSpecificMiddlewareSpec.scala:165:23: private class TestClientMiddleware in object ServerEndpointMiddlewareSpec is never used
[error] [http4s]   private final class TestClientMiddleware(shouldFail: Boolean)
[error] [http4s]                       ^
[error] [http4s] 23 errors found
[error] [http4s] (Test / compileIncremental) Compilation failed
[error] Total time: 8 s, completed Jan. 9, 2023, 3:37:15 p.m.
sbt:http4s> 
```

After:

```
> Test / compile
[info] [http4s] compiling 12 Scala sources to /Users/David.Francoeur/workspace/dev/smithy4s/modules/http4s/target/ce3-jvm-2.13/classes ...
software.amazon.smithy.openapi.OpenApiException: The `httpPrefixHeaders` trait is not supported by OpenAPI and was found on `aws.protocoltests.restjson#HttpPrefixHeadersInput$fooMap`
  | => tat software.amazon.smithy.openapi.fromsmithy.mappers.CheckForPrefixHeaders.check(CheckForPrefixHeaders.java:78)
  | => hat software.amazon.smithy.openapi.fromsmithy.mappers.CheckForPrefixHeaders.lambda$before$1(CheckForPrefixHeaders.java:55)
        at java.base/java.util.HashMap$KeySpliterator.forEachRemaining(HashMap.java:1707)
        at java.base/java.util.stream.ReferencePipeline$Head.forEach(ReferencePipeline.java:762)
        at software.amazon.smithy.openapi.fromsmithy.mappers.CheckForPrefixHeaders.before(CheckForPrefixHeaders.java:54)
        at software.amazon.smithy.openapi.fromsmithy.OpenApiMapper$1.before(OpenApiMapper.java:416)
        at software.amazon.smithy.openapi.fromsmithy.OpenApiConverter.convertWithEnvironment(OpenApiConverter.java:311)
        at software.amazon.smithy.openapi.fromsmithy.OpenApiConverter.convert(OpenApiConverter.java:144)
        at alloy.openapi.package$.$anonfun$convert$6(package.scala:85)
        at scala.collection.StrictOptimizedIterableOps.map(StrictOptimizedIterableOps.scala:100)
        at scala.collection.StrictOptimizedIterableOps.map$(StrictOptimizedIterableOps.scala:87)
        at scala.collection.immutable.Set$Set1.map(Set.scala:156)
        at alloy.openapi.package$.$anonfun$convert$4(package.scala:80)
        at scala.collection.immutable.List.flatMap(List.scala:293)
        at alloy.openapi.package$.convert(package.scala:77)
        at smithy4s.codegen.internals.CodegenImpl$.processSpecs(CodegenImpl.scala:67)
        at smithy4s.codegen.Codegen$.processSpecs(Codegen.scala:23)
        at smithy4s.codegen.cli.Main$.$anonfun$main$1(Main.scala:45)
        at smithy4s.codegen.cli.Main$.$anonfun$main$1$adapted(Main.scala:43)
        at scala.util.Either.map(Either.scala:382)
        at smithy4s.codegen.cli.Main$.main(Main.scala:43)
        at smithy4s.codegen.cli.Main.main(Main.scala)
[error] [http4s] (Test / managedSources) Nonzero exit code: 1
```