### PR TITLE
Fix decoding an optional `Document.DNull` field

### DIFF
--- a/modules/core/src/smithy4s/internals/DocumentDecoderSchemaVisitor.scala
+++ b/modules/core/src/smithy4s/internals/DocumentDecoderSchemaVisitor.scala
@@ -311,7 +311,6 @@ class DocumentDecoderSchemaVisitor(
         Map[String, Document]
     ) => Unit = {
       val jLabel = jsonLabel(field)
-
       val maybeDefault = field.instance.getDefault
 
       if (field.isOptional) {
@@ -323,6 +322,7 @@ class DocumentDecoderSchemaVisitor(
           val path = PayloadPath.Segment(jLabel) :: pp
           fields
             .get(jLabel) match {
+            case Some(DNull) => buffer(None)
             case Some(document) =>
               buffer(Some(apply(field.instance)(path, document)))
             case None => buffer(None)

--- a/modules/core/test/src/smithy4s/DocumentSpec.scala
+++ b/modules/core/test/src/smithy4s/DocumentSpec.scala
@@ -283,5 +283,18 @@ class DocumentSpec() extends FunSuite {
     expect.same(document, expectedDocument)
     expect.same(roundTripped, Right(mapTest))
   }
+  
+  test(
+    "optional values allow Document.DNull"
+  ) {
+    val optionalFieldSchema =
+      Schema
+        .struct[Option[String]](Schema.string.optional[Option[String]]("test", identity))(identity)
 
+    val result = Document.Decoder
+      .fromSchema(optionalFieldSchema)
+      .decode(Document.obj("test" -> Document.DNull))
+    expect.same(result, Left(None))
+
+  }
 }

--- a/modules/core/test/src/smithy4s/DocumentSpec.scala
+++ b/modules/core/test/src/smithy4s/DocumentSpec.scala
@@ -283,18 +283,21 @@ class DocumentSpec() extends FunSuite {
     expect.same(document, expectedDocument)
     expect.same(roundTripped, Right(mapTest))
   }
-  
+
   test(
-    "optional values allow Document.DNull"
+    "optional fields for structs should decode Document.DNull"
   ) {
     val optionalFieldSchema =
       Schema
-        .struct[Option[String]](Schema.string.optional[Option[String]]("test", identity))(identity)
+        .struct[Option[String]](
+          Schema.string.optional[Option[String]]("test", identity)
+        )(identity)
 
-    val result = Document.Decoder
+    val decoded = Document.Decoder
       .fromSchema(optionalFieldSchema)
       .decode(Document.obj("test" -> Document.DNull))
-    expect.same(result, Left(None))
+
+    expect.same(decoded, Right(None))
 
   }
 }


### PR DESCRIPTION
Fixes: https://github.com/disneystreaming/smithy4s/issues/697

Test was made from kubukoz's reproduction example:
```scala
//> using scala "3.2.1"
//> using lib "com.disneystreaming.smithy4s::smithy4s-core:0.17.2"
import smithy4s.schema.Schema
import smithy4s.Document

@main def demo = println {
  val optionalFieldSchema =
    Schema
      .struct[Option[String]](Schema.string.optional[Option[String]]("test", identity))(identity)

  Document
    .Decoder
    .fromSchema(optionalFieldSchema)
    .decode(Document.obj("test" -> Document.DNull))
}
```