### PR TITLE
Generate scaladoc for `@documentation` trait

### DIFF
--- a/modules/codegen/src/smithy4s/codegen/internals/IR.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/IR.scala
@@ -250,7 +250,7 @@ private[internals] object Hint {
   case class Constraint(tr: Type.Ref, native: Native) extends Hint
   case class Protocol(traits: List[Type.Ref]) extends Hint
   case class Default(typedNode: Fix[TypedNode]) extends Hint
-  case class Documentation(docString: String) extends Hint
+  case class Documentation(docString: String, memberDocs: Map[String, String]) extends Hint
   case class Deprecated(message: Option[String], since: Option[String])
       extends Hint
   // traits that get rendered generically

--- a/modules/codegen/src/smithy4s/codegen/internals/IR.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/IR.scala
@@ -250,8 +250,10 @@ private[internals] object Hint {
   case class Constraint(tr: Type.Ref, native: Native) extends Hint
   case class Protocol(traits: List[Type.Ref]) extends Hint
   case class Default(typedNode: Fix[TypedNode]) extends Hint
-  case class Documentation(docString: String, memberDocs: Map[String, String])
-      extends Hint
+  case class Documentation(
+      docString: Option[String],
+      memberDocs: Option[Map[String, String]]
+  ) extends Hint
   case class Deprecated(message: Option[String], since: Option[String])
       extends Hint
   // traits that get rendered generically

--- a/modules/codegen/src/smithy4s/codegen/internals/IR.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/IR.scala
@@ -250,7 +250,8 @@ private[internals] object Hint {
   case class Constraint(tr: Type.Ref, native: Native) extends Hint
   case class Protocol(traits: List[Type.Ref]) extends Hint
   case class Default(typedNode: Fix[TypedNode]) extends Hint
-  case class Documentation(docString: String, memberDocs: Map[String, String]) extends Hint
+  case class Documentation(docString: String, memberDocs: Map[String, String])
+      extends Hint
   case class Deprecated(message: Option[String], since: Option[String])
       extends Hint
   // traits that get rendered generically

--- a/modules/codegen/src/smithy4s/codegen/internals/IR.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/IR.scala
@@ -250,6 +250,7 @@ private[internals] object Hint {
   case class Constraint(tr: Type.Ref, native: Native) extends Hint
   case class Protocol(traits: List[Type.Ref]) extends Hint
   case class Default(typedNode: Fix[TypedNode]) extends Hint
+  case class Documentation(docString: String) extends Hint
   case class Deprecated(message: Option[String], since: Option[String])
       extends Hint
   // traits that get rendered generically

--- a/modules/codegen/src/smithy4s/codegen/internals/IR.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/IR.scala
@@ -251,8 +251,8 @@ private[internals] object Hint {
   case class Protocol(traits: List[Type.Ref]) extends Hint
   case class Default(typedNode: Fix[TypedNode]) extends Hint
   case class Documentation(
-      docString: Option[String],
-      memberDocs: Option[Map[String, String]]
+      docLines: List[String],
+      memberDocLines: Map[String, List[String]]
   ) extends Hint
   case class Deprecated(message: Option[String], since: Option[String])
       extends Hint

--- a/modules/codegen/src/smithy4s/codegen/internals/Renderer.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/Renderer.scala
@@ -174,10 +174,9 @@ private[internals] class Renderer(compilationUnit: CompilationUnit) { self =>
     @tailrec
     def loop(l: List[String], acc: List[Line]): List[Line] = {
       l match {
-        case Nil => acc
-        case hd :: Nil =>
-          loop(Nil, acc :+ line"  * $hd" :+ line"  */")
-        case hd :: tl => loop(tl, acc :+ line"  * $hd")
+        case hd :: Nil => acc :+ line"  * $hd" :+ line"  */"
+        case hd :: tl  => loop(tl, acc :+ line"  * $hd")
+        case Nil       => acc
       }
     }
     loop(nel.tail, List(line"/** ${nel.head}"))

--- a/modules/codegen/src/smithy4s/codegen/internals/Renderer.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/Renderer.scala
@@ -174,9 +174,10 @@ private[internals] class Renderer(compilationUnit: CompilationUnit) { self =>
     @tailrec
     def loop(l: List[String], acc: List[Line]): List[Line] = {
       l match {
-        case Nil                  => acc
-        case _ :: tl if tl == Nil => loop(tl, acc :+ line"  */")
-        case hd :: tl             => loop(tl, acc :+ line"  * $hd")
+        case Nil => acc
+        case hd :: tl if tl == Nil =>
+          loop(tl, acc :+ line"  * $hd" :+ line"  */")
+        case hd :: tl => loop(tl, acc :+ line"  * $hd")
       }
     }
     loop(l.tail, List(line"/** ${l.head}"))

--- a/modules/codegen/src/smithy4s/codegen/internals/Renderer.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/Renderer.scala
@@ -186,18 +186,18 @@ private[internals] class Renderer(compilationUnit: CompilationUnit) { self =>
 
     hints
       .collectFirst { case h: Hint.Documentation => h }
-      .map { doc =>
-        val shapeLinesOpt = split(doc.docString).map(_.toList)
-        val memberLinesOpt = doc.memberDocs.flatMap {
+      .flatMap { doc =>
+        val shapeLinesOpt = doc.docString.map(split(_)).map(_.toList)
+        val memberLinesOpt = doc.memberDocs.map(m => m.flatMap {
           case (memberName, memberDoc) =>
             split(memberDoc) match {
               case Some(NonEmptyList(head, rest)) =>
                 s"@param $memberName $head" :: rest
               case None => Nil
             }
-        }.toList
+        })
 
-        List(shapeLinesOpt, Some(memberLinesOpt)).flatten.flatten
+        List(shapeLinesOpt, memberLinesOpt).flatten.flatten
       }
       .flatMap(NonEmptyList.fromList(_))
       .foldMap {

--- a/modules/codegen/src/smithy4s/codegen/internals/Renderer.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/Renderer.scala
@@ -176,8 +176,8 @@ private[internals] class Renderer(compilationUnit: CompilationUnit) { self =>
     val typeAliases = compilationUnit.declarations.collect {
       case TypeAlias(_, name, _, _, _, hints) =>
         lines(
-          deprecationAnnotation(hints),
           documentationAnnotation(hints),
+          deprecationAnnotation(hints),
           line"type $name = ${compilationUnit.namespace}.${name}.Type"
         )
     }
@@ -228,15 +228,15 @@ private[internals] class Renderer(compilationUnit: CompilationUnit) { self =>
     val opTraitNameRef = opTraitName.toNameRef
 
     lines(
-      deprecationAnnotation(hints),
       documentationAnnotation(hints),
+      deprecationAnnotation(hints),
       block(line"trait $genName[F[_, _, _, _, _]]")(
         line"self =>",
         newline,
         ops.map { op =>
           lines(
-            deprecationAnnotation(op.hints),
             documentationAnnotation(op.hints),
+            deprecationAnnotation(op.hints),
             line"def ${op.methodName}(${op.renderArgs}): F[${op
               .renderAlgParams(genNameRef.name)}]"
           )
@@ -565,8 +565,8 @@ private[internals] class Renderer(compilationUnit: CompilationUnit) { self =>
         )
 
     lines(
-      deprecationAnnotation(product.hints),
       documentationAnnotation(product.hints),
+      deprecationAnnotation(product.hints),
       base
     )
   }
@@ -629,8 +629,8 @@ private[internals] class Renderer(compilationUnit: CompilationUnit) { self =>
     }
     def altVal(altName: String) = line"${uncapitalise(altName)}Alt"
     lines(
-      deprecationAnnotation(hints),
       documentationAnnotation(hints),
+      deprecationAnnotation(hints),
       line"type ${NameDef(name.name)} = ${members
         .map { case (_, tpe) => line"$tpe" }
         .intercalate(line" | ")}",
@@ -677,8 +677,8 @@ private[internals] class Renderer(compilationUnit: CompilationUnit) { self =>
       caseNames.zip(alts.map(_.member == UnionMember.UnitCase))
 
     lines(
-      deprecationAnnotation(hints),
       documentationAnnotation(hints),
+      deprecationAnnotation(hints),
       block(
         line"sealed trait ${NameDef(name.name)} extends scala.Product with scala.Serializable"
       )(
@@ -694,8 +694,8 @@ private[internals] class Renderer(compilationUnit: CompilationUnit) { self =>
             val cn = caseName(a)
             // format: off
             lines(
-              deprecationAnnotation(altHints),
               documentationAnnotation(altHints),
+              deprecationAnnotation(altHints),
               line"case object $cn extends $name",
               line"""private val ${cn}Alt = $Schema_.constant($cn)${renderConstraintValidation(altHints)}.oneOf[$name]("$realName").addHints(hints)""",
               line"private val ${cn}AltWithValue = ${cn}Alt($cn)"
@@ -704,8 +704,8 @@ private[internals] class Renderer(compilationUnit: CompilationUnit) { self =>
           case a @ Alt(altName, _, UnionMember.TypeCase(tpe), altHints) =>
             val cn = caseName(a)
             lines(
-              deprecationAnnotation(altHints),
               documentationAnnotation(altHints),
+              deprecationAnnotation(altHints),
               line"case class $cn(${uncapitalise(altName)}: $tpe) extends $name"
             )
           case Alt(_, realName, UnionMember.ProductCase(struct), altHints) =>
@@ -807,8 +807,8 @@ private[internals] class Renderer(compilationUnit: CompilationUnit) { self =>
       values: List[EnumValue],
       hints: List[Hint]
   ): Lines = lines(
-    deprecationAnnotation(hints),
     documentationAnnotation(hints),
+    deprecationAnnotation(hints),
     block(
       line"sealed abstract class ${name.name}(_value: String, _name: String, _intValue: Int, _hints: $Hints_) extends $Enumeration_.Value"
     )(
@@ -828,8 +828,8 @@ private[internals] class Renderer(compilationUnit: CompilationUnit) { self =>
         val valueHints = line"$Hints_(${memberHints(e.hints)})"
 
         lines(
-          deprecationAnnotation(hints),
           documentationAnnotation(hints),
+          deprecationAnnotation(hints),
           line"""case object $valueName extends $name("$value", "${e.name}", $intValue, $valueHints)"""
         )
       },
@@ -855,8 +855,8 @@ private[internals] class Renderer(compilationUnit: CompilationUnit) { self =>
       line".withId(id).addHints(hints)${renderConstraintValidation(hints)}"
     val closing = if (recursive) ")" else ""
     lines(
-      deprecationAnnotation(hints),
       documentationAnnotation(hints),
+      deprecationAnnotation(hints),
       obj(name, line"$Newtype_[$tpe]")(
         renderId(shapeId),
         renderHintsVal(hints),

--- a/modules/codegen/src/smithy4s/codegen/internals/Renderer.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/Renderer.scala
@@ -701,8 +701,13 @@ private[internals] class Renderer(compilationUnit: CompilationUnit) { self =>
     val caseNamesAndIsUnit =
       caseNames.zip(alts.map(_.member == UnionMember.UnitCase))
 
+    val shapeDocs = hints
+      .collectFirst { case h: Hint.Documentation => h }
+      .map(doc => List(Hint.Documentation(doc.docLines, Map())))
+      .getOrElse(List())
+
     lines(
-      documentationAnnotation(hints),
+      documentationAnnotation(shapeDocs),
       deprecationAnnotation(hints),
       block(
         line"sealed trait ${NameDef(name.name)} extends scala.Product with scala.Serializable"

--- a/modules/codegen/src/smithy4s/codegen/internals/Renderer.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/Renderer.scala
@@ -199,7 +199,9 @@ private[internals] class Renderer(compilationUnit: CompilationUnit) { self =>
       .collectFirst { case h: Hint.Documentation => h }
       .map { doc =>
         val shapeDocs =
-          NonEmptyList.fromList(doc.docString.linesIterator.toList)
+          NonEmptyList.fromList(
+            doc.docString.replace("*/", "\\*\\/").linesIterator.toList
+          )
         val memberDocs = doc.memberDocs
         (shapeDocs, memberDocs)
       }

--- a/modules/codegen/src/smithy4s/codegen/internals/Renderer.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/Renderer.scala
@@ -701,13 +701,8 @@ private[internals] class Renderer(compilationUnit: CompilationUnit) { self =>
     val caseNamesAndIsUnit =
       caseNames.zip(alts.map(_.member == UnionMember.UnitCase))
 
-    val shapeDocs = hints
-      .collectFirst { case h: Hint.Documentation => h }
-      .map(doc => List(Hint.Documentation(doc.docLines, Map())))
-      .getOrElse(List())
-
     lines(
-      documentationAnnotation(shapeDocs),
+      documentationAnnotation(hints),
       deprecationAnnotation(hints),
       block(
         line"sealed trait ${NameDef(name.name)} extends scala.Product with scala.Serializable"

--- a/modules/codegen/src/smithy4s/codegen/internals/SmithyToIR.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/SmithyToIR.scala
@@ -752,6 +752,9 @@ private[codegen] class SmithyToIR(model: Model, namespace: String) {
   }
 
   private def documentationHint(shape: Shape): Option[Hint] = {
+
+    def split(s: String) =
+      s.replace("*/", "\\*\\/").linesIterator.toList
     val memberDocs = shape
       .members()
       .asScala
@@ -767,14 +770,12 @@ private[codegen] class SmithyToIR(model: Model, namespace: String) {
           memberDocs.orElse(targetDocs)
         )
       }
-      .collect { case (name, Some(v)) => (name, v.getValue()) }
+      .collect { case (name, Some(v)) => (name, split(v.getValue())) }
       .toMap
 
-
-    // todo: what if the shape in question doesn't have docs, but members do?
     shape.getTrait(classOf[DocumentationTrait]).asScala.map { doc =>
-      val memberDocsPresent = if (memberDocs.isEmpty) None else Some(memberDocs)
-      Hint.Documentation(Option(doc.getValue), memberDocsPresent)
+      val shapeDocs = split(doc.getValue())
+      Hint.Documentation(shapeDocs, memberDocs)
     }
   }
 

--- a/modules/codegen/src/smithy4s/codegen/internals/SmithyToIR.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/SmithyToIR.scala
@@ -105,7 +105,7 @@ private[codegen] class SmithyToIR(model: Model, namespace: String) {
     new ShapeVisitor[Option[Decl]] {
 
       private def getDefault(shape: Shape): Option[Decl] = {
-        val hints = traitsToHints(shape.getAllTraits().asScala.values.toList)
+        val hints = SmithyToIR.this.hints(shape)
 
         val recursive = hints.exists {
           case Hint.Trait => true
@@ -218,7 +218,7 @@ private[codegen] class SmithyToIR(model: Model, namespace: String) {
       }
 
       override def structureShape(shape: StructureShape): Option[Decl] = {
-        val hints = traitsToHints(shape.getAllTraits().asScala.values.toList)
+        val hints = SmithyToIR.this.hints(shape)
         val isTrait = hints.exists {
           case Hint.Trait => true
           case _          => false
@@ -251,7 +251,7 @@ private[codegen] class SmithyToIR(model: Model, namespace: String) {
       override def unionShape(shape: UnionShape): Option[Decl] = {
         val rec = isRecursive(shape.getId())
 
-        val hints = traitsToHints(shape.getAllTraits().asScala.values.toList)
+        val hints = SmithyToIR.this.hints(shape)
         val isTrait = hints.exists {
           case Hint.Trait => true
           case _          => false
@@ -681,10 +681,6 @@ private[codegen] class SmithyToIR(model: Model, namespace: String) {
 
     }
 
-  private def hints(shape: Shape): List[Hint] = traitsToHints(
-    shape.getAllTraits().asScala.values.toList
-  )
-
   def toTypeRef(id: ToShapeId): Type.Ref = {
     val shapeId = id.toShapeId()
     Type.Ref(shapeId.getNamespace(), shapeId.getName())
@@ -730,7 +726,7 @@ private[codegen] class SmithyToIR(model: Model, namespace: String) {
   @annotation.nowarn(
     "msg=class UniqueItemsTrait in package traits is deprecated"
   )
-  private val traitToHint: PartialFunction[Trait, Hint] = {
+  private def traitToHint(shape: Shape): PartialFunction[Trait, Hint] = {
     case _: ErrorTrait => Hint.Error
     case t: ProtocolDefinitionTrait =>
       val shapeIds = t.getTraits()
@@ -743,7 +739,18 @@ private[codegen] class SmithyToIR(model: Model, namespace: String) {
     case d: DeprecatedTrait =>
       Hint.Deprecated(d.getMessage.asScala, d.getSince.asScala)
     case doc: DocumentationTrait =>
-      Hint.Documentation(doc.getValue())
+      val memberDocs = shape
+        .members()
+        .asScala
+        .map(_.getTarget())
+        .map(shapeId => (shapeId.name, model.expectShape(shapeId)))
+        .map({ case (name, shape) =>
+          (name, shape.getTrait(classOf[DocumentationTrait]).asScala)
+        })
+        .collect({ case (name, Some(v)) => (name, v.getValue()) })
+        .toMap
+
+      Hint.Documentation(doc.getValue(), memberDocs)
     case _: ErrorMessageTrait =>
       Hint.ErrorMessage
     case _: VectorTrait =>
@@ -757,7 +764,8 @@ private[codegen] class SmithyToIR(model: Model, namespace: String) {
     case ConstraintTrait(tr) => Hint.Constraint(toTypeRef(tr), unfoldTrait(tr))
   }
 
-  private def traitsToHints(traits: List[Trait]): List[Hint] = {
+  private def hints(shape: Shape): List[Hint] = {
+    val traits = shape.getAllTraits().asScala.values.toList
     val nonMetaTraits =
       traits
         .filterNot(_.toShapeId().getNamespace() == "smithy4s.meta")
@@ -770,7 +778,9 @@ private[codegen] class SmithyToIR(model: Model, namespace: String) {
     val nonConstraintNonMetaTraits = nonMetaTraits.collect {
       case t if ConstraintTrait.unapply(t).isEmpty => t
     }
-    traits.collect(traitToHint) ++ nonConstraintNonMetaTraits.map(unfoldTrait)
+    traits.collect(traitToHint(shape)) ++ nonConstraintNonMetaTraits.map(
+      unfoldTrait
+    )
   }
 
   case class AltInfo(name: String, tpe: Type, isAdtMember: Boolean)

--- a/modules/codegen/src/smithy4s/codegen/internals/SmithyToIR.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/SmithyToIR.scala
@@ -755,23 +755,27 @@ private[codegen] class SmithyToIR(model: Model, namespace: String) {
 
     def split(s: String) =
       s.replace("*/", "\\*\\/").linesIterator.toList
-    val memberDocs = shape
-      .members()
-      .asScala
-      .map { member =>
-        val memberDocs = member.getTrait(classOf[DocumentationTrait]).asScala
-        def targetDocs = model
-          .expectShape(member.getTarget)
-          .getTrait(classOf[DocumentationTrait])
+    val memberDocs: Map[String, List[String]] =
+      if (shape.isUnionShape()) Map.empty
+      else
+        shape
+          .members()
           .asScala
+          .map { member =>
+            val memberDocs =
+              member.getTrait(classOf[DocumentationTrait]).asScala
+            def targetDocs = model
+              .expectShape(member.getTarget)
+              .getTrait(classOf[DocumentationTrait])
+              .asScala
 
-        (
-          member.getMemberName(),
-          memberDocs.orElse(targetDocs)
-        )
-      }
-      .collect { case (name, Some(v)) => (name, split(v.getValue())) }
-      .toMap
+            (
+              member.getMemberName(),
+              memberDocs.orElse(targetDocs)
+            )
+          }
+          .collect { case (name, Some(v)) => (name, split(v.getValue())) }
+          .toMap
 
     shape.getTrait(classOf[DocumentationTrait]).asScala.map { doc =>
       val shapeDocs = split(doc.getValue())

--- a/modules/codegen/src/smithy4s/codegen/internals/SmithyToIR.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/SmithyToIR.scala
@@ -742,6 +742,8 @@ private[codegen] class SmithyToIR(model: Model, namespace: String) {
       Hint.PackedInputs
     case d: DeprecatedTrait =>
       Hint.Deprecated(d.getMessage.asScala, d.getSince.asScala)
+    case doc: DocumentationTrait =>
+      Hint.Documentation(doc.getValue())
     case _: ErrorMessageTrait =>
       Hint.ErrorMessage
     case _: VectorTrait =>

--- a/modules/codegen/src/smithy4s/codegen/internals/SmithyToIR.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/SmithyToIR.scala
@@ -770,9 +770,11 @@ private[codegen] class SmithyToIR(model: Model, namespace: String) {
       .collect { case (name, Some(v)) => (name, v.getValue()) }
       .toMap
 
+
     // todo: what if the shape in question doesn't have docs, but members do?
     shape.getTrait(classOf[DocumentationTrait]).asScala.map { doc =>
-      Hint.Documentation(doc.getValue(), memberDocs)
+      val memberDocsPresent = if (memberDocs.isEmpty) None else Some(memberDocs)
+      Hint.Documentation(Option(doc.getValue), memberDocsPresent)
     }
   }
 

--- a/modules/example/resources/smithy4s.example.ObjectService.json
+++ b/modules/example/resources/smithy4s.example.ObjectService.json
@@ -12,16 +12,20 @@
                     {
                         "name": "key",
                         "in": "path",
+                        "description": "Sent in the URI label named \"key\".\nKey can also be seen as the filename\nIt is always required for a GET operation",
                         "schema": {
-                            "type": "string"
+                            "type": "string",
+                            "description": "Sent in the URI label named \"key\".\nKey can also be seen as the filename\nIt is always required for a GET operation"
                         },
                         "required": true
                     },
                     {
                         "name": "bucketName",
                         "in": "path",
+                        "description": "Sent in the URI label named \"bucketName\".",
                         "schema": {
-                            "type": "string"
+                            "type": "string",
+                            "description": "Sent in the URI label named \"bucketName\"."
                         },
                         "required": true
                     }
@@ -134,6 +138,7 @@
     "components": {
         "schemas": {
             "Foo": {
+                "description": "Helpful information for Foo\nint, bigInt and bDec are useful number constructs\nThe string case is there because.",
                 "oneOf": [
                     {
                         "type": "object",
@@ -153,7 +158,8 @@
                         "title": "str",
                         "properties": {
                             "str": {
-                                "type": "string"
+                                "type": "string",
+                                "description": "this is a comment saying you should be careful for this case\nyou never know what lies ahead with Strings like this"
                             }
                         },
                         "required": [

--- a/modules/example/src/smithy4s/example/AString.scala
+++ b/modules/example/src/smithy4s/example/AString.scala
@@ -7,11 +7,11 @@ import smithy4s.ShapeId
 import smithy4s.schema.Schema.bijection
 import smithy4s.schema.Schema.string
 
-/** This is a simple example of a "quoted string" */
+/** A plain Smithy string */
 object AString extends Newtype[String] {
   val id: ShapeId = ShapeId("smithy4s.example", "AString")
   val hints: Hints = Hints(
-    smithy.api.Documentation("This is a simple example of a \"quoted string\""),
+    smithy.api.Documentation("A plain Smithy string"),
   )
   val underlyingSchema: Schema[String] = string.withId(id).addHints(hints)
   implicit val schema: Schema[AString] = bijection(underlyingSchema, asBijection)

--- a/modules/example/src/smithy4s/example/AString.scala
+++ b/modules/example/src/smithy4s/example/AString.scala
@@ -7,6 +7,7 @@ import smithy4s.ShapeId
 import smithy4s.schema.Schema.bijection
 import smithy4s.schema.Schema.string
 
+/** This is a simple example of a "quoted string" */
 object AString extends Newtype[String] {
   val id: ShapeId = ShapeId("smithy4s.example", "AString")
   val hints: Hints = Hints(

--- a/modules/example/src/smithy4s/example/AString.scala
+++ b/modules/example/src/smithy4s/example/AString.scala
@@ -7,11 +7,11 @@ import smithy4s.ShapeId
 import smithy4s.schema.Schema.bijection
 import smithy4s.schema.Schema.string
 
-/** A plain Smithy string */
+/** This is a simple example of a "quoted string" */
 object AString extends Newtype[String] {
   val id: ShapeId = ShapeId("smithy4s.example", "AString")
   val hints: Hints = Hints(
-    smithy.api.Documentation("A plain Smithy string"),
+    smithy.api.Documentation("This is a simple example of a \"quoted string\""),
   )
   val underlyingSchema: Schema[String] = string.withId(id).addHints(hints)
   implicit val schema: Schema[AString] = bijection(underlyingSchema, asBijection)

--- a/modules/example/src/smithy4s/example/AnotherString.scala
+++ b/modules/example/src/smithy4s/example/AnotherString.scala
@@ -1,0 +1,22 @@
+package smithy4s.example
+
+import smithy4s.Hints
+import smithy4s.Newtype
+import smithy4s.Schema
+import smithy4s.ShapeId
+import smithy4s.schema.Schema.bijection
+import smithy4s.schema.Schema.string
+
+/** Multiple line doc comment for another string
+  * I'm putting a random \*\/ here. Who would do such a thing?
+  * Because.
+  * Seriously, it's import to escape special characters.
+  */
+object AnotherString extends Newtype[String] {
+  val id: ShapeId = ShapeId("smithy4s.example", "AnotherString")
+  val hints: Hints = Hints(
+    smithy.api.Documentation("Multiple line doc comment for another string\nI\'m putting a random */ here. Who would do such a thing?\nBecause.\nSeriously, it\'s import to escape special characters."),
+  )
+  val underlyingSchema: Schema[String] = string.withId(id).addHints(hints)
+  implicit val schema: Schema[AnotherString] = bijection(underlyingSchema, asBijection)
+}

--- a/modules/example/src/smithy4s/example/AnotherString.scala
+++ b/modules/example/src/smithy4s/example/AnotherString.scala
@@ -8,14 +8,13 @@ import smithy4s.schema.Schema.bijection
 import smithy4s.schema.Schema.string
 
 /** Multiple line doc comment for another string
-  * I'm putting a random \*\/ here. Who would do such a thing?
-  * Because.
-  * Seriously, it's import to escape special characters.
+  * Containing a random \*\/ here.
+  * Seriously, it's important to escape special characters.
   */
 object AnotherString extends Newtype[String] {
   val id: ShapeId = ShapeId("smithy4s.example", "AnotherString")
   val hints: Hints = Hints(
-    smithy.api.Documentation("Multiple line doc comment for another string\nI\'m putting a random */ here. Who would do such a thing?\nBecause.\nSeriously, it\'s import to escape special characters."),
+    smithy.api.Documentation("Multiple line doc comment for another string\nContaining a random */ here.\nSeriously, it\'s important to escape special characters."),
   )
   val underlyingSchema: Schema[String] = string.withId(id).addHints(hints)
   implicit val schema: Schema[AnotherString] = bijection(underlyingSchema, asBijection)

--- a/modules/example/src/smithy4s/example/EnumWithDeprecations.scala
+++ b/modules/example/src/smithy4s/example/EnumWithDeprecations.scala
@@ -7,8 +7,8 @@ import smithy4s.ShapeId
 import smithy4s.ShapeTag
 import smithy4s.schema.Schema.enumeration
 
-@deprecated
 /** some docs here */
+@deprecated
 sealed abstract class EnumWithDeprecations(_value: String, _name: String, _intValue: Int, _hints: Hints) extends Enumeration.Value {
   override val value: String = _value
   override val name: String = _name

--- a/modules/example/src/smithy4s/example/EnumWithDeprecations.scala
+++ b/modules/example/src/smithy4s/example/EnumWithDeprecations.scala
@@ -8,6 +8,7 @@ import smithy4s.ShapeTag
 import smithy4s.schema.Schema.enumeration
 
 @deprecated
+/** some docs here */
 sealed abstract class EnumWithDeprecations(_value: String, _name: String, _intValue: Int, _hints: Hints) extends Enumeration.Value {
   override val value: String = _value
   override val name: String = _name

--- a/modules/example/src/smithy4s/example/FaceCard.scala
+++ b/modules/example/src/smithy4s/example/FaceCard.scala
@@ -8,6 +8,7 @@ import smithy4s.ShapeId
 import smithy4s.ShapeTag
 import smithy4s.schema.Schema.enumeration
 
+/** FaceCard types */
 sealed abstract class FaceCard(_value: String, _name: String, _intValue: Int, _hints: Hints) extends Enumeration.Value {
   override val value: String = _value
   override val name: String = _name

--- a/modules/example/src/smithy4s/example/Foo.scala
+++ b/modules/example/src/smithy4s/example/Foo.scala
@@ -14,8 +14,9 @@ import smithy4s.schema.Schema.union
 /** Helpful information for Foo
   * int, bigInt and bDec are useful number constructs
   * The string case is there because.
-  * @param str this is a comment saying you should be careful for this case
-  * you never know what lies ahead with Strings like this
+  * @param str
+  *   this is a comment saying you should be careful for this case
+  *   you never know what lies ahead with Strings like this
   */
 sealed trait Foo extends scala.Product with scala.Serializable {
   @inline final def widen: Foo = this

--- a/modules/example/src/smithy4s/example/Foo.scala
+++ b/modules/example/src/smithy4s/example/Foo.scala
@@ -14,9 +14,6 @@ import smithy4s.schema.Schema.union
 /** Helpful information for Foo
   * int, bigInt and bDec are useful number constructs
   * The string case is there because.
-  * @param str
-  *   this is a comment saying you should be careful for this case
-  *   you never know what lies ahead with Strings like this
   */
 sealed trait Foo extends scala.Product with scala.Serializable {
   @inline final def widen: Foo = this

--- a/modules/example/src/smithy4s/example/Foo.scala
+++ b/modules/example/src/smithy4s/example/Foo.scala
@@ -11,15 +11,22 @@ import smithy4s.schema.Schema.int
 import smithy4s.schema.Schema.string
 import smithy4s.schema.Schema.union
 
+/** Helpful information for Foo
+  * int, bigInt and bDec are useful number constructs
+  */
 sealed trait Foo extends scala.Product with scala.Serializable {
   @inline final def widen: Foo = this
 }
 object Foo extends ShapeTag.Companion[Foo] {
   val id: ShapeId = ShapeId("smithy4s.example", "Foo")
 
-  val hints: Hints = Hints.empty
+  val hints: Hints = Hints(
+    smithy.api.Documentation("Helpful information for Foo\nint, bigInt and bDec are useful number constructs\nThe string case is there because."),
+  )
 
   case class IntCase(int: Int) extends Foo
+  /** this is a comment saying you should be careful for this case
+    */
   case class StrCase(str: String) extends Foo
   case class BIntCase(bInt: BigInt) extends Foo
   case class BDecCase(bDec: BigDecimal) extends Foo
@@ -30,7 +37,9 @@ object Foo extends ShapeTag.Companion[Foo] {
     val alt = schema.oneOf[Foo]("int")
   }
   object StrCase {
-    val hints: Hints = Hints.empty
+    val hints: Hints = Hints(
+      smithy.api.Documentation("this is a comment saying you should be careful for this case\nyou never know what lies ahead with Strings like this"),
+    )
     val schema: Schema[StrCase] = bijection(string.addHints(hints), StrCase(_), _.str)
     val alt = schema.oneOf[Foo]("str")
   }

--- a/modules/example/src/smithy4s/example/Foo.scala
+++ b/modules/example/src/smithy4s/example/Foo.scala
@@ -13,6 +13,7 @@ import smithy4s.schema.Schema.union
 
 /** Helpful information for Foo
   * int, bigInt and bDec are useful number constructs
+  * The string case is there because.
   */
 sealed trait Foo extends scala.Product with scala.Serializable {
   @inline final def widen: Foo = this
@@ -26,6 +27,7 @@ object Foo extends ShapeTag.Companion[Foo] {
 
   case class IntCase(int: Int) extends Foo
   /** this is a comment saying you should be careful for this case
+    * you never know what lies ahead with Strings like this
     */
   case class StrCase(str: String) extends Foo
   case class BIntCase(bInt: BigInt) extends Foo

--- a/modules/example/src/smithy4s/example/Foo.scala
+++ b/modules/example/src/smithy4s/example/Foo.scala
@@ -14,6 +14,8 @@ import smithy4s.schema.Schema.union
 /** Helpful information for Foo
   * int, bigInt and bDec are useful number constructs
   * The string case is there because.
+  * @param str this is a comment saying you should be careful for this case
+  * you never know what lies ahead with Strings like this
   */
 sealed trait Foo extends scala.Product with scala.Serializable {
   @inline final def widen: Foo = this

--- a/modules/example/src/smithy4s/example/FooService.scala
+++ b/modules/example/src/smithy4s/example/FooService.scala
@@ -11,9 +11,14 @@ import smithy4s.kinds.PolyFunction5
 import smithy4s.kinds.toPolyFunction5.const5
 import smithy4s.schema.Schema.unit
 
+/** The most basics of services
+  */
 trait FooServiceGen[F[_, _, _, _, _]] {
   self =>
 
+  /** Returns a useful Foo
+    * No input necessary to find our Foo
+    */
   def getFoo(): F[Unit, Nothing, GetFooOutput, Nothing, Nothing]
 
   def transform: Transformation.PartiallyApplied[FooServiceGen[F]] = Transformation.of[FooServiceGen[F]](this)
@@ -30,7 +35,9 @@ object FooServiceGen extends Service.Mixin[FooServiceGen, FooServiceOperation] {
 
   val id: ShapeId = ShapeId("smithy4s.example", "FooService")
 
-  val hints: Hints = Hints.empty
+  val hints: Hints = Hints(
+    smithy.api.Documentation("The most basics of services\nGetFoo is it\'s only operation"),
+  )
 
   val endpoints: List[FooServiceGen.Endpoint[_, _, _, _, _]] = List(
     GetFoo,
@@ -69,6 +76,7 @@ object FooServiceGen extends Service.Mixin[FooServiceGen, FooServiceOperation] {
     val streamedOutput: StreamingSchema[Nothing] = StreamingSchema.nothing
     val hints: Hints = Hints(
       smithy.api.Http(method = smithy.api.NonEmptyString("GET"), uri = smithy.api.NonEmptyString("/foo"), code = 200),
+      smithy.api.Documentation("Returns a useful Foo\nNo input necessary to find our Foo\nThe path for this operation is \"/foo\""),
       smithy.api.Readonly(),
     )
     def wrap(input: Unit) = GetFoo()

--- a/modules/example/src/smithy4s/example/FooService.scala
+++ b/modules/example/src/smithy4s/example/FooService.scala
@@ -12,7 +12,7 @@ import smithy4s.kinds.toPolyFunction5.const5
 import smithy4s.schema.Schema.unit
 
 /** The most basics of services
-  * GetFoo is it's only operation
+  * GetFoo is its only operation
   */
 trait FooServiceGen[F[_, _, _, _, _]] {
   self =>
@@ -38,7 +38,7 @@ object FooServiceGen extends Service.Mixin[FooServiceGen, FooServiceOperation] {
   val id: ShapeId = ShapeId("smithy4s.example", "FooService")
 
   val hints: Hints = Hints(
-    smithy.api.Documentation("The most basics of services\nGetFoo is it\'s only operation"),
+    smithy.api.Documentation("The most basics of services\nGetFoo is its only operation"),
   )
 
   val endpoints: List[FooServiceGen.Endpoint[_, _, _, _, _]] = List(

--- a/modules/example/src/smithy4s/example/FooService.scala
+++ b/modules/example/src/smithy4s/example/FooService.scala
@@ -12,12 +12,14 @@ import smithy4s.kinds.toPolyFunction5.const5
 import smithy4s.schema.Schema.unit
 
 /** The most basics of services
+  * GetFoo is it's only operation
   */
 trait FooServiceGen[F[_, _, _, _, _]] {
   self =>
 
   /** Returns a useful Foo
     * No input necessary to find our Foo
+    * The path for this operation is "/foo"
     */
   def getFoo(): F[Unit, Nothing, GetFooOutput, Nothing, Nothing]
 

--- a/modules/example/src/smithy4s/example/GetObjectInput.scala
+++ b/modules/example/src/smithy4s/example/GetObjectInput.scala
@@ -10,10 +10,12 @@ import smithy4s.schema.Schema.struct
   * all fields are required
   * and are given through HTTP labels
   * See https://smithy.io/2.0/spec/http-bindings.html?highlight=httppayload#http-uri-label
-  * @param key Sent in the URI label named "key".
-  * Key can also be seen as the filename
-  * It is always required for a GET operation
-  * @param bucketName Sent in the URI label named "bucketName".
+  * @param key
+  *   Sent in the URI label named "key".
+  *   Key can also be seen as the filename
+  *   It is always required for a GET operation
+  * @param bucketName
+  *   Sent in the URI label named "bucketName".
   */
 case class GetObjectInput(key: ObjectKey, bucketName: BucketName)
 object GetObjectInput extends ShapeTag.Companion[GetObjectInput] {

--- a/modules/example/src/smithy4s/example/GetObjectInput.scala
+++ b/modules/example/src/smithy4s/example/GetObjectInput.scala
@@ -10,6 +10,10 @@ import smithy4s.schema.Schema.struct
   * all fields are required
   * and are given through HTTP labels
   * See https://smithy.io/2.0/spec/http-bindings.html?highlight=httppayload#http-uri-label
+  * @param key Sent in the URI label named "key".
+  * Key can also be seen as the filename
+  * It is always required for a GET operation
+  * @param bucketName Sent in the URI label named "bucketName".
   */
 case class GetObjectInput(key: ObjectKey, bucketName: BucketName)
 object GetObjectInput extends ShapeTag.Companion[GetObjectInput] {

--- a/modules/example/src/smithy4s/example/GetObjectInput.scala
+++ b/modules/example/src/smithy4s/example/GetObjectInput.scala
@@ -9,6 +9,7 @@ import smithy4s.schema.Schema.struct
 /** Input for getting an Object
   * all fields are required
   * and are given through HTTP labels
+  * See https://smithy.io/2.0/spec/http-bindings.html?highlight=httppayload#http-uri-label
   */
 case class GetObjectInput(key: ObjectKey, bucketName: BucketName)
 object GetObjectInput extends ShapeTag.Companion[GetObjectInput] {

--- a/modules/example/src/smithy4s/example/GetObjectInput.scala
+++ b/modules/example/src/smithy4s/example/GetObjectInput.scala
@@ -6,15 +6,21 @@ import smithy4s.ShapeId
 import smithy4s.ShapeTag
 import smithy4s.schema.Schema.struct
 
+/** Input for getting an Object
+  * all fields are required
+  * and are given through HTTP labels
+  */
 case class GetObjectInput(key: ObjectKey, bucketName: BucketName)
 object GetObjectInput extends ShapeTag.Companion[GetObjectInput] {
   val id: ShapeId = ShapeId("smithy4s.example", "GetObjectInput")
 
-  val hints: Hints = Hints.empty
+  val hints: Hints = Hints(
+    smithy.api.Documentation("Input for getting an Object\nall fields are required\nand are given through HTTP labels\nSee https://smithy.io/2.0/spec/http-bindings.html?highlight=httppayload#http-uri-label"),
+  )
 
   implicit val schema: Schema[GetObjectInput] = struct(
-    ObjectKey.schema.required[GetObjectInput]("key", _.key).addHints(smithy.api.HttpLabel(), smithy.api.Required()),
-    BucketName.schema.required[GetObjectInput]("bucketName", _.bucketName).addHints(smithy.api.HttpLabel(), smithy.api.Required()),
+    ObjectKey.schema.required[GetObjectInput]("key", _.key).addHints(smithy.api.Required(), smithy.api.Documentation("Sent in the URI label named \"key\".\nKey can also be seen as the filename\nIt is always required for a GET operation"), smithy.api.HttpLabel()),
+    BucketName.schema.required[GetObjectInput]("bucketName", _.bucketName).addHints(smithy.api.Required(), smithy.api.Documentation("Sent in the URI label named \"bucketName\"."), smithy.api.HttpLabel()),
   ){
     GetObjectInput.apply
   }.withId(id).addHints(hints)

--- a/modules/example/src/smithy4s/example/OrderType.scala
+++ b/modules/example/src/smithy4s/example/OrderType.scala
@@ -9,20 +9,27 @@ import smithy4s.schema.Schema.string
 import smithy4s.schema.Schema.struct
 import smithy4s.schema.Schema.union
 
+/** Our order types have different ways to identify a product
+  */
 sealed trait OrderType extends scala.Product with scala.Serializable {
   @inline final def widen: OrderType = this
 }
 object OrderType extends ShapeTag.Companion[OrderType] {
   val id: ShapeId = ShapeId("smithy4s.example", "OrderType")
 
-  val hints: Hints = Hints.empty
+  val hints: Hints = Hints(
+    smithy.api.Documentation("Our order types have different ways to identify a product\nExcept for preview orders, these don\'t have an ID"),
+  )
 
   case class OnlineCase(online: OrderNumber) extends OrderType
+  /** For an InStoreOrder a location ID isn't needed */
   case class InStoreOrder(id: OrderNumber = smithy4s.example.OrderNumber(0), locationId: Option[String] = None) extends OrderType
   object InStoreOrder extends ShapeTag.Companion[InStoreOrder] {
     val id: ShapeId = ShapeId("smithy4s.example", "InStoreOrder")
 
-    val hints: Hints = Hints.empty
+    val hints: Hints = Hints(
+      smithy.api.Documentation("For an InStoreOrder a location ID isn\'t needed"),
+    )
 
     val schema: Schema[InStoreOrder] = struct(
       OrderNumber.schema.required[InStoreOrder]("id", _.id).addHints(smithy.api.Default(smithy4s.Document.fromDouble(0.0d)), smithy.api.Required()),

--- a/modules/example/src/smithy4s/example/OrderType.scala
+++ b/modules/example/src/smithy4s/example/OrderType.scala
@@ -11,6 +11,7 @@ import smithy4s.schema.Schema.union
 
 /** Our order types have different ways to identify a product
   * Except for preview orders, these don't have an ID
+  * @param inStore For an InStoreOrder a location ID isn't needed
   */
 sealed trait OrderType extends scala.Product with scala.Serializable {
   @inline final def widen: OrderType = this

--- a/modules/example/src/smithy4s/example/OrderType.scala
+++ b/modules/example/src/smithy4s/example/OrderType.scala
@@ -11,7 +11,8 @@ import smithy4s.schema.Schema.union
 
 /** Our order types have different ways to identify a product
   * Except for preview orders, these don't have an ID
-  * @param inStore For an InStoreOrder a location ID isn't needed
+  * @param inStore
+  *   For an InStoreOrder a location ID isn't needed
   */
 sealed trait OrderType extends scala.Product with scala.Serializable {
   @inline final def widen: OrderType = this

--- a/modules/example/src/smithy4s/example/OrderType.scala
+++ b/modules/example/src/smithy4s/example/OrderType.scala
@@ -11,8 +11,6 @@ import smithy4s.schema.Schema.union
 
 /** Our order types have different ways to identify a product
   * Except for preview orders, these don't have an ID
-  * @param inStore
-  *   For an InStoreOrder a location ID isn't needed
   */
 sealed trait OrderType extends scala.Product with scala.Serializable {
   @inline final def widen: OrderType = this

--- a/modules/example/src/smithy4s/example/OrderType.scala
+++ b/modules/example/src/smithy4s/example/OrderType.scala
@@ -10,6 +10,7 @@ import smithy4s.schema.Schema.struct
 import smithy4s.schema.Schema.union
 
 /** Our order types have different ways to identify a product
+  * Except for preview orders, these don't have an ID
   */
 sealed trait OrderType extends scala.Product with scala.Serializable {
   @inline final def widen: OrderType = this

--- a/modules/example/src/smithy4s/example/PutObjectInput.scala
+++ b/modules/example/src/smithy4s/example/PutObjectInput.scala
@@ -7,11 +7,14 @@ import smithy4s.ShapeTag
 import smithy4s.schema.Schema.string
 import smithy4s.schema.Schema.struct
 
+/** A key and bucket is always required for putting a new file in a bucket */
 case class PutObjectInput(key: ObjectKey, bucketName: BucketName, data: String, foo: Option[LowHigh] = None, someValue: Option[SomeValue] = None)
 object PutObjectInput extends ShapeTag.Companion[PutObjectInput] {
   val id: ShapeId = ShapeId("smithy4s.example", "PutObjectInput")
 
-  val hints: Hints = Hints.empty
+  val hints: Hints = Hints(
+    smithy.api.Documentation("A key and bucket is always required for putting a new file in a bucket"),
+  )
 
   implicit val schema: Schema[PutObjectInput] = struct(
     ObjectKey.schema.required[PutObjectInput]("key", _.key).addHints(smithy.api.HttpLabel(), smithy.api.Required()),

--- a/modules/example/src/smithy4s/example/package.scala
+++ b/modules/example/src/smithy4s/example/package.scala
@@ -16,7 +16,7 @@ package object example {
   val DeprecatedService = DeprecatedServiceGen
 
   type StreamedBlob = smithy4s.example.StreamedBlob.Type
-  /** A plain Smithy string */
+  /** This is a simple example of a "quoted string" */
   type AString = smithy4s.example.AString.Type
   type NonEmptyMapNumbers = smithy4s.example.NonEmptyMapNumbers.Type
   type SomeValue = smithy4s.example.SomeValue.Type

--- a/modules/example/src/smithy4s/example/package.scala
+++ b/modules/example/src/smithy4s/example/package.scala
@@ -16,7 +16,7 @@ package object example {
   val DeprecatedService = DeprecatedServiceGen
 
   type StreamedBlob = smithy4s.example.StreamedBlob.Type
-  /** This is a simple example of a "quoted string" */
+  /** A plain Smithy string */
   type AString = smithy4s.example.AString.Type
   type NonEmptyMapNumbers = smithy4s.example.NonEmptyMapNumbers.Type
   type SomeValue = smithy4s.example.SomeValue.Type

--- a/modules/example/src/smithy4s/example/package.scala
+++ b/modules/example/src/smithy4s/example/package.scala
@@ -42,5 +42,11 @@ package object example {
   type NonEmptyCandies = smithy4s.example.NonEmptyCandies.Type
   type SomeIndexSeq = smithy4s.example.SomeIndexSeq.Type
   type StringList = smithy4s.example.StringList.Type
+  /** Multiple line doc comment for another string
+    * I'm putting a random \*\/ here. Who would do such a thing?
+    * Because.
+    * Seriously, it's import to escape special characters.
+    */
+  type AnotherString = smithy4s.example.AnotherString.Type
 
 }

--- a/modules/example/src/smithy4s/example/package.scala
+++ b/modules/example/src/smithy4s/example/package.scala
@@ -16,6 +16,7 @@ package object example {
   val DeprecatedService = DeprecatedServiceGen
 
   type StreamedBlob = smithy4s.example.StreamedBlob.Type
+  /** This is a simple example of a "quoted string" */
   type AString = smithy4s.example.AString.Type
   type NonEmptyMapNumbers = smithy4s.example.NonEmptyMapNumbers.Type
   type SomeValue = smithy4s.example.SomeValue.Type

--- a/modules/example/src/smithy4s/example/package.scala
+++ b/modules/example/src/smithy4s/example/package.scala
@@ -43,9 +43,8 @@ package object example {
   type SomeIndexSeq = smithy4s.example.SomeIndexSeq.Type
   type StringList = smithy4s.example.StringList.Type
   /** Multiple line doc comment for another string
-    * I'm putting a random \*\/ here. Who would do such a thing?
-    * Because.
-    * Seriously, it's import to escape special characters.
+    * Containing a random \*\/ here.
+    * Seriously, it's important to escape special characters.
     */
   type AnotherString = smithy4s.example.AnotherString.Type
 

--- a/sampleSpecs/adtMember.smithy
+++ b/sampleSpecs/adtMember.smithy
@@ -4,8 +4,11 @@ use smithy4s.meta#adtMember
 
 integer OrderNumber
 
+/// Our order types have different ways to identify a product
+/// Except for preview orders, these don't have an ID 
 union OrderType {
   online: OrderNumber,
+  /// For an InStoreOrder a location ID isn't needed
   inStore: InStoreOrder,
   preview: Unit
 }

--- a/sampleSpecs/example.smithy
+++ b/sampleSpecs/example.smithy
@@ -32,7 +32,7 @@ operation GetObject {
 }
 
 /// The most basics of services
-/// GetFoo is it's only operation
+/// GetFoo is its only operation
 service FooService {
   version: "1.0.0",
   operations: [GetFoo]

--- a/sampleSpecs/example.smithy
+++ b/sampleSpecs/example.smithy
@@ -44,9 +44,9 @@ service FooService {
 @readonly
 @http(method: "GET", uri: "/foo", code: 200)
 operation GetFoo {
-  // Represents the structure of the output of the Foo
-  // if we find a Foo at all
-  // else we return a generic HTTP error code
+  /// Represents the structure of the output of the Foo
+  /// if we find a Foo at all
+  /// else we return a generic HTTP error code
   output: GetFooOutput
 }
 

--- a/sampleSpecs/example.smithy
+++ b/sampleSpecs/example.smithy
@@ -50,6 +50,7 @@ operation GetFoo {
   output: GetFooOutput
 }
 
+/// A key and bucket is always required for putting a new file in a bucket
 structure PutObjectInput {
     // Sent in the URI label named "key".
     @required

--- a/sampleSpecs/example.smithy
+++ b/sampleSpecs/example.smithy
@@ -31,14 +31,22 @@ operation GetObject {
   errors: [ServerError]
 }
 
+/// The most basics of services
+/// GetFoo is it's only operation
 service FooService {
   version: "1.0.0",
   operations: [GetFoo]
 }
 
+/// Returns a useful Foo
+/// No input necessary to find our Foo
+/// The path for this operation is "/foo"
 @readonly
 @http(method: "GET", uri: "/foo", code: 200)
 operation GetFoo {
+  // Represents the structure of the output of the Foo
+  // if we find a Foo at all
+  // else we return a generic HTTP error code
   output: GetFooOutput
 }
 
@@ -67,13 +75,19 @@ structure PutObjectInput {
     data: String
 }
 
+/// Input for getting an Object
+/// all fields are required
+/// and are given through HTTP labels
+/// See https://smithy.io/2.0/spec/http-bindings.html?highlight=httppayload#http-uri-label
 structure GetObjectInput {
-    // Sent in the URI label named "key".
+    /// Sent in the URI label named "key".
+    /// Key can also be seen as the filename
+    /// It is always required for a GET operation
     @required
     @httpLabel
     key: ObjectKey,
 
-    // Sent in the URI label named "bucketName".
+    /// Sent in the URI label named "bucketName".
     @required
     @httpLabel
     bucketName: BucketName,
@@ -92,8 +106,13 @@ structure GetFooOutput {
   foo: Foo
 }
 
+/// Helpful information for Foo
+/// int, bigInt and bDec are useful number constructs
+/// The string case is there because.
 union Foo {
   int: Integer,
+  /// this is a comment saying you should be careful for this case
+  /// you never know what lies ahead with Strings like this
   str: String,
   bInt: BigInteger,
   bDec: BigDecimal

--- a/sampleSpecs/quoted_string.smithy
+++ b/sampleSpecs/quoted_string.smithy
@@ -5,6 +5,11 @@ namespace smithy4s.example
 @documentation("This is a simple example of a \"quoted string\"")
 string AString
 
+/// Multiple line doc comment for another string
+/// Containing a random */ here.
+/// Seriously, it's import to escape special characters.
+string AnotherString
+
 structure AStructure {
 
     astring: AString = "\"Hello World\" with \"quotes\""

--- a/sampleSpecs/quoted_string.smithy
+++ b/sampleSpecs/quoted_string.smithy
@@ -2,7 +2,7 @@ $version: "2"
 
 namespace smithy4s.example
 
-@documentation("A plain Smithy string")
+@documentation("This is a simple example of a \"quoted string\"")
 string AString
 
 structure AStructure {

--- a/sampleSpecs/quoted_string.smithy
+++ b/sampleSpecs/quoted_string.smithy
@@ -7,7 +7,7 @@ string AString
 
 /// Multiple line doc comment for another string
 /// Containing a random */ here.
-/// Seriously, it's import to escape special characters.
+/// Seriously, it's important to escape special characters.
 string AnotherString
 
 structure AStructure {

--- a/sampleSpecs/quoted_string.smithy
+++ b/sampleSpecs/quoted_string.smithy
@@ -2,7 +2,7 @@ $version: "2"
 
 namespace smithy4s.example
 
-@documentation("This is a simple example of a \"quoted string\"")
+@documentation("A plain Smithy string")
 string AString
 
 structure AStructure {


### PR DESCRIPTION
Attempt at resolving: https://github.com/disneystreaming/smithy4s/issues/256
@kubukoz's feedback loop tips in https://github.com/disneystreaming/smithy4s/issues/496 were very very helpful!
Still a draft, because I am not sure if I am following the logic of `Renderer.scala` correct everywhere.
However I was quite happy seeing this:
<img width="964" alt="image" src="https://user-images.githubusercontent.com/1857826/212494563-9445994e-f150-46ff-ab00-01fc14412490.png">
