### PR TITLE
Tweak background highlight color

### DIFF
--- a/modules/website/src/css/custom.css
+++ b/modules/website/src/css/custom.css
@@ -14,15 +14,15 @@
   --ifm-color-primary-lighter: #4897D8;
   --ifm-color-primary-lightest: #4897D8;
   --ifm-code-font-size: 95%;
+  --docusaurus-highlighted-code-line-bg: rgba(53, 53, 53, 0.1);
 }
 
 .docusaurus-highlight-code-line {
-  background-color: rgba(18, 101, 202, 0.1);
   display: block;
   margin: 0 calc(-1 * var(--ifm-pre-padding));
   padding: 0 var(--ifm-pre-padding);
 }
 
-html[data-theme='dark'] .docusaurus-highlight-code-line {
-  background-color: rgba(18, 101, 202, 0.3);
+[data-theme='dark'] {
+  --docusaurus-highlighted-code-line-bg: rgba(70, 70, 70, 0.3);
 }


### PR DESCRIPTION
Turns out the original style is not applied. The dark one is, but the other one isn't. This solution: overriding the var works for both:

Dark:

![Screen Shot 2023-01-16 at 10 05 27](https://user-images.githubusercontent.com/5230460/212710283-f5e5fb28-649b-448e-8dc0-4b0231a60a4b.png)

Light:

![Screen Shot 2023-01-16 at 10 02 20](https://user-images.githubusercontent.com/5230460/212710289-10848327-83a0-474a-85d3-276af39c8093.png)
