### PR TITLE
Load file from credentials file (~/.aws/credentials)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -310,6 +310,7 @@ lazy val aws = projectMatrix
       // Only building this module against CE3
       Seq(
         Dependencies.Fs2.core.value,
+        Dependencies.Fs2.io.value,
         Dependencies.Weaver.cats.value % Test,
         Dependencies.Weaver.scalacheck.value % Test
       )

--- a/modules/aws-http4s/src/smithy4s/aws/http4s/package.scala
+++ b/modules/aws-http4s/src/smithy4s/aws/http4s/package.scala
@@ -17,7 +17,7 @@
 package smithy4s
 package aws
 
-import cats.effect.Temporal
+import cats.effect.Async
 import cats.effect.Resource
 import org.http4s.client.Client
 
@@ -27,7 +27,7 @@ package object http4s {
       private[this] val service: smithy4s.Service[Alg]
   ) {
 
-    def awsClient[F[_]: Temporal](
+    def awsClient[F[_]: Async](
         client: Client[F],
         awsRegion: AwsRegion
     ): Resource[F, AwsClient[Alg, F]] = for {

--- a/modules/aws-kernel/src/smithy4s/aws/package.scala
+++ b/modules/aws-kernel/src/smithy4s/aws/package.scala
@@ -24,6 +24,7 @@ package object kernel {
   val AWS_ACCESS_KEY_ID = "AWS_ACCESS_KEY_ID"
   val AWS_SECRET_ACCESS_KEY = "AWS_SECRET_ACCESS_KEY"
   val AWS_SESSION_TOKEN = "AWS_SESSION_TOKEN"
+  val AWS_PROFILE = "AWS_PROFILE"
   val `X-Amzn-Errortype` = "X-Amzn-Errortype"
 
   type AwsRegion = AwsRegion.Type

--- a/modules/aws/src/smithy4s/aws/AwsCredentialsFile.scala
+++ b/modules/aws/src/smithy4s/aws/AwsCredentialsFile.scala
@@ -16,15 +16,14 @@
 
 package smithy4s.aws
 
+import cats.effect.Resource
+import cats.effect.Sync
 import cats.syntax.all._
+import java.nio.file.Paths
 import smithy4s.aws.kernel.AWS_ACCESS_KEY_ID
 import smithy4s.aws.kernel.AWS_SECRET_ACCESS_KEY
 import smithy4s.aws.kernel.AWS_SESSION_TOKEN
 import smithy4s.aws.kernel.AwsCredentials
-
-import java.nio.file.Paths
-import cats.effect.Sync
-import cats.effect.Resource
 
 final case class AwsCredentialsFile(
     default: Option[AwsCredentials],

--- a/modules/aws/src/smithy4s/aws/AwsCredentialsFile.scala
+++ b/modules/aws/src/smithy4s/aws/AwsCredentialsFile.scala
@@ -1,0 +1,159 @@
+/*
+ *  Copyright 2021-2022 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package smithy4s.aws
+
+import cats.syntax.all._
+import smithy4s.aws.kernel.AWS_ACCESS_KEY_ID
+import smithy4s.aws.kernel.AWS_SECRET_ACCESS_KEY
+import smithy4s.aws.kernel.AWS_SESSION_TOKEN
+import smithy4s.aws.kernel.AwsCredentials
+
+import java.nio.file.Paths
+import cats.effect.Sync
+import cats.effect.Resource
+
+final case class AwsCredentialsFile(
+    default: Option[AwsCredentials],
+    profiles: Map[String, AwsCredentials]
+)
+
+object AwsCredentialsFile {
+  def loadFromDisk[F[_]](home: String, profile: Option[String])(implicit
+      F: Sync[F]
+  ): F[AwsCredentials] = {
+    loadFile(home)
+      .use(lines => processFileLines(lines).pure[F])
+      .flatMap(creds =>
+        profile
+          .map(p =>
+            creds.profiles
+              .get(p)
+              .toRight(
+                new RuntimeException(
+                  s"Profile `$p` was not found in the credentials file."
+                )
+              )
+              .liftTo[F]
+          )
+          .getOrElse(
+            creds.default
+              .toRight(
+                new RuntimeException(
+                  s"No default profile is available in the credentials file."
+                )
+              )
+              .liftTo[F]
+          )
+      )
+  }
+
+  private[aws] def processFileLines(lines: List[String]): AwsCredentialsFile = {
+    def inProfile(
+        rest: List[String],
+        currentProfile: String,
+        data: Map[String, String]
+    ): (Map[String, String], List[String]) = {
+      rest match {
+        case Nil =>
+          (data, Nil)
+        case head :: _ if head.trim().startsWith("[") =>
+          (data, rest)
+        case head :: next =>
+          val parts = head.split("=")
+          val key = parts(0).trim().toLowerCase
+          val value = parts(1).trim().toLowerCase()
+          val updated = data + (key -> value)
+          inProfile(next, currentProfile, updated)
+      }
+    }
+
+    def lookingForProfile(
+        rest: List[String],
+        data: Map[String, Map[String, String]]
+    ): Map[String, Map[String, String]] = {
+      rest match {
+        case head :: next =>
+          val profile = head.trim() match {
+            case Profile.Prefixed(profile)    => profile
+            case Profile.Default(profile)     => profile
+            case Profile.NonPrefixed(profile) => profile
+          }
+
+          val (profileData, rest) = inProfile(next, profile, Map.empty)
+          lookingForProfile(rest, data + (profile -> profileData))
+        case Nil =>
+          data
+      }
+    }
+
+    val data = lookingForProfile(lines.filter(_.trim.nonEmpty), Map.empty)
+    AwsCredentialsFile.profilesFromMap(data)
+  }
+
+  private def loadFile[F[_]: Sync](home: String): Resource[F, List[String]] =
+    Resource
+      .fromAutoCloseable(
+        Sync[F].delay(
+          scala.io.Source
+            .fromFile(Paths.get(home, ".aws", "credentials").toUri())
+        )
+      )
+      .map(_.getLines().toList)
+
+  private def credentialsFromMap(data: Map[String, String]): AwsCredentials =
+    AwsCredentials.Default(
+      data(AWS_ACCESS_KEY_ID.toLowerCase()),
+      data(AWS_SECRET_ACCESS_KEY.toLowerCase()),
+      data.get(AWS_SESSION_TOKEN.toLowerCase())
+    )
+
+  private def profilesFromMap(
+      dataPerProfile: Map[String, Map[String, String]]
+  ): AwsCredentialsFile = {
+    val default = dataPerProfile.get("default").map(credentialsFromMap)
+    val others = dataPerProfile
+      .filterNot(_._1 == "default")
+      .map { case (profile, data) =>
+        profile -> credentialsFromMap(data)
+      }
+    AwsCredentialsFile(default, others)
+  }
+}
+
+object Profile {
+  private val profileMatch = "([\\w_-]*)"
+  object Default {
+    def unapply(s: String): Option[String] =
+      if (s == "[default]") Some("default") else None
+  }
+
+  object Prefixed {
+    private val reg = s"^\\[profile $profileMatch\\]$$".r
+    def unapply(s: String): Option[String] = s match {
+      case reg(first) => Some(first)
+      case _          => None
+    }
+  }
+
+  object NonPrefixed {
+    private val reg = s"^\\[$profileMatch\\]$$".r
+    def unapply(s: String): Option[String] = s match {
+      case reg(first) => Some(first)
+      case _          => None
+    }
+  }
+}

--- a/modules/aws/src/smithy4s/aws/AwsCredentialsProvider.scala
+++ b/modules/aws/src/smithy4s/aws/AwsCredentialsProvider.scala
@@ -74,7 +74,11 @@ object AwsCredentialsProvider {
           .exists(path)
           .ifM(
             path.pure[F],
-            MonadThrow[F].raiseError(AwsCredentialsFileException("rip"))
+            MonadThrow[F].raiseError(
+              AwsCredentialsFileException(
+                s"Credentials file not found at '$path'"
+              )
+            )
           )
       }
 

--- a/modules/aws/src/smithy4s/aws/AwsEnvironment.scala
+++ b/modules/aws/src/smithy4s/aws/AwsEnvironment.scala
@@ -16,7 +16,7 @@
 
 package smithy4s.aws
 
-import cats.effect.Temporal
+import cats.effect.Async
 import cats.effect.Resource
 import cats.implicits._
 
@@ -32,7 +32,7 @@ object AwsEnvironment {
   def default[F[_]](
       client: SimpleHttpClient[F],
       region: AwsRegion
-  )(implicit F: Temporal[F]): Resource[F, AwsEnvironment[F]] =
+  )(implicit F: Async[F]): Resource[F, AwsEnvironment[F]] =
     AwsCredentialsProvider.default[F](client).map { credentialsF =>
       make(
         client,

--- a/modules/aws/test/src/smithy4s/aws/AwsCredentialsFileTest.scala
+++ b/modules/aws/test/src/smithy4s/aws/AwsCredentialsFileTest.scala
@@ -17,77 +17,139 @@
 package smithy4s.aws
 
 import weaver._
+import fs2.io.file.Files
+import cats.effect.IO
+import smithy4s.aws.kernel.AwsCredentials
 
 object AwsCredentialsFileTest extends FunSuite {
   val creds = AwsCredentials.Default("key", "sec", Some("token"))
 
-  test("find default profile") {
-    val res = AwsCredentialsFile.processFileLines(
-      asLines(
-        """|[default]
-           |aws_secret_access_key = sec
-           |aws_access_key_id     = key
-           |aws_session_token     = token""".stripMargin
-      )
+  private def expectRight[A](
+      e: Either[Throwable, A]
+  )(f: A => Expectations): Expectations =
+    e.fold(
+      err => failure(s"Got Left but expected a Right. ${err.getMessage}"),
+      f
     )
-    expect.same(res.default, Some(creds)) &&
-    expect.same(true, res.profiles.isEmpty)
+
+  test("find default profile") {
+    expectRight(
+      AwsCredentialsFile.processFileLines(
+        asLines(
+          """|[default]
+             |aws_secret_access_key = sec
+             |aws_access_key_id     = key
+             |aws_session_token     = token""".stripMargin
+        )
+      )
+    ) { res =>
+      expect.same(Some(creds), res.default) &&
+      expect.same(true, res.profiles.isEmpty)
+    }
   }
 
   test("find some other profile") {
-    val res = AwsCredentialsFile.processFileLines(
-      asLines(
-        """|[profile other]
-           |aws_secret_access_key = sec
-           |aws_access_key_id     = key
-           |aws_session_token     = token""".stripMargin
+    expectRight(
+      AwsCredentialsFile.processFileLines(
+        asLines(
+          """|[profile other]
+             |aws_secret_access_key = sec
+             |aws_access_key_id     = key
+             |aws_session_token     = token""".stripMargin
+        )
       )
-    )
-    expect.same(res.default, None) &&
-    expect.same(
-      res.profiles.head,
-      "other" -> creds
-    )
+    ) { res =>
+      expect.same(None, res.default) &&
+      expect.same(
+        "other" -> creds,
+        res.profiles.head
+      )
+    }
   }
 
   test("find some other profile w/o prefix") {
-    val res = AwsCredentialsFile.processFileLines(
-      asLines(
-        """|[other]
-           |aws_secret_access_key = sec
-           |aws_access_key_id     = key
-           |aws_session_token     = token""".stripMargin
+    expectRight(
+      AwsCredentialsFile.processFileLines(
+        asLines(
+          """|[other]
+             |aws_secret_access_key = sec
+             |aws_access_key_id     = key
+             |aws_session_token     = token""".stripMargin
+        )
       )
-    )
-    expect.same(res.default, None) &&
-    expect.same(
-      res.profiles.head,
-      "other" -> creds
-    )
+    ) { res =>
+      expect.same(None, res.default) &&
+      expect.same(
+        "other" -> creds,
+        res.profiles.head
+      )
+    }
   }
 
   test("find default and some other profiles") {
-    val res = AwsCredentialsFile.processFileLines(
-      asLines(
-        """|[default]
-           |aws_secret_access_key = sec
-           |aws_access_key_id     = key
-           |aws_session_token     = token
-           |[profile p1]
-           |aws_secret_access_key = sec
-           |aws_access_key_id     = key
-           |aws_session_token     = token
-           |
-           |[p2]
-           |aws_secret_access_key = sec
-           |aws_access_key_id     = key
-           |aws_session_token     = token""".stripMargin
+    expectRight(
+      AwsCredentialsFile.processFileLines(
+        asLines(
+          """|[default]
+             |aws_secret_access_key = sec
+             |aws_access_key_id     = key
+             |aws_session_token     = token
+             |[profile p1]
+             |aws_secret_access_key = sec
+             |aws_access_key_id     = key
+             |aws_session_token     = token
+             |
+             |[p2]
+             |aws_secret_access_key = sec
+             |aws_access_key_id     = key
+             |aws_session_token     = token""".stripMargin
+        )
       )
-    )
-    expect.same(res.default, Some(creds)) &&
-    expect.same(res.profiles("p1"), creds) &&
-    expect.same(res.profiles("p2"), creds)
+    ) { res =>
+      expect.same(Some(creds), res.default) &&
+      expect.same(creds, res.profiles("p1")) &&
+      expect.same(creds, res.profiles("p2"))
+    }
   }
 
   private def asLines(s: String) = s.split("\\n").toList
+}
+
+object AwsCredentialsFileReadTest extends SimpleIOSuite {
+  test("read credentials from a file") {
+    Files[IO].tempFile.use { path =>
+      val content = """|[default]
+                       |aws_secret_access_key = def_sec
+                       |aws_access_key_id     = def_key
+                       |aws_session_token     = def_token
+                       |[profile p1]
+                       |aws_secret_access_key = sec
+                       |aws_access_key_id     = key
+                       |aws_session_token     = token
+                  """.stripMargin
+
+      val writeFile = fs2.Stream
+        .emit(content)
+        .through(fs2.text.utf8.encode)
+        .through(Files[IO].writeAll(path))
+        .compile
+        .drain
+      val readDefault = AwsCredentialsFile.fromDisk(path, None)
+      val readP1 = AwsCredentialsFile.fromDisk(path, Some("p1"))
+
+      for {
+        _ <- writeFile
+
+        default <- readDefault
+        p1 <- readP1
+      } yield {
+        val expectedP1 =
+          AwsCredentials.Default("key", "sec", Some("token"))
+        val expectedDefault =
+          AwsCredentials.Default("def_key", "def_sec", Some("def_token"))
+        expect.same(expectedDefault, default) &&
+        expect.same(expectedP1, p1)
+      }
+    }
+  }
 }

--- a/modules/aws/test/src/smithy4s/aws/AwsCredentialsFileTest.scala
+++ b/modules/aws/test/src/smithy4s/aws/AwsCredentialsFileTest.scala
@@ -1,0 +1,93 @@
+/*
+ *  Copyright 2021-2022 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package smithy4s.aws
+
+import weaver._
+
+object AwsCredentialsFileTest extends FunSuite {
+  val creds = AwsCredentials.Default("key", "sec", Some("token"))
+
+  test("find default profile") {
+    val res = AwsCredentialsFile.processFileLines(
+      asLines(
+        """|[default]
+           |aws_secret_access_key = sec
+           |aws_access_key_id     = key
+           |aws_session_token     = token""".stripMargin
+      )
+    )
+    expect.same(res.default, Some(creds)) &&
+    expect.same(true, res.profiles.isEmpty)
+  }
+
+  test("find some other profile") {
+    val res = AwsCredentialsFile.processFileLines(
+      asLines(
+        """|[profile other]
+           |aws_secret_access_key = sec
+           |aws_access_key_id     = key
+           |aws_session_token     = token""".stripMargin
+      )
+    )
+    expect.same(res.default, None) &&
+    expect.same(
+      res.profiles.head,
+      "other" -> creds
+    )
+  }
+
+  test("find some other profile w/o prefix") {
+    val res = AwsCredentialsFile.processFileLines(
+      asLines(
+        """|[other]
+           |aws_secret_access_key = sec
+           |aws_access_key_id     = key
+           |aws_session_token     = token""".stripMargin
+      )
+    )
+    expect.same(res.default, None) &&
+    expect.same(
+      res.profiles.head,
+      "other" -> creds
+    )
+  }
+
+  test("find default and some other profiles") {
+    val res = AwsCredentialsFile.processFileLines(
+      asLines(
+        """|[default]
+           |aws_secret_access_key = sec
+           |aws_access_key_id     = key
+           |aws_session_token     = token
+           |[profile p1]
+           |aws_secret_access_key = sec
+           |aws_access_key_id     = key
+           |aws_session_token     = token
+           |
+           |[p2]
+           |aws_secret_access_key = sec
+           |aws_access_key_id     = key
+           |aws_session_token     = token""".stripMargin
+      )
+    )
+    expect.same(res.default, Some(creds)) &&
+    expect.same(res.profiles("p1"), creds) &&
+    expect.same(res.profiles("p2"), creds)
+  }
+
+  private def asLines(s: String) = s.split("\\n").toList
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -51,8 +51,11 @@ object Dependencies {
       Def.setting("com.monovore" %%% "decline-effect" % declineVersion)
   }
   object Fs2 {
+    val fs2Version = "3.5.0"
     val core: Def.Initialize[ModuleID] =
-      Def.setting("co.fs2" %%% "fs2-core" % "3.4.0")
+      Def.setting("co.fs2" %%% "fs2-core" % fs2Version)
+    val io: Def.Initialize[ModuleID] =
+      Def.setting("co.fs2" %%% "fs2-io" % fs2Version)
   }
 
   object Mill {


### PR DESCRIPTION
While working on #722 I realized we could not pull the info from `~/.aws/credentials` so I added it.

what do you think?