### PR TITLE
Fixes a bug that prevent the inclusion of upstream libraries

### DIFF
--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/multimodule-staged/bar/src/main/scala/Test.scala
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/multimodule-staged/bar/src/main/scala/Test.scala
@@ -17,10 +17,12 @@
 package bar
 
 import foo._
+import upstream._
 
 object BarTest {
 
   def main(args: Array[String]): Unit = {
+    println(Upstream(1))
     println(Bar(Some(Foo(Some(1)))))
   }
 

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/multimodule-staged/build.sbt
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/multimodule-staged/build.sbt
@@ -16,6 +16,13 @@ lazy val foo = (project in file("foo"))
     )
   )
 
+lazy val upstream = (project in file("upstream"))
+  .settings(
+    crossScalaVersions := Nil,
+    crossPaths := false,
+    autoScalaLibrary := false
+  )
+
 lazy val bar = (project in file("bar"))
   .enablePlugins(Smithy4sCodegenPlugin)
   .settings(
@@ -23,6 +30,7 @@ lazy val bar = (project in file("bar"))
     // that foo depended on for its own codegen. Therefore, these are retrieved from foo's manifest,
     // resolved and added to the list of jars to seek smithy models from during code generation
     libraryDependencies ++= Seq(
+      "foobar" % "upstream" % version.value % Smithy4s,
       "foobar" %% "foo" % version.value
     )
   )

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/multimodule-staged/test
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/multimodule-staged/test
@@ -1,5 +1,6 @@
 # check if smithy4sCodegen works with libraries that were built with Smithy4s
 > foo/publishLocal
+> upstream/publishLocal
 > bar/compile
 $ exists bar/target/scala-2.13/src_managed/main/bar/Bar.scala
 $ absent bar/target/scala-2.13/src_managed/main/foo/Foo.scala

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/multimodule-staged/upstream/src/main/resources/META-INF/smithy/manifest
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/multimodule-staged/upstream/src/main/resources/META-INF/smithy/manifest
@@ -1,0 +1,1 @@
+upstream.smithy

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/multimodule-staged/upstream/src/main/resources/META-INF/smithy/upstream.smithy
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/multimodule-staged/upstream/src/main/resources/META-INF/smithy/upstream.smithy
@@ -1,0 +1,8 @@
+$version: "2.0"
+
+namespace upstream
+
+structure Upstream {
+  @required
+  upstream: Integer
+}

--- a/modules/codegen-plugin/src/smithy4s/codegen/Smithy4sCodegenPlugin.scala
+++ b/modules/codegen-plugin/src/smithy4s/codegen/Smithy4sCodegenPlugin.scala
@@ -329,7 +329,9 @@ object Smithy4sCodegenPlugin extends AutoPlugin {
           .map(_.allFiles)
           .fold(uw => throw uw.resolveException, identity)
       }
-      getJars(dependenciesTask.value)
+      // Forcing configurations to None as the dynamic fetcher seems to emit
+      // every moduleID that has a configuration.
+      getJars(dependenciesTask.value.map(_.withConfigurations(None)))
     }
 
   def transitiveLibraryDependencies: Def.Initialize[Task[Seq[ModuleID]]] = {

--- a/modules/codegen-plugin/src/smithy4s/codegen/Smithy4sCodegenPlugin.scala
+++ b/modules/codegen-plugin/src/smithy4s/codegen/Smithy4sCodegenPlugin.scala
@@ -329,7 +329,7 @@ object Smithy4sCodegenPlugin extends AutoPlugin {
           .map(_.allFiles)
           .fold(uw => throw uw.resolveException, identity)
       }
-      // Forcing configurations to None as the dynamic fetcher seems to emit
+      // Forcing configurations to None as the dynamic fetcher seems to omit
       // every moduleID that has a configuration.
       getJars(dependenciesTask.value.map(_.withConfigurations(None)))
     }


### PR DESCRIPTION
Fixes a bug reported by @ahjohannessen, that leads normal dependencies to not be included in the classpath that Smithy4s receives to load the specs from. 

