### PR TITLE
Fix collection hint generation

### DIFF
--- a/modules/codegen/src/smithy4s/codegen/internals/CollisionAvoidance.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/CollisionAvoidance.scala
@@ -101,9 +101,18 @@ private[internals] object CollisionAvoidance {
 
   private def modType(tpe: Type): Type = tpe match {
     case Type.Collection(collectionType, member, memberHints) =>
-      Type.Collection(collectionType, modType(member), memberHints)
+      Type.Collection(
+        collectionType = collectionType,
+        member = modType(member),
+        memberHints = memberHints.map(modHint(_))
+      )
     case Type.Map(key, keyHints, value, valueHints) =>
-      Type.Map(modType(key), keyHints, modType(value), valueHints)
+      Type.Map(
+        key = modType(key),
+        keyHints = keyHints.map(modHint(_)),
+        value = modType(value),
+        valueHints = valueHints.map(modHint(_))
+      )
     case Type.Ref(namespace, name) =>
       Type.Ref(namespace, protectType(name.capitalize))
     case Alias(namespace, name, tpe, isUnwrapped) =>

--- a/modules/codegen/test/src/smithy4s/codegen/internals/RendererSpec.scala
+++ b/modules/codegen/test/src/smithy4s/codegen/internals/RendererSpec.scala
@@ -44,7 +44,7 @@ final class RendererSpec extends munit.FunSuite {
       }
 
     val memberSchemaString =
-      """string.addHints(smithy.api.documentation("listFoo"), smithy.api.deprecated(message = None, since = None))"""
+      """string.addHints(smithy.api.Documentation("listFoo"), smithy.api.Deprecated(message = None, since = None))"""
     val requiredString =
       s"""val underlyingSchema: Schema[List[String]] = list($memberSchemaString)"""
     assert(definition.contains(requiredString))
@@ -78,9 +78,9 @@ final class RendererSpec extends munit.FunSuite {
       }
 
     val keySchemaString =
-      """string.addHints(smithy.api.documentation("mapFoo"))"""
+      """string.addHints(smithy.api.Documentation("mapFoo"))"""
     val valueSchemaString =
-      """int.addHints(smithy.api.documentation("mapBar"), smithy.api.deprecated(message = None, since = None))"""
+      """int.addHints(smithy.api.Documentation("mapBar"), smithy.api.Deprecated(message = None, since = None))"""
     val requiredString =
       s"""val underlyingSchema: Schema[Map[String, Int]] = map($keySchemaString, $valueSchemaString)"""
     assert(definition.contains(requiredString))


### PR DESCRIPTION
Closes #774.

We were just missing a hint renaming round in `CollisionAvoidance`, which tbh might not have been the best name for this.

Tested manually on the sample from the ticket and more:

```smithy
$version: "2"

namespace demo

/// a list
list AList {
  /// a list member
  member: String
}

/// a map, doh
map AMap {
  /// a map key
  key: String
  /// a map value
  value: String
}
```

The generated files have the hints and compile:

```scala
// AList companion
val underlyingSchema: Schema[List[String]] = list(string.addHints(smithy.api.Documentation("a list member"))).withId(id).addHints(hints)

// AMap companion
val underlyingSchema: Schema[Map[String, String]] = map(string.addHints(smithy.api.Documentation("a map key")), string.addHints(smithy.api.Documentation("a map value"))).withId(id).addHints(hints)
```