### PR TITLE
Add more docs on assembly

### DIFF
--- a/modules/docs/markdown/01-overview/05-sharing-specs.md
+++ b/modules/docs/markdown/01-overview/05-sharing-specs.md
@@ -205,16 +205,16 @@ One side-effect of this is that if you produce JARs containing artifacts produce
 ```sbt
 assemblyMergeStrategy := {
   case PathList("META-INF", xs @ _*) =>
-        xs map { _.toLowerCase } match {
-          // http4s-swagger provides the swagger webjar, which can conflict
-          case "resources" :: "webjars" :: xs               => MergeStrategy.first
-          // There is no harm in removing the tracking file
-          case "smithy" :: "smithy4s.tracking.smithy"       => MergeStrategy.discard
-          // Keep the correct smithy manifest
-          case "smithy" :: "manifest"                       => MergeStrategy.first
-          // Discard the rest
-          case _                                            => MergeStrategy.discard
-        }
+    xs.map(_.toLowerCase) match {
+      // http4s-swagger provides the swagger webjar, which can conflict
+      case "resources" :: "webjars" :: xs               => MergeStrategy.first
+      // There is no harm in removing the tracking file
+      case "smithy" :: "smithy4s.tracking.smithy"       => MergeStrategy.discard
+      // Keep the correct smithy manifest
+      case "smithy" :: "manifest"                       => MergeStrategy.first
+      // Discard the rest
+      case _                                            => MergeStrategy.discard
+    }
   case x =>
     val oldStrategy = assemblyMergeStrategy.value
     oldStrategy(x)

--- a/modules/docs/markdown/01-overview/05-sharing-specs.md
+++ b/modules/docs/markdown/01-overview/05-sharing-specs.md
@@ -205,7 +205,7 @@ One side-effect of this is that if you produce JARs containing artifacts produce
 ```sbt
 assemblyMergeStrategy := {
   case PathList("META-INF", xs @ _*) =>
-        (xs map { _.toLowerCase }) match {
+        xs map { _.toLowerCase } match {
           // http4s-swagger provides the swagger webjar, which can conflict
           case "resources" :: "webjars" :: xs               => MergeStrategy.first
           // There is no harm in removing the tracking file


### PR DESCRIPTION
Hey there - 

@kubukoz and I ran into this problem when running `sbt-assembly` on a project that contained the `http4s-swagger` routes. I had some additional conflicts that I needed to work through, and thought that I would propose my work here as a part of the docs. Feel free to update this or ignore it. 