### PR TITLE
Fixes Scala code being copied in resources folder

### DIFF
--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/defaults/test
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/defaults/test
@@ -1,6 +1,6 @@
 # check if smithy4sCodegen works
 > compile
-$ exists target/scala-2.13/src_managed/main/smithy4s/example/ObjectService.scala
+$ exists target/scala-2.13/src_managed/main/scala/smithy4s/example/ObjectService.scala
 $ exists target/scala-2.13/resource_managed/main/smithy4s.example.ObjectService.json
 
 # check if code can run, this can reveal runtime issues
@@ -8,7 +8,7 @@ $ exists target/scala-2.13/resource_managed/main/smithy4s.example.ObjectService.
 > run
 $ copy-file example-added.smithy src/main/smithy/example-added.smithy
 > compile
-$ exists target/scala-2.13/src_managed/main/smithy4s/example/Added.scala
+$ exists target/scala-2.13/src_managed/main/scala/smithy4s/example/Added.scala
 
 # ensuring that removing existing files removes their outputs
 $ delete src/main/smithy/example.smithy

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/extra-configs/test
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/extra-configs/test
@@ -1,7 +1,7 @@
 # check if main sources are generated
 > compile
-$ exists target/scala-2.13/src_managed/main/example/ExampleStruct.scala
+$ exists target/scala-2.13/src_managed/main/scala/example/ExampleStruct.scala
 
 # check if test sources are generated
 > Test/compile
-$ exists target/scala-2.13/src_managed/test/testexample/TestStruct.scala
+$ exists target/scala-2.13/src_managed/test/scala/testexample/TestStruct.scala

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/multimodule-aws/test
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/multimodule-aws/test
@@ -1,5 +1,5 @@
 # check if smithy4sCodegen works with libraries that were built with Smithy4s
 > show bar/smithy4sAllExternalDependencies
 > compile
-$ exists foo/target/scala-2.13/src_managed/main/foo/Lambda.scala
-$ absent bar/target/scala-2.13/src_managed/main/foo/Lambda.scala
+$ exists foo/target/scala-2.13/src_managed/main/scala/foo/Lambda.scala
+$ absent bar/target/scala-2.13/src_managed/main/scala/foo/Lambda.scala

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/multimodule-staged/test
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/multimodule-staged/test
@@ -2,8 +2,8 @@
 > foo/publishLocal
 > upstream/publishLocal
 > bar/compile
-$ exists bar/target/scala-2.13/src_managed/main/bar/Bar.scala
-$ absent bar/target/scala-2.13/src_managed/main/foo/Foo.scala
+$ exists bar/target/scala-2.13/src_managed/main/scala/bar/Bar.scala
+$ absent bar/target/scala-2.13/src_managed/main/scala/foo/Foo.scala
 
 # check if code can run, this can reveal runtime issues# such as initialization errors
 > bar/run

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/multimodule/test
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/multimodule/test
@@ -1,10 +1,10 @@
 # check if smithy4sCodegen works in multimodule contexts
 > compile
-$ exists bar/target/scala-2.13/src_managed/main/bar/Bar.scala
-$ absent bar/target/scala-2.13/src_managed/main/foo/Foo.scala
-$ absent bar/target/scala-2.13/src_managed/main/foodir/FooDir.scala
-$ exists foo/target/scala-2.13/src_managed/main/foo/Foo.scala
-$ exists foo/target/scala-2.13/src_managed/main/foodir/FooDir.scala
+$ exists bar/target/scala-2.13/src_managed/main/scala/bar/Bar.scala
+$ absent bar/target/scala-2.13/src_managed/main/scala/foo/Foo.scala
+$ absent bar/target/scala-2.13/src_managed/main/scala/foodir/FooDir.scala
+$ exists foo/target/scala-2.13/src_managed/main/scala/foo/Foo.scala
+$ exists foo/target/scala-2.13/src_managed/main/scala/foodir/FooDir.scala
 
 # check if code can run, this can reveal runtime issues# such as initialization errors
 > bar/run

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/scala3/test
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/scala3/test
@@ -1,10 +1,10 @@
 # check if smithy4sCodegen works
 > compile
 
-$ exists target/scala-3.2.1/src_managed/main/smithy4s/errors/BadRequest.scala
-$ exists target/scala-3.2.1/src_managed/main/smithy4s/errors/InternalServerError.scala
-$ exists target/scala-3.2.1/src_managed/main/smithy4s/errors/ErrorService.scala
-$ exists target/scala-3.2.1/src_managed/main/smithy4s/errors/package.scala
+$ exists target/scala-3.2.1/src_managed/main/scala/smithy4s/errors/BadRequest.scala
+$ exists target/scala-3.2.1/src_managed/main/scala/smithy4s/errors/InternalServerError.scala
+$ exists target/scala-3.2.1/src_managed/main/scala/smithy4s/errors/ErrorService.scala
+$ exists target/scala-3.2.1/src_managed/main/scala/smithy4s/errors/package.scala
 
 # check if code can run
 > run

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/smithy-rules/build.sbt
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/smithy-rules/build.sbt
@@ -1,0 +1,10 @@
+lazy val root = (project in file("."))
+  .enablePlugins(Smithy4sCodegenPlugin)
+  .settings(
+    scalaVersion := "2.13.10",
+    libraryDependencies ++= Seq(
+      "com.disneystreaming.smithy4s" %% "smithy4s-core" % smithy4sVersion.value,
+      "software.amazon.smithy" % "smithy-rules-engine" % smithy4s.codegen.BuildInfo.smithyVersion % Smithy4s
+    ),
+    Compile / smithy4sAllowedNamespaces := List("smithy.rules")
+  )

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/smithy-rules/project/build.properties
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/smithy-rules/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.8.2

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/smithy-rules/project/plugins.sbt
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/smithy-rules/project/plugins.sbt
@@ -1,0 +1,9 @@
+sys.props.get("plugin.version") match {
+  case Some(x) =>
+    addSbtPlugin("com.disneystreaming.smithy4s" % "smithy4s-sbt-codegen" % x)
+  case _ =>
+    sys.error(
+      """|The system property 'plugin.version' is not defined.
+         |Specify this property using the scriptedLaunchOpts -D.""".stripMargin
+    )
+}

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/smithy-rules/test
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/smithy-rules/test
@@ -1,0 +1,3 @@
+# check if smithy4sCodegen works
+> compile
+$ exists target/scala-2.13/src_managed/main/smithy/rules

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/smithy-rules/test
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/smithy-rules/test
@@ -1,3 +1,3 @@
 # check if smithy4sCodegen works
 > compile
-$ exists target/scala-2.13/src_managed/main/smithy/rules
+$ exists target/scala-2.13/src_managed/main/scala/smithy/rules

--- a/modules/codegen-plugin/src/smithy4s/codegen/Smithy4sCodegenPlugin.scala
+++ b/modules/codegen-plugin/src/smithy4s/codegen/Smithy4sCodegenPlugin.scala
@@ -161,7 +161,7 @@ object Smithy4sCodegenPlugin extends AutoPlugin {
       (config / sourceDirectory).value / "smithy",
       (config / sourceManaged).value / "smithy"
     ),
-    config / smithy4sOutputDir := (config / sourceManaged).value,
+    config / smithy4sOutputDir := (config / sourceManaged).value / "scala",
     config / smithy4sResourceDir := (config / resourceManaged).value,
     config / smithy4sCodegen := cachedSmithyCodegen(config).value,
     config / smithy4sSmithyLibrary := true,

--- a/modules/codegen/src/smithy4s/codegen/internals/SmithyResources.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/SmithyResources.scala
@@ -29,9 +29,15 @@ private[smithy4s] object SmithyResources {
 
   def produce(
       resourceOutputFolder: os.Path,
-      localSmithyFiles: List[os.Path],
+      specs: List[os.Path],
       namespaces: List[String]
   ): List[os.Path] = {
+
+    val localSmithyFiles = specs.flatMap { spec =>
+      if (os.isDir(spec)) os.walk(spec).filter(_.ext == "smithy")
+      else if (spec.ext == "smithy") List(spec)
+      else Nil
+    }
 
     val smithyFolder = resourceOutputFolder / "META-INF" / "smithy"
     val trackingFile = smithyFolder / s"smithy4s.tracking.smithy"
@@ -60,10 +66,6 @@ private[smithy4s] object SmithyResources {
     os.write.over(trackingFile, content, createFolders = true)
 
     localSmithyFiles
-      .flatMap {
-        case p if os.isDir(p) => os.list(p)
-        case p                => List(p)
-      }
       .foreach { path =>
         os.copy.over(
           from = path,

--- a/modules/codegen/src/smithy4s/codegen/internals/SmithyResources.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/SmithyResources.scala
@@ -34,8 +34,9 @@ private[smithy4s] object SmithyResources {
   ): List[os.Path] = {
 
     val localSmithyFiles = specs.flatMap { spec =>
-      if (os.isDir(spec)) os.walk(spec).filter(_.ext == "smithy")
-      else if (spec.ext == "smithy") List(spec)
+      if (os.isDir(spec))
+        os.walk(spec).filter(f => Set("smithy", "json").contains(f.ext))
+      else if (Set("smithy", "json").contains(spec.ext)) List(spec)
       else Nil
     }
 


### PR DESCRIPTION
Under the right condition, before this fix, generated scala code would be copied to the resources folder, which would lead to some compilation errors due to duplication, because the compiler picks up resources as sources for some reason.

The bug was introduced in https://github.com/disneystreaming/smithy4s/pulls?page=2&q=is%3Apr+is%3Aclosed, which generate some smithy files under the `sourcesManaged / "smithy"` directory, which is then used as an input for the codegen. The codegen has a resource generator to it, which copies local files under input directories to the META-INF/smithy resource folder.

However, when generating a namespace that starts with "smithy", the Scala code gets generated in the same sourcesManaged / "smithy" directory. 

~Arguably, the problem is that it should be generated in sourcesManaged / "scala" / "smithy", but at this point I'm unsure what the implications for doing that are. So instead, I'm ensuring that whatever gets copied in META-INF/smithy are actual smithy files.~ 

After a quick test, it looks like Intellij is cool with the sources being generated under `sourcesManaged / "scala"`, so I've changed the behaviour of the SBT plugin to do that and have adjusted the tests accordingly. 