### PR TITLE
Upgrade to latest coursier

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -393,7 +393,7 @@ lazy val codegen = projectMatrix
       "com.lihaoyi" %% "os-lib" % "0.8.1",
       "org.scala-lang.modules" %% "scala-collection-compat" % "2.2.0",
       "org.scala-lang" % "scala-reflect" % scalaVersion.value,
-      "io.get-coursier" %% "coursier" % "2.0.16"
+      "io.get-coursier" %% "coursier" % "2.1.0-RC5"
     ),
     libraryDependencies ++= munitDeps.value,
     scalacOptions := scalacOptions.value


### PR DESCRIPTION
Upgrade the codegen module's coursier dependency. This is to upgrade the transitive scala-xml dependency from 1.3.0 to 2.1.0, to make the sbt plugin compatible with sbt 1.8.0+.

You can find a couple of entrances to the rabbit hole [here](https://github.com/sbt/sbt/issues/6997) and [here](https://github.com/coursier/coursier/pull/2548) but the TLDR is that the ecosystem has finally made the jump from scala-xml 1.x to 2.x. In sbt 1.8.x, sbt itself and nearly all plugins depend on scala-xml 2.x, so any plugins that still bring in a dependency on scala-xml 1.x trigger an eviction warning.