### PR TITLE
Ignore default on refinements

### DIFF
--- a/modules/codegen/src/smithy4s/codegen/internals/IR.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/IR.scala
@@ -170,6 +170,11 @@ private[internals] sealed trait Type {
     case other                    => other
   }
 
+  def isExternal: Boolean = this.dealiased match {
+    case _: Type.ExternalType => true
+    case _                    => false
+  }
+
   def isResolved: Boolean = {
     val isUnwrapped = this match {
       case Type.Alias(_, _, _, unwrapped) => unwrapped

--- a/modules/codegen/src/smithy4s/codegen/internals/SmithyToIR.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/SmithyToIR.scala
@@ -838,11 +838,12 @@ private[codegen] class SmithyToIR(model: Model, namespace: String) {
             if (defaultRenderMode == DefaultRenderMode.Full)
               maybeDefault(member)
             else List.empty
+          val defaultable = member.hasTrait(classOf[DefaultTrait]) &&
+            !member.tpe.exists(_.isExternal)
           (
             member.getMemberName(),
             member.tpe,
-            member.hasTrait(classOf[RequiredTrait]) ||
-              member.hasTrait(classOf[DefaultTrait]),
+            member.hasTrait(classOf[RequiredTrait]) || defaultable,
             hints(member) ++ default ++ noDefault
           )
         }

--- a/modules/example/src/smithy4s/example/StructureWithRefinedTypes.scala
+++ b/modules/example/src/smithy4s/example/StructureWithRefinedTypes.scala
@@ -6,15 +6,16 @@ import smithy4s.ShapeId
 import smithy4s.ShapeTag
 import smithy4s.schema.Schema.struct
 
-case class StructureWithRefinedTypes(age: Age, personAge: PersonAge, fancyList: Option[smithy4s.example.FancyList] = None, unwrappedFancyList: Option[smithy4s.example.refined.FancyList] = None, name: Option[smithy4s.example.Name] = None, dogName: Option[smithy4s.example.refined.Name] = None)
+case class StructureWithRefinedTypes(requiredAge: Age, age: Option[Age] = None, personAge: Option[PersonAge] = None, fancyList: Option[smithy4s.example.FancyList] = None, unwrappedFancyList: Option[smithy4s.example.refined.FancyList] = None, name: Option[smithy4s.example.Name] = None, dogName: Option[smithy4s.example.refined.Name] = None)
 object StructureWithRefinedTypes extends ShapeTag.Companion[StructureWithRefinedTypes] {
   val id: ShapeId = ShapeId("smithy4s.example", "StructureWithRefinedTypes")
 
   val hints: Hints = Hints.empty
 
   implicit val schema: Schema[StructureWithRefinedTypes] = struct(
-    Age.schema.required[StructureWithRefinedTypes]("age", _.age).addHints(smithy.api.Default(smithy4s.Document.fromDouble(0.0d))),
-    PersonAge.schema.required[StructureWithRefinedTypes]("personAge", _.personAge).addHints(smithy.api.Default(smithy4s.Document.fromDouble(0.0d))),
+    Age.schema.required[StructureWithRefinedTypes]("requiredAge", _.requiredAge).addHints(smithy.api.Default(smithy4s.Document.fromDouble(0.0d)), smithy.api.Required()),
+    Age.schema.optional[StructureWithRefinedTypes]("age", _.age).addHints(smithy.api.Default(smithy4s.Document.fromDouble(0.0d))),
+    PersonAge.schema.optional[StructureWithRefinedTypes]("personAge", _.personAge).addHints(smithy.api.Default(smithy4s.Document.fromDouble(0.0d))),
     smithy4s.example.FancyList.schema.optional[StructureWithRefinedTypes]("fancyList", _.fancyList),
     UnwrappedFancyList.underlyingSchema.optional[StructureWithRefinedTypes]("unwrappedFancyList", _.unwrappedFancyList),
     smithy4s.example.Name.schema.optional[StructureWithRefinedTypes]("name", _.name),

--- a/sampleSpecs/refined.smithy
+++ b/sampleSpecs/refined.smithy
@@ -88,6 +88,8 @@ string DogName
 structure StructureWithRefinedTypes {
   age: Age,
   personAge: PersonAge,
+  @required
+  requiredAge: Age,
   fancyList: FancyList,
   unwrappedFancyList: UnwrappedFancyList,
   name: Name,


### PR DESCRIPTION
In this PR, I attempt to solve #791 which renders product member as if they were required. The issue happens because the Smithy definitions happen in a v1 IDL language version and the shape in question gets `Default` trait added.

The boolean that indicates whether or not the member should be wrapped in option check for `Required` or `Default` trait on the shape, and if they are there, it will make it required.

So a non-required field, gets an automatic `Default` because it is defined in a v1 spec, and thus the rendering code scraps the optionality off of it.

In this PR, I replace the `Default` trait presence check with a more involved one. The check is now:
`if hasDefault && typeIsNotExternal`.

I assume a Type.external necessarily mean a refined type (but I'm not 100% sure about that).

In any case, this change behaves
how I want and we can see that in the few examples that are updated in this PR. I added and extra field with `@required` to make sure it was still respected.