### PR TITLE
Emit warning on default trait on refined types

### DIFF
--- a/modules/protocol-tests/test/src/smithy4s/api/validation/RefinementTraitValidatorSpec.scala
+++ b/modules/protocol-tests/test/src/smithy4s/api/validation/RefinementTraitValidatorSpec.scala
@@ -31,7 +31,7 @@ object RefinementTraitValidatorSpec extends weaver.FunSuite {
   test(
     "validation events are returned when multiple refinements are applied to one shape"
   ) {
-    val modelString =
+    val model = loadModel(
       """|namespace test
          |
          |use smithy4s.meta#refinement
@@ -48,14 +48,7 @@ object RefinementTraitValidatorSpec extends weaver.FunSuite {
          |@trtTwo
          |integer TestIt
          |""".stripMargin
-
-    val model = Model
-      .assembler()
-      .disableValidation()
-      .discoverModels()
-      .addUnparsedModel("test.smithy", modelString)
-      .assemble()
-      .unwrap()
+    )
 
     val result = validator.validate(model).asScala.toList
     val expected = List(
@@ -76,7 +69,7 @@ object RefinementTraitValidatorSpec extends weaver.FunSuite {
   test(
     "no validation events are returned when one refinement is applied to a shape"
   ) {
-    val modelString =
+    val model = loadModel(
       """|namespace test
          |
          |use smithy4s.meta#refinement
@@ -92,14 +85,7 @@ object RefinementTraitValidatorSpec extends weaver.FunSuite {
          |@trtOne
          |integer TestIt
          |""".stripMargin
-
-    val model = Model
-      .assembler()
-      .disableValidation()
-      .discoverModels()
-      .addUnparsedModel("test.smithy", modelString)
-      .assemble()
-      .unwrap()
+    )
 
     val result = validator.validate(model).asScala.toList
     val expected = List.empty
@@ -109,7 +95,7 @@ object RefinementTraitValidatorSpec extends weaver.FunSuite {
   test(
     "no validation events are returned when all shapes have only one refinement"
   ) {
-    val modelString =
+    val model = loadModel(
       """|namespace test
          |
          |use smithy4s.meta#refinement
@@ -128,14 +114,7 @@ object RefinementTraitValidatorSpec extends weaver.FunSuite {
          |@trtTwo
          |integer TestItAgain
          |""".stripMargin
-
-    val model = Model
-      .assembler()
-      .disableValidation()
-      .discoverModels()
-      .addUnparsedModel("test.smithy", modelString)
-      .assemble()
-      .unwrap()
+    )
 
     val result = validator.validate(model).asScala.toList
     val expected = List.empty
@@ -145,7 +124,7 @@ object RefinementTraitValidatorSpec extends weaver.FunSuite {
   test(
     "validation events are returned when using refinement trait on disallowed shape"
   ) {
-    val modelString =
+    val model = loadModel(
       """|namespace test
          |
          |use smithy4s.meta#refinement
@@ -157,14 +136,7 @@ object RefinementTraitValidatorSpec extends weaver.FunSuite {
          |@trtOne
          |structure TestIt {}
          |""".stripMargin
-
-    val model = Model
-      .assembler()
-      .disableValidation()
-      .discoverModels()
-      .addUnparsedModel("test.smithy", modelString)
-      .assemble()
-      .unwrap()
+    )
 
     val result = validator.validate(model).asScala.toList
     val expected = List(
@@ -185,7 +157,7 @@ object RefinementTraitValidatorSpec extends weaver.FunSuite {
   test(
     "validation events are returned when using refinement trait on disallowed shape - enum"
   ) {
-    val modelString =
+    val model = loadModel(
       """|namespace test
          |
          |use smithy4s.meta#refinement
@@ -201,14 +173,7 @@ object RefinementTraitValidatorSpec extends weaver.FunSuite {
          |])
          |string TestIt
          |""".stripMargin
-
-    val model = Model
-      .assembler()
-      .disableValidation()
-      .discoverModels()
-      .addUnparsedModel("test.smithy", modelString)
-      .assemble()
-      .unwrap()
+    )
 
     val result = validator.validate(model).asScala.toList
     val expected = List(
@@ -268,7 +233,7 @@ object RefinementTraitValidatorSpec extends weaver.FunSuite {
   test(
     "check that provider import format is valid - should fail"
   ) {
-    val modelString =
+    val result = loadValidationErrors(
       """|$version: "2.0"
          |
          |namespace test
@@ -282,15 +247,7 @@ object RefinementTraitValidatorSpec extends weaver.FunSuite {
          |@trtOne
          |string TestIt
          |""".stripMargin
-
-    val result = Model
-      .assembler()
-      .discoverModels()
-      .addUnparsedModel("test.smithy", modelString)
-      .assemble()
-      .getValidationEvents()
-      .asScala
-      .toList
+    )
 
     val expected = List(
       ValidationEvent
@@ -310,7 +267,7 @@ object RefinementTraitValidatorSpec extends weaver.FunSuite {
   test(
     "no validation events are returned when one refinement is applied to a simple member shape"
   ) {
-    val modelString =
+    val model = loadModel(
       """|namespace test
          |
          |use smithy4s.meta#refinement
@@ -324,18 +281,34 @@ object RefinementTraitValidatorSpec extends weaver.FunSuite {
          |  value: String
          |}
          |""".stripMargin
+    )
 
-    val model = Model
+    val result = validator.validate(model).asScala.toList
+    val expected = List.empty
+    expect.same(result, expected)
+  }
+
+  private def loadModel(modelString: String): Model = {
+    Model
       .assembler()
       .disableValidation()
       .discoverModels()
       .addUnparsedModel("test.smithy", modelString)
       .assemble()
       .unwrap()
+  }
 
-    val result = validator.validate(model).asScala.toList
-    val expected = List.empty
-    expect.same(result, expected)
+  private def loadValidationErrors(
+      modelString: String
+  ): List[ValidationEvent] = {
+    Model
+      .assembler()
+      .discoverModels()
+      .addUnparsedModel("test.smithy", modelString)
+      .assemble()
+      .getValidationEvents()
+      .asScala
+      .toList
   }
 
 }

--- a/modules/protocol/src/smithy4s/meta/validation/RefinementTraitValidator.java
+++ b/modules/protocol/src/smithy4s/meta/validation/RefinementTraitValidator.java
@@ -38,11 +38,13 @@ public final class RefinementTraitValidator extends AbstractValidator {
 
 	boolean isAllowedType(Model model, Shape shape) {
 		boolean notConstrained = shape.getAllTraits().values().stream().allMatch(t -> {
+			@SuppressWarnings("deprecation") // EnumTrait
 			boolean isConstrained = t instanceof EnumTrait || t instanceof LengthTrait || t instanceof RangeTrait
 					|| t instanceof PatternTrait;
 			return !isConstrained;
 		});
 		boolean _isSimple = isSimple(model, shape) && notConstrained;
+		@SuppressWarnings("deprecation") // isSetShape
 		boolean isCollection = shape.isListShape() || shape.isMapShape() || shape.isSetShape();
 		return _isSimple || isCollection;
 	}

--- a/modules/protocol/src/smithy4s/meta/validation/RefinementTraitValidator.java
+++ b/modules/protocol/src/smithy4s/meta/validation/RefinementTraitValidator.java
@@ -22,11 +22,15 @@ import software.amazon.smithy.model.shapes.ShapeType;
 import software.amazon.smithy.model.traits.*;
 import software.amazon.smithy.model.validation.AbstractValidator;
 import software.amazon.smithy.model.validation.ValidationEvent;
+import software.amazon.smithy.model.SourceLocation;
 import smithy4s.meta.RefinementTrait;
 
 import java.util.List;
+import java.util.Optional;
+import java.util.Collections;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import java.util.Set;
 
 public final class RefinementTraitValidator extends AbstractValidator {
 
@@ -49,9 +53,35 @@ public final class RefinementTraitValidator extends AbstractValidator {
 		return _isSimple || isCollection;
 	}
 
+	// inspired from:
+	// https://github.com/awslabs/smithy/blob/7f7669e0ee1f563488d111e9ee9c8df9179533d3/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/Upgrade1to2Command.java#L256
+	private boolean isSyntheticDefault(Shape shape, DefaultTrait defTrait) {
+		Optional<SourceLocation> defaultLocation = shape.getTrait(DefaultTrait.class).map(Trait::getSourceLocation);
+		// When Smithy injects the default trait, it sets the source
+		// location equal to the shape's source location. This is
+		// impossible in any other scenario, so we can use this info
+		// to know whether it was injected or not.
+		return shape.getSourceLocation().equals(defTrait.getSourceLocation());
+	}
+
+	// if there is a default trait, and it is not a synthetic one
+	// then we can assume the user added it
+	boolean hasUserDefault(Shape shape) {
+		Optional<DefaultTrait> defaultTrait = shape.getTrait(DefaultTrait.class);
+		return defaultTrait.filter(d -> !isSyntheticDefault(shape, d)).isPresent();
+	}
+
+	Stream<ValidationEvent> refinedTraitsNoDefault(Model model) {
+		return model.getShapesWithTrait(RefinementTrait.class).stream().flatMap(refinedTrait -> {
+			return model.getShapesWithTrait(refinedTrait.getId()).stream().filter(shape -> hasUserDefault(shape))
+					.map(shape -> warning(shape, refinedTrait.getId() + " is a refinement trait. It is applied to "
+							+ shape.getId() + " along with a @default trait. You should avoid mixing the two."));
+		});
+	}
+
 	@Override
 	public List<ValidationEvent> validate(Model model) {
-		return model.shapes().flatMap(s -> {
+		Stream<ValidationEvent> countErrors = model.shapes().flatMap(s -> {
 			long numRefinedTraits = s.getAllTraits().values().stream().flatMap(t -> {
 				return OptionHelper.toStream(model.getShape(t.toShapeId())).flatMap(traitShape -> {
 					return OptionHelper.toStream(traitShape.getTrait(RefinementTrait.class));
@@ -65,6 +95,8 @@ public final class RefinementTraitValidator extends AbstractValidator {
 			} else {
 				return Stream.empty();
 			}
-		}).collect(Collectors.toList());
+		});
+		Stream<ValidationEvent> defaultUsageWarnings = refinedTraitsNoDefault(model);
+		return Stream.of(countErrors, defaultUsageWarnings).flatMap(s -> s).collect(Collectors.toList());
 	}
 }


### PR DESCRIPTION
Following #795 , it suggested that the validator emits a warning if a user adds a `@default` annotation on a shape that's acting as a refinement trait. That's what I added in this PR.

I grabbed the synthetic default trick from the smithy-model source code and the tests show that it works.