### PR TITLE
Fix skip comments when parsing ~/.aws/credentials

### DIFF
--- a/modules/aws/src/smithy4s/aws/AwsCredentialsFile.scala
+++ b/modules/aws/src/smithy4s/aws/AwsCredentialsFile.scala
@@ -91,6 +91,8 @@ object AwsCredentialsFile {
       }
     }
 
+    def withoutComments(line: String): String = line.replaceAll("#.+", "")
+
     def lookingForProfile(
         rest: List[String],
         data: Map[String, Map[String, String]]
@@ -111,7 +113,10 @@ object AwsCredentialsFile {
     }
     Either
       .catchNonFatal(
-        lookingForProfile(lines.filter(_.trim.nonEmpty), Map.empty)
+        lookingForProfile(
+          lines.map(withoutComments).filter(_.trim.nonEmpty),
+          Map.empty
+        )
       )
       .leftMap(ex =>
         AwsCredentialsFileException("Unable to parse credentials file.", ex)

--- a/modules/aws/test/src/smithy4s/aws/AwsCredentialsFileTest.scala
+++ b/modules/aws/test/src/smithy4s/aws/AwsCredentialsFileTest.scala
@@ -48,6 +48,22 @@ object AwsCredentialsFileTest extends FunSuite {
     }
   }
 
+  test("parse comments") {
+    expectRight(
+      AwsCredentialsFile.processFileLines(
+        asLines(
+          """|# A comment
+             |[default] # another comment
+             |aws_secret_access_key = sec
+             |aws_access_key_id     = key #yet another comment
+             |aws_session_token     = token""".stripMargin
+        )
+      )
+    ) { res =>
+      expect.same(Some(creds), res.default)
+    }
+  }
+
   test("find some other profile") {
     expectRight(
       AwsCredentialsFile.processFileLines(


### PR DESCRIPTION
Fixes #810