### PR TITLE
[http4s] Enrich Http Endpoint Exception message

### DIFF
--- a/modules/http4s/src/smithy4s/http4s/SmithyHttp4sReverseRouter.scala
+++ b/modules/http4s/src/smithy4s/http4s/SmithyHttp4sReverseRouter.scala
@@ -62,7 +62,7 @@ class SmithyHttp4sReverseRouter[Alg[_[_, _, _, _, _]], Op[_, _, _, _, _], F[_]](
           .left
           .map { e =>
             throw new Exception(
-              s"Operation ${endpoint.name} is not bound to http semantics",
+              s"Operation ${endpoint.name} is not bound to http semantics: ${e.message}",
               e
             )
           }


### PR DESCRIPTION
persists the cause of  endpoint failure into the message of the Exception thrown