### PR TITLE
[Compliance Tests] split uri assert into path assert and query assert

### DIFF
--- a/modules/compliance-tests/src/smithy4s/compliancetests/internals/ClientHttpComplianceTestCase.scala
+++ b/modules/compliance-tests/src/smithy4s/compliancetests/internals/ClientHttpComplianceTestCase.scala
@@ -73,8 +73,12 @@ private[compliancetests] class ClientHttpComplianceTestCase[
         parseQueryParams(testCase.queryParams)
       )
 
-    val uriAssert =
-      assert.eql(expectedUri.renderString, request.uri.renderString)
+    val pathAssert =
+      assert.eql(expectedUri.path.renderString, request.uri.path.renderString)
+    val queryAssert = assert.eql(
+      expectedUri.query.renderString,
+      request.uri.query.renderString
+    )
     val methodAssert = assert.eql(
       testCase.method.toLowerCase(),
       request.method.name.toLowerCase()
@@ -82,7 +86,8 @@ private[compliancetests] class ClientHttpComplianceTestCase[
     val ioAsserts: List[F[ComplianceResult]] = bodyAssert +:
       List(
         assert.testCase.checkHeaders(testCase, request.headers),
-        uriAssert,
+        pathAssert,
+        queryAssert,
         methodAssert
       )
         .map(_.pure[F])


### PR DESCRIPTION
allows for ignoring the base uri which was neverv part of the test framework and is incompatible with the aws-http4s model