### PR TITLE
[Http4s] - client uses withEmptyBody instead of withEntity when there is no body

### DIFF
--- a/modules/http4s/src/smithy4s/http4s/internals/SmithyHttp4sClientEndpoint.scala
+++ b/modules/http4s/src/smithy4s/http4s/internals/SmithyHttp4sClientEndpoint.scala
@@ -25,7 +25,6 @@ import org.http4s.Request
 import org.http4s.Response
 import org.http4s.Uri
 import org.http4s.client.Client
-import scodec.bits.ByteVector
 import smithy4s.kinds._
 import smithy4s.http._
 import smithy4s.schema.SchemaAlt
@@ -122,7 +121,7 @@ private[http4s] class SmithyHttp4sClientEndpointImpl[F[_], Op[_, _, _, _, _], I,
     val baseRequest = Request[F](method, uri, headers = headers)
     if (inputHasBody) {
       baseRequest.withEntity(input)
-    } else baseRequest.withEntity(ByteVector.empty)
+    } else baseRequest.withEmptyBody
   }
 
   private def outputFromResponse(response: Response[F]): F[O] =


### PR DESCRIPTION
this solves the issue of a content-length header provided on GET requests when there is no body
