### PR TITLE
[Core] MetaEncode/MetaDecode when handling httpQueryParams trait

### DIFF
--- a/modules/core/src/smithy4s/http/Metadata.scala
+++ b/modules/core/src/smithy4s/http/Metadata.scala
@@ -70,7 +70,7 @@ case class Metadata(
   def addQueryParam(key: String, value: String): Metadata =
     query.get(key) match {
       case Some(existing) =>
-        copy(query = query + (key -> (value +: existing)))
+        copy(query = query + (key -> (existing :+ value)))
       case None => copy(query = query + (key -> List(value)))
     }
   def addQueryParamsIfNoExist(key: String, values: String*): Metadata =
@@ -94,7 +94,7 @@ case class Metadata(
   def addMultipleQueryParams(key: String, value: List[String]): Metadata =
     query.get(key) match {
       case Some(existing) =>
-        copy(query = query + (key -> (value ++ existing)))
+        copy(query = query + (key -> ( existing ++ value)))
       case None => copy(query = query + (key -> value))
     }
 

--- a/modules/core/src/smithy4s/http/Metadata.scala
+++ b/modules/core/src/smithy4s/http/Metadata.scala
@@ -73,6 +73,11 @@ case class Metadata(
         copy(query = query + (key -> (value +: existing)))
       case None => copy(query = query + (key -> List(value)))
     }
+  def addQueryParamsIfNoExist(key: String, values: String*): Metadata =
+    query.get(key) match {
+      case Some(_) => self
+      case None    => copy(query = query + (key -> values.toList))
+    }
   def addMultipleHeaders(
       ciKey: CaseInsensitive,
       value: List[String]

--- a/modules/core/src/smithy4s/http/Metadata.scala
+++ b/modules/core/src/smithy4s/http/Metadata.scala
@@ -94,7 +94,7 @@ case class Metadata(
   def addMultipleQueryParams(key: String, value: List[String]): Metadata =
     query.get(key) match {
       case Some(existing) =>
-        copy(query = query + (key -> ( existing ++ value)))
+        copy(query = query + (key -> (existing ++ value)))
       case None => copy(query = query + (key -> value))
     }
 

--- a/modules/core/src/smithy4s/http/internals/MetaDecode.scala
+++ b/modules/core/src/smithy4s/http/internals/MetaDecode.scala
@@ -97,7 +97,9 @@ private[http] sealed abstract class MetaDecode[+A] {
         (metadata, putField) =>
           val iter: Iterator[(FieldName, FieldName)] = metadata.query.iterator
             .map { case (k, values) =>
-              k -> values.head
+              if (values.nonEmpty) {
+                k -> values.head
+              } else throw MetadataError.NotFound(fieldName, QueryParamsBinding)
             }
           if (iter.nonEmpty && optional) putField.putSome(fieldName, f(iter))
           else if (iter.isEmpty && optional) putField.putNone(fieldName)

--- a/modules/core/src/smithy4s/http/internals/MetaDecode.scala
+++ b/modules/core/src/smithy4s/http/internals/MetaDecode.scala
@@ -45,7 +45,6 @@ private[http] sealed abstract class MetaDecode[+A] {
       binding: HttpBinding,
       fieldName: String,
       optional: Boolean,
-      reservedQueries: Set[String],
       maybeDefault: Option[Any]
   ): (Metadata, PutField) => Unit = {
     // format: off
@@ -94,8 +93,7 @@ private[http] sealed abstract class MetaDecode[+A] {
         }
       case (QueryParamsBinding, StringMapMetaDecode(f)) => {
         (metadata, putField) =>
-          val iter = metadata.query.iterator
-            .filterNot { case (k, _) => reservedQueries(k) }
+          val iter: Iterator[(FieldName, FieldName)] = metadata.query.iterator
             .map { case (k, values) =>
               if (values.size == 1) {
                 k -> values.head
@@ -108,7 +106,6 @@ private[http] sealed abstract class MetaDecode[+A] {
       case (QueryParamsBinding, StringListMapMetaDecode(f)) => {
         (metadata, putField) =>
           val iter = metadata.query.iterator
-            .filterNot { case (k, _) => reservedQueries(k) }
             .map { case (k, values) =>
               k -> values.iterator
             }

--- a/modules/core/src/smithy4s/http/internals/MetaDecode.scala
+++ b/modules/core/src/smithy4s/http/internals/MetaDecode.scala
@@ -95,9 +95,7 @@ private[http] sealed abstract class MetaDecode[+A] {
         (metadata, putField) =>
           val iter: Iterator[(FieldName, FieldName)] = metadata.query.iterator
             .map { case (k, values) =>
-              if (values.size == 1) {
-                k -> values.head
-              } else throw MetadataError.ArityError(fieldName, QueryBinding(k))
+              k -> values.head
             }
           if (iter.nonEmpty && optional) putField.putSome(fieldName, f(iter))
           else if (iter.isEmpty && optional) putField.putNone(fieldName)

--- a/modules/core/src/smithy4s/http/internals/MetaDecode.scala
+++ b/modules/core/src/smithy4s/http/internals/MetaDecode.scala
@@ -91,6 +91,8 @@ private[http] sealed abstract class MetaDecode[+A] {
         lookupAndProcess(_.query, q) { (values, fieldName, putField) =>
           putField(fieldName, f(values.iterator))
         }
+        // see https://smithy.io/2.0/spec/http-bindings.html#httpqueryparams-trait 
+      // when targeting Map[String,String] we take the first value encountered
       case (QueryParamsBinding, StringMapMetaDecode(f)) => {
         (metadata, putField) =>
           val iter: Iterator[(FieldName, FieldName)] = metadata.query.iterator

--- a/modules/core/src/smithy4s/http/internals/MetaDecode.scala
+++ b/modules/core/src/smithy4s/http/internals/MetaDecode.scala
@@ -91,7 +91,7 @@ private[http] sealed abstract class MetaDecode[+A] {
         lookupAndProcess(_.query, q) { (values, fieldName, putField) =>
           putField(fieldName, f(values.iterator))
         }
-        // see https://smithy.io/2.0/spec/http-bindings.html#httpqueryparams-trait 
+      // see https://smithy.io/2.0/spec/http-bindings.html#httpqueryparams-trait
       // when targeting Map[String,String] we take the first value encountered
       case (QueryParamsBinding, StringMapMetaDecode(f)) => {
         (metadata, putField) =>

--- a/modules/core/src/smithy4s/http/internals/MetaEncode.scala
+++ b/modules/core/src/smithy4s/http/internals/MetaEncode.scala
@@ -44,12 +44,12 @@ sealed trait MetaEncode[-A] {
       case (QueryParamsBinding, StringMapMetaEncode(f)) =>
         (metadata: Metadata, a: A) =>
           f(a).foldLeft(metadata) { case (m, (k, v)) =>
-            m.addQueryParam(k, v)
+            m.addQueryParamsIfNoExist(k, v)
           }
       case (QueryParamsBinding, StringListMapMetaEncode(f)) =>
         (metadata: Metadata, a: A) =>
           f(a).foldLeft(metadata) { case (m, (k, v)) =>
-            m.addMultipleQueryParams(k, v)
+            m.addQueryParamsIfNoExist(k, v: _*)
           }
       case (HeaderPrefixBinding(prefix), StringMapMetaEncode(f)) =>
         (metadata: Metadata, a: A) =>

--- a/modules/core/src/smithy4s/http/internals/SchemaVisitorMetadataReader.scala
+++ b/modules/core/src/smithy4s/http/internals/SchemaVisitorMetadataReader.scala
@@ -123,13 +123,6 @@ private[http] class SchemaVisitorMetadataReader(
       fields: Vector[SchemaField[S, _]],
       make: IndexedSeq[Any] => S
   ): MetaDecode[S] = {
-    val reservedQueries =
-      fields
-        .map(f => HttpBinding.fromHints(f.label, f.hints, hints))
-        .collect { case Some(HttpBinding.QueryBinding(query)) =>
-          query
-        }
-        .toSet
 
     def decodeField[A](
         field: SchemaField[S, A]
@@ -146,7 +139,6 @@ private[http] class SchemaVisitorMetadataReader(
             binding,
             label,
             field.isOptional,
-            reservedQueries,
             maybeDefault
           )
         FieldDecode(label, binding, update)

--- a/modules/core/src/smithy4s/http/internals/SchemaVisitorMetadataWriter.scala
+++ b/modules/core/src/smithy4s/http/internals/SchemaVisitorMetadataWriter.scala
@@ -18,6 +18,7 @@ package smithy4s
 package http
 package internals
 
+import smithy.api.HttpQueryParams
 import smithy4s.http.HttpBinding
 import smithy4s.http.internals.MetaEncode._
 import smithy4s.schema.{
@@ -139,13 +140,20 @@ class SchemaVisitorMetadataWriter(
           field.leftFolder(folderT)
         }
     }
-    val updateFunctions = fields.flatMap(field => encodeField(field))
+    // pull out the query params field as it must be applied last to the metadata
+    val (queryParamFieldVec, theRest) =
+      fields.partition(_.instance.hints.has[HttpQueryParams])
+    val queryParams = queryParamFieldVec.headOption.flatMap(encodeField)
+    val updateFunctions = theRest.flatMap(field => encodeField(field))
 
-    StructureMetaEncode(s =>
-      updateFunctions.foldLeft(Metadata.empty)((metadata, updateFunction) =>
-        updateFunction(metadata, s)
-      )
-    )
+    StructureMetaEncode(s => {
+      //  this is a non commutative operation
+      val metadata =
+        updateFunctions.foldLeft(Metadata.empty)((metadata, updateFunction) =>
+          updateFunction(metadata, s)
+        )
+      queryParams.fold(metadata)(updateFunction => updateFunction(metadata, s))
+    })
   }
 
   override def union[U](

--- a/modules/core/src/smithy4s/http/internals/SchemaVisitorMetadataWriter.scala
+++ b/modules/core/src/smithy4s/http/internals/SchemaVisitorMetadataWriter.scala
@@ -143,7 +143,8 @@ class SchemaVisitorMetadataWriter(
     // pull out the query params field as it must be applied last to the metadata
     val (queryParamFieldVec, theRest) =
       fields.partition(_.instance.hints.has[HttpQueryParams])
-    val queryParams = queryParamFieldVec.headOption.flatMap(encodeField)
+    val queryParams =
+      queryParamFieldVec.flatMap(field => encodeField(field)).headOption
     val updateFunctions = theRest.flatMap(field => encodeField(field))
 
     StructureMetaEncode(s => {

--- a/modules/core/test/src/smithy4s/http/internals/MetadataSpec.scala
+++ b/modules/core/test/src/smithy4s/http/internals/MetadataSpec.scala
@@ -60,7 +60,6 @@ class MetadataSpec() extends FunSuite {
       .flatMap { partial =>
         s.compile(FromMetadataSchemaVisitor).read(partial.decoded.toMap)
       }
-    println(s"decoded: $result")
     expect.same(encoded, expectedEncoding)
     expect(result == Right(a))
     checkRoundTripTotal(a, expectedEncoding)

--- a/modules/core/test/src/smithy4s/http/internals/MetadataSpec.scala
+++ b/modules/core/test/src/smithy4s/http/internals/MetadataSpec.scala
@@ -65,6 +65,27 @@ class MetadataSpec() extends FunSuite {
     checkRoundTripTotal(a, expectedEncoding)
   }
 
+  def checkQueryRoundTrip[A](
+      initial: A,
+      expectedEncoding: Metadata,
+      finished: A
+  )(implicit
+      s: Schema[A],
+      loc: Location
+  ): Unit = {
+    val encoded = Metadata.encode(initial)
+    val result = Metadata
+      .decodePartial[A](encoded)
+      .left
+      .map(_.getMessage())
+      .flatMap { partial =>
+        s.compile(FromMetadataSchemaVisitor).read(partial.decoded.toMap)
+      }
+    expect.same(encoded, expectedEncoding)
+    expect(result == Right(finished))
+    checkQueryRoundTripTotal(initial, expectedEncoding, finished)
+  }
+
   def checkRoundTripDefault[A](expectedDecoded: A)(implicit
       s: Schema[A],
       loc: Location
@@ -134,6 +155,26 @@ class MetadataSpec() extends FunSuite {
     expect.same(result, Some(Right(a)))
   }
 
+  def checkQueryRoundTripTotal[A](
+      initial: A,
+      expectedEncoding: Metadata,
+      finished: A
+  )(implicit
+      s: Schema[A],
+      loc: Location
+  ): Unit = {
+    val encoded = Metadata.encode(initial)
+    val result = Metadata
+      .decodeTotal[A](encoded)
+      .map(
+        _.left
+          .map(_.getMessage())
+      )
+
+    expect.same(encoded, expectedEncoding)
+    expect.same(result, Some(Right(finished)))
+  }
+
   def checkRoundTripTotalDefault[A](expectedDecoded: A)(implicit
       s: Schema[A],
       loc: Location
@@ -160,10 +201,11 @@ class MetadataSpec() extends FunSuite {
   // QUERY PARAMETERS
   // ///////////////////////////////////////////////////////////
   test("String query parameter") {
-    val queries =
+    val queries = Queries(str = Some("hello"))
+    val finished =
       Queries(str = Some("hello"), slm = Some(Map("str" -> "hello")))
     val expected = Metadata(query = Map("str" -> List("hello")))
-    checkRoundTrip(queries, expected)
+    checkQueryRoundTrip(queries, expected, finished)
   }
 
   test("String query parameter with default") {
@@ -205,48 +247,56 @@ class MetadataSpec() extends FunSuite {
   }
 
   test("Integer query parameter") {
-    val queries = Queries(int = Some(123), slm = Some(Map("int" -> "123")))
+    val queries = Queries(int = Some(123))
+    val finished = Queries(int = Some(123), slm = Some(Map("int" -> "123")))
     val expected = Metadata(query = Map("int" -> List("123")))
-    checkRoundTrip(queries, expected)
+    checkQueryRoundTrip(queries, expected, finished)
   }
 
   test("Boolean query parameter") {
-    val queries = Queries(b = Some(true), slm = Some(Map("b" -> "true")))
+    val queries = Queries(b = Some(true))
+    val finished = Queries(b = Some(true), slm = Some(Map("b" -> "true")))
     val expected = Metadata(query = Map("b" -> List("true")))
-    checkRoundTrip(queries, expected)
+    checkQueryRoundTrip(queries, expected, finished)
   }
 
   test("timestamp query parameters (no format)") {
     val ts = Timestamp(1970, 1, 1, 0, 0, 0)
-    val queries = Queries(ts1 = Some(ts), slm = Some(Map("ts1" -> epochString)))
+    val queries = Queries(ts1 = Some(ts))
+    val finished =
+      Queries(ts1 = Some(ts), slm = Some(Map("ts1" -> epochString)))
     val expected = Metadata(query = Map("ts1" -> List(epochString)))
-    checkRoundTrip(queries, expected)
+    checkQueryRoundTrip(queries, expected, finished)
   }
 
   test("timestamp query parameters (date-time format)") {
     val ts = Timestamp(1970, 1, 1, 0, 0, 0)
-    val queries = Queries(ts2 = Some(ts), slm = Some(Map("ts2" -> epochString)))
+    val queries = Queries(ts2 = Some(ts))
+    val finished =
+      Queries(ts2 = Some(ts), slm = Some(Map("ts2" -> epochString)))
     val expected = Metadata(query = Map("ts2" -> List(epochString)))
-    checkRoundTrip(queries, expected)
+    checkQueryRoundTrip(queries, expected, finished)
   }
 
   test("timestamp query parameters (epoch-seconds format)") {
     val ts = Timestamp(1234567890L, 0)
-    val queries =
+    val queries = Queries(ts3 = Some(ts))
+    val finished =
       Queries(ts3 = Some(ts), slm = Some(Map("ts3" -> "1234567890")))
     val expected = Metadata(query = Map("ts3" -> List("1234567890")))
-    checkRoundTrip(queries, expected)
+    checkQueryRoundTrip(queries, expected, finished)
   }
 
   test("timestamp query parameters (http-date)") {
     val ts = Timestamp(1970, 1, 1, 0, 0, 0)
-    val queries = Queries(
+    val queries = Queries(ts4 = Some(ts))
+    val finished = Queries(
       ts4 = Some(ts),
       slm = Some(Map("ts4" -> "Thu, 01 Jan 1970 00:00:00 GMT"))
     )
     val expected =
       Metadata(query = Map("ts4" -> List("Thu, 01 Jan 1970 00:00:00 GMT")))
-    checkRoundTrip(queries, expected)
+    checkQueryRoundTrip(queries, expected, finished)
   }
 
   test("map of strings query param") {
@@ -259,18 +309,20 @@ class MetadataSpec() extends FunSuite {
 
   test("list of strings query param") {
     val list = List("hello", "world")
-    val queries = Queries(sl = Some(list), slm = Some(Map("sl" -> "hello")))
+    val queries = Queries(sl = Some(list))
+    val finished = Queries(sl = Some(list), slm = Some(Map("sl" -> "hello")))
     val expected = Metadata(query = Map("sl" -> list))
-    checkRoundTrip(queries, expected)
+    checkQueryRoundTrip(queries, expected, finished)
   }
 
   test("Int Enum query parameter") {
-    val queries = Queries(
+    val queries = Queries(ie = Some(smithy4s.example.Numbers.ONE))
+    val finished = Queries(
       ie = Some(smithy4s.example.Numbers.ONE),
       slm = Some(Map("nums" -> "1"))
     )
     val expected = Metadata(query = Map("nums" -> List("1")))
-    checkRoundTrip(queries, expected)
+    checkQueryRoundTrip(queries, expected, finished)
   }
 
   // ///////////////////////////////////////////////////////////

--- a/modules/core/test/src/smithy4s/http/internals/MetadataSpec.scala
+++ b/modules/core/test/src/smithy4s/http/internals/MetadataSpec.scala
@@ -60,6 +60,7 @@ class MetadataSpec() extends FunSuite {
       .flatMap { partial =>
         s.compile(FromMetadataSchemaVisitor).read(partial.decoded.toMap)
       }
+    println(s"decoded: $result")
     expect.same(encoded, expectedEncoding)
     expect(result == Right(a))
     checkRoundTripTotal(a, expectedEncoding)
@@ -160,7 +161,8 @@ class MetadataSpec() extends FunSuite {
   // QUERY PARAMETERS
   // ///////////////////////////////////////////////////////////
   test("String query parameter") {
-    val queries = Queries(str = Some("hello"))
+    val queries =
+      Queries(str = Some("hello"), slm = Some(Map("str" -> "hello")))
     val expected = Metadata(query = Map("str" -> List("hello")))
     checkRoundTrip(queries, expected)
   }
@@ -204,41 +206,45 @@ class MetadataSpec() extends FunSuite {
   }
 
   test("Integer query parameter") {
-    val queries = Queries(int = Some(123))
+    val queries = Queries(int = Some(123), slm = Some(Map("int" -> "123")))
     val expected = Metadata(query = Map("int" -> List("123")))
     checkRoundTrip(queries, expected)
   }
 
   test("Boolean query parameter") {
-    val queries = Queries(b = Some(true))
+    val queries = Queries(b = Some(true), slm = Some(Map("b" -> "true")))
     val expected = Metadata(query = Map("b" -> List("true")))
     checkRoundTrip(queries, expected)
   }
 
   test("timestamp query parameters (no format)") {
     val ts = Timestamp(1970, 1, 1, 0, 0, 0)
-    val queries = Queries(ts1 = Some(ts))
+    val queries = Queries(ts1 = Some(ts), slm = Some(Map("ts1" -> epochString)))
     val expected = Metadata(query = Map("ts1" -> List(epochString)))
     checkRoundTrip(queries, expected)
   }
 
   test("timestamp query parameters (date-time format)") {
     val ts = Timestamp(1970, 1, 1, 0, 0, 0)
-    val queries = Queries(ts2 = Some(ts))
+    val queries = Queries(ts2 = Some(ts), slm = Some(Map("ts2" -> epochString)))
     val expected = Metadata(query = Map("ts2" -> List(epochString)))
     checkRoundTrip(queries, expected)
   }
 
   test("timestamp query parameters (epoch-seconds format)") {
     val ts = Timestamp(1234567890L, 0)
-    val queries = Queries(ts3 = Some(ts))
+    val queries =
+      Queries(ts3 = Some(ts), slm = Some(Map("ts3" -> "1234567890")))
     val expected = Metadata(query = Map("ts3" -> List("1234567890")))
     checkRoundTrip(queries, expected)
   }
 
   test("timestamp query parameters (http-date)") {
     val ts = Timestamp(1970, 1, 1, 0, 0, 0)
-    val queries = Queries(ts4 = Some(ts))
+    val queries = Queries(
+      ts4 = Some(ts),
+      slm = Some(Map("ts4" -> "Thu, 01 Jan 1970 00:00:00 GMT"))
+    )
     val expected =
       Metadata(query = Map("ts4" -> List("Thu, 01 Jan 1970 00:00:00 GMT")))
     checkRoundTrip(queries, expected)
@@ -254,13 +260,16 @@ class MetadataSpec() extends FunSuite {
 
   test("list of strings query param") {
     val list = List("hello", "world")
-    val queries = Queries(sl = Some(list))
+    val queries = Queries(sl = Some(list), slm = Some(Map("sl" -> "hello")))
     val expected = Metadata(query = Map("sl" -> list))
     checkRoundTrip(queries, expected)
   }
 
   test("Int Enum query parameter") {
-    val queries = Queries(ie = Some(smithy4s.example.Numbers.ONE))
+    val queries = Queries(
+      ie = Some(smithy4s.example.Numbers.ONE),
+      slm = Some(Map("nums" -> "1"))
+    )
     val expected = Metadata(query = Map("nums" -> List("1")))
     checkRoundTrip(queries, expected)
   }


### PR DESCRIPTION
### **This contains both MetaEncode and MetaDecode changes**
I would like to have split them up into separate PR's however the Metadata tests perform a full round trip of encoding and decoding , making this a more difficult task to separate out


This contains some changes to how metadata is encoded and decoded when a structure has the [`httpQueryParams`](https://smithy.io/2.0/spec/http-bindings.html#smithy-api-httpqueryparams-trait) trait on a member

Decoder:
1. the Reserved Queries was removed , this was create to prevent exactly what we **want** to happen , which is that all query params should end up in the structure that is annotated with the `httpQueryParams`  regardless if they are also bound to another structure member
2. we also need to handle when the `httpQueryParams` trait is applied to a `Map[String,String]` and repeated query param is found, for this instead of throwing an exception , we grab the first value 
From https://smithy.io/2.0/spec/http-bindings.html#httpqueryparams-trait

> When servers deserialize the query string into a map of string, they SHOULD take the first encountered value for each key. Since this rule applies to all future query string values, and changing from a map of string to a map of list of string is backwards-incompatible, care should be taken to use map of string only when it is certain that multiple values for any query string will never be meaningful for the operation.

Encoder:
For this we needed to require the values annotated with `httpQueryParams` never override values annotated with `httpQuery`
see previous link

> If a member with the httpQueryParams trait and a member with the [httpQuery trait](https://smithy.io/2.0/spec/http-bindings.html#httpquery-trait) conflict, clients MUST use the value set by the member with the [httpQuery trait](https://smithy.io/2.0/spec/http-bindings.html#httpquery-trait) and disregard the value set by httpQueryParams. 

We do this by inserting values into the Metadata only if the key doesnt exist, and in the SchemaVisitorMetadataWriter we ensure that the field with the `httpQueryParams` annotation is processed last



