### PR TITLE
escape @ in scaladocs

### DIFF
--- a/modules/codegen/src/smithy4s/codegen/internals/Renderer.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/Renderer.scala
@@ -203,13 +203,13 @@ private[internals] class Renderer(compilationUnit: CompilationUnit) { self =>
       .collectFirst { case h: Hint.Documentation => h }
       .foldMap { doc =>
         val shapeDocs: List[String] =
-          doc.docLines.map(_.replaceAll("@", "{@literal @}"))
+          doc.docLines.map(_.replace("@", "{@literal @}"))
         val memberDocs: List[String] =
           if (skipMemberDocs) List.empty
           else
             doc.memberDocLines.flatMap { case (memberName, text) =>
               s"@param $memberName" :: text
-                .map(_.replaceAll("@", "{@literal @}"))
+                .map(_.replace("@", "{@literal @}"))
                 .map("  " + _)
             }.toList
 

--- a/modules/codegen/src/smithy4s/codegen/internals/Renderer.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/Renderer.scala
@@ -202,12 +202,15 @@ private[internals] class Renderer(compilationUnit: CompilationUnit) { self =>
     hints
       .collectFirst { case h: Hint.Documentation => h }
       .foldMap { doc =>
-        val shapeDocs: List[String] = doc.docLines
+        val shapeDocs: List[String] =
+          doc.docLines.map(_.replaceAll("@", "{@literal @}"))
         val memberDocs: List[String] =
           if (skipMemberDocs) List.empty
           else
             doc.memberDocLines.flatMap { case (memberName, text) =>
-              s"@param $memberName" :: text.map("  " + _)
+              s"@param $memberName" :: text
+                .map(_.replaceAll("@", "{@literal @}"))
+                .map("  " + _)
             }.toList
 
         val maybeNewline =

--- a/modules/example/src/smithy4s/example/DocTest.scala
+++ b/modules/example/src/smithy4s/example/DocTest.scala
@@ -1,0 +1,21 @@
+package smithy4s.example
+
+import smithy4s.Hints
+import smithy4s.Schema
+import smithy4s.ShapeId
+import smithy4s.ShapeTag
+import smithy4s.schema.Schema.constant
+
+/** Test if an at-sign is rendered appropriately
+  * {@literal @}test
+  */
+case class DocTest()
+object DocTest extends ShapeTag.Companion[DocTest] {
+  val id: ShapeId = ShapeId("smithy4s.example", "DocTest")
+
+  val hints: Hints = Hints(
+    smithy.api.Documentation("Test if an at-sign is rendered appropriately\n@test"),
+  )
+
+  implicit val schema: Schema[DocTest] = constant(DocTest()).withId(id).addHints(hints)
+}

--- a/sampleSpecs/example.smithy
+++ b/sampleSpecs/example.smithy
@@ -155,3 +155,7 @@ list SomeIndexSeq {
 list SomeVector {
   member: String
 }
+
+/// Test if an at-sign is rendered appropriately
+/// @test
+structure DocTest {}


### PR DESCRIPTION
Currently, if the `@` symbol is left unescaped then it leads to warnings when generating the scaladoc and the `@` signs won't actually show up in the final html.

The following smithy:

```smithy
/// Test if an at-sign is rendered appropriately
/// @test
structure DocTest {}
```

used to lead to the following docs:

```scala
/** Test if an at-sign is rendered appropriately
  * @test
  */
case class DocTest()
```

Which gives the following warning during scaladoc generation:

```
Tag '@test' is not recognised
```

And renders without the `@test`:

![CleanShot 2023-03-08 at 11 08 01](https://user-images.githubusercontent.com/13733772/223794815-d9d4dd41-b297-468e-9cc8-40ef4beb90fe.png)

Now with the change in this PR,  we have no warning from scaladoc generation:

```scala
/** Test if an at-sign is rendered appropriately
  * {@literal @}test
  */
case class DocTest()
```

And the resultant html looks like:

![CleanShot 2023-03-08 at 11 07 00](https://user-images.githubusercontent.com/13733772/223794719-2dbf3488-796f-4c29-993b-5bb96bf8e5de.png)

Note, to test the scaladoc for yourself, you can checkout this branch and run `sbt example/doc`.

There are likely other characters we need to worry about, but I don't exactly know which ones those are off the top of my head and with some quick tests I haven't found any others yet.
