### PR TITLE
this repros a collision where an operation is named Endpoint

### DIFF
--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/scala3/src/main/scala/Main.scala
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/scala3/src/main/scala/Main.scala
@@ -17,12 +17,12 @@
 import smithy4s.errors.*
 
 object Main extends App {
-  val service = ErrorServiceGen
+  val serviceOps = ErrorServiceOperation
   val knownError1 = BadRequest("foo")
   val knownError2 = InternalServerError("bar")
   val unknownError = new RuntimeException("baz")
-  assert(service.ErrorOp.liftError(unknownError) == None)
-  assert(service.ErrorOp.liftError(knownError1) == Some(knownError1))
-  assert(service.ErrorOp.liftError(knownError2) == Some(knownError2))
-  assert(service.ErrorOp.unliftError(knownError1) == knownError1)
+  assert(serviceOps.ErrorOp.liftError(unknownError) == None)
+  assert(serviceOps.ErrorOp.liftError(knownError1) == Some(knownError1))
+  assert(serviceOps.ErrorOp.liftError(knownError2) == Some(knownError2))
+  assert(serviceOps.ErrorOp.unliftError(knownError1) == knownError1)
 }

--- a/modules/codegen/src/smithy4s/codegen/internals/Renderer.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/Renderer.scala
@@ -329,7 +329,7 @@ private[internals] class Renderer(compilationUnit: CompilationUnit) { self =>
           line"type $Default_[F[+_, +_]] = $Constant_[smithy4s.kinds.stubs.Kind2[F]#toKind5]"
         ),
         newline,
-        line"val endpoints: $list[smithy4s.Endpoint[$opTraitName,$wildcardArgument, $wildcardArgument, $wildcardArgument, $wildcardArgument, $wildcardArgument]] = $list"
+        line"val endpoints: $list[smithy4s.Endpoint[$opTraitName, $wildcardArgument, $wildcardArgument, $wildcardArgument, $wildcardArgument, $wildcardArgument]] = $list"
           .args(ops.map(op => line"${opTraitNameRef}.${op.name}")),
         newline,
         line"def $endpoint_[I, E, O, SI, SO](op: $opTraitNameRef[I, E, O, SI, SO]) = op.$endpoint_",

--- a/modules/codegen/src/smithy4s/codegen/internals/Renderer.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/Renderer.scala
@@ -305,7 +305,7 @@ private[internals] class Renderer(compilationUnit: CompilationUnit) { self =>
             ),
             deprecationAnnotation(op.hints),
             line"def ${op.methodName}(${op.renderArgs}): F[${op
-              .renderAlgParams(genNameRef.name)}]"
+              .renderAlgParams(opTraitNameRef.name)}]"
           )
         },
         newline,
@@ -317,6 +317,11 @@ private[internals] class Renderer(compilationUnit: CompilationUnit) { self =>
         ext = line"$Service_.Mixin[$genNameRef, $opTraitNameRef]"
       )(
         newline,
+        renderId(shapeId),
+        line"""val version: String = "$version"""",
+        newline,
+        renderHintsVal(hints),
+        newline,
         line"def $apply_[F[_]](implicit F: $Impl_[F]): F.type = F",
         newline,
         block(line"object $ErrorAware_")(
@@ -324,19 +329,31 @@ private[internals] class Renderer(compilationUnit: CompilationUnit) { self =>
           line"type $Default_[F[+_, +_]] = $Constant_[smithy4s.kinds.stubs.Kind2[F]#toKind5]"
         ),
         newline,
-        renderId(shapeId),
-        newline,
-        renderHintsVal(hints),
-        newline,
         line"val endpoints: $list[smithy4s.Endpoint[$opTraitName,$wildcardArgument, $wildcardArgument, $wildcardArgument, $wildcardArgument, $wildcardArgument]] = $list"
-          .args(ops.map(_.name)),
-        newline,
-        line"""val version: String = "$version"""",
+          .args(ops.map(op => line"${opTraitNameRef}.${op.name}")),
         newline,
         line"def $endpoint_[I, E, O, SI, SO](op: $opTraitNameRef[I, E, O, SI, SO]) = op.$endpoint_",
+        line"class $Constant_[P[-_, +_, +_, +_, +_]](value: P[Any, Nothing, Nothing, Nothing, Nothing]) extends ${opTraitNameRef}.$Transformed_[$opTraitNameRef, P](reified, $const5_(value))",
+        line"type $Default_[F[+_]] = $Constant_[smithy4s.kinds.stubs.Kind1[F]#toKind5]",
+        line"def reified: $genNameRef[$opTraitNameRef] = ${opTraitNameRef}.${NameRef("reified")}",
+        line"def $mapK5_[P[_, _, _, _, _], P1[_, _, _, _, _]](alg: $genNameRef[P], f: $PolyFunction5_[P, P1]): $genNameRef[P1] = new $opTraitNameRef.$Transformed_(alg, f)",
+        line"def $fromPolyFunction_[P[_, _, _, _, _]](f: $PolyFunction5_[$opTraitNameRef, P]): $genNameRef[P] = new $opTraitNameRef.$Transformed_(reified, f)",
+        line"def $toPolyFunction_[P[_, _, _, _, _]](impl: $genNameRef[P]): $PolyFunction5_[$opTraitNameRef, P] = $opTraitNameRef.$toPolyFunction_(impl)"
+      ),
+      newline,
+      block(
+        line"sealed trait $opTraitName[Input, Err, Output, StreamedInput, StreamedOutput]"
+      )(
+        line"def run[F[_, _, _, _, _]](impl: $genName[F]): F[Input, Err, Output, StreamedInput, StreamedOutput]",
+        line"def endpoint: (Input, $Endpoint_[$opTraitName, Input, Err, Output, StreamedInput, StreamedOutput])"
+      ),
+      newline,
+      block(
+        line"object $opTraitName"
+      )(
         newline,
         block(
-          line"object ${NameRef("reified")} extends $genNameRef[$opTraitNameRef]"
+          line"object ${NameDef("reified")} extends $genNameRef[$opTraitNameRef]"
         ) {
           ops.map {
             case op if op.input == Type.unit =>
@@ -347,22 +364,15 @@ private[internals] class Renderer(compilationUnit: CompilationUnit) { self =>
               line"def ${op.methodName}(${op.renderArgs}) = ${op.name}(${op.input}(${op.renderParams}))"
           }
         },
-        newline,
-        line"def $mapK5_[P[_, _, _, _, _], P1[_, _, _, _, _]](alg: $genNameRef[P], f: $PolyFunction5_[P, P1]): $genNameRef[P1] = new $Transformed_(alg, f)",
-        newline,
-        line"def $fromPolyFunction_[P[_, _, _, _, _]](f: $PolyFunction5_[$opTraitNameRef, P]): $genNameRef[P] = new $Transformed_(reified, f)",
         block(
           line"class $Transformed_[P[_, _, _, _, _], P1[_ ,_ ,_ ,_ ,_]](alg: $genNameRef[P], f: $PolyFunction5_[P, P1]) extends $genNameRef[P1]"
         ) {
           ops.map { op =>
             val opName = op.methodName
             line"def $opName(${op.renderArgs}) = f[${op
-              .renderAlgParams(genName.name)}](alg.$opName(${op.renderParams}))"
+              .renderAlgParams(opTraitNameRef.name)}](alg.$opName(${op.renderParams}))"
           }
         },
-        newline,
-        line"class $Constant_[P[-_, +_, +_, +_, +_]](value: P[Any, Nothing, Nothing, Nothing, Nothing]) extends $Transformed_[$opTraitNameRef, P](reified, $const5_(value))",
-        line"type $Default_[F[+_]] = $Constant_[smithy4s.kinds.stubs.Kind1[F]#toKind5]",
         newline,
         block(
           line"def $toPolyFunction_[P[_, _, _, _, _]](impl: $genNameRef[P]): $PolyFunction5_[$opTraitNameRef, P] = new $PolyFunction5_[$opTraitNameRef, P]"
@@ -374,13 +384,6 @@ private[internals] class Renderer(compilationUnit: CompilationUnit) { self =>
           }
         ),
         ops.map(renderOperation(name, _))
-      ),
-      newline,
-      block(
-        line"sealed trait $opTraitName[Input, Err, Output, StreamedInput, StreamedOutput]"
-      )(
-        line"def run[F[_, _, _, _, _]](impl: $genName[F]): F[Input, Err, Output, StreamedInput, StreamedOutput]",
-        line"def endpoint: (Input, $Endpoint_[$opTraitName, Input, Err, Output, StreamedInput, StreamedOutput])"
       ),
       newline
     )
@@ -397,6 +400,7 @@ private[internals] class Renderer(compilationUnit: CompilationUnit) { self =>
       line"input"
     } else line"()"
     val genServiceName = serviceName + "Gen"
+    val opObjectName = serviceName + "Operation"
     val opName = op.name
     val opNameRef = NameRef(opName)
     val traitName = NameRef(s"${serviceName}Operation")
@@ -447,17 +451,17 @@ private[internals] class Renderer(compilationUnit: CompilationUnit) { self =>
 
     lines(
       block(
-        line"case class ${NameDef(opName)}($params) extends $traitName[${op.renderAlgParams(genServiceName)}]"
+        line"case class ${NameDef(opName)}($params) extends $traitName[${op.renderAlgParams(opObjectName)}]"
       )(
         line"def run[F[_, _, _, _, _]](impl: $genServiceName[F]): F[${op
-          .renderAlgParams(genServiceName)}] = impl.${op.methodName}(${op.renderAccessedParams})",
+          .renderAlgParams(opObjectName)}] = impl.${op.methodName}(${op.renderAccessedParams})",
         line"def endpoint: (${op.input}, smithy4s.Endpoint[$traitName,${op
-          .renderAlgParams(genServiceName)}]) = ($inputRef, $opNameRef)"
+          .renderAlgParams(opObjectName)}]) = ($inputRef, $opNameRef)"
       ),
       obj(
         opNameRef,
         ext =
-          line"smithy4s.Endpoint[$traitName,${op.renderAlgParams(genServiceName)}]$errorable"
+          line"smithy4s.Endpoint[$traitName,${op.renderAlgParams(opObjectName)}]$errorable"
       )(
         renderId(op.shapeId),
         line"val input: $Schema_[${op.input}] = ${op.input.schemaRef}.addHints(smithy4s.internals.InputOutput.Input.widen)",

--- a/modules/codegen/src/smithy4s/codegen/internals/Renderer.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/Renderer.scala
@@ -338,7 +338,18 @@ private[internals] class Renderer(compilationUnit: CompilationUnit) { self =>
         line"def reified: $genNameRef[$opTraitNameRef] = ${opTraitNameRef}.${NameRef("reified")}",
         line"def $mapK5_[P[_, _, _, _, _], P1[_, _, _, _, _]](alg: $genNameRef[P], f: $PolyFunction5_[P, P1]): $genNameRef[P1] = new $opTraitNameRef.$Transformed_(alg, f)",
         line"def $fromPolyFunction_[P[_, _, _, _, _]](f: $PolyFunction5_[$opTraitNameRef, P]): $genNameRef[P] = new $opTraitNameRef.$Transformed_(reified, f)",
-        line"def $toPolyFunction_[P[_, _, _, _, _]](impl: $genNameRef[P]): $PolyFunction5_[$opTraitNameRef, P] = $opTraitNameRef.$toPolyFunction_(impl)"
+        line"def $toPolyFunction_[P[_, _, _, _, _]](impl: $genNameRef[P]): $PolyFunction5_[$opTraitNameRef, P] = $opTraitNameRef.$toPolyFunction_(impl)",
+        newline,
+        ops.map { op =>
+          if (op.errors.isEmpty) Lines.empty
+          else {
+            val errorName = NameRef(op.name + "Error")
+            lines(
+              line"type $errorName = $opTraitNameRef.$errorName",
+              line"val $errorName = $opTraitNameRef.$errorName"
+            )
+          }
+        }
       ),
       newline,
       block(

--- a/modules/codegen/src/smithy4s/codegen/internals/Renderer.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/Renderer.scala
@@ -310,7 +310,7 @@ private[internals] class Renderer(compilationUnit: CompilationUnit) { self =>
         newline,
         renderHintsVal(hints),
         newline,
-        line"val endpoints: $list[$genNameRef.Endpoint[$wildcardArgument, $wildcardArgument, $wildcardArgument, $wildcardArgument, $wildcardArgument]] = $list"
+        line"val endpoints: $list[smithy4s.Endpoint[$opTraitName,$wildcardArgument, $wildcardArgument, $wildcardArgument, $wildcardArgument, $wildcardArgument]] = $list"
           .args(ops.map(_.name)),
         newline,
         line"""val version: String = "$version"""",
@@ -433,13 +433,13 @@ private[internals] class Renderer(compilationUnit: CompilationUnit) { self =>
       )(
         line"def run[F[_, _, _, _, _]](impl: $genServiceName[F]): F[${op
           .renderAlgParams(genServiceName)}] = impl.${op.methodName}(${op.renderAccessedParams})",
-        line"def endpoint: (${op.input}, $Endpoint_[${op
+        line"def endpoint: (${op.input}, smithy4s.Endpoint[$traitName,${op
           .renderAlgParams(genServiceName)}]) = ($inputRef, $opNameRef)"
       ),
       obj(
         opNameRef,
         ext =
-          line"$genServiceName.Endpoint[${op.renderAlgParams(genServiceName)}]$errorable"
+          line"smithy4s.Endpoint[$traitName,${op.renderAlgParams(genServiceName)}]$errorable"
       )(
         renderId(op.shapeId),
         line"val input: $Schema_[${op.input}] = ${op.input.schemaRef}.addHints(smithy4s.internals.InputOutput.Input.widen)",

--- a/modules/codegen/test/src/smithy4s/codegen/internals/RendererConfigSpec.scala
+++ b/modules/codegen/test/src/smithy4s/codegen/internals/RendererConfigSpec.scala
@@ -183,8 +183,8 @@ final class RendererConfigSpec extends munit.FunSuite {
     val serviceCode = generateScalaCode(smithy)("smithy4s.Service")
 
     assertContainsSection(serviceCode, "val endpoints")(
-      """val endpoints: List[ServiceGen.Endpoint[?, ?, ?, ?, ?]] = List(
-        |  Operation,
+      """val endpoints: List[smithy4s.Endpoint[ServiceOperation, ?, ?, ?, ?, ?]] = List(
+        |  ServiceOperation.Operation,
         |)""".stripMargin
     )
   }
@@ -210,8 +210,8 @@ final class RendererConfigSpec extends munit.FunSuite {
     val serviceCode = generateScalaCode(smithy)("smithy4s.Service")
 
     assertContainsSection(serviceCode, "val endpoints")(
-      """val endpoints: List[ServiceGen.Endpoint[_, _, _, _, _]] = List(
-        |  Operation,
+      """val endpoints: List[smithy4s.Endpoint[ServiceOperation, _, _, _, _, _]] = List(
+        |  ServiceOperation.Operation,
         |)""".stripMargin
     )
   }

--- a/modules/core/test/src/smithy4s/http/ErrorAltPickerSpec.scala
+++ b/modules/core/test/src/smithy4s/http/ErrorAltPickerSpec.scala
@@ -18,7 +18,7 @@ package smithy4s
 package http
 
 import smithy4s.example._
-import ErrorHandlingServiceGen._
+import ErrorHandlingServiceOperation._
 
 final class ErrorAltPickerSpec extends munit.FunSuite {
 
@@ -90,7 +90,7 @@ final class ErrorAltPickerSpec extends munit.FunSuite {
   private val alts =
     ErrorHandlingOperation.error.alternatives.asInstanceOf[Vector[GenericAlt]]
   private val altsExtra =
-    ErrorHandlingServiceExtraErrorsGen.ExtraErrorOperation.error.alternatives
+    ErrorHandlingServiceExtraErrorsOperation.ExtraErrorOperation.error.alternatives
       .asInstanceOf[Vector[GenericAlt]]
 
   test(

--- a/modules/core/test/src/smithy4s/http/internals/PathSpec.scala
+++ b/modules/core/test/src/smithy4s/http/internals/PathSpec.scala
@@ -21,7 +21,7 @@ import smithy.api.Http
 import smithy.api.NonEmptyString
 import smithy4s.Schema
 import smithy4s.Timestamp
-import smithy4s.example.DummyServiceGen.DummyPath
+import smithy4s.example.DummyServiceOperation.DummyPath
 import smithy4s.example.PathParams
 import smithy4s.http.HttpEndpoint
 import smithy4s.http.PathSegment

--- a/modules/example/src/smithy4s/example/BrandService.scala
+++ b/modules/example/src/smithy4s/example/BrandService.scala
@@ -21,6 +21,11 @@ trait BrandServiceGen[F[_, _, _, _, _]] {
 
 object BrandServiceGen extends Service.Mixin[BrandServiceGen, BrandServiceOperation] {
 
+  val id: ShapeId = ShapeId("smithy4s.example", "BrandService")
+  val version: String = "1"
+
+  val hints: Hints = Hints.empty
+
   def apply[F[_]](implicit F: Impl[F]): F.type = F
 
   object ErrorAware {
@@ -28,31 +33,32 @@ object BrandServiceGen extends Service.Mixin[BrandServiceGen, BrandServiceOperat
     type Default[F[+_, +_]] = Constant[smithy4s.kinds.stubs.Kind2[F]#toKind5]
   }
 
-  val id: ShapeId = ShapeId("smithy4s.example", "BrandService")
-
-  val hints: Hints = Hints.empty
-
   val endpoints: List[smithy4s.Endpoint[BrandServiceOperation,_, _, _, _, _]] = List(
-    AddBrands,
+    BrandServiceOperation.AddBrands,
   )
 
-  val version: String = "1"
-
   def endpoint[I, E, O, SI, SO](op: BrandServiceOperation[I, E, O, SI, SO]) = op.endpoint
+  class Constant[P[-_, +_, +_, +_, +_]](value: P[Any, Nothing, Nothing, Nothing, Nothing]) extends BrandServiceOperation.Transformed[BrandServiceOperation, P](reified, const5(value))
+  type Default[F[+_]] = Constant[smithy4s.kinds.stubs.Kind1[F]#toKind5]
+  def reified: BrandServiceGen[BrandServiceOperation] = BrandServiceOperation.reified
+  def mapK5[P[_, _, _, _, _], P1[_, _, _, _, _]](alg: BrandServiceGen[P], f: PolyFunction5[P, P1]): BrandServiceGen[P1] = new BrandServiceOperation.Transformed(alg, f)
+  def fromPolyFunction[P[_, _, _, _, _]](f: PolyFunction5[BrandServiceOperation, P]): BrandServiceGen[P] = new BrandServiceOperation.Transformed(reified, f)
+  def toPolyFunction[P[_, _, _, _, _]](impl: BrandServiceGen[P]): PolyFunction5[BrandServiceOperation, P] = BrandServiceOperation.toPolyFunction(impl)
+}
+
+sealed trait BrandServiceOperation[Input, Err, Output, StreamedInput, StreamedOutput] {
+  def run[F[_, _, _, _, _]](impl: BrandServiceGen[F]): F[Input, Err, Output, StreamedInput, StreamedOutput]
+  def endpoint: (Input, Endpoint[BrandServiceOperation, Input, Err, Output, StreamedInput, StreamedOutput])
+}
+
+object BrandServiceOperation {
 
   object reified extends BrandServiceGen[BrandServiceOperation] {
     def addBrands(brands: Option[List[String]] = None) = AddBrands(AddBrandsInput(brands))
   }
-
-  def mapK5[P[_, _, _, _, _], P1[_, _, _, _, _]](alg: BrandServiceGen[P], f: PolyFunction5[P, P1]): BrandServiceGen[P1] = new Transformed(alg, f)
-
-  def fromPolyFunction[P[_, _, _, _, _]](f: PolyFunction5[BrandServiceOperation, P]): BrandServiceGen[P] = new Transformed(reified, f)
   class Transformed[P[_, _, _, _, _], P1[_ ,_ ,_ ,_ ,_]](alg: BrandServiceGen[P], f: PolyFunction5[P, P1]) extends BrandServiceGen[P1] {
     def addBrands(brands: Option[List[String]] = None) = f[AddBrandsInput, Nothing, Unit, Nothing, Nothing](alg.addBrands(brands))
   }
-
-  class Constant[P[-_, +_, +_, +_, +_]](value: P[Any, Nothing, Nothing, Nothing, Nothing]) extends Transformed[BrandServiceOperation, P](reified, const5(value))
-  type Default[F[+_]] = Constant[smithy4s.kinds.stubs.Kind1[F]#toKind5]
 
   def toPolyFunction[P[_, _, _, _, _]](impl: BrandServiceGen[P]): PolyFunction5[BrandServiceOperation, P] = new PolyFunction5[BrandServiceOperation, P] {
     def apply[I, E, O, SI, SO](op: BrandServiceOperation[I, E, O, SI, SO]): P[I, E, O, SI, SO] = op.run(impl) 
@@ -72,9 +78,4 @@ object BrandServiceGen extends Service.Mixin[BrandServiceGen, BrandServiceOperat
     )
     def wrap(input: AddBrandsInput) = AddBrands(input)
   }
-}
-
-sealed trait BrandServiceOperation[Input, Err, Output, StreamedInput, StreamedOutput] {
-  def run[F[_, _, _, _, _]](impl: BrandServiceGen[F]): F[Input, Err, Output, StreamedInput, StreamedOutput]
-  def endpoint: (Input, Endpoint[BrandServiceOperation, Input, Err, Output, StreamedInput, StreamedOutput])
 }

--- a/modules/example/src/smithy4s/example/BrandService.scala
+++ b/modules/example/src/smithy4s/example/BrandService.scala
@@ -32,7 +32,7 @@ object BrandServiceGen extends Service.Mixin[BrandServiceGen, BrandServiceOperat
 
   val hints: Hints = Hints.empty
 
-  val endpoints: List[BrandServiceGen.Endpoint[_, _, _, _, _]] = List(
+  val endpoints: List[smithy4s.Endpoint[BrandServiceOperation,_, _, _, _, _]] = List(
     AddBrands,
   )
 
@@ -59,9 +59,9 @@ object BrandServiceGen extends Service.Mixin[BrandServiceGen, BrandServiceOperat
   }
   case class AddBrands(input: AddBrandsInput) extends BrandServiceOperation[AddBrandsInput, Nothing, Unit, Nothing, Nothing] {
     def run[F[_, _, _, _, _]](impl: BrandServiceGen[F]): F[AddBrandsInput, Nothing, Unit, Nothing, Nothing] = impl.addBrands(input.brands)
-    def endpoint: (AddBrandsInput, Endpoint[AddBrandsInput, Nothing, Unit, Nothing, Nothing]) = (input, AddBrands)
+    def endpoint: (AddBrandsInput, smithy4s.Endpoint[BrandServiceOperation,AddBrandsInput, Nothing, Unit, Nothing, Nothing]) = (input, AddBrands)
   }
-  object AddBrands extends BrandServiceGen.Endpoint[AddBrandsInput, Nothing, Unit, Nothing, Nothing] {
+  object AddBrands extends smithy4s.Endpoint[BrandServiceOperation,AddBrandsInput, Nothing, Unit, Nothing, Nothing] {
     val id: ShapeId = ShapeId("smithy4s.example", "AddBrands")
     val input: Schema[AddBrandsInput] = AddBrandsInput.schema.addHints(smithy4s.internals.InputOutput.Input.widen)
     val output: Schema[Unit] = unit.addHints(smithy4s.internals.InputOutput.Output.widen)

--- a/modules/example/src/smithy4s/example/BrandService.scala
+++ b/modules/example/src/smithy4s/example/BrandService.scala
@@ -44,6 +44,7 @@ object BrandServiceGen extends Service.Mixin[BrandServiceGen, BrandServiceOperat
   def mapK5[P[_, _, _, _, _], P1[_, _, _, _, _]](alg: BrandServiceGen[P], f: PolyFunction5[P, P1]): BrandServiceGen[P1] = new BrandServiceOperation.Transformed(alg, f)
   def fromPolyFunction[P[_, _, _, _, _]](f: PolyFunction5[BrandServiceOperation, P]): BrandServiceGen[P] = new BrandServiceOperation.Transformed(reified, f)
   def toPolyFunction[P[_, _, _, _, _]](impl: BrandServiceGen[P]): PolyFunction5[BrandServiceOperation, P] = BrandServiceOperation.toPolyFunction(impl)
+
 }
 
 sealed trait BrandServiceOperation[Input, Err, Output, StreamedInput, StreamedOutput] {

--- a/modules/example/src/smithy4s/example/BrandService.scala
+++ b/modules/example/src/smithy4s/example/BrandService.scala
@@ -33,7 +33,7 @@ object BrandServiceGen extends Service.Mixin[BrandServiceGen, BrandServiceOperat
     type Default[F[+_, +_]] = Constant[smithy4s.kinds.stubs.Kind2[F]#toKind5]
   }
 
-  val endpoints: List[smithy4s.Endpoint[BrandServiceOperation,_, _, _, _, _]] = List(
+  val endpoints: List[smithy4s.Endpoint[BrandServiceOperation, _, _, _, _, _]] = List(
     BrandServiceOperation.AddBrands,
   )
 

--- a/modules/example/src/smithy4s/example/DeprecatedService.scala
+++ b/modules/example/src/smithy4s/example/DeprecatedService.scala
@@ -37,7 +37,7 @@ object DeprecatedServiceGen extends Service.Mixin[DeprecatedServiceGen, Deprecat
     type Default[F[+_, +_]] = Constant[smithy4s.kinds.stubs.Kind2[F]#toKind5]
   }
 
-  val endpoints: List[smithy4s.Endpoint[DeprecatedServiceOperation,_, _, _, _, _]] = List(
+  val endpoints: List[smithy4s.Endpoint[DeprecatedServiceOperation, _, _, _, _, _]] = List(
     DeprecatedServiceOperation.DeprecatedOperation,
   )
 

--- a/modules/example/src/smithy4s/example/DeprecatedService.scala
+++ b/modules/example/src/smithy4s/example/DeprecatedService.scala
@@ -48,6 +48,7 @@ object DeprecatedServiceGen extends Service.Mixin[DeprecatedServiceGen, Deprecat
   def mapK5[P[_, _, _, _, _], P1[_, _, _, _, _]](alg: DeprecatedServiceGen[P], f: PolyFunction5[P, P1]): DeprecatedServiceGen[P1] = new DeprecatedServiceOperation.Transformed(alg, f)
   def fromPolyFunction[P[_, _, _, _, _]](f: PolyFunction5[DeprecatedServiceOperation, P]): DeprecatedServiceGen[P] = new DeprecatedServiceOperation.Transformed(reified, f)
   def toPolyFunction[P[_, _, _, _, _]](impl: DeprecatedServiceGen[P]): PolyFunction5[DeprecatedServiceOperation, P] = DeprecatedServiceOperation.toPolyFunction(impl)
+
 }
 
 sealed trait DeprecatedServiceOperation[Input, Err, Output, StreamedInput, StreamedOutput] {

--- a/modules/example/src/smithy4s/example/DeprecatedService.scala
+++ b/modules/example/src/smithy4s/example/DeprecatedService.scala
@@ -23,6 +23,13 @@ trait DeprecatedServiceGen[F[_, _, _, _, _]] {
 
 object DeprecatedServiceGen extends Service.Mixin[DeprecatedServiceGen, DeprecatedServiceOperation] {
 
+  val id: ShapeId = ShapeId("smithy4s.example", "DeprecatedService")
+  val version: String = ""
+
+  val hints: Hints = Hints(
+    smithy.api.Deprecated(message = None, since = None),
+  )
+
   def apply[F[_]](implicit F: Impl[F]): F.type = F
 
   object ErrorAware {
@@ -30,33 +37,32 @@ object DeprecatedServiceGen extends Service.Mixin[DeprecatedServiceGen, Deprecat
     type Default[F[+_, +_]] = Constant[smithy4s.kinds.stubs.Kind2[F]#toKind5]
   }
 
-  val id: ShapeId = ShapeId("smithy4s.example", "DeprecatedService")
-
-  val hints: Hints = Hints(
-    smithy.api.Deprecated(message = None, since = None),
-  )
-
   val endpoints: List[smithy4s.Endpoint[DeprecatedServiceOperation,_, _, _, _, _]] = List(
-    DeprecatedOperation,
+    DeprecatedServiceOperation.DeprecatedOperation,
   )
-
-  val version: String = ""
 
   def endpoint[I, E, O, SI, SO](op: DeprecatedServiceOperation[I, E, O, SI, SO]) = op.endpoint
+  class Constant[P[-_, +_, +_, +_, +_]](value: P[Any, Nothing, Nothing, Nothing, Nothing]) extends DeprecatedServiceOperation.Transformed[DeprecatedServiceOperation, P](reified, const5(value))
+  type Default[F[+_]] = Constant[smithy4s.kinds.stubs.Kind1[F]#toKind5]
+  def reified: DeprecatedServiceGen[DeprecatedServiceOperation] = DeprecatedServiceOperation.reified
+  def mapK5[P[_, _, _, _, _], P1[_, _, _, _, _]](alg: DeprecatedServiceGen[P], f: PolyFunction5[P, P1]): DeprecatedServiceGen[P1] = new DeprecatedServiceOperation.Transformed(alg, f)
+  def fromPolyFunction[P[_, _, _, _, _]](f: PolyFunction5[DeprecatedServiceOperation, P]): DeprecatedServiceGen[P] = new DeprecatedServiceOperation.Transformed(reified, f)
+  def toPolyFunction[P[_, _, _, _, _]](impl: DeprecatedServiceGen[P]): PolyFunction5[DeprecatedServiceOperation, P] = DeprecatedServiceOperation.toPolyFunction(impl)
+}
+
+sealed trait DeprecatedServiceOperation[Input, Err, Output, StreamedInput, StreamedOutput] {
+  def run[F[_, _, _, _, _]](impl: DeprecatedServiceGen[F]): F[Input, Err, Output, StreamedInput, StreamedOutput]
+  def endpoint: (Input, Endpoint[DeprecatedServiceOperation, Input, Err, Output, StreamedInput, StreamedOutput])
+}
+
+object DeprecatedServiceOperation {
 
   object reified extends DeprecatedServiceGen[DeprecatedServiceOperation] {
     def deprecatedOperation() = DeprecatedOperation()
   }
-
-  def mapK5[P[_, _, _, _, _], P1[_, _, _, _, _]](alg: DeprecatedServiceGen[P], f: PolyFunction5[P, P1]): DeprecatedServiceGen[P1] = new Transformed(alg, f)
-
-  def fromPolyFunction[P[_, _, _, _, _]](f: PolyFunction5[DeprecatedServiceOperation, P]): DeprecatedServiceGen[P] = new Transformed(reified, f)
   class Transformed[P[_, _, _, _, _], P1[_ ,_ ,_ ,_ ,_]](alg: DeprecatedServiceGen[P], f: PolyFunction5[P, P1]) extends DeprecatedServiceGen[P1] {
     def deprecatedOperation() = f[Unit, Nothing, Unit, Nothing, Nothing](alg.deprecatedOperation())
   }
-
-  class Constant[P[-_, +_, +_, +_, +_]](value: P[Any, Nothing, Nothing, Nothing, Nothing]) extends Transformed[DeprecatedServiceOperation, P](reified, const5(value))
-  type Default[F[+_]] = Constant[smithy4s.kinds.stubs.Kind1[F]#toKind5]
 
   def toPolyFunction[P[_, _, _, _, _]](impl: DeprecatedServiceGen[P]): PolyFunction5[DeprecatedServiceOperation, P] = new PolyFunction5[DeprecatedServiceOperation, P] {
     def apply[I, E, O, SI, SO](op: DeprecatedServiceOperation[I, E, O, SI, SO]): P[I, E, O, SI, SO] = op.run(impl) 
@@ -76,9 +82,4 @@ object DeprecatedServiceGen extends Service.Mixin[DeprecatedServiceGen, Deprecat
     )
     def wrap(input: Unit) = DeprecatedOperation()
   }
-}
-
-sealed trait DeprecatedServiceOperation[Input, Err, Output, StreamedInput, StreamedOutput] {
-  def run[F[_, _, _, _, _]](impl: DeprecatedServiceGen[F]): F[Input, Err, Output, StreamedInput, StreamedOutput]
-  def endpoint: (Input, Endpoint[DeprecatedServiceOperation, Input, Err, Output, StreamedInput, StreamedOutput])
 }

--- a/modules/example/src/smithy4s/example/DeprecatedService.scala
+++ b/modules/example/src/smithy4s/example/DeprecatedService.scala
@@ -36,7 +36,7 @@ object DeprecatedServiceGen extends Service.Mixin[DeprecatedServiceGen, Deprecat
     smithy.api.Deprecated(message = None, since = None),
   )
 
-  val endpoints: List[DeprecatedServiceGen.Endpoint[_, _, _, _, _]] = List(
+  val endpoints: List[smithy4s.Endpoint[DeprecatedServiceOperation,_, _, _, _, _]] = List(
     DeprecatedOperation,
   )
 
@@ -63,9 +63,9 @@ object DeprecatedServiceGen extends Service.Mixin[DeprecatedServiceGen, Deprecat
   }
   case class DeprecatedOperation() extends DeprecatedServiceOperation[Unit, Nothing, Unit, Nothing, Nothing] {
     def run[F[_, _, _, _, _]](impl: DeprecatedServiceGen[F]): F[Unit, Nothing, Unit, Nothing, Nothing] = impl.deprecatedOperation()
-    def endpoint: (Unit, Endpoint[Unit, Nothing, Unit, Nothing, Nothing]) = ((), DeprecatedOperation)
+    def endpoint: (Unit, smithy4s.Endpoint[DeprecatedServiceOperation,Unit, Nothing, Unit, Nothing, Nothing]) = ((), DeprecatedOperation)
   }
-  object DeprecatedOperation extends DeprecatedServiceGen.Endpoint[Unit, Nothing, Unit, Nothing, Nothing] {
+  object DeprecatedOperation extends smithy4s.Endpoint[DeprecatedServiceOperation,Unit, Nothing, Unit, Nothing, Nothing] {
     val id: ShapeId = ShapeId("smithy4s.example", "DeprecatedOperation")
     val input: Schema[Unit] = unit.addHints(smithy4s.internals.InputOutput.Input.widen)
     val output: Schema[Unit] = unit.addHints(smithy4s.internals.InputOutput.Output.widen)

--- a/modules/example/src/smithy4s/example/FooService.scala
+++ b/modules/example/src/smithy4s/example/FooService.scala
@@ -42,7 +42,7 @@ object FooServiceGen extends Service.Mixin[FooServiceGen, FooServiceOperation] {
     type Default[F[+_, +_]] = Constant[smithy4s.kinds.stubs.Kind2[F]#toKind5]
   }
 
-  val endpoints: List[smithy4s.Endpoint[FooServiceOperation,_, _, _, _, _]] = List(
+  val endpoints: List[smithy4s.Endpoint[FooServiceOperation, _, _, _, _, _]] = List(
     FooServiceOperation.GetFoo,
   )
 

--- a/modules/example/src/smithy4s/example/FooService.scala
+++ b/modules/example/src/smithy4s/example/FooService.scala
@@ -53,6 +53,7 @@ object FooServiceGen extends Service.Mixin[FooServiceGen, FooServiceOperation] {
   def mapK5[P[_, _, _, _, _], P1[_, _, _, _, _]](alg: FooServiceGen[P], f: PolyFunction5[P, P1]): FooServiceGen[P1] = new FooServiceOperation.Transformed(alg, f)
   def fromPolyFunction[P[_, _, _, _, _]](f: PolyFunction5[FooServiceOperation, P]): FooServiceGen[P] = new FooServiceOperation.Transformed(reified, f)
   def toPolyFunction[P[_, _, _, _, _]](impl: FooServiceGen[P]): PolyFunction5[FooServiceOperation, P] = FooServiceOperation.toPolyFunction(impl)
+
 }
 
 sealed trait FooServiceOperation[Input, Err, Output, StreamedInput, StreamedOutput] {

--- a/modules/example/src/smithy4s/example/FooService.scala
+++ b/modules/example/src/smithy4s/example/FooService.scala
@@ -28,6 +28,13 @@ trait FooServiceGen[F[_, _, _, _, _]] {
 
 object FooServiceGen extends Service.Mixin[FooServiceGen, FooServiceOperation] {
 
+  val id: ShapeId = ShapeId("smithy4s.example", "FooService")
+  val version: String = "1.0.0"
+
+  val hints: Hints = Hints(
+    smithy.api.Documentation("The most basics of services\nGetFoo is its only operation"),
+  )
+
   def apply[F[_]](implicit F: Impl[F]): F.type = F
 
   object ErrorAware {
@@ -35,33 +42,32 @@ object FooServiceGen extends Service.Mixin[FooServiceGen, FooServiceOperation] {
     type Default[F[+_, +_]] = Constant[smithy4s.kinds.stubs.Kind2[F]#toKind5]
   }
 
-  val id: ShapeId = ShapeId("smithy4s.example", "FooService")
-
-  val hints: Hints = Hints(
-    smithy.api.Documentation("The most basics of services\nGetFoo is its only operation"),
-  )
-
   val endpoints: List[smithy4s.Endpoint[FooServiceOperation,_, _, _, _, _]] = List(
-    GetFoo,
+    FooServiceOperation.GetFoo,
   )
-
-  val version: String = "1.0.0"
 
   def endpoint[I, E, O, SI, SO](op: FooServiceOperation[I, E, O, SI, SO]) = op.endpoint
+  class Constant[P[-_, +_, +_, +_, +_]](value: P[Any, Nothing, Nothing, Nothing, Nothing]) extends FooServiceOperation.Transformed[FooServiceOperation, P](reified, const5(value))
+  type Default[F[+_]] = Constant[smithy4s.kinds.stubs.Kind1[F]#toKind5]
+  def reified: FooServiceGen[FooServiceOperation] = FooServiceOperation.reified
+  def mapK5[P[_, _, _, _, _], P1[_, _, _, _, _]](alg: FooServiceGen[P], f: PolyFunction5[P, P1]): FooServiceGen[P1] = new FooServiceOperation.Transformed(alg, f)
+  def fromPolyFunction[P[_, _, _, _, _]](f: PolyFunction5[FooServiceOperation, P]): FooServiceGen[P] = new FooServiceOperation.Transformed(reified, f)
+  def toPolyFunction[P[_, _, _, _, _]](impl: FooServiceGen[P]): PolyFunction5[FooServiceOperation, P] = FooServiceOperation.toPolyFunction(impl)
+}
+
+sealed trait FooServiceOperation[Input, Err, Output, StreamedInput, StreamedOutput] {
+  def run[F[_, _, _, _, _]](impl: FooServiceGen[F]): F[Input, Err, Output, StreamedInput, StreamedOutput]
+  def endpoint: (Input, Endpoint[FooServiceOperation, Input, Err, Output, StreamedInput, StreamedOutput])
+}
+
+object FooServiceOperation {
 
   object reified extends FooServiceGen[FooServiceOperation] {
     def getFoo() = GetFoo()
   }
-
-  def mapK5[P[_, _, _, _, _], P1[_, _, _, _, _]](alg: FooServiceGen[P], f: PolyFunction5[P, P1]): FooServiceGen[P1] = new Transformed(alg, f)
-
-  def fromPolyFunction[P[_, _, _, _, _]](f: PolyFunction5[FooServiceOperation, P]): FooServiceGen[P] = new Transformed(reified, f)
   class Transformed[P[_, _, _, _, _], P1[_ ,_ ,_ ,_ ,_]](alg: FooServiceGen[P], f: PolyFunction5[P, P1]) extends FooServiceGen[P1] {
     def getFoo() = f[Unit, Nothing, GetFooOutput, Nothing, Nothing](alg.getFoo())
   }
-
-  class Constant[P[-_, +_, +_, +_, +_]](value: P[Any, Nothing, Nothing, Nothing, Nothing]) extends Transformed[FooServiceOperation, P](reified, const5(value))
-  type Default[F[+_]] = Constant[smithy4s.kinds.stubs.Kind1[F]#toKind5]
 
   def toPolyFunction[P[_, _, _, _, _]](impl: FooServiceGen[P]): PolyFunction5[FooServiceOperation, P] = new PolyFunction5[FooServiceOperation, P] {
     def apply[I, E, O, SI, SO](op: FooServiceOperation[I, E, O, SI, SO]): P[I, E, O, SI, SO] = op.run(impl) 
@@ -83,9 +89,4 @@ object FooServiceGen extends Service.Mixin[FooServiceGen, FooServiceOperation] {
     )
     def wrap(input: Unit) = GetFoo()
   }
-}
-
-sealed trait FooServiceOperation[Input, Err, Output, StreamedInput, StreamedOutput] {
-  def run[F[_, _, _, _, _]](impl: FooServiceGen[F]): F[Input, Err, Output, StreamedInput, StreamedOutput]
-  def endpoint: (Input, Endpoint[FooServiceOperation, Input, Err, Output, StreamedInput, StreamedOutput])
 }

--- a/modules/example/src/smithy4s/example/FooService.scala
+++ b/modules/example/src/smithy4s/example/FooService.scala
@@ -41,7 +41,7 @@ object FooServiceGen extends Service.Mixin[FooServiceGen, FooServiceOperation] {
     smithy.api.Documentation("The most basics of services\nGetFoo is its only operation"),
   )
 
-  val endpoints: List[FooServiceGen.Endpoint[_, _, _, _, _]] = List(
+  val endpoints: List[smithy4s.Endpoint[FooServiceOperation,_, _, _, _, _]] = List(
     GetFoo,
   )
 
@@ -68,9 +68,9 @@ object FooServiceGen extends Service.Mixin[FooServiceGen, FooServiceOperation] {
   }
   case class GetFoo() extends FooServiceOperation[Unit, Nothing, GetFooOutput, Nothing, Nothing] {
     def run[F[_, _, _, _, _]](impl: FooServiceGen[F]): F[Unit, Nothing, GetFooOutput, Nothing, Nothing] = impl.getFoo()
-    def endpoint: (Unit, Endpoint[Unit, Nothing, GetFooOutput, Nothing, Nothing]) = ((), GetFoo)
+    def endpoint: (Unit, smithy4s.Endpoint[FooServiceOperation,Unit, Nothing, GetFooOutput, Nothing, Nothing]) = ((), GetFoo)
   }
-  object GetFoo extends FooServiceGen.Endpoint[Unit, Nothing, GetFooOutput, Nothing, Nothing] {
+  object GetFoo extends smithy4s.Endpoint[FooServiceOperation,Unit, Nothing, GetFooOutput, Nothing, Nothing] {
     val id: ShapeId = ShapeId("smithy4s.example", "GetFoo")
     val input: Schema[Unit] = unit.addHints(smithy4s.internals.InputOutput.Input.widen)
     val output: Schema[GetFooOutput] = GetFooOutput.schema.addHints(smithy4s.internals.InputOutput.Output.widen)

--- a/modules/example/src/smithy4s/example/NameCollision.scala
+++ b/modules/example/src/smithy4s/example/NameCollision.scala
@@ -38,7 +38,7 @@ object NameCollisionGen extends Service.Mixin[NameCollisionGen, NameCollisionOpe
     type Default[F[+_, +_]] = Constant[smithy4s.kinds.stubs.Kind2[F]#toKind5]
   }
 
-  val endpoints: List[smithy4s.Endpoint[NameCollisionOperation,_, _, _, _, _]] = List(
+  val endpoints: List[smithy4s.Endpoint[NameCollisionOperation, _, _, _, _, _]] = List(
     NameCollisionOperation.MyOp,
     NameCollisionOperation.Endpoint,
   )

--- a/modules/example/src/smithy4s/example/NameCollision.scala
+++ b/modules/example/src/smithy4s/example/NameCollision.scala
@@ -50,6 +50,9 @@ object NameCollisionGen extends Service.Mixin[NameCollisionGen, NameCollisionOpe
   def mapK5[P[_, _, _, _, _], P1[_, _, _, _, _]](alg: NameCollisionGen[P], f: PolyFunction5[P, P1]): NameCollisionGen[P1] = new NameCollisionOperation.Transformed(alg, f)
   def fromPolyFunction[P[_, _, _, _, _]](f: PolyFunction5[NameCollisionOperation, P]): NameCollisionGen[P] = new NameCollisionOperation.Transformed(reified, f)
   def toPolyFunction[P[_, _, _, _, _]](impl: NameCollisionGen[P]): PolyFunction5[NameCollisionOperation, P] = NameCollisionOperation.toPolyFunction(impl)
+
+  type MyOpError = NameCollisionOperation.MyOpError
+  val MyOpError = NameCollisionOperation.MyOpError
 }
 
 sealed trait NameCollisionOperation[Input, Err, Output, StreamedInput, StreamedOutput] {

--- a/modules/example/src/smithy4s/example/NameCollision.scala
+++ b/modules/example/src/smithy4s/example/NameCollision.scala
@@ -18,13 +18,18 @@ import smithy4s.schema.Schema.unit
 trait NameCollisionGen[F[_, _, _, _, _]] {
   self =>
 
-  def myOp(): F[Unit, NameCollisionGen.MyOpError, Unit, Nothing, Nothing]
+  def myOp(): F[Unit, NameCollisionOperation.MyOpError, Unit, Nothing, Nothing]
   def endpoint(): F[Unit, Nothing, Unit, Nothing, Nothing]
 
   def transform: Transformation.PartiallyApplied[NameCollisionGen[F]] = Transformation.of[NameCollisionGen[F]](this)
 }
 
 object NameCollisionGen extends Service.Mixin[NameCollisionGen, NameCollisionOperation] {
+
+  val id: ShapeId = ShapeId("smithy4s.example", "NameCollision")
+  val version: String = ""
+
+  val hints: Hints = Hints.empty
 
   def apply[F[_]](implicit F: Impl[F]): F.type = F
 
@@ -33,43 +38,44 @@ object NameCollisionGen extends Service.Mixin[NameCollisionGen, NameCollisionOpe
     type Default[F[+_, +_]] = Constant[smithy4s.kinds.stubs.Kind2[F]#toKind5]
   }
 
-  val id: ShapeId = ShapeId("smithy4s.example", "NameCollision")
-
-  val hints: Hints = Hints.empty
-
   val endpoints: List[smithy4s.Endpoint[NameCollisionOperation,_, _, _, _, _]] = List(
-    MyOp,
-    Endpoint,
+    NameCollisionOperation.MyOp,
+    NameCollisionOperation.Endpoint,
   )
 
-  val version: String = ""
-
   def endpoint[I, E, O, SI, SO](op: NameCollisionOperation[I, E, O, SI, SO]) = op.endpoint
+  class Constant[P[-_, +_, +_, +_, +_]](value: P[Any, Nothing, Nothing, Nothing, Nothing]) extends NameCollisionOperation.Transformed[NameCollisionOperation, P](reified, const5(value))
+  type Default[F[+_]] = Constant[smithy4s.kinds.stubs.Kind1[F]#toKind5]
+  def reified: NameCollisionGen[NameCollisionOperation] = NameCollisionOperation.reified
+  def mapK5[P[_, _, _, _, _], P1[_, _, _, _, _]](alg: NameCollisionGen[P], f: PolyFunction5[P, P1]): NameCollisionGen[P1] = new NameCollisionOperation.Transformed(alg, f)
+  def fromPolyFunction[P[_, _, _, _, _]](f: PolyFunction5[NameCollisionOperation, P]): NameCollisionGen[P] = new NameCollisionOperation.Transformed(reified, f)
+  def toPolyFunction[P[_, _, _, _, _]](impl: NameCollisionGen[P]): PolyFunction5[NameCollisionOperation, P] = NameCollisionOperation.toPolyFunction(impl)
+}
+
+sealed trait NameCollisionOperation[Input, Err, Output, StreamedInput, StreamedOutput] {
+  def run[F[_, _, _, _, _]](impl: NameCollisionGen[F]): F[Input, Err, Output, StreamedInput, StreamedOutput]
+  def endpoint: (Input, smithy4s.Endpoint[NameCollisionOperation, Input, Err, Output, StreamedInput, StreamedOutput])
+}
+
+object NameCollisionOperation {
 
   object reified extends NameCollisionGen[NameCollisionOperation] {
     def myOp() = MyOp()
     def endpoint() = Endpoint()
   }
-
-  def mapK5[P[_, _, _, _, _], P1[_, _, _, _, _]](alg: NameCollisionGen[P], f: PolyFunction5[P, P1]): NameCollisionGen[P1] = new Transformed(alg, f)
-
-  def fromPolyFunction[P[_, _, _, _, _]](f: PolyFunction5[NameCollisionOperation, P]): NameCollisionGen[P] = new Transformed(reified, f)
   class Transformed[P[_, _, _, _, _], P1[_ ,_ ,_ ,_ ,_]](alg: NameCollisionGen[P], f: PolyFunction5[P, P1]) extends NameCollisionGen[P1] {
-    def myOp() = f[Unit, NameCollisionGen.MyOpError, Unit, Nothing, Nothing](alg.myOp())
+    def myOp() = f[Unit, NameCollisionOperation.MyOpError, Unit, Nothing, Nothing](alg.myOp())
     def endpoint() = f[Unit, Nothing, Unit, Nothing, Nothing](alg.endpoint())
   }
-
-  class Constant[P[-_, +_, +_, +_, +_]](value: P[Any, Nothing, Nothing, Nothing, Nothing]) extends Transformed[NameCollisionOperation, P](reified, const5(value))
-  type Default[F[+_]] = Constant[smithy4s.kinds.stubs.Kind1[F]#toKind5]
 
   def toPolyFunction[P[_, _, _, _, _]](impl: NameCollisionGen[P]): PolyFunction5[NameCollisionOperation, P] = new PolyFunction5[NameCollisionOperation, P] {
     def apply[I, E, O, SI, SO](op: NameCollisionOperation[I, E, O, SI, SO]): P[I, E, O, SI, SO] = op.run(impl) 
   }
-  case class MyOp() extends NameCollisionOperation[Unit, NameCollisionGen.MyOpError, Unit, Nothing, Nothing] {
-    def run[F[_, _, _, _, _]](impl: NameCollisionGen[F]): F[Unit, NameCollisionGen.MyOpError, Unit, Nothing, Nothing] = impl.myOp()
-    def endpoint: (Unit, smithy4s.Endpoint[NameCollisionOperation,Unit, NameCollisionGen.MyOpError, Unit, Nothing, Nothing]) = ((), MyOp)
+  case class MyOp() extends NameCollisionOperation[Unit, NameCollisionOperation.MyOpError, Unit, Nothing, Nothing] {
+    def run[F[_, _, _, _, _]](impl: NameCollisionGen[F]): F[Unit, NameCollisionOperation.MyOpError, Unit, Nothing, Nothing] = impl.myOp()
+    def endpoint: (Unit, smithy4s.Endpoint[NameCollisionOperation,Unit, NameCollisionOperation.MyOpError, Unit, Nothing, Nothing]) = ((), MyOp)
   }
-  object MyOp extends smithy4s.Endpoint[NameCollisionOperation,Unit, NameCollisionGen.MyOpError, Unit, Nothing, Nothing] with Errorable[MyOpError] {
+  object MyOp extends smithy4s.Endpoint[NameCollisionOperation,Unit, NameCollisionOperation.MyOpError, Unit, Nothing, Nothing] with Errorable[MyOpError] {
     val id: ShapeId = ShapeId("smithy4s.example", "MyOp")
     val input: Schema[Unit] = unit.addHints(smithy4s.internals.InputOutput.Input.widen)
     val output: Schema[Unit] = unit.addHints(smithy4s.internals.InputOutput.Output.widen)
@@ -122,9 +128,4 @@ object NameCollisionGen extends Service.Mixin[NameCollisionGen, NameCollisionOpe
     val hints: Hints = Hints.empty
     def wrap(input: Unit) = Endpoint()
   }
-}
-
-sealed trait NameCollisionOperation[Input, Err, Output, StreamedInput, StreamedOutput] {
-  def run[F[_, _, _, _, _]](impl: NameCollisionGen[F]): F[Input, Err, Output, StreamedInput, StreamedOutput]
-  def endpoint: (Input, smithy4s.Endpoint[NameCollisionOperation, Input, Err, Output, StreamedInput, StreamedOutput])
 }

--- a/modules/example/src/smithy4s/example/ObjectService.scala
+++ b/modules/example/src/smithy4s/example/ObjectService.scala
@@ -47,7 +47,7 @@ object ObjectServiceGen extends Service.Mixin[ObjectServiceGen, ObjectServiceOpe
     alloy.SimpleRestJson(),
   )
 
-  val endpoints: List[ObjectServiceGen.Endpoint[_, _, _, _, _]] = List(
+  val endpoints: List[smithy4s.Endpoint[ObjectServiceOperation,_, _, _, _, _]] = List(
     PutObject,
     GetObject,
   )
@@ -77,9 +77,9 @@ object ObjectServiceGen extends Service.Mixin[ObjectServiceGen, ObjectServiceOpe
   }
   case class PutObject(input: PutObjectInput) extends ObjectServiceOperation[PutObjectInput, ObjectServiceGen.PutObjectError, Unit, Nothing, Nothing] {
     def run[F[_, _, _, _, _]](impl: ObjectServiceGen[F]): F[PutObjectInput, ObjectServiceGen.PutObjectError, Unit, Nothing, Nothing] = impl.putObject(input.key, input.bucketName, input.data, input.foo, input.someValue)
-    def endpoint: (PutObjectInput, Endpoint[PutObjectInput, ObjectServiceGen.PutObjectError, Unit, Nothing, Nothing]) = (input, PutObject)
+    def endpoint: (PutObjectInput, smithy4s.Endpoint[ObjectServiceOperation,PutObjectInput, ObjectServiceGen.PutObjectError, Unit, Nothing, Nothing]) = (input, PutObject)
   }
-  object PutObject extends ObjectServiceGen.Endpoint[PutObjectInput, ObjectServiceGen.PutObjectError, Unit, Nothing, Nothing] with Errorable[PutObjectError] {
+  object PutObject extends smithy4s.Endpoint[ObjectServiceOperation,PutObjectInput, ObjectServiceGen.PutObjectError, Unit, Nothing, Nothing] with Errorable[PutObjectError] {
     val id: ShapeId = ShapeId("smithy4s.example", "PutObject")
     val input: Schema[PutObjectInput] = PutObjectInput.schema.addHints(smithy4s.internals.InputOutput.Input.widen)
     val output: Schema[Unit] = unit.addHints(smithy4s.internals.InputOutput.Output.widen)
@@ -134,9 +134,9 @@ object ObjectServiceGen extends Service.Mixin[ObjectServiceGen, ObjectServiceOpe
   }
   case class GetObject(input: GetObjectInput) extends ObjectServiceOperation[GetObjectInput, ObjectServiceGen.GetObjectError, GetObjectOutput, Nothing, Nothing] {
     def run[F[_, _, _, _, _]](impl: ObjectServiceGen[F]): F[GetObjectInput, ObjectServiceGen.GetObjectError, GetObjectOutput, Nothing, Nothing] = impl.getObject(input.key, input.bucketName)
-    def endpoint: (GetObjectInput, Endpoint[GetObjectInput, ObjectServiceGen.GetObjectError, GetObjectOutput, Nothing, Nothing]) = (input, GetObject)
+    def endpoint: (GetObjectInput, smithy4s.Endpoint[ObjectServiceOperation,GetObjectInput, ObjectServiceGen.GetObjectError, GetObjectOutput, Nothing, Nothing]) = (input, GetObject)
   }
-  object GetObject extends ObjectServiceGen.Endpoint[GetObjectInput, ObjectServiceGen.GetObjectError, GetObjectOutput, Nothing, Nothing] with Errorable[GetObjectError] {
+  object GetObject extends smithy4s.Endpoint[ObjectServiceOperation,GetObjectInput, ObjectServiceGen.GetObjectError, GetObjectOutput, Nothing, Nothing] with Errorable[GetObjectError] {
     val id: ShapeId = ShapeId("smithy4s.example", "GetObject")
     val input: Schema[GetObjectInput] = GetObjectInput.schema.addHints(smithy4s.internals.InputOutput.Input.widen)
     val output: Schema[GetObjectOutput] = GetObjectOutput.schema.addHints(smithy4s.internals.InputOutput.Output.widen)

--- a/modules/example/src/smithy4s/example/ObjectService.scala
+++ b/modules/example/src/smithy4s/example/ObjectService.scala
@@ -19,7 +19,7 @@ import smithy4s.schema.Schema.unit
 trait ObjectServiceGen[F[_, _, _, _, _]] {
   self =>
 
-  def putObject(key: ObjectKey, bucketName: BucketName, data: String, foo: Option[LowHigh] = None, someValue: Option[SomeValue] = None): F[PutObjectInput, ObjectServiceGen.PutObjectError, Unit, Nothing, Nothing]
+  def putObject(key: ObjectKey, bucketName: BucketName, data: String, foo: Option[LowHigh] = None, someValue: Option[SomeValue] = None): F[PutObjectInput, ObjectServiceOperation.PutObjectError, Unit, Nothing, Nothing]
   /** @param key
     *   Sent in the URI label named "key".
     *   Key can also be seen as the filename
@@ -27,12 +27,19 @@ trait ObjectServiceGen[F[_, _, _, _, _]] {
     * @param bucketName
     *   Sent in the URI label named "bucketName".
     */
-  def getObject(key: ObjectKey, bucketName: BucketName): F[GetObjectInput, ObjectServiceGen.GetObjectError, GetObjectOutput, Nothing, Nothing]
+  def getObject(key: ObjectKey, bucketName: BucketName): F[GetObjectInput, ObjectServiceOperation.GetObjectError, GetObjectOutput, Nothing, Nothing]
 
   def transform: Transformation.PartiallyApplied[ObjectServiceGen[F]] = Transformation.of[ObjectServiceGen[F]](this)
 }
 
 object ObjectServiceGen extends Service.Mixin[ObjectServiceGen, ObjectServiceOperation] {
+
+  val id: ShapeId = ShapeId("smithy4s.example", "ObjectService")
+  val version: String = "1.0.0"
+
+  val hints: Hints = Hints(
+    alloy.SimpleRestJson(),
+  )
 
   def apply[F[_]](implicit F: Impl[F]): F.type = F
 
@@ -41,45 +48,44 @@ object ObjectServiceGen extends Service.Mixin[ObjectServiceGen, ObjectServiceOpe
     type Default[F[+_, +_]] = Constant[smithy4s.kinds.stubs.Kind2[F]#toKind5]
   }
 
-  val id: ShapeId = ShapeId("smithy4s.example", "ObjectService")
-
-  val hints: Hints = Hints(
-    alloy.SimpleRestJson(),
-  )
-
   val endpoints: List[smithy4s.Endpoint[ObjectServiceOperation,_, _, _, _, _]] = List(
-    PutObject,
-    GetObject,
+    ObjectServiceOperation.PutObject,
+    ObjectServiceOperation.GetObject,
   )
-
-  val version: String = "1.0.0"
 
   def endpoint[I, E, O, SI, SO](op: ObjectServiceOperation[I, E, O, SI, SO]) = op.endpoint
+  class Constant[P[-_, +_, +_, +_, +_]](value: P[Any, Nothing, Nothing, Nothing, Nothing]) extends ObjectServiceOperation.Transformed[ObjectServiceOperation, P](reified, const5(value))
+  type Default[F[+_]] = Constant[smithy4s.kinds.stubs.Kind1[F]#toKind5]
+  def reified: ObjectServiceGen[ObjectServiceOperation] = ObjectServiceOperation.reified
+  def mapK5[P[_, _, _, _, _], P1[_, _, _, _, _]](alg: ObjectServiceGen[P], f: PolyFunction5[P, P1]): ObjectServiceGen[P1] = new ObjectServiceOperation.Transformed(alg, f)
+  def fromPolyFunction[P[_, _, _, _, _]](f: PolyFunction5[ObjectServiceOperation, P]): ObjectServiceGen[P] = new ObjectServiceOperation.Transformed(reified, f)
+  def toPolyFunction[P[_, _, _, _, _]](impl: ObjectServiceGen[P]): PolyFunction5[ObjectServiceOperation, P] = ObjectServiceOperation.toPolyFunction(impl)
+}
+
+sealed trait ObjectServiceOperation[Input, Err, Output, StreamedInput, StreamedOutput] {
+  def run[F[_, _, _, _, _]](impl: ObjectServiceGen[F]): F[Input, Err, Output, StreamedInput, StreamedOutput]
+  def endpoint: (Input, Endpoint[ObjectServiceOperation, Input, Err, Output, StreamedInput, StreamedOutput])
+}
+
+object ObjectServiceOperation {
 
   object reified extends ObjectServiceGen[ObjectServiceOperation] {
     def putObject(key: ObjectKey, bucketName: BucketName, data: String, foo: Option[LowHigh] = None, someValue: Option[SomeValue] = None) = PutObject(PutObjectInput(key, bucketName, data, foo, someValue))
     def getObject(key: ObjectKey, bucketName: BucketName) = GetObject(GetObjectInput(key, bucketName))
   }
-
-  def mapK5[P[_, _, _, _, _], P1[_, _, _, _, _]](alg: ObjectServiceGen[P], f: PolyFunction5[P, P1]): ObjectServiceGen[P1] = new Transformed(alg, f)
-
-  def fromPolyFunction[P[_, _, _, _, _]](f: PolyFunction5[ObjectServiceOperation, P]): ObjectServiceGen[P] = new Transformed(reified, f)
   class Transformed[P[_, _, _, _, _], P1[_ ,_ ,_ ,_ ,_]](alg: ObjectServiceGen[P], f: PolyFunction5[P, P1]) extends ObjectServiceGen[P1] {
-    def putObject(key: ObjectKey, bucketName: BucketName, data: String, foo: Option[LowHigh] = None, someValue: Option[SomeValue] = None) = f[PutObjectInput, ObjectServiceGen.PutObjectError, Unit, Nothing, Nothing](alg.putObject(key, bucketName, data, foo, someValue))
-    def getObject(key: ObjectKey, bucketName: BucketName) = f[GetObjectInput, ObjectServiceGen.GetObjectError, GetObjectOutput, Nothing, Nothing](alg.getObject(key, bucketName))
+    def putObject(key: ObjectKey, bucketName: BucketName, data: String, foo: Option[LowHigh] = None, someValue: Option[SomeValue] = None) = f[PutObjectInput, ObjectServiceOperation.PutObjectError, Unit, Nothing, Nothing](alg.putObject(key, bucketName, data, foo, someValue))
+    def getObject(key: ObjectKey, bucketName: BucketName) = f[GetObjectInput, ObjectServiceOperation.GetObjectError, GetObjectOutput, Nothing, Nothing](alg.getObject(key, bucketName))
   }
-
-  class Constant[P[-_, +_, +_, +_, +_]](value: P[Any, Nothing, Nothing, Nothing, Nothing]) extends Transformed[ObjectServiceOperation, P](reified, const5(value))
-  type Default[F[+_]] = Constant[smithy4s.kinds.stubs.Kind1[F]#toKind5]
 
   def toPolyFunction[P[_, _, _, _, _]](impl: ObjectServiceGen[P]): PolyFunction5[ObjectServiceOperation, P] = new PolyFunction5[ObjectServiceOperation, P] {
     def apply[I, E, O, SI, SO](op: ObjectServiceOperation[I, E, O, SI, SO]): P[I, E, O, SI, SO] = op.run(impl) 
   }
-  case class PutObject(input: PutObjectInput) extends ObjectServiceOperation[PutObjectInput, ObjectServiceGen.PutObjectError, Unit, Nothing, Nothing] {
-    def run[F[_, _, _, _, _]](impl: ObjectServiceGen[F]): F[PutObjectInput, ObjectServiceGen.PutObjectError, Unit, Nothing, Nothing] = impl.putObject(input.key, input.bucketName, input.data, input.foo, input.someValue)
-    def endpoint: (PutObjectInput, smithy4s.Endpoint[ObjectServiceOperation,PutObjectInput, ObjectServiceGen.PutObjectError, Unit, Nothing, Nothing]) = (input, PutObject)
+  case class PutObject(input: PutObjectInput) extends ObjectServiceOperation[PutObjectInput, ObjectServiceOperation.PutObjectError, Unit, Nothing, Nothing] {
+    def run[F[_, _, _, _, _]](impl: ObjectServiceGen[F]): F[PutObjectInput, ObjectServiceOperation.PutObjectError, Unit, Nothing, Nothing] = impl.putObject(input.key, input.bucketName, input.data, input.foo, input.someValue)
+    def endpoint: (PutObjectInput, smithy4s.Endpoint[ObjectServiceOperation,PutObjectInput, ObjectServiceOperation.PutObjectError, Unit, Nothing, Nothing]) = (input, PutObject)
   }
-  object PutObject extends smithy4s.Endpoint[ObjectServiceOperation,PutObjectInput, ObjectServiceGen.PutObjectError, Unit, Nothing, Nothing] with Errorable[PutObjectError] {
+  object PutObject extends smithy4s.Endpoint[ObjectServiceOperation,PutObjectInput, ObjectServiceOperation.PutObjectError, Unit, Nothing, Nothing] with Errorable[PutObjectError] {
     val id: ShapeId = ShapeId("smithy4s.example", "PutObject")
     val input: Schema[PutObjectInput] = PutObjectInput.schema.addHints(smithy4s.internals.InputOutput.Input.widen)
     val output: Schema[Unit] = unit.addHints(smithy4s.internals.InputOutput.Output.widen)
@@ -132,11 +138,11 @@ object ObjectServiceGen extends Service.Mixin[ObjectServiceGen, ObjectServiceOpe
       case c: NoMoreSpaceCase => NoMoreSpaceCase.alt(c)
     }
   }
-  case class GetObject(input: GetObjectInput) extends ObjectServiceOperation[GetObjectInput, ObjectServiceGen.GetObjectError, GetObjectOutput, Nothing, Nothing] {
-    def run[F[_, _, _, _, _]](impl: ObjectServiceGen[F]): F[GetObjectInput, ObjectServiceGen.GetObjectError, GetObjectOutput, Nothing, Nothing] = impl.getObject(input.key, input.bucketName)
-    def endpoint: (GetObjectInput, smithy4s.Endpoint[ObjectServiceOperation,GetObjectInput, ObjectServiceGen.GetObjectError, GetObjectOutput, Nothing, Nothing]) = (input, GetObject)
+  case class GetObject(input: GetObjectInput) extends ObjectServiceOperation[GetObjectInput, ObjectServiceOperation.GetObjectError, GetObjectOutput, Nothing, Nothing] {
+    def run[F[_, _, _, _, _]](impl: ObjectServiceGen[F]): F[GetObjectInput, ObjectServiceOperation.GetObjectError, GetObjectOutput, Nothing, Nothing] = impl.getObject(input.key, input.bucketName)
+    def endpoint: (GetObjectInput, smithy4s.Endpoint[ObjectServiceOperation,GetObjectInput, ObjectServiceOperation.GetObjectError, GetObjectOutput, Nothing, Nothing]) = (input, GetObject)
   }
-  object GetObject extends smithy4s.Endpoint[ObjectServiceOperation,GetObjectInput, ObjectServiceGen.GetObjectError, GetObjectOutput, Nothing, Nothing] with Errorable[GetObjectError] {
+  object GetObject extends smithy4s.Endpoint[ObjectServiceOperation,GetObjectInput, ObjectServiceOperation.GetObjectError, GetObjectOutput, Nothing, Nothing] with Errorable[GetObjectError] {
     val id: ShapeId = ShapeId("smithy4s.example", "GetObject")
     val input: Schema[GetObjectInput] = GetObjectInput.schema.addHints(smithy4s.internals.InputOutput.Input.widen)
     val output: Schema[GetObjectOutput] = GetObjectOutput.schema.addHints(smithy4s.internals.InputOutput.Output.widen)
@@ -179,9 +185,4 @@ object ObjectServiceGen extends Service.Mixin[ObjectServiceGen, ObjectServiceOpe
       case c: ServerErrorCase => ServerErrorCase.alt(c)
     }
   }
-}
-
-sealed trait ObjectServiceOperation[Input, Err, Output, StreamedInput, StreamedOutput] {
-  def run[F[_, _, _, _, _]](impl: ObjectServiceGen[F]): F[Input, Err, Output, StreamedInput, StreamedOutput]
-  def endpoint: (Input, Endpoint[ObjectServiceOperation, Input, Err, Output, StreamedInput, StreamedOutput])
 }

--- a/modules/example/src/smithy4s/example/ObjectService.scala
+++ b/modules/example/src/smithy4s/example/ObjectService.scala
@@ -48,7 +48,7 @@ object ObjectServiceGen extends Service.Mixin[ObjectServiceGen, ObjectServiceOpe
     type Default[F[+_, +_]] = Constant[smithy4s.kinds.stubs.Kind2[F]#toKind5]
   }
 
-  val endpoints: List[smithy4s.Endpoint[ObjectServiceOperation,_, _, _, _, _]] = List(
+  val endpoints: List[smithy4s.Endpoint[ObjectServiceOperation, _, _, _, _, _]] = List(
     ObjectServiceOperation.PutObject,
     ObjectServiceOperation.GetObject,
   )

--- a/modules/example/src/smithy4s/example/ObjectService.scala
+++ b/modules/example/src/smithy4s/example/ObjectService.scala
@@ -60,6 +60,11 @@ object ObjectServiceGen extends Service.Mixin[ObjectServiceGen, ObjectServiceOpe
   def mapK5[P[_, _, _, _, _], P1[_, _, _, _, _]](alg: ObjectServiceGen[P], f: PolyFunction5[P, P1]): ObjectServiceGen[P1] = new ObjectServiceOperation.Transformed(alg, f)
   def fromPolyFunction[P[_, _, _, _, _]](f: PolyFunction5[ObjectServiceOperation, P]): ObjectServiceGen[P] = new ObjectServiceOperation.Transformed(reified, f)
   def toPolyFunction[P[_, _, _, _, _]](impl: ObjectServiceGen[P]): PolyFunction5[ObjectServiceOperation, P] = ObjectServiceOperation.toPolyFunction(impl)
+
+  type PutObjectError = ObjectServiceOperation.PutObjectError
+  val PutObjectError = ObjectServiceOperation.PutObjectError
+  type GetObjectError = ObjectServiceOperation.GetObjectError
+  val GetObjectError = ObjectServiceOperation.GetObjectError
 }
 
 sealed trait ObjectServiceOperation[Input, Err, Output, StreamedInput, StreamedOutput] {

--- a/modules/example/src/smithy4s/example/StreamedObjects.scala
+++ b/modules/example/src/smithy4s/example/StreamedObjects.scala
@@ -46,6 +46,7 @@ object StreamedObjectsGen extends Service.Mixin[StreamedObjectsGen, StreamedObje
   def mapK5[P[_, _, _, _, _], P1[_, _, _, _, _]](alg: StreamedObjectsGen[P], f: PolyFunction5[P, P1]): StreamedObjectsGen[P1] = new StreamedObjectsOperation.Transformed(alg, f)
   def fromPolyFunction[P[_, _, _, _, _]](f: PolyFunction5[StreamedObjectsOperation, P]): StreamedObjectsGen[P] = new StreamedObjectsOperation.Transformed(reified, f)
   def toPolyFunction[P[_, _, _, _, _]](impl: StreamedObjectsGen[P]): PolyFunction5[StreamedObjectsOperation, P] = StreamedObjectsOperation.toPolyFunction(impl)
+
 }
 
 sealed trait StreamedObjectsOperation[Input, Err, Output, StreamedInput, StreamedOutput] {

--- a/modules/example/src/smithy4s/example/StreamedObjects.scala
+++ b/modules/example/src/smithy4s/example/StreamedObjects.scala
@@ -22,6 +22,11 @@ trait StreamedObjectsGen[F[_, _, _, _, _]] {
 
 object StreamedObjectsGen extends Service.Mixin[StreamedObjectsGen, StreamedObjectsOperation] {
 
+  val id: ShapeId = ShapeId("smithy4s.example", "StreamedObjects")
+  val version: String = "1.0.0"
+
+  val hints: Hints = Hints.empty
+
   def apply[F[_]](implicit F: Impl[F]): F.type = F
 
   object ErrorAware {
@@ -29,34 +34,35 @@ object StreamedObjectsGen extends Service.Mixin[StreamedObjectsGen, StreamedObje
     type Default[F[+_, +_]] = Constant[smithy4s.kinds.stubs.Kind2[F]#toKind5]
   }
 
-  val id: ShapeId = ShapeId("smithy4s.example", "StreamedObjects")
-
-  val hints: Hints = Hints.empty
-
   val endpoints: List[smithy4s.Endpoint[StreamedObjectsOperation,_, _, _, _, _]] = List(
-    PutStreamedObject,
-    GetStreamedObject,
+    StreamedObjectsOperation.PutStreamedObject,
+    StreamedObjectsOperation.GetStreamedObject,
   )
 
-  val version: String = "1.0.0"
-
   def endpoint[I, E, O, SI, SO](op: StreamedObjectsOperation[I, E, O, SI, SO]) = op.endpoint
+  class Constant[P[-_, +_, +_, +_, +_]](value: P[Any, Nothing, Nothing, Nothing, Nothing]) extends StreamedObjectsOperation.Transformed[StreamedObjectsOperation, P](reified, const5(value))
+  type Default[F[+_]] = Constant[smithy4s.kinds.stubs.Kind1[F]#toKind5]
+  def reified: StreamedObjectsGen[StreamedObjectsOperation] = StreamedObjectsOperation.reified
+  def mapK5[P[_, _, _, _, _], P1[_, _, _, _, _]](alg: StreamedObjectsGen[P], f: PolyFunction5[P, P1]): StreamedObjectsGen[P1] = new StreamedObjectsOperation.Transformed(alg, f)
+  def fromPolyFunction[P[_, _, _, _, _]](f: PolyFunction5[StreamedObjectsOperation, P]): StreamedObjectsGen[P] = new StreamedObjectsOperation.Transformed(reified, f)
+  def toPolyFunction[P[_, _, _, _, _]](impl: StreamedObjectsGen[P]): PolyFunction5[StreamedObjectsOperation, P] = StreamedObjectsOperation.toPolyFunction(impl)
+}
+
+sealed trait StreamedObjectsOperation[Input, Err, Output, StreamedInput, StreamedOutput] {
+  def run[F[_, _, _, _, _]](impl: StreamedObjectsGen[F]): F[Input, Err, Output, StreamedInput, StreamedOutput]
+  def endpoint: (Input, Endpoint[StreamedObjectsOperation, Input, Err, Output, StreamedInput, StreamedOutput])
+}
+
+object StreamedObjectsOperation {
 
   object reified extends StreamedObjectsGen[StreamedObjectsOperation] {
     def putStreamedObject(key: String) = PutStreamedObject(PutStreamedObjectInput(key))
     def getStreamedObject(key: String) = GetStreamedObject(GetStreamedObjectInput(key))
   }
-
-  def mapK5[P[_, _, _, _, _], P1[_, _, _, _, _]](alg: StreamedObjectsGen[P], f: PolyFunction5[P, P1]): StreamedObjectsGen[P1] = new Transformed(alg, f)
-
-  def fromPolyFunction[P[_, _, _, _, _]](f: PolyFunction5[StreamedObjectsOperation, P]): StreamedObjectsGen[P] = new Transformed(reified, f)
   class Transformed[P[_, _, _, _, _], P1[_ ,_ ,_ ,_ ,_]](alg: StreamedObjectsGen[P], f: PolyFunction5[P, P1]) extends StreamedObjectsGen[P1] {
     def putStreamedObject(key: String) = f[PutStreamedObjectInput, Nothing, Unit, StreamedBlob, Nothing](alg.putStreamedObject(key))
     def getStreamedObject(key: String) = f[GetStreamedObjectInput, Nothing, GetStreamedObjectOutput, Nothing, StreamedBlob](alg.getStreamedObject(key))
   }
-
-  class Constant[P[-_, +_, +_, +_, +_]](value: P[Any, Nothing, Nothing, Nothing, Nothing]) extends Transformed[StreamedObjectsOperation, P](reified, const5(value))
-  type Default[F[+_]] = Constant[smithy4s.kinds.stubs.Kind1[F]#toKind5]
 
   def toPolyFunction[P[_, _, _, _, _]](impl: StreamedObjectsGen[P]): PolyFunction5[StreamedObjectsOperation, P] = new PolyFunction5[StreamedObjectsOperation, P] {
     def apply[I, E, O, SI, SO](op: StreamedObjectsOperation[I, E, O, SI, SO]): P[I, E, O, SI, SO] = op.run(impl) 
@@ -87,9 +93,4 @@ object StreamedObjectsGen extends Service.Mixin[StreamedObjectsGen, StreamedObje
     val hints: Hints = Hints.empty
     def wrap(input: GetStreamedObjectInput) = GetStreamedObject(input)
   }
-}
-
-sealed trait StreamedObjectsOperation[Input, Err, Output, StreamedInput, StreamedOutput] {
-  def run[F[_, _, _, _, _]](impl: StreamedObjectsGen[F]): F[Input, Err, Output, StreamedInput, StreamedOutput]
-  def endpoint: (Input, Endpoint[StreamedObjectsOperation, Input, Err, Output, StreamedInput, StreamedOutput])
 }

--- a/modules/example/src/smithy4s/example/StreamedObjects.scala
+++ b/modules/example/src/smithy4s/example/StreamedObjects.scala
@@ -34,7 +34,7 @@ object StreamedObjectsGen extends Service.Mixin[StreamedObjectsGen, StreamedObje
     type Default[F[+_, +_]] = Constant[smithy4s.kinds.stubs.Kind2[F]#toKind5]
   }
 
-  val endpoints: List[smithy4s.Endpoint[StreamedObjectsOperation,_, _, _, _, _]] = List(
+  val endpoints: List[smithy4s.Endpoint[StreamedObjectsOperation, _, _, _, _, _]] = List(
     StreamedObjectsOperation.PutStreamedObject,
     StreamedObjectsOperation.GetStreamedObject,
   )

--- a/modules/example/src/smithy4s/example/StreamedObjects.scala
+++ b/modules/example/src/smithy4s/example/StreamedObjects.scala
@@ -33,7 +33,7 @@ object StreamedObjectsGen extends Service.Mixin[StreamedObjectsGen, StreamedObje
 
   val hints: Hints = Hints.empty
 
-  val endpoints: List[StreamedObjectsGen.Endpoint[_, _, _, _, _]] = List(
+  val endpoints: List[smithy4s.Endpoint[StreamedObjectsOperation,_, _, _, _, _]] = List(
     PutStreamedObject,
     GetStreamedObject,
   )
@@ -63,9 +63,9 @@ object StreamedObjectsGen extends Service.Mixin[StreamedObjectsGen, StreamedObje
   }
   case class PutStreamedObject(input: PutStreamedObjectInput) extends StreamedObjectsOperation[PutStreamedObjectInput, Nothing, Unit, StreamedBlob, Nothing] {
     def run[F[_, _, _, _, _]](impl: StreamedObjectsGen[F]): F[PutStreamedObjectInput, Nothing, Unit, StreamedBlob, Nothing] = impl.putStreamedObject(input.key)
-    def endpoint: (PutStreamedObjectInput, Endpoint[PutStreamedObjectInput, Nothing, Unit, StreamedBlob, Nothing]) = (input, PutStreamedObject)
+    def endpoint: (PutStreamedObjectInput, smithy4s.Endpoint[StreamedObjectsOperation,PutStreamedObjectInput, Nothing, Unit, StreamedBlob, Nothing]) = (input, PutStreamedObject)
   }
-  object PutStreamedObject extends StreamedObjectsGen.Endpoint[PutStreamedObjectInput, Nothing, Unit, StreamedBlob, Nothing] {
+  object PutStreamedObject extends smithy4s.Endpoint[StreamedObjectsOperation,PutStreamedObjectInput, Nothing, Unit, StreamedBlob, Nothing] {
     val id: ShapeId = ShapeId("smithy4s.example", "PutStreamedObject")
     val input: Schema[PutStreamedObjectInput] = PutStreamedObjectInput.schema.addHints(smithy4s.internals.InputOutput.Input.widen)
     val output: Schema[Unit] = unit.addHints(smithy4s.internals.InputOutput.Output.widen)
@@ -76,9 +76,9 @@ object StreamedObjectsGen extends Service.Mixin[StreamedObjectsGen, StreamedObje
   }
   case class GetStreamedObject(input: GetStreamedObjectInput) extends StreamedObjectsOperation[GetStreamedObjectInput, Nothing, GetStreamedObjectOutput, Nothing, StreamedBlob] {
     def run[F[_, _, _, _, _]](impl: StreamedObjectsGen[F]): F[GetStreamedObjectInput, Nothing, GetStreamedObjectOutput, Nothing, StreamedBlob] = impl.getStreamedObject(input.key)
-    def endpoint: (GetStreamedObjectInput, Endpoint[GetStreamedObjectInput, Nothing, GetStreamedObjectOutput, Nothing, StreamedBlob]) = (input, GetStreamedObject)
+    def endpoint: (GetStreamedObjectInput, smithy4s.Endpoint[StreamedObjectsOperation,GetStreamedObjectInput, Nothing, GetStreamedObjectOutput, Nothing, StreamedBlob]) = (input, GetStreamedObject)
   }
-  object GetStreamedObject extends StreamedObjectsGen.Endpoint[GetStreamedObjectInput, Nothing, GetStreamedObjectOutput, Nothing, StreamedBlob] {
+  object GetStreamedObject extends smithy4s.Endpoint[StreamedObjectsOperation,GetStreamedObjectInput, Nothing, GetStreamedObjectOutput, Nothing, StreamedBlob] {
     val id: ShapeId = ShapeId("smithy4s.example", "GetStreamedObject")
     val input: Schema[GetStreamedObjectInput] = GetStreamedObjectInput.schema.addHints(smithy4s.internals.InputOutput.Input.widen)
     val output: Schema[GetStreamedObjectOutput] = GetStreamedObjectOutput.schema.addHints(smithy4s.internals.InputOutput.Output.widen)

--- a/modules/example/src/smithy4s/example/collision/ReservedNameService.scala
+++ b/modules/example/src/smithy4s/example/collision/ReservedNameService.scala
@@ -38,7 +38,7 @@ object ReservedNameServiceGen extends Service.Mixin[ReservedNameServiceGen, Rese
     type Default[F[+_, +_]] = Constant[smithy4s.kinds.stubs.Kind2[F]#toKind5]
   }
 
-  val endpoints: List[smithy4s.Endpoint[ReservedNameServiceOperation,_, _, _, _, _]] = List(
+  val endpoints: List[smithy4s.Endpoint[ReservedNameServiceOperation, _, _, _, _, _]] = List(
     ReservedNameServiceOperation._Set,
     ReservedNameServiceOperation._List,
     ReservedNameServiceOperation._Map,

--- a/modules/example/src/smithy4s/example/collision/ReservedNameService.scala
+++ b/modules/example/src/smithy4s/example/collision/ReservedNameService.scala
@@ -37,7 +37,7 @@ object ReservedNameServiceGen extends Service.Mixin[ReservedNameServiceGen, Rese
     alloy.SimpleRestJson(),
   )
 
-  val endpoints: List[ReservedNameServiceGen.Endpoint[_, _, _, _, _]] = List(
+  val endpoints: List[smithy4s.Endpoint[ReservedNameServiceOperation,_, _, _, _, _]] = List(
     _Set,
     _List,
     _Map,
@@ -73,9 +73,9 @@ object ReservedNameServiceGen extends Service.Mixin[ReservedNameServiceGen, Rese
   }
   case class _Set(input: SetInput) extends ReservedNameServiceOperation[SetInput, Nothing, Unit, Nothing, Nothing] {
     def run[F[_, _, _, _, _]](impl: ReservedNameServiceGen[F]): F[SetInput, Nothing, Unit, Nothing, Nothing] = impl.set(input.set)
-    def endpoint: (SetInput, Endpoint[SetInput, Nothing, Unit, Nothing, Nothing]) = (input, _Set)
+    def endpoint: (SetInput, smithy4s.Endpoint[ReservedNameServiceOperation,SetInput, Nothing, Unit, Nothing, Nothing]) = (input, _Set)
   }
-  object _Set extends ReservedNameServiceGen.Endpoint[SetInput, Nothing, Unit, Nothing, Nothing] {
+  object _Set extends smithy4s.Endpoint[ReservedNameServiceOperation,SetInput, Nothing, Unit, Nothing, Nothing] {
     val id: ShapeId = ShapeId("smithy4s.example.collision", "Set")
     val input: Schema[SetInput] = SetInput.schema.addHints(smithy4s.internals.InputOutput.Input.widen)
     val output: Schema[Unit] = unit.addHints(smithy4s.internals.InputOutput.Output.widen)
@@ -88,9 +88,9 @@ object ReservedNameServiceGen extends Service.Mixin[ReservedNameServiceGen, Rese
   }
   case class _List(input: ListInput) extends ReservedNameServiceOperation[ListInput, Nothing, Unit, Nothing, Nothing] {
     def run[F[_, _, _, _, _]](impl: ReservedNameServiceGen[F]): F[ListInput, Nothing, Unit, Nothing, Nothing] = impl.list(input.list)
-    def endpoint: (ListInput, Endpoint[ListInput, Nothing, Unit, Nothing, Nothing]) = (input, _List)
+    def endpoint: (ListInput, smithy4s.Endpoint[ReservedNameServiceOperation,ListInput, Nothing, Unit, Nothing, Nothing]) = (input, _List)
   }
-  object _List extends ReservedNameServiceGen.Endpoint[ListInput, Nothing, Unit, Nothing, Nothing] {
+  object _List extends smithy4s.Endpoint[ReservedNameServiceOperation,ListInput, Nothing, Unit, Nothing, Nothing] {
     val id: ShapeId = ShapeId("smithy4s.example.collision", "List")
     val input: Schema[ListInput] = ListInput.schema.addHints(smithy4s.internals.InputOutput.Input.widen)
     val output: Schema[Unit] = unit.addHints(smithy4s.internals.InputOutput.Output.widen)
@@ -103,9 +103,9 @@ object ReservedNameServiceGen extends Service.Mixin[ReservedNameServiceGen, Rese
   }
   case class _Map(input: MapInput) extends ReservedNameServiceOperation[MapInput, Nothing, Unit, Nothing, Nothing] {
     def run[F[_, _, _, _, _]](impl: ReservedNameServiceGen[F]): F[MapInput, Nothing, Unit, Nothing, Nothing] = impl.map(input.value)
-    def endpoint: (MapInput, Endpoint[MapInput, Nothing, Unit, Nothing, Nothing]) = (input, _Map)
+    def endpoint: (MapInput, smithy4s.Endpoint[ReservedNameServiceOperation,MapInput, Nothing, Unit, Nothing, Nothing]) = (input, _Map)
   }
-  object _Map extends ReservedNameServiceGen.Endpoint[MapInput, Nothing, Unit, Nothing, Nothing] {
+  object _Map extends smithy4s.Endpoint[ReservedNameServiceOperation,MapInput, Nothing, Unit, Nothing, Nothing] {
     val id: ShapeId = ShapeId("smithy4s.example.collision", "Map")
     val input: Schema[MapInput] = MapInput.schema.addHints(smithy4s.internals.InputOutput.Input.widen)
     val output: Schema[Unit] = unit.addHints(smithy4s.internals.InputOutput.Output.widen)
@@ -118,9 +118,9 @@ object ReservedNameServiceGen extends Service.Mixin[ReservedNameServiceGen, Rese
   }
   case class _Option(input: OptionInput) extends ReservedNameServiceOperation[OptionInput, Nothing, Unit, Nothing, Nothing] {
     def run[F[_, _, _, _, _]](impl: ReservedNameServiceGen[F]): F[OptionInput, Nothing, Unit, Nothing, Nothing] = impl.option(input.value)
-    def endpoint: (OptionInput, Endpoint[OptionInput, Nothing, Unit, Nothing, Nothing]) = (input, _Option)
+    def endpoint: (OptionInput, smithy4s.Endpoint[ReservedNameServiceOperation,OptionInput, Nothing, Unit, Nothing, Nothing]) = (input, _Option)
   }
-  object _Option extends ReservedNameServiceGen.Endpoint[OptionInput, Nothing, Unit, Nothing, Nothing] {
+  object _Option extends smithy4s.Endpoint[ReservedNameServiceOperation,OptionInput, Nothing, Unit, Nothing, Nothing] {
     val id: ShapeId = ShapeId("smithy4s.example.collision", "Option")
     val input: Schema[OptionInput] = OptionInput.schema.addHints(smithy4s.internals.InputOutput.Input.widen)
     val output: Schema[Unit] = unit.addHints(smithy4s.internals.InputOutput.Output.widen)

--- a/modules/example/src/smithy4s/example/collision/ReservedNameService.scala
+++ b/modules/example/src/smithy4s/example/collision/ReservedNameService.scala
@@ -24,6 +24,13 @@ trait ReservedNameServiceGen[F[_, _, _, _, _]] {
 
 object ReservedNameServiceGen extends Service.Mixin[ReservedNameServiceGen, ReservedNameServiceOperation] {
 
+  val id: ShapeId = ShapeId("smithy4s.example.collision", "ReservedNameService")
+  val version: String = "1.0.0"
+
+  val hints: Hints = Hints(
+    alloy.SimpleRestJson(),
+  )
+
   def apply[F[_]](implicit F: Impl[F]): F.type = F
 
   object ErrorAware {
@@ -31,22 +38,28 @@ object ReservedNameServiceGen extends Service.Mixin[ReservedNameServiceGen, Rese
     type Default[F[+_, +_]] = Constant[smithy4s.kinds.stubs.Kind2[F]#toKind5]
   }
 
-  val id: ShapeId = ShapeId("smithy4s.example.collision", "ReservedNameService")
-
-  val hints: Hints = Hints(
-    alloy.SimpleRestJson(),
-  )
-
   val endpoints: List[smithy4s.Endpoint[ReservedNameServiceOperation,_, _, _, _, _]] = List(
-    _Set,
-    _List,
-    _Map,
-    _Option,
+    ReservedNameServiceOperation._Set,
+    ReservedNameServiceOperation._List,
+    ReservedNameServiceOperation._Map,
+    ReservedNameServiceOperation._Option,
   )
-
-  val version: String = "1.0.0"
 
   def endpoint[I, E, O, SI, SO](op: ReservedNameServiceOperation[I, E, O, SI, SO]) = op.endpoint
+  class Constant[P[-_, +_, +_, +_, +_]](value: P[Any, Nothing, Nothing, Nothing, Nothing]) extends ReservedNameServiceOperation.Transformed[ReservedNameServiceOperation, P](reified, const5(value))
+  type Default[F[+_]] = Constant[smithy4s.kinds.stubs.Kind1[F]#toKind5]
+  def reified: ReservedNameServiceGen[ReservedNameServiceOperation] = ReservedNameServiceOperation.reified
+  def mapK5[P[_, _, _, _, _], P1[_, _, _, _, _]](alg: ReservedNameServiceGen[P], f: PolyFunction5[P, P1]): ReservedNameServiceGen[P1] = new ReservedNameServiceOperation.Transformed(alg, f)
+  def fromPolyFunction[P[_, _, _, _, _]](f: PolyFunction5[ReservedNameServiceOperation, P]): ReservedNameServiceGen[P] = new ReservedNameServiceOperation.Transformed(reified, f)
+  def toPolyFunction[P[_, _, _, _, _]](impl: ReservedNameServiceGen[P]): PolyFunction5[ReservedNameServiceOperation, P] = ReservedNameServiceOperation.toPolyFunction(impl)
+}
+
+sealed trait ReservedNameServiceOperation[Input, Err, Output, StreamedInput, StreamedOutput] {
+  def run[F[_, _, _, _, _]](impl: ReservedNameServiceGen[F]): F[Input, Err, Output, StreamedInput, StreamedOutput]
+  def endpoint: (Input, Endpoint[ReservedNameServiceOperation, Input, Err, Output, StreamedInput, StreamedOutput])
+}
+
+object ReservedNameServiceOperation {
 
   object reified extends ReservedNameServiceGen[ReservedNameServiceOperation] {
     def set(set: Set[String]) = _Set(SetInput(set))
@@ -54,19 +67,12 @@ object ReservedNameServiceGen extends Service.Mixin[ReservedNameServiceGen, Rese
     def map(value: Map[String, String]) = _Map(MapInput(value))
     def option(value: Option[String] = None) = _Option(OptionInput(value))
   }
-
-  def mapK5[P[_, _, _, _, _], P1[_, _, _, _, _]](alg: ReservedNameServiceGen[P], f: PolyFunction5[P, P1]): ReservedNameServiceGen[P1] = new Transformed(alg, f)
-
-  def fromPolyFunction[P[_, _, _, _, _]](f: PolyFunction5[ReservedNameServiceOperation, P]): ReservedNameServiceGen[P] = new Transformed(reified, f)
   class Transformed[P[_, _, _, _, _], P1[_ ,_ ,_ ,_ ,_]](alg: ReservedNameServiceGen[P], f: PolyFunction5[P, P1]) extends ReservedNameServiceGen[P1] {
     def set(set: Set[String]) = f[SetInput, Nothing, Unit, Nothing, Nothing](alg.set(set))
     def list(list: List[String]) = f[ListInput, Nothing, Unit, Nothing, Nothing](alg.list(list))
     def map(value: Map[String, String]) = f[MapInput, Nothing, Unit, Nothing, Nothing](alg.map(value))
     def option(value: Option[String] = None) = f[OptionInput, Nothing, Unit, Nothing, Nothing](alg.option(value))
   }
-
-  class Constant[P[-_, +_, +_, +_, +_]](value: P[Any, Nothing, Nothing, Nothing, Nothing]) extends Transformed[ReservedNameServiceOperation, P](reified, const5(value))
-  type Default[F[+_]] = Constant[smithy4s.kinds.stubs.Kind1[F]#toKind5]
 
   def toPolyFunction[P[_, _, _, _, _]](impl: ReservedNameServiceGen[P]): PolyFunction5[ReservedNameServiceOperation, P] = new PolyFunction5[ReservedNameServiceOperation, P] {
     def apply[I, E, O, SI, SO](op: ReservedNameServiceOperation[I, E, O, SI, SO]): P[I, E, O, SI, SO] = op.run(impl) 
@@ -131,9 +137,4 @@ object ReservedNameServiceGen extends Service.Mixin[ReservedNameServiceGen, Rese
     )
     def wrap(input: OptionInput) = _Option(input)
   }
-}
-
-sealed trait ReservedNameServiceOperation[Input, Err, Output, StreamedInput, StreamedOutput] {
-  def run[F[_, _, _, _, _]](impl: ReservedNameServiceGen[F]): F[Input, Err, Output, StreamedInput, StreamedOutput]
-  def endpoint: (Input, Endpoint[ReservedNameServiceOperation, Input, Err, Output, StreamedInput, StreamedOutput])
 }

--- a/modules/example/src/smithy4s/example/collision/ReservedNameService.scala
+++ b/modules/example/src/smithy4s/example/collision/ReservedNameService.scala
@@ -52,6 +52,7 @@ object ReservedNameServiceGen extends Service.Mixin[ReservedNameServiceGen, Rese
   def mapK5[P[_, _, _, _, _], P1[_, _, _, _, _]](alg: ReservedNameServiceGen[P], f: PolyFunction5[P, P1]): ReservedNameServiceGen[P1] = new ReservedNameServiceOperation.Transformed(alg, f)
   def fromPolyFunction[P[_, _, _, _, _]](f: PolyFunction5[ReservedNameServiceOperation, P]): ReservedNameServiceGen[P] = new ReservedNameServiceOperation.Transformed(reified, f)
   def toPolyFunction[P[_, _, _, _, _]](impl: ReservedNameServiceGen[P]): PolyFunction5[ReservedNameServiceOperation, P] = ReservedNameServiceOperation.toPolyFunction(impl)
+
 }
 
 sealed trait ReservedNameServiceOperation[Input, Err, Output, StreamedInput, StreamedOutput] {

--- a/modules/example/src/smithy4s/example/imp/ImportService.scala
+++ b/modules/example/src/smithy4s/example/imp/ImportService.scala
@@ -42,7 +42,7 @@ object ImportServiceGen extends Service.Mixin[ImportServiceGen, ImportServiceOpe
     type Default[F[+_, +_]] = Constant[smithy4s.kinds.stubs.Kind2[F]#toKind5]
   }
 
-  val endpoints: List[smithy4s.Endpoint[ImportServiceOperation,_, _, _, _, _]] = List(
+  val endpoints: List[smithy4s.Endpoint[ImportServiceOperation, _, _, _, _, _]] = List(
     ImportServiceOperation.ImportOperation,
   )
 

--- a/modules/example/src/smithy4s/example/imp/ImportService.scala
+++ b/modules/example/src/smithy4s/example/imp/ImportService.scala
@@ -21,12 +21,19 @@ import smithy4s.schema.Schema.unit
 trait ImportServiceGen[F[_, _, _, _, _]] {
   self =>
 
-  def importOperation(): F[Unit, ImportServiceGen.ImportOperationError, OpOutput, Nothing, Nothing]
+  def importOperation(): F[Unit, ImportServiceOperation.ImportOperationError, OpOutput, Nothing, Nothing]
 
   def transform: Transformation.PartiallyApplied[ImportServiceGen[F]] = Transformation.of[ImportServiceGen[F]](this)
 }
 
 object ImportServiceGen extends Service.Mixin[ImportServiceGen, ImportServiceOperation] {
+
+  val id: ShapeId = ShapeId("smithy4s.example.imp", "ImportService")
+  val version: String = "1.0.0"
+
+  val hints: Hints = Hints(
+    alloy.SimpleRestJson(),
+  )
 
   def apply[F[_]](implicit F: Impl[F]): F.type = F
 
@@ -35,42 +42,41 @@ object ImportServiceGen extends Service.Mixin[ImportServiceGen, ImportServiceOpe
     type Default[F[+_, +_]] = Constant[smithy4s.kinds.stubs.Kind2[F]#toKind5]
   }
 
-  val id: ShapeId = ShapeId("smithy4s.example.imp", "ImportService")
-
-  val hints: Hints = Hints(
-    alloy.SimpleRestJson(),
-  )
-
   val endpoints: List[smithy4s.Endpoint[ImportServiceOperation,_, _, _, _, _]] = List(
-    ImportOperation,
+    ImportServiceOperation.ImportOperation,
   )
-
-  val version: String = "1.0.0"
 
   def endpoint[I, E, O, SI, SO](op: ImportServiceOperation[I, E, O, SI, SO]) = op.endpoint
+  class Constant[P[-_, +_, +_, +_, +_]](value: P[Any, Nothing, Nothing, Nothing, Nothing]) extends ImportServiceOperation.Transformed[ImportServiceOperation, P](reified, const5(value))
+  type Default[F[+_]] = Constant[smithy4s.kinds.stubs.Kind1[F]#toKind5]
+  def reified: ImportServiceGen[ImportServiceOperation] = ImportServiceOperation.reified
+  def mapK5[P[_, _, _, _, _], P1[_, _, _, _, _]](alg: ImportServiceGen[P], f: PolyFunction5[P, P1]): ImportServiceGen[P1] = new ImportServiceOperation.Transformed(alg, f)
+  def fromPolyFunction[P[_, _, _, _, _]](f: PolyFunction5[ImportServiceOperation, P]): ImportServiceGen[P] = new ImportServiceOperation.Transformed(reified, f)
+  def toPolyFunction[P[_, _, _, _, _]](impl: ImportServiceGen[P]): PolyFunction5[ImportServiceOperation, P] = ImportServiceOperation.toPolyFunction(impl)
+}
+
+sealed trait ImportServiceOperation[Input, Err, Output, StreamedInput, StreamedOutput] {
+  def run[F[_, _, _, _, _]](impl: ImportServiceGen[F]): F[Input, Err, Output, StreamedInput, StreamedOutput]
+  def endpoint: (Input, Endpoint[ImportServiceOperation, Input, Err, Output, StreamedInput, StreamedOutput])
+}
+
+object ImportServiceOperation {
 
   object reified extends ImportServiceGen[ImportServiceOperation] {
     def importOperation() = ImportOperation()
   }
-
-  def mapK5[P[_, _, _, _, _], P1[_, _, _, _, _]](alg: ImportServiceGen[P], f: PolyFunction5[P, P1]): ImportServiceGen[P1] = new Transformed(alg, f)
-
-  def fromPolyFunction[P[_, _, _, _, _]](f: PolyFunction5[ImportServiceOperation, P]): ImportServiceGen[P] = new Transformed(reified, f)
   class Transformed[P[_, _, _, _, _], P1[_ ,_ ,_ ,_ ,_]](alg: ImportServiceGen[P], f: PolyFunction5[P, P1]) extends ImportServiceGen[P1] {
-    def importOperation() = f[Unit, ImportServiceGen.ImportOperationError, OpOutput, Nothing, Nothing](alg.importOperation())
+    def importOperation() = f[Unit, ImportServiceOperation.ImportOperationError, OpOutput, Nothing, Nothing](alg.importOperation())
   }
-
-  class Constant[P[-_, +_, +_, +_, +_]](value: P[Any, Nothing, Nothing, Nothing, Nothing]) extends Transformed[ImportServiceOperation, P](reified, const5(value))
-  type Default[F[+_]] = Constant[smithy4s.kinds.stubs.Kind1[F]#toKind5]
 
   def toPolyFunction[P[_, _, _, _, _]](impl: ImportServiceGen[P]): PolyFunction5[ImportServiceOperation, P] = new PolyFunction5[ImportServiceOperation, P] {
     def apply[I, E, O, SI, SO](op: ImportServiceOperation[I, E, O, SI, SO]): P[I, E, O, SI, SO] = op.run(impl) 
   }
-  case class ImportOperation() extends ImportServiceOperation[Unit, ImportServiceGen.ImportOperationError, OpOutput, Nothing, Nothing] {
-    def run[F[_, _, _, _, _]](impl: ImportServiceGen[F]): F[Unit, ImportServiceGen.ImportOperationError, OpOutput, Nothing, Nothing] = impl.importOperation()
-    def endpoint: (Unit, smithy4s.Endpoint[ImportServiceOperation,Unit, ImportServiceGen.ImportOperationError, OpOutput, Nothing, Nothing]) = ((), ImportOperation)
+  case class ImportOperation() extends ImportServiceOperation[Unit, ImportServiceOperation.ImportOperationError, OpOutput, Nothing, Nothing] {
+    def run[F[_, _, _, _, _]](impl: ImportServiceGen[F]): F[Unit, ImportServiceOperation.ImportOperationError, OpOutput, Nothing, Nothing] = impl.importOperation()
+    def endpoint: (Unit, smithy4s.Endpoint[ImportServiceOperation,Unit, ImportServiceOperation.ImportOperationError, OpOutput, Nothing, Nothing]) = ((), ImportOperation)
   }
-  object ImportOperation extends smithy4s.Endpoint[ImportServiceOperation,Unit, ImportServiceGen.ImportOperationError, OpOutput, Nothing, Nothing] with Errorable[ImportOperationError] {
+  object ImportOperation extends smithy4s.Endpoint[ImportServiceOperation,Unit, ImportServiceOperation.ImportOperationError, OpOutput, Nothing, Nothing] with Errorable[ImportOperationError] {
     val id: ShapeId = ShapeId("smithy4s.example.import_test", "ImportOperation")
     val input: Schema[Unit] = unit.addHints(smithy4s.internals.InputOutput.Input.widen)
     val output: Schema[OpOutput] = OpOutput.schema.addHints(smithy4s.internals.InputOutput.Output.widen)
@@ -112,9 +118,4 @@ object ImportServiceGen extends Service.Mixin[ImportServiceGen, ImportServiceOpe
       case c: NotFoundErrorCase => NotFoundErrorCase.alt(c)
     }
   }
-}
-
-sealed trait ImportServiceOperation[Input, Err, Output, StreamedInput, StreamedOutput] {
-  def run[F[_, _, _, _, _]](impl: ImportServiceGen[F]): F[Input, Err, Output, StreamedInput, StreamedOutput]
-  def endpoint: (Input, Endpoint[ImportServiceOperation, Input, Err, Output, StreamedInput, StreamedOutput])
 }

--- a/modules/example/src/smithy4s/example/imp/ImportService.scala
+++ b/modules/example/src/smithy4s/example/imp/ImportService.scala
@@ -53,6 +53,9 @@ object ImportServiceGen extends Service.Mixin[ImportServiceGen, ImportServiceOpe
   def mapK5[P[_, _, _, _, _], P1[_, _, _, _, _]](alg: ImportServiceGen[P], f: PolyFunction5[P, P1]): ImportServiceGen[P1] = new ImportServiceOperation.Transformed(alg, f)
   def fromPolyFunction[P[_, _, _, _, _]](f: PolyFunction5[ImportServiceOperation, P]): ImportServiceGen[P] = new ImportServiceOperation.Transformed(reified, f)
   def toPolyFunction[P[_, _, _, _, _]](impl: ImportServiceGen[P]): PolyFunction5[ImportServiceOperation, P] = ImportServiceOperation.toPolyFunction(impl)
+
+  type ImportOperationError = ImportServiceOperation.ImportOperationError
+  val ImportOperationError = ImportServiceOperation.ImportOperationError
 }
 
 sealed trait ImportServiceOperation[Input, Err, Output, StreamedInput, StreamedOutput] {

--- a/modules/example/src/smithy4s/example/imp/ImportService.scala
+++ b/modules/example/src/smithy4s/example/imp/ImportService.scala
@@ -41,7 +41,7 @@ object ImportServiceGen extends Service.Mixin[ImportServiceGen, ImportServiceOpe
     alloy.SimpleRestJson(),
   )
 
-  val endpoints: List[ImportServiceGen.Endpoint[_, _, _, _, _]] = List(
+  val endpoints: List[smithy4s.Endpoint[ImportServiceOperation,_, _, _, _, _]] = List(
     ImportOperation,
   )
 
@@ -68,9 +68,9 @@ object ImportServiceGen extends Service.Mixin[ImportServiceGen, ImportServiceOpe
   }
   case class ImportOperation() extends ImportServiceOperation[Unit, ImportServiceGen.ImportOperationError, OpOutput, Nothing, Nothing] {
     def run[F[_, _, _, _, _]](impl: ImportServiceGen[F]): F[Unit, ImportServiceGen.ImportOperationError, OpOutput, Nothing, Nothing] = impl.importOperation()
-    def endpoint: (Unit, Endpoint[Unit, ImportServiceGen.ImportOperationError, OpOutput, Nothing, Nothing]) = ((), ImportOperation)
+    def endpoint: (Unit, smithy4s.Endpoint[ImportServiceOperation,Unit, ImportServiceGen.ImportOperationError, OpOutput, Nothing, Nothing]) = ((), ImportOperation)
   }
-  object ImportOperation extends ImportServiceGen.Endpoint[Unit, ImportServiceGen.ImportOperationError, OpOutput, Nothing, Nothing] with Errorable[ImportOperationError] {
+  object ImportOperation extends smithy4s.Endpoint[ImportServiceOperation,Unit, ImportServiceGen.ImportOperationError, OpOutput, Nothing, Nothing] with Errorable[ImportOperationError] {
     val id: ShapeId = ShapeId("smithy4s.example.import_test", "ImportOperation")
     val input: Schema[Unit] = unit.addHints(smithy4s.internals.InputOutput.Input.widen)
     val output: Schema[OpOutput] = OpOutput.schema.addHints(smithy4s.internals.InputOutput.Output.widen)

--- a/sampleSpecs/namecollision.smithy
+++ b/sampleSpecs/namecollision.smithy
@@ -4,9 +4,12 @@ namespace smithy4s.example
 
 
 service NameCollision {
-operations: [MyOp]
+operations: [MyOp,Endpoint]
 }
 
+operation Endpoint {
+
+}
 operation MyOp {
 errors: [MyOpError]
 }


### PR DESCRIPTION
[Oli's description] 

Changes the rendering so the operations objects are generated in the companion object of the generated operation trait. This is important to protect against conflicts with the [path-dependant type aliases](https://github.com/disneystreaming/smithy4s/blob/series/0.17/modules/core/src/smithy4s/Service.scala#L38-L44) that are declared in the `smithy4s.Service` interface, as those take precedence over imports and would require fully-qualifying everything in order to prevent collision (which I'm still unwilling to do).

The path-dependant type aliases are very, very important for maintainers and developers of integration layers, as they make the code a lot more readable. 