### PR TITLE
[ComplianceTests] provide ability to handle intended short circuit over tcp

### DIFF
--- a/modules/compliance-tests/src/smithy4s/compliancetests/internals/IntendedShortCircuit.scala
+++ b/modules/compliance-tests/src/smithy4s/compliancetests/internals/IntendedShortCircuit.scala
@@ -18,4 +18,6 @@ package smithy4s.compliancetests
 package internals
 
 private[compliancetests] case class IntendedShortCircuit()
-    extends scala.util.control.NoStackTrace
+    extends scala.util.control.NoStackTrace {
+    override def getMessage: String = toString
+}

--- a/modules/compliance-tests/src/smithy4s/compliancetests/internals/IntendedShortCircuit.scala
+++ b/modules/compliance-tests/src/smithy4s/compliancetests/internals/IntendedShortCircuit.scala
@@ -19,5 +19,5 @@ package internals
 
 private[compliancetests] case class IntendedShortCircuit()
     extends scala.util.control.NoStackTrace {
-    override def getMessage: String = toString
+  override def getMessage: String = toString
 }

--- a/modules/compliance-tests/src/smithy4s/compliancetests/internals/ServerHttpComplianceTestCase.scala
+++ b/modules/compliance-tests/src/smithy4s/compliancetests/internals/ServerHttpComplianceTestCase.scala
@@ -129,12 +129,14 @@ private[compliancetests] class ServerHttpComplianceTestCase[
                           }
                     }
                   case Right(response) =>
-                    response.body.compile.toVector.map { message =>
-                      assert.fail(
-                        s"Expected a IntendedShortCircuit error, but got a response with status ${response.status} and message ${message
-                          .map(_.toChar)
-                          .mkString}"
-                      )
+                    response.body.compile.toVector.map(_.map(_.toChar).mkString).map { message => {
+                      if (message.contains("IntendedShortCircuit")) assert.success
+                      else {
+                        assert.fail(
+                          s"Expected a IntendedShortCircuit error, but got a response with status ${response.status} and message $message"
+                        )
+                      }
+                    }
                     }
                 }
             }

--- a/modules/compliance-tests/src/smithy4s/compliancetests/internals/ServerHttpComplianceTestCase.scala
+++ b/modules/compliance-tests/src/smithy4s/compliancetests/internals/ServerHttpComplianceTestCase.scala
@@ -129,15 +129,24 @@ private[compliancetests] class ServerHttpComplianceTestCase[
                           }
                     }
                   case Right(response) =>
-                    response.body.compile.toVector.map(_.map(_.toChar).mkString).map { message => {
-                      if (message.toLowerCase().contains(IntendedShortCircuit.getClass.getName.toLowerCase)) assert.success
-                      else {
-                        assert.fail(
-                          s"Expected a IntendedShortCircuit error, but got a response with status ${response.status} and message $message"
-                        )
+                    response.body.compile.toVector
+                      .map(_.map(_.toChar).mkString)
+                      .map { message =>
+                        {
+                          if (
+                            message
+                              .toLowerCase()
+                              .contains(
+                                IntendedShortCircuit.getClass.getName.toLowerCase
+                              )
+                          ) assert.success
+                          else {
+                            assert.fail(
+                              s"Expected a IntendedShortCircuit error, but got a response with status ${response.status} and message $message"
+                            )
+                          }
+                        }
                       }
-                    }
-                    }
                 }
             }
         }

--- a/modules/compliance-tests/src/smithy4s/compliancetests/internals/ServerHttpComplianceTestCase.scala
+++ b/modules/compliance-tests/src/smithy4s/compliancetests/internals/ServerHttpComplianceTestCase.scala
@@ -130,7 +130,7 @@ private[compliancetests] class ServerHttpComplianceTestCase[
                     }
                   case Right(response) =>
                     response.body.compile.toVector.map(_.map(_.toChar).mkString).map { message => {
-                      if (message.contains("IntendedShortCircuit")) assert.success
+                      if (message.toLowerCase().contains(IntendedShortCircuit.getClass.getName.toLowerCase)) assert.success
                       else {
                         assert.fail(
                           s"Expected a IntendedShortCircuit error, but got a response with status ${response.status} and message $message"


### PR DESCRIPTION
Problem: When running the protocol compliance tests on the server side for we need to exit the fake implementation , we do so via throwing an IntendedShortCircuit exception. 
we handle the exception before asserting the test results
This creates a problem when running the tests over tcp as the exception is thrown on a different JVM and interpreted into whatever the local https server running decides to do. Usually there is some default exception handler.
The simple stupid solution is :
Often http servers tend to use the exception class name in the body of the response . so we just add a clause to check for intended short circuit in the body .
I would prefer something more principled , but this is all I have right now.

A different solution would be to allow Exception Handling to be propagated in the restJsonBuilders, we currently only allow error transformation to be propagated
