### PR TITLE
POC: dynamic binding with schemas

### DIFF
--- a/modules/core/src/smithy4s/Hints.scala
+++ b/modules/core/src/smithy4s/Hints.scala
@@ -16,8 +16,6 @@
 
 package smithy4s
 
-import smithy4s.Schema
-
 /**
   * A hint is an arbitrary piece of data that can be added to a schema,
   * at the struct level, or at the field/member level.

--- a/modules/dynamic/src-jvm/DynamicSchemaIndexPlatform.scala
+++ b/modules/dynamic/src-jvm/DynamicSchemaIndexPlatform.scala
@@ -30,9 +30,17 @@ private[dynamic] trait DynamicSchemaIndexPlatform {
       model: software.amazon.smithy.model.Model
   ): Either[PayloadError, DynamicSchemaIndex] = {
     val flattenedModel =
-      ModelTransformer.create().flattenAndRemoveMixins(model);
-    val node = ModelSerializer.builder().build.serialize(flattenedModel)
+      ModelTransformer.create().flattenAndRemoveMixins(model)
+
+    val node = ModelSerializer
+      .builder()
+      // Note: this needs to be discussed
+      .includePrelude(true)
+      .build
+      .serialize(flattenedModel)
+
     val document = NodeToDocument(node)
+
     smithy4s.Document
       .decode[smithy4s.dynamic.model.Model](document)
       .map(load(_))


### PR DESCRIPTION
Experimenting with the idea of giving dynamic Hint bindings access to the trait's schema.

This would enable uniform access to the trait schema on both kinds of hint bindings, enabling the analysis of traits like "give me this service's supported protocols":

```scala
def supportedProtocolsStatic[Alg[_[_, _, _, _, _]]](
    service: Service[Alg]
): List[ShapeId] = service.hints.all.toList
  .flatMap { binding =>
    val hints = binding match {
      case Hints.Binding.StaticBinding(key, _)        => key.schema.hints
      case Hints.Binding.DynamicBinding(_, _, schema) => schema().hints
    }

    hints.get(api.ProtocolDefinition).map(_ => binding.keyId)
  }
```