### PR TITLE
Add a test to showcase router issue

### DIFF
--- a/modules/http4s/test/src/smithy4s/http4s/RouterSpec.scala
+++ b/modules/http4s/test/src/smithy4s/http4s/RouterSpec.scala
@@ -1,0 +1,49 @@
+/*
+ *  Copyright 2021-2022 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package smithy4s.http4s
+
+import cats.effect.IO
+import cats.effect.syntax.resource._
+import smithy4s.example._
+import weaver._
+import org.http4s.client.Client
+import org.http4s.server.Router
+
+object RouterSpec extends SimpleIOSuite {
+
+  private val pizzaImpl: PizzaAdminService[IO] =
+    new PizzaAdminService.Default[IO](IO.stub) {
+      override def version(): IO[VersionOutput] =
+        IO.pure(VersionOutput("1.0.0"))
+    }
+
+  test(
+    "SimpleProtocolBuilder (client) fails when the protocol is not present"
+  ) {
+    val test = for {
+      routes <- SimpleRestJsonBuilder.routes(pizzaImpl).resource
+      routed = Router("/api" -> routes).orNotFound
+      client = Client.fromHttpApp(routed)
+      pizzaClient <- SimpleRestJsonBuilder(PizzaAdminService)
+        .client(client)
+        .resource
+      _ <- pizzaClient.version().toResource
+    } yield ()
+    test.use { _ => IO.pure(assert(true)) }
+  }
+
+}


### PR DESCRIPTION
I've been trying to replicate a user issue where they build a `HttpRoutes` via the `SimpleRestJsonBuilder` facility. Then they use that router inside a http4s `Router` (like seen in the test).

When calling the server at the right url: `/hello/world` => `/api/hello/world`, they get a 404.