### PR TITLE
Adds methods and type aliases to streamline the creation of client interpreters/algebra

### DIFF
--- a/modules/core/src-2/kinds/package.scala
+++ b/modules/core/src-2/kinds/package.scala
@@ -28,10 +28,16 @@ package object kinds {
   type Kind1[F[_]] = {
     type toKind2[E, O] = F[O]
     type toKind5[I, E, O, SI, SO] = F[O]
+    type handler[I, E, O, SI, SO] = I => F[O]
   }
 
   type Kind2[F[_, _]] = {
     type toKind5[I, E, O, SI, SO] = F[E, O]
+    type handler[I, E, O, SI, SO] = I => F[E, O]
+  }
+
+  type Kind5[F[_, _, _, _, _]] = {
+    type handler[I, E, O, SI, SO] = I => F[I, E, O, SI, SO]
   }
 
 }

--- a/modules/core/src-3/kinds/package.scala
+++ b/modules/core/src-3/kinds/package.scala
@@ -29,10 +29,16 @@ package object kinds {
   type Kind1[F[_]] = {
     type toKind2[E, O] = F[O]
     type toKind5[I, E, O, SI, SO] = F[O]
+    type handler[I, E, O, SI, SO] = I => F[O]
   }
 
   type Kind2[F[_, _]] = {
     type toKind5[I, E, O, SI, SO] = F[E, O]
+    type handler[I, E, O, SI, SO] = I => F[E, O]
+  }
+
+  type Kind5[F[_, _, _, _, _]] = {
+    type handler[I, E, O, SI, SO] = I => F[I, E, O, SI, SO]
   }
 
 }

--- a/modules/core/src/smithy4s/PartialData.scala
+++ b/modules/core/src/smithy4s/PartialData.scala
@@ -26,7 +26,7 @@ import scala.collection.compat.immutable.ArraySeq
   *
   * For instance :
   *
-  * ```
+  * {{{
   * structure AB {
   *   @httpPayload
   *   @required
@@ -36,7 +36,7 @@ import scala.collection.compat.immutable.ArraySeq
   *   @required
   *   b: String
   * }
-  * ```
+  * }}}
   *
   * translates to this case class {{{ case class AB(a: String, b: String) }}}.
   *

--- a/modules/core/src/smithy4s/Service.scala
+++ b/modules/core/src/smithy4s/Service.scala
@@ -84,7 +84,7 @@ trait Service[Alg[_[_, _, _, _, _]]] extends FunctorK5[Alg] with HasId {
   type FunctorEndpointCompiler[F[_]] = PolyFunction5[Endpoint, kinds.Kind1[F]#handler]
 
   /**
-   * A handler compiler specialised for effects of kind `* -> (*, *)`, like Either bifunctor IO
+   * A handler compiler specialised for effects of kind `* -> (*, *)`, like Either or bifunctor IO
    */
   type BiFunctorEndpointCompiler[F[_, _]] = PolyFunction5[Endpoint, kinds.Kind2[F]#handler]
 

--- a/modules/core/src/smithy4s/Service.scala
+++ b/modules/core/src/smithy4s/Service.scala
@@ -92,7 +92,7 @@ trait Service[Alg[_[_, _, _, _, _]]] extends FunctorK5[Alg] with HasId {
    * A short-hand for algebras that are specialised for effects of kind `* -> *`.
    *
    * NB: this alias should be used in polymorphic implementations. When using the Smithy4s
-   * code generator, equivalent aliases that are named after the service are generated.
+   * code generator, equivalent aliases that are named after the service are generated (e.g. `Weather` corresponding to `WeatherGen`).
    */
   type Impl[F[_]] = Alg[kinds.Kind1[F]#toKind5]
 

--- a/modules/http4s/test/src-jvm/smithy4s/http4s/Http4sDynamicPizzaClientSpec.scala
+++ b/modules/http4s/test/src-jvm/smithy4s/http4s/Http4sDynamicPizzaClientSpec.scala
@@ -53,7 +53,7 @@ class DynamicHttpProxy(client: Client[IO]) {
           .liftTo[IO]
           .map { dynamicClient =>
             JsonIOProtocol
-              .fromJsonF[PizzaAdminServiceGen, PizzaAdminServiceOperation](
+              .fromJsonF[PizzaAdminServiceGen](
                 JsonIOProtocol.toJsonF(dynamicClient)(dsi.service)
               )
 


### PR DESCRIPTION
* Adds methods and path-dependant type aliases to the `Service` interface to make it easier to create (typically client-side) algebra, by taking care of the pre-computation and the routing.

* Adds scaladocs to various type aliases and methods. 