### PR TITLE
[Aws-Http4s] Fix content header for Aws Signature Client

### DIFF
--- a/modules/aws-http4s/src/smithy4s/aws/internals/AwsSignatureClient.scala
+++ b/modules/aws-http4s/src/smithy4s/aws/internals/AwsSignatureClient.scala
@@ -33,8 +33,8 @@ private[aws] object AwsSigningClient {
       .getOrElse(serviceId.name)
       .toLowerCase()
     val newline = System.lineSeparator()
-    val `Content-Type` =
-      org.http4s.headers.`Content-Type`.headerInstance.name
+    val contentType = org.http4s.headers.`Content-Type`.headerInstance
+    val `Content-Type` = contentType.name
     val `Host` = CIString("host")
     val `X-Amz-Date` = CIString("X-Amz-Date")
     val `X-Amz-Security-Token` = CIString("X-Amz-Security-Token")
@@ -73,7 +73,7 @@ private[aws] object AwsSigningClient {
 
         // // !\ Important: these must remain in the same order
         val baseHeadersList = List(
-          `Content-Type` -> request.contentType.map(_.toString()).orNull,
+          `Content-Type` -> request.contentType.map(contentType.value(_)).orNull,
           `Host` -> request.uri.host.map(_.renderString).orNull,
           `X-Amz-Date` -> timestamp.conciseDateTime,
           `X-Amz-Security-Token` -> credentials.sessionToken.orNull,

--- a/modules/aws-http4s/src/smithy4s/aws/internals/AwsSignatureClient.scala
+++ b/modules/aws-http4s/src/smithy4s/aws/internals/AwsSignatureClient.scala
@@ -1,3 +1,19 @@
+/*
+ *  Copyright 2021-2022 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 package smithy4s.aws
 package internals
 

--- a/modules/core/src-js/smithy4s/Timestamp.scala
+++ b/modules/core/src-js/smithy4s/Timestamp.scala
@@ -279,7 +279,7 @@ object Timestamp {
 
   def showFormat(format: TimestampFormat): String = format match {
     case TimestampFormat.DATE_TIME =>
-      "date-time timestamp (YYYY-MM-DDThh:mm:ss.sssZ)"
+      "date-time timestamp (YYYY-MM-ddThh:mm:ss.sssZ)"
     case TimestampFormat.EPOCH_SECONDS => "epoch-second timestamp"
     case TimestampFormat.HTTP_DATE =>
       "http-date timestamp (EEE, dd MMM yyyy HH:mm:ss.sss z)"

--- a/modules/core/src-js/smithy4s/Timestamp.scala
+++ b/modules/core/src-js/smithy4s/Timestamp.scala
@@ -282,7 +282,7 @@ object Timestamp {
       "date-time timestamp (YYYY-MM-ddThh:mm:ss.sssZ)"
     case TimestampFormat.EPOCH_SECONDS => "epoch-second timestamp"
     case TimestampFormat.HTTP_DATE =>
-      "http-date timestamp (EEE, dd MMM yyyy HH:mm:ss.sss z)"
+      "http-date timestamp (EEE, dd MMM yyyy hh:mm:ss.sss z)"
   }
 
   private[this] def parseDateTime(s: String): Timestamp = {

--- a/modules/core/src-jvm-native/smithy4s/Timestamp.scala
+++ b/modules/core/src-jvm-native/smithy4s/Timestamp.scala
@@ -256,7 +256,7 @@ object Timestamp extends TimestampCompanionPlatform {
 
   def showFormat(format: TimestampFormat): String = format match {
     case TimestampFormat.DATE_TIME =>
-      "date-time timestamp (YYYY-MM-DDThh:mm:ss.sssZ)"
+      "date-time timestamp (YYYY-MM-ddThh:mm:ss.sssZ)"
     case TimestampFormat.EPOCH_SECONDS => "epoch-second timestamp"
     case TimestampFormat.HTTP_DATE =>
       "http-date timestamp (EEE, dd MMM yyyy HH:mm:ss.sss z)"

--- a/modules/core/src-jvm-native/smithy4s/Timestamp.scala
+++ b/modules/core/src-jvm-native/smithy4s/Timestamp.scala
@@ -259,7 +259,7 @@ object Timestamp extends TimestampCompanionPlatform {
       "date-time timestamp (YYYY-MM-ddThh:mm:ss.sssZ)"
     case TimestampFormat.EPOCH_SECONDS => "epoch-second timestamp"
     case TimestampFormat.HTTP_DATE =>
-      "http-date timestamp (EEE, dd MMM yyyy HH:mm:ss.sss z)"
+      "http-date timestamp (EEE, dd MMM yyyy hh:mm:ss.sss z)"
   }
 
   private[this] def parseDateTime(s: String): Timestamp = {


### PR DESCRIPTION
In its current state , the AwsSignatureClient renders the **value** of the Content-Type header as 
```Content-Type(MediaType(application/json),None)```
which is the string representation of the http4s Content-Type class
This small fix uses the header instance that accompanies that class to extract the value out