### PR TITLE
Rework codec interfaces

### DIFF
--- a/modules/aws-http4s/src/smithy4s/aws/AwsClient.scala
+++ b/modules/aws-http4s/src/smithy4s/aws/AwsClient.scala
@@ -58,7 +58,7 @@ object AwsClient {
     private def interpreter[F[_]: Concurrent](
         awsEnv: AwsEnvironment[F]
     ): service.FunctorInterpreter[F] = {
-      val clientCodecs: UnaryClientCodecs[F] = awsProtocol match {
+      val clientCodecs: UnaryClientCodecs.Make[F] = awsProtocol match {
         case AwsProtocol.AWS_JSON_1_0(_) =>
           AwsJsonCodecs.make[F]("application/x-amz-json-1.0")
 

--- a/modules/aws-http4s/src/smithy4s/aws/internals/AwsInterpreter.scala
+++ b/modules/aws-http4s/src/smithy4s/aws/internals/AwsInterpreter.scala
@@ -26,12 +26,12 @@ import cats.effect.Concurrent
 // scalafmt: { align.preset = most, danglingParentheses.preset = false, maxColumn = 240, align.tokens = [{code = ":"}]}
 
 private[aws] class AwsInterpreter[Alg[_[_, _, _, _, _]], F[_]](
-    val service:   smithy4s.Service[Alg],
-    awsService:    AwsService,
-    client:        Client[F],
-    clientCodecs:  UnaryClientCodecs[F],
-    awsEnv:        AwsEnvironment[F]
-)(implicit effect: Concurrent[F]) {
+    val service:      smithy4s.Service[Alg],
+    awsService:       AwsService,
+    client:           Client[F],
+    makeClientCodecs: UnaryClientCodecs.Make[F],
+    awsEnv:           AwsEnvironment[F]
+)(implicit effect:    Concurrent[F]) {
 // format: on
 
   val impl: service.Impl[F] = service.impl {
@@ -43,7 +43,7 @@ private[aws] class AwsInterpreter[Alg[_[_, _, _, _, _]], F[_]](
           awsService,
           awsEnv,
           endpoint,
-          clientCodecs
+          makeClientCodecs
         )
     }
   }

--- a/modules/aws-http4s/src/smithy4s/aws/internals/AwsJsonCodecs.scala
+++ b/modules/aws-http4s/src/smithy4s/aws/internals/AwsJsonCodecs.scala
@@ -35,7 +35,7 @@ private[aws] object AwsJsonCodecs {
     aws.protocols.AwsJson1_0.protocol.hintMask ++
       aws.protocols.AwsJson1_1.protocol.hintMask ++ HintMask(IntEnum)
 
-  def make[F[_]: Concurrent](contentType: String): UnaryClientCodecs[F] = {
+  def make[F[_]: Concurrent](contentType: String): UnaryClientCodecs.Make[F] = {
     val httpMediaType = HttpMediaType(contentType)
     val underlyingCodecs = new smithy4s.http.json.JsonCodecAPI(
       cache => new AwsSchemaVisitorJCodec(cache),
@@ -60,7 +60,7 @@ private[aws] object AwsJsonCodecs {
       EntityDecoders.fromCodecAPI[F](underlyingCodecs)
     )
     val discriminator = AwsErrorTypeDecoder.fromResponse(decoders)
-    UnaryClientCodecs.make[F](encoders, decoders, decoders, discriminator)
+    UnaryClientCodecs.Make[F](encoders, decoders, decoders, discriminator)
   }
 
 }

--- a/modules/codegen/src/smithy4s/codegen/internals/Renderer.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/Renderer.scala
@@ -669,7 +669,10 @@ private[internals] class Renderer(compilationUnit: CompilationUnit) { self =>
   private def renderErrorable(op: Operation): Lines = {
     val errorName = NameRef(op.name + "Error")
     val scala3Unions = compilationUnit.rendererConfig.errorsAsScala3Unions
-    if (op.errors.isEmpty) Lines.empty
+    if (op.errors.isEmpty)
+      lines(
+        line"override val errorable: $option[Nothing] = None"
+      )
     else
       lines(
         line"override val errorable: $option[$Errorable_[$errorName]] = $some(this)",

--- a/modules/core/src/smithy4s/Endpoint.scala
+++ b/modules/core/src/smithy4s/Endpoint.scala
@@ -37,7 +37,7 @@ package smithy4s
   * If this trait is present in one on one of the members of Input/Output, the
   * member is removed from the Scala representation, in order to avoid polluting
   * datatypes that typically fit in memory with concerns of streaming (which can
-  * be encoded a great many ways, using a greatt many libraries)
+  * be encoded a great many ways, using a great many libraries)
   */
 trait Endpoint[Op[_, _, _, _, _], I, E, O, SI, SO]
     extends Endpoint.Base[I, E, O, SI, SO] {

--- a/modules/core/src/smithy4s/Endpoint.scala
+++ b/modules/core/src/smithy4s/Endpoint.scala
@@ -40,19 +40,9 @@ package smithy4s
   * be encoded a great many ways, using a greatt many libraries)
   */
 trait Endpoint[Op[_, _, _, _, _], I, E, O, SI, SO]
-    extends Endpoint.Schemas[I, E, O, SI, SO] {
-  def id: ShapeId
-  final def name: String = id.name
-  def input: Schema[I]
-  def output: Schema[O]
-  def streamedInput: StreamingSchema[SI]
-  def streamedOutput: StreamingSchema[SO]
-
-  def hints: Hints
+    extends Endpoint.Base[I, E, O, SI, SO] {
 
   def wrap(input: I): Op[I, E, O, SI, SO]
-
-  def errorable: Option[Errorable[E]] = None
 
   object Error {
     def unapply(throwable: Throwable): Option[(Errorable[E], E)] =
@@ -64,12 +54,16 @@ trait Endpoint[Op[_, _, _, _, _], I, E, O, SI, SO]
 
 object Endpoint {
 
-  trait Schemas[I, E, O, SI, SO] {
+  trait Base[I, E, O, SI, SO] {
+    def id: ShapeId
+    final def name: String = id.name
+    def hints: Hints
     def input: Schema[I]
     def output: Schema[O]
     def errorable: Option[Errorable[E]]
     def streamedInput: StreamingSchema[SI]
     def streamedOutput: StreamingSchema[SO]
+
   }
 
 }

--- a/modules/core/src/smithy4s/http/HttpEndpoint.scala
+++ b/modules/core/src/smithy4s/http/HttpEndpoint.scala
@@ -39,12 +39,12 @@ trait HttpEndpoint[I] {
 
 object HttpEndpoint {
 
-  def unapply[Op[_, _, _, _, _], I, E, O, SI, SO](
-      endpoint: Endpoint[Op, I, E, O, SI, SO]
+  def unapply[I, E, O, SI, SO](
+      endpoint: Endpoint.Base[I, E, O, SI, SO]
   ): Option[HttpEndpoint[I]] = cast(endpoint).toOption
 
-  def cast[Op[_, _, _, _, _], I, E, O, SI, SO](
-      endpoint: Endpoint[Op, I, E, O, SI, SO]
+  def cast[I, E, O, SI, SO](
+      endpoint: Endpoint.Base[I, E, O, SI, SO]
   ): Either[HttpEndpointError, HttpEndpoint[I]] = {
     for {
       http <- endpoint.hints

--- a/modules/example/src/smithy4s/example/BrandService.scala
+++ b/modules/example/src/smithy4s/example/BrandService.scala
@@ -78,5 +78,6 @@ object BrandServiceOperation {
       smithy.api.Http(method = smithy.api.NonEmptyString("POST"), uri = smithy.api.NonEmptyString("/brands"), code = 200),
     )
     def wrap(input: AddBrandsInput) = AddBrands(input)
+    override val errorable: Option[Nothing] = None
   }
 }

--- a/modules/example/src/smithy4s/example/DeprecatedService.scala
+++ b/modules/example/src/smithy4s/example/DeprecatedService.scala
@@ -82,5 +82,6 @@ object DeprecatedServiceOperation {
       smithy.api.Deprecated(message = None, since = None),
     )
     def wrap(input: Unit) = DeprecatedOperation()
+    override val errorable: Option[Nothing] = None
   }
 }

--- a/modules/example/src/smithy4s/example/FooService.scala
+++ b/modules/example/src/smithy4s/example/FooService.scala
@@ -89,5 +89,6 @@ object FooServiceOperation {
       smithy.api.Readonly(),
     )
     def wrap(input: Unit) = GetFoo()
+    override val errorable: Option[Nothing] = None
   }
 }

--- a/modules/example/src/smithy4s/example/NameCollision.scala
+++ b/modules/example/src/smithy4s/example/NameCollision.scala
@@ -130,5 +130,6 @@ object NameCollisionOperation {
     val streamedOutput: StreamingSchema[Nothing] = StreamingSchema.nothing
     val hints: Hints = Hints.empty
     def wrap(input: Unit) = Endpoint()
+    override val errorable: Option[Nothing] = None
   }
 }

--- a/modules/example/src/smithy4s/example/StreamedObjects.scala
+++ b/modules/example/src/smithy4s/example/StreamedObjects.scala
@@ -80,6 +80,7 @@ object StreamedObjectsOperation {
     val streamedOutput: StreamingSchema[Nothing] = StreamingSchema.nothing
     val hints: Hints = Hints.empty
     def wrap(input: PutStreamedObjectInput) = PutStreamedObject(input)
+    override val errorable: Option[Nothing] = None
   }
   final case class GetStreamedObject(input: GetStreamedObjectInput) extends StreamedObjectsOperation[GetStreamedObjectInput, Nothing, GetStreamedObjectOutput, Nothing, StreamedBlob] {
     def run[F[_, _, _, _, _]](impl: StreamedObjectsGen[F]): F[GetStreamedObjectInput, Nothing, GetStreamedObjectOutput, Nothing, StreamedBlob] = impl.getStreamedObject(input.key)
@@ -93,5 +94,6 @@ object StreamedObjectsOperation {
     val streamedOutput: StreamingSchema[StreamedBlob] = StreamingSchema("GetStreamedObjectOutput", StreamedBlob.schema.addHints(smithy.api.Default(smithy4s.Document.fromString(""))))
     val hints: Hints = Hints.empty
     def wrap(input: GetStreamedObjectInput) = GetStreamedObject(input)
+    override val errorable: Option[Nothing] = None
   }
 }

--- a/modules/example/src/smithy4s/example/collision/ReservedNameService.scala
+++ b/modules/example/src/smithy4s/example/collision/ReservedNameService.scala
@@ -92,6 +92,7 @@ object ReservedNameServiceOperation {
       smithy.api.Http(method = smithy.api.NonEmptyString("POST"), uri = smithy.api.NonEmptyString("/api/set/"), code = 204),
     )
     def wrap(input: SetInput) = _Set(input)
+    override val errorable: Option[Nothing] = None
   }
   final case class _List(input: ListInput) extends ReservedNameServiceOperation[ListInput, Nothing, Unit, Nothing, Nothing] {
     def run[F[_, _, _, _, _]](impl: ReservedNameServiceGen[F]): F[ListInput, Nothing, Unit, Nothing, Nothing] = impl.list(input.list)
@@ -107,6 +108,7 @@ object ReservedNameServiceOperation {
       smithy.api.Http(method = smithy.api.NonEmptyString("POST"), uri = smithy.api.NonEmptyString("/api/list/"), code = 204),
     )
     def wrap(input: ListInput) = _List(input)
+    override val errorable: Option[Nothing] = None
   }
   final case class _Map(input: MapInput) extends ReservedNameServiceOperation[MapInput, Nothing, Unit, Nothing, Nothing] {
     def run[F[_, _, _, _, _]](impl: ReservedNameServiceGen[F]): F[MapInput, Nothing, Unit, Nothing, Nothing] = impl.map(input.value)
@@ -122,6 +124,7 @@ object ReservedNameServiceOperation {
       smithy.api.Http(method = smithy.api.NonEmptyString("POST"), uri = smithy.api.NonEmptyString("/api/map/"), code = 204),
     )
     def wrap(input: MapInput) = _Map(input)
+    override val errorable: Option[Nothing] = None
   }
   final case class _Option(input: OptionInput) extends ReservedNameServiceOperation[OptionInput, Nothing, Unit, Nothing, Nothing] {
     def run[F[_, _, _, _, _]](impl: ReservedNameServiceGen[F]): F[OptionInput, Nothing, Unit, Nothing, Nothing] = impl.option(input.value)
@@ -137,5 +140,6 @@ object ReservedNameServiceOperation {
       smithy.api.Http(method = smithy.api.NonEmptyString("POST"), uri = smithy.api.NonEmptyString("/api/option/"), code = 204),
     )
     def wrap(input: OptionInput) = _Option(input)
+    override val errorable: Option[Nothing] = None
   }
 }

--- a/modules/http4s-kernel/src/smithy4s/http4s/kernel/MessageEncoder.scala
+++ b/modules/http4s-kernel/src/smithy4s/http4s/kernel/MessageEncoder.scala
@@ -27,6 +27,7 @@ import smithy4s.http.HttpRestSchema
 import smithy4s.http.HttpEndpoint
 import smithy4s.http.Metadata
 import smithy4s.schema._
+import org.http4s.Method
 
 trait MessageEncoder[F[_], A]
     extends RequestEncoder[F, A]
@@ -99,7 +100,8 @@ object MessageEncoder {
       val newUri = oldUri
         .copy(path = oldUri.path.addSegments(path.map(Uri.Path.Segment(_))))
         .withMultiValueQueryParams(staticQueries)
-      request.withUri(newUri)
+      val method = toHttp4sMethod(httpEndpoint.method).getOrElse(Method.POST)
+      request.withUri(newUri).withMethod(method)
     }
 
     def addToResponse(response: Response[F], input: I): Response[F] = {

--- a/modules/http4s-kernel/src/smithy4s/http4s/kernel/UnaryClientCodecs.scala
+++ b/modules/http4s-kernel/src/smithy4s/http4s/kernel/UnaryClientCodecs.scala
@@ -26,11 +26,9 @@ import smithy4s.http.HttpEndpoint
 trait UnaryClientCodecs[F[_], I, E, O] {
 
   // MUST return fixed values
-  // format: off
-  val inputEncoder : RequestEncoder[F, I]
-  val outputDecoder : ResponseDecoder[F, O]
-  val errorDecoder : ResponseDecoder[F, Throwable]
-  // format: on
+  val inputEncoder: RequestEncoder[F, I]
+  val outputDecoder: ResponseDecoder[F, O]
+  val errorDecoder: ResponseDecoder[F, Throwable]
 }
 
 object UnaryClientCodecs {
@@ -56,21 +54,27 @@ object UnaryClientCodecs {
       def apply[I, E, O, SI, SO](
           endpoint: Endpoint.Base[I, E, O, SI, SO]
       ): UnaryClientCodecs[F, I, E, O] = new UnaryClientCodecs[F, I, E, O] {
-      //format: off
 
-      val inputEncoder: RequestEncoder[F,I] = HttpEndpoint.cast(endpoint).toOption match {
-        case Some(httpEndpoint) => {
-          val httpInputEncoder = MessageEncoder.fromHttpEndpoint[F, I](httpEndpoint)
-          val requestEncoder = input.fromSchema(endpoint.input, requestEncoderCache)
-          RequestEncoder.combine(httpInputEncoder, requestEncoder)
-        }
-        case None => input.fromSchema(endpoint.input, requestEncoderCache)
-      }
+        val inputEncoder: RequestEncoder[F, I] =
+          HttpEndpoint.cast(endpoint).toOption match {
+            case Some(httpEndpoint) => {
+              val httpInputEncoder =
+                MessageEncoder.fromHttpEndpoint[F, I](httpEndpoint)
+              val requestEncoder =
+                input.fromSchema(endpoint.input, requestEncoderCache)
+              RequestEncoder.combine(httpInputEncoder, requestEncoder)
+            }
+            case None => input.fromSchema(endpoint.input, requestEncoderCache)
+          }
 
-      val outputDecoder: ResponseDecoder[F,O] = output.fromSchema(endpoint.output, responseDecoderCache)
-      val errorDecoder: ResponseDecoder[F,Throwable] =
-        ResponseDecoder.forErrorAsThrowable(endpoint.errorable, error, errorDiscriminator)
-      //format: on
+        val outputDecoder: ResponseDecoder[F, O] =
+          output.fromSchema(endpoint.output, responseDecoderCache)
+        val errorDecoder: ResponseDecoder[F, Throwable] =
+          ResponseDecoder.forErrorAsThrowable(
+            endpoint.errorable,
+            error,
+            errorDiscriminator
+          )
       }
     }
   }

--- a/modules/http4s-kernel/src/smithy4s/http4s/kernel/UnaryClientCodecs.scala
+++ b/modules/http4s-kernel/src/smithy4s/http4s/kernel/UnaryClientCodecs.scala
@@ -17,40 +17,62 @@
 package smithy4s.http4s.kernel
 
 import smithy4s.schema.CachedSchemaCompiler
-import smithy4s.schema.Schema
-import smithy4s.Errorable
 import org.http4s.Response
 import smithy4s.http.HttpDiscriminator
 import cats.effect.Concurrent
+import smithy4s.Endpoint
+import smithy4s.http.HttpEndpoint
 
-trait UnaryClientCodecs[F[_]] {
+trait UnaryClientCodecs[F[_], I, E, O] {
 
+  // MUST return fixed values
   // format: off
-  def inputEncoder[I](schema: Schema[I]) : RequestEncoder[F, I]
-  def outputDecoder[O](schema: Schema[O]) : ResponseDecoder[F, O]
-  def errorDecoder[E](errorable: Option[Errorable[E]]) : ResponseDecoder[F, Throwable]
+  val inputEncoder : RequestEncoder[F, I]
+  val outputDecoder : ResponseDecoder[F, O]
+  val errorDecoder : ResponseDecoder[F, Throwable]
   // format: on
 }
 
 object UnaryClientCodecs {
 
-  def make[F[_]: Concurrent](
-      input: CachedSchemaCompiler[RequestEncoder[F, *]],
-      output: CachedSchemaCompiler[ResponseDecoder[F, *]],
-      error: CachedSchemaCompiler[ResponseDecoder[F, *]],
-      errorDiscriminator: Response[F] => F[Option[HttpDiscriminator]]
-  ): UnaryClientCodecs[F] =
-    new UnaryClientCodecs[F] {
+  type For[F[_]] = {
+    type toKind5[I, E, O, SI, SO] = UnaryClientCodecs[F, I, E, O]
+  }
+
+  type Make[F[_]] =
+    smithy4s.kinds.PolyFunction5[Endpoint.Base, For[F]#toKind5]
+
+  object Make {
+    def apply[F[_]: Concurrent](
+        input: CachedSchemaCompiler[RequestEncoder[F, *]],
+        output: CachedSchemaCompiler[ResponseDecoder[F, *]],
+        error: CachedSchemaCompiler[ResponseDecoder[F, *]],
+        errorDiscriminator: Response[F] => F[Option[HttpDiscriminator]]
+    ): Make[F] = new Make[F] {
+
+      private val requestEncoderCache: input.Cache = input.createCache()
+      private val responseDecoderCache: output.Cache = output.createCache()
+
+      def apply[I, E, O, SI, SO](
+          endpoint: Endpoint.Base[I, E, O, SI, SO]
+      ): UnaryClientCodecs[F, I, E, O] = new UnaryClientCodecs[F, I, E, O] {
       //format: off
-      def inputEncoder[I](schema: Schema[I]): RequestEncoder[F,I] = input.fromSchema(schema, requestEncoderCache)
 
-      def outputDecoder[O](schema: Schema[O]): ResponseDecoder[F,O] = output.fromSchema(schema, responseDecoderCache)
+      val inputEncoder: RequestEncoder[F,I] = HttpEndpoint.cast(endpoint).toOption match {
+        case Some(httpEndpoint) => {
+          val httpInputEncoder = MessageEncoder.fromHttpEndpoint[F, I](httpEndpoint)
+          val requestEncoder = input.fromSchema(endpoint.input, requestEncoderCache)
+          RequestEncoder.combine(httpInputEncoder, requestEncoder)
+        }
+        case None => input.fromSchema(endpoint.input, requestEncoderCache)
+      }
 
-      def errorDecoder[E](errorable: Option[Errorable[E]]): ResponseDecoder[F,Throwable] =
-        ResponseDecoder.forErrorAsThrowable(errorable, error, errorDiscriminator)
-
-      val requestEncoderCache: input.Cache = input.createCache()
-      val responseDecoderCache: output.Cache = output.createCache()
+      val outputDecoder: ResponseDecoder[F,O] = output.fromSchema(endpoint.output, responseDecoderCache)
+      val errorDecoder: ResponseDecoder[F,Throwable] =
+        ResponseDecoder.forErrorAsThrowable(endpoint.errorable, error, errorDiscriminator)
+      //format: on
+      }
     }
+  }
 
 }

--- a/modules/http4s-kernel/src/smithy4s/http4s/kernel/UnaryServerCodecs.scala
+++ b/modules/http4s-kernel/src/smithy4s/http4s/kernel/UnaryServerCodecs.scala
@@ -21,12 +21,10 @@ import smithy4s.schema.Schema
 import smithy4s.Endpoint
 
 trait UnaryServerCodecs[F[_], I, E, O] {
-  // format: off
-  val inputDecoder : RequestDecoder[F, I]
-  val outputEncoder : ResponseEncoder[F, O]
-  def errorEncoder[EE](schema: Schema[EE]) : ResponseEncoder[F, EE]
-  val errorEncoder : ResponseEncoder[F, E]
-  // format: on
+  val inputDecoder: RequestDecoder[F, I]
+  val outputEncoder: ResponseEncoder[F, O]
+  def errorEncoder[EE](schema: Schema[EE]): ResponseEncoder[F, EE]
+  val errorEncoder: ResponseEncoder[F, E]
 }
 
 object UnaryServerCodecs {
@@ -50,17 +48,19 @@ object UnaryServerCodecs {
     def apply[I, E, O, SI, SO](
         endpoint: Endpoint.Base[I, E, O, SI, SO]
     ): UnaryServerCodecs[F, I, E, O] = new UnaryServerCodecs[F, I, E, O] {
-      //format: off
-      val inputDecoder: RequestDecoder[F,I] =
+      val inputDecoder: RequestDecoder[F, I] =
         input.fromSchema(endpoint.input, requestDecoderCache)
-      val outputEncoder: ResponseEncoder[F,O] =
+      val outputEncoder: ResponseEncoder[F, O] =
         output.fromSchema(endpoint.output, responseEncoderCache)
-      val errorEncoder: ResponseEncoder[F,E] =
-          ResponseEncoder.forError(smithy4s.errorTypeHeader, endpoint.errorable, error)
-      def errorEncoder[EE](schema: Schema[EE]) : ResponseEncoder[F, EE] =
+      val errorEncoder: ResponseEncoder[F, E] =
+        ResponseEncoder.forError(
+          smithy4s.errorTypeHeader,
+          endpoint.errorable,
+          error
+        )
+      def errorEncoder[EE](schema: Schema[EE]): ResponseEncoder[F, EE] =
         error.fromSchema(schema, errorResponseEncoderCache)
     }
   }
-
 
 }

--- a/modules/http4s-kernel/src/smithy4s/http4s/kernel/UnaryServerCodecs.scala
+++ b/modules/http4s-kernel/src/smithy4s/http4s/kernel/UnaryServerCodecs.scala
@@ -18,38 +18,49 @@ package smithy4s.http4s.kernel
 
 import smithy4s.schema.CachedSchemaCompiler
 import smithy4s.schema.Schema
-import smithy4s.Errorable
+import smithy4s.Endpoint
 
-trait UnaryServerCodecs[F[_]] {
+trait UnaryServerCodecs[F[_], I, E, O] {
   // format: off
-  def inputDecoder[I](schema: Schema[I]) : RequestDecoder[F, I]
-  def outputEncoder[O](schema: Schema[O]) : ResponseEncoder[F, O]
-  def errorEncoder[E](schema: Schema[E]) : ResponseEncoder[F, E]
-  def errorEncoder[E](errorable: Option[Errorable[E]]) : ResponseEncoder[F, E]
+  val inputDecoder : RequestDecoder[F, I]
+  val outputEncoder : ResponseEncoder[F, O]
+  def errorEncoder[EE](schema: Schema[EE]) : ResponseEncoder[F, EE]
+  val errorEncoder : ResponseEncoder[F, E]
   // format: on
 }
 
 object UnaryServerCodecs {
 
+  type For[F[_]] = {
+    type toKind5[I, E, O, SI, SO] = UnaryServerCodecs[F, I, E, O]
+  }
+
+  type Make[F[_]] =
+    smithy4s.kinds.PolyFunction5[Endpoint.Base, For[F]#toKind5]
+
   def make[F[_]](
       input: CachedSchemaCompiler[RequestDecoder[F, *]],
       output: CachedSchemaCompiler[ResponseEncoder[F, *]],
       error: CachedSchemaCompiler[ResponseEncoder[F, *]]
-  ): UnaryServerCodecs[F] =
-    new UnaryServerCodecs[F] {
-      //format: off
-      def inputDecoder[I](schema: Schema[I]): RequestDecoder[F,I] =
-        input.fromSchema(schema, requestDecoderCache)
-      def outputEncoder[O](schema: Schema[O]): ResponseEncoder[F,O] =
-        output.fromSchema(schema, responseEncoderCache)
-      def errorEncoder[E](schema: Schema[E]) : ResponseEncoder[F, E] =
-        error.fromSchema(schema, errorResponseEncoderCache)
-      def errorEncoder[E](errorable: Option[Errorable[E]]): ResponseEncoder[F,E] =
-         ResponseEncoder.forError(smithy4s.errorTypeHeader, errorable, error)
+  ): Make[F] = new Make[F] {
+    val requestDecoderCache: input.Cache = input.createCache()
+    val responseEncoderCache: output.Cache = output.createCache()
+    val errorResponseEncoderCache: error.Cache = error.createCache()
 
-      val requestDecoderCache: input.Cache = input.createCache()
-      val responseEncoderCache: output.Cache = output.createCache()
-      val errorResponseEncoderCache: error.Cache = error.createCache()
+    def apply[I, E, O, SI, SO](
+        endpoint: Endpoint.Base[I, E, O, SI, SO]
+    ): UnaryServerCodecs[F, I, E, O] = new UnaryServerCodecs[F, I, E, O] {
+      //format: off
+      val inputDecoder: RequestDecoder[F,I] =
+        input.fromSchema(endpoint.input, requestDecoderCache)
+      val outputEncoder: ResponseEncoder[F,O] =
+        output.fromSchema(endpoint.output, responseEncoderCache)
+      val errorEncoder: ResponseEncoder[F,E] =
+          ResponseEncoder.forError(smithy4s.errorTypeHeader, endpoint.errorable, error)
+      def errorEncoder[EE](schema: Schema[EE]) : ResponseEncoder[F, EE] =
+        error.fromSchema(schema, errorResponseEncoderCache)
     }
+  }
+
 
 }

--- a/modules/http4s/src/smithy4s/http4s/SimpleProtocolBuilder.scala
+++ b/modules/http4s/src/smithy4s/http4s/SimpleProtocolBuilder.scala
@@ -24,6 +24,8 @@ import org.http4s.Uri
 import org.http4s.client.Client
 import org.http4s.implicits._
 import smithy4s.kinds._
+import smithy4s.http4s.internals.SmithyHttp4sReverseRouter
+import smithy4s.http4s.internals.SmithyHttp4sRouter
 
 /**
   * Abstract construct helping the construction of routers and clients

--- a/modules/http4s/src/smithy4s/http4s/SimpleProtocolBuilder.scala
+++ b/modules/http4s/src/smithy4s/http4s/SimpleProtocolBuilder.scala
@@ -99,13 +99,13 @@ abstract class SimpleProtocolBuilder[P](
         // Making sure the router is evaluated lazily, so that all the compilation inside it
         // doesn't happen in case of a missing protocol
         .map { _ =>
-          new SmithyHttp4sReverseRouter[Alg, F](
+          SmithyHttp4sReverseRouter.impl[Alg, F](
             uri,
             service,
             client,
             simpleProtocolCodecs.makeClientCodecs[F],
             middleware
-          ).impl
+          )
         }
     }
   }

--- a/modules/http4s/src/smithy4s/http4s/SimpleProtocolCodecs.scala
+++ b/modules/http4s/src/smithy4s/http4s/SimpleProtocolCodecs.scala
@@ -21,7 +21,7 @@ import smithy4s.http4s.kernel._
 
 trait SimpleProtocolCodecs {
 
-  def makeServerCodecs[F[_]: Concurrent]: UnaryServerCodecs[F]
-  def makeClientCodecs[F[_]: Concurrent]: UnaryClientCodecs[F]
+  def makeServerCodecs[F[_]: Concurrent]: UnaryServerCodecs.Make[F]
+  def makeClientCodecs[F[_]: Concurrent]: UnaryClientCodecs.Make[F]
 
 }

--- a/modules/http4s/src/smithy4s/http4s/SmithyHttp4sRouter.scala
+++ b/modules/http4s/src/smithy4s/http4s/SmithyHttp4sRouter.scala
@@ -31,7 +31,7 @@ class SmithyHttp4sRouter[Alg[_[_, _, _, _, _]], Op[_, _, _, _, _], F[_]](
     service: smithy4s.Service.Aux[Alg, Op],
     impl: FunctorInterpreter[Op, F],
     errorTransformation: PartialFunction[Throwable, F[Throwable]],
-    serverCodecs: UnaryServerCodecs[F],
+    makeServerCodecs: UnaryServerCodecs.Make[F],
     middleware: ServerEndpointMiddleware[F]
 )(implicit effect: Concurrent[F]) {
 
@@ -51,7 +51,7 @@ class SmithyHttp4sRouter[Alg[_[_, _, _, _, _]], Op[_, _, _, _, _], F[_]](
         SmithyHttp4sServerEndpoint.make(
           impl,
           ep,
-          serverCodecs,
+          makeServerCodecs,
           errorTransformation,
           middleware.prepare(service) _
         )

--- a/modules/http4s/src/smithy4s/http4s/internals/SimpleRestJsonCodecs.scala
+++ b/modules/http4s/src/smithy4s/http4s/internals/SimpleRestJsonCodecs.scala
@@ -28,7 +28,7 @@ private[http4s] class SimpleRestJsonCodecs(maxArity: Int)
     alloy.SimpleRestJson.protocol.hintMask ++ HintMask(IntEnum)
   private val underlyingCodecs = smithy4s.http.json.codecs(hintMask, maxArity)
 
-  def makeServerCodecs[F[_]: Concurrent]: UnaryServerCodecs[F] = {
+  def makeServerCodecs[F[_]: Concurrent]: UnaryServerCodecs.Make[F] = {
     val messageDecoderCompiler =
       MessageDecoder.restSchemaCompiler[F](
         EntityDecoders.fromCodecAPI[F](underlyingCodecs)
@@ -44,7 +44,7 @@ private[http4s] class SimpleRestJsonCodecs(maxArity: Int)
     )
   }
 
-  def makeClientCodecs[F[_]: Concurrent]: UnaryClientCodecs[F] = {
+  def makeClientCodecs[F[_]: Concurrent]: UnaryClientCodecs.Make[F] = {
     val messageDecoderCompiler =
       MessageDecoder.restSchemaCompiler[F](
         EntityDecoders.fromCodecAPI[F](underlyingCodecs)
@@ -53,7 +53,7 @@ private[http4s] class SimpleRestJsonCodecs(maxArity: Int)
       MessageEncoder.restSchemaCompiler[F](
         EntityEncoders.fromCodecAPI[F](underlyingCodecs)
       )
-    UnaryClientCodecs.make[F](
+    UnaryClientCodecs.Make[F](
       input = messageEncoderCompiler,
       output = messageDecoderCompiler,
       error = messageDecoderCompiler,

--- a/modules/http4s/src/smithy4s/http4s/internals/SmithyHttp4sReverseRouter.scala
+++ b/modules/http4s/src/smithy4s/http4s/internals/SmithyHttp4sReverseRouter.scala
@@ -15,17 +15,18 @@
  */
 
 package smithy4s
-package http4s
+package http4s.internals
 
 import org.http4s._
 import org.http4s.client.Client
 import smithy4s.http4s.kernel._
 import smithy4s.http4s.internals.SmithyHttp4sClientEndpoint
+import smithy4s.http4s.ClientEndpointMiddleware
 import cats.effect.Concurrent
 
 // scalafmt: { align.preset = most, danglingParentheses.preset = false, maxColumn = 240, align.tokens = [{code = ":"}]}
 
-object SmithyHttp4sReverseRouter {
+private[http4s] object SmithyHttp4sReverseRouter {
 
   def impl[Alg[_[_, _, _, _, _]], F[_]](
       baseUri:         Uri,

--- a/modules/http4s/src/smithy4s/http4s/internals/SmithyHttp4sReverseRouter.scala
+++ b/modules/http4s/src/smithy4s/http4s/internals/SmithyHttp4sReverseRouter.scala
@@ -20,7 +20,6 @@ package http4s.internals
 import org.http4s._
 import org.http4s.client.Client
 import smithy4s.http4s.kernel._
-import smithy4s.http4s.internals.SmithyHttp4sClientEndpoint
 import smithy4s.http4s.ClientEndpointMiddleware
 import cats.effect.Concurrent
 

--- a/modules/http4s/src/smithy4s/http4s/internals/SmithyHttp4sRouter.scala
+++ b/modules/http4s/src/smithy4s/http4s/internals/SmithyHttp4sRouter.scala
@@ -21,7 +21,6 @@ import cats.data.Kleisli
 import cats.data.OptionT
 import cats.implicits._
 import org.http4s._
-import smithy4s.http4s.internals.SmithyHttp4sServerEndpoint
 import smithy4s.kinds._
 import smithy4s.http4s.kernel._
 import cats.effect.Concurrent

--- a/modules/http4s/src/smithy4s/http4s/internals/SmithyHttp4sRouter.scala
+++ b/modules/http4s/src/smithy4s/http4s/internals/SmithyHttp4sRouter.scala
@@ -15,7 +15,7 @@
  */
 
 package smithy4s
-package http4s
+package http4s.internals
 
 import cats.data.Kleisli
 import cats.data.OptionT
@@ -25,9 +25,10 @@ import smithy4s.http4s.internals.SmithyHttp4sServerEndpoint
 import smithy4s.kinds._
 import smithy4s.http4s.kernel._
 import cats.effect.Concurrent
+import smithy4s.http4s.ServerEndpointMiddleware
 
 // format: off
-class SmithyHttp4sRouter[Alg[_[_, _, _, _, _]], Op[_, _, _, _, _], F[_]](
+private[http4s] class SmithyHttp4sRouter[Alg[_[_, _, _, _, _]], Op[_, _, _, _, _], F[_]](
     service: smithy4s.Service.Aux[Alg, Op],
     impl: FunctorInterpreter[Op, F],
     errorTransformation: PartialFunction[Throwable, F[Throwable]],

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.8.2


### PR DESCRIPTION
Rework the UnaryCodecs interfaces to be a static group of the codecs necessary for the interpreters. They are now accompanied by a `Make` construct to build them from an Endpoint, as a certain amount of encoding and decoding logic depends on hints that are carried by the Endpoint.

