### PR TITLE
[Aws-Http4s] Add the http method to the Request when deriving a Message Encoder from HttpEndpoint

### DIFF
--- a/modules/http4s-kernel/src/smithy4s/http4s/kernel/MessageEncoder.scala
+++ b/modules/http4s-kernel/src/smithy4s/http4s/kernel/MessageEncoder.scala
@@ -22,6 +22,7 @@ import org.http4s.Request
 import org.http4s.Response
 import org.http4s.Status
 import org.http4s.Uri
+import org.http4s.Method
 import smithy4s.PartialData
 import smithy4s.http.HttpRestSchema
 import smithy4s.http.HttpEndpoint
@@ -95,11 +96,16 @@ object MessageEncoder {
     def addToRequest(request: Request[F], input: I): Request[F] = {
       val path = httpEndpoint.path(input)
       val staticQueries = httpEndpoint.staticQueryParams
+      val method = httpEndpoint.method
       val oldUri = request.uri
       val newUri = oldUri
         .copy(path = oldUri.path.addSegments(path.map(Uri.Path.Segment(_))))
         .withMultiValueQueryParams(staticQueries)
-      request.withUri(newUri)
+      request
+        .withUri(newUri)
+        .withMethod(
+          Method.fromString(method.toString).getOrElse(request.method)
+        )
     }
 
     def addToResponse(response: Response[F], input: I): Response[F] = {


### PR DESCRIPTION
when testing the restJson1 protocol, I discovered that all Requests were set as POST, which IIUC comes from the default request over here https://github.com/disneystreaming/smithy4s/blob/83fbb92d89649f238dced745a7af0190521853e7/modules/aws-http4s/src/smithy4s/aws/internals/AwsUnaryEndpoint.scala#L81
While this makes sense for certain protocols it seems it should be overwritten wherever the `@http` trait is being used
