### PR TITLE
[Compliance Test]  Query Params Comparison

### DIFF
--- a/modules/compliance-tests/src/smithy4s/compliancetests/internals/Assertions.scala
+++ b/modules/compliance-tests/src/smithy4s/compliancetests/internals/Assertions.scala
@@ -116,11 +116,11 @@ private[internals] object assert {
       testCase: Option[List[String]]
   ) = {
     testCase.toList.flatten
-      .map(_.split("=", 2))
+      .map(splitQuery)
       .collect {
-        case Array(key, _) if !queryParameters.contains(key) =>
+        case (key, _) if !queryParameters.contains(key) =>
           fail(s"missing query parameter $key")
-        case Array(key, expectedValue)
+        case (key, expectedValue)
             if !queryParameters
               .get(key)
               .toList

--- a/modules/compliance-tests/src/smithy4s/compliancetests/internals/ClientHttpComplianceTestCase.scala
+++ b/modules/compliance-tests/src/smithy4s/compliancetests/internals/ClientHttpComplianceTestCase.scala
@@ -20,7 +20,6 @@ package internals
 import cats.implicits._
 import cats.effect.Temporal
 import cats.effect.syntax.all._
-import org.http4s.headers.`Content-Type`
 import org.http4s.HttpApp
 import org.http4s.Request
 import org.http4s.Response
@@ -34,8 +33,6 @@ import smithy4s.Service
 import cats.Eq
 import smithy4s.compliancetests.internals.TestConfig._
 import scala.concurrent.duration._
-import org.http4s.MediaType
-import org.http4s.Headers
 import smithy4s.schema.Alt
 
 private[compliancetests] class ClientHttpComplianceTestCase[
@@ -168,7 +165,6 @@ private[compliancetests] class ClientHttpComplianceTestCase[
             .left
             .map(_.errorEq[F])
         }
-        val mediaType = expectedResponseType(endpoint.output)
         val status = Status.fromInt(testCase.code).liftTo[F]
 
         status.flatMap { status =>
@@ -182,9 +178,7 @@ private[compliancetests] class ClientHttpComplianceTestCase[
                 }
                 .getOrElse(fs2.Stream.empty)
 
-            val headers = Headers(
-              `Content-Type`(MediaType.unsafeParse(mediaType.value))
-            ) ++ parseHeaders(testCase.headers)
+            val headers = parseHeaders(testCase.headers)
 
             req.body.compile.drain.as(
               Response[F](status)

--- a/modules/compliance-tests/src/smithy4s/compliancetests/internals/ClientHttpComplianceTestCase.scala
+++ b/modules/compliance-tests/src/smithy4s/compliancetests/internals/ClientHttpComplianceTestCase.scala
@@ -77,10 +77,9 @@ private[compliancetests] class ClientHttpComplianceTestCase[
         expectedUri.path.renderString,
         "path test :"
       )
-    val queryAssert = assert.eql(
-      request.uri.query.renderString,
-      expectedUri.query.renderString,
-      "query test :"
+    val queryAssert = assert.testCase.checkQueryParameters(
+      testCase,
+      expectedUri.query.multiParams
     )
     val methodAssert = assert.eql(
       request.method.name.toLowerCase(),

--- a/modules/compliance-tests/src/smithy4s/compliancetests/internals/package.scala
+++ b/modules/compliance-tests/src/smithy4s/compliancetests/internals/package.scala
@@ -24,7 +24,7 @@ import java.nio.charset.StandardCharsets
 import scala.collection.immutable.ListMap
 
 package object internals {
-  private def splitQuery(queryString: String): (String, String) = {
+  def splitQuery(queryString: String): (String, String) = {
     queryString.split("=", 2) match {
       case Array(k, v) =>
         (


### PR DESCRIPTION
### This PR  will require adjusting AllowList for Alloy  ###
Added 
- handle forbid and require query params
- changed mechanism for comparing query params as order is not guaranteed
- per [Smithy Issue](https://github.com/awslabs/smithy/issues/1771) , we should not be adding any additional headers to the response including content-type

