### PR TITLE
[Core : Fix]fix string enum for StringAndBlobCodecSchemaVisitor

### DIFF
--- a/modules/core/test/src/smithy4s/http/StringAndBlobSpec.scala
+++ b/modules/core/test/src/smithy4s/http/StringAndBlobSpec.scala
@@ -75,6 +75,27 @@ class StringAndBlobSpec() extends munit.FunSuite {
     expect.same(Right(input), roundTripped)
     expect.same(HttpMediaType("text/csv"), mediaType)
   }
+  test("String Enum  ") {
+    val input = StringEnumBody(StringEnum.INTERESTING)
+    val codec = stringsAndBlobs.compileCodec(StringEnumBody.schema)
+    val result = stringsAndBlobs.writeToArray(codec, input)
+    val roundTripped = stringsAndBlobs.decodeFromByteArray(codec, result)
+    val mediaType = stringsAndBlobs.mediaType(codec)
+    expect(result.sameElements("interesting".getBytes()))
+    expect.same(Right(input), roundTripped)
+    expect.same(HttpMediaType("text/plain"), mediaType)
+  }
+
+  test("String Enum (custom media-type)") {
+    val input = AudioEnumBody(AudioEnum.BASS)
+    val codec = stringsAndBlobs.compileCodec(AudioEnumBody.schema)
+    val result = stringsAndBlobs.writeToArray(codec, input)
+    val roundTripped = stringsAndBlobs.decodeFromByteArray(codec, result)
+    val mediaType = stringsAndBlobs.mediaType(codec)
+    expect(result.sameElements("bass".getBytes()))
+    expect.same(Right(input), roundTripped)
+    expect.same(HttpMediaType("audio/mpeg3"), mediaType)
+  }
 
   test("Blobs") {
     val input = BlobBody(ByteArray("hello".getBytes()))

--- a/modules/core/test/src/smithy4s/http/StringAndBlobSpec.scala
+++ b/modules/core/test/src/smithy4s/http/StringAndBlobSpec.scala
@@ -75,7 +75,7 @@ class StringAndBlobSpec() extends munit.FunSuite {
     expect.same(Right(input), roundTripped)
     expect.same(HttpMediaType("text/csv"), mediaType)
   }
-  test("String Enum  ") {
+  test("String Enum") {
     val input = StringEnumBody(StringEnum.INTERESTING)
     val codec = stringsAndBlobs.compileCodec(StringEnumBody.schema)
     val result = stringsAndBlobs.writeToArray(codec, input)

--- a/sampleSpecs/bodies.smithy
+++ b/sampleSpecs/bodies.smithy
@@ -1,9 +1,23 @@
+$version: "2"
+
 namespace smithy4s.example
 
 structure StringBody {
   @httpPayload
   @required
   str: String
+}
+
+structure StringEnumBody {
+    @httpPayload
+    @required
+    str: StringEnum
+}
+
+structure AudioEnumBody {
+    @httpPayload
+    @required
+    str: AudioEnum
 }
 
 structure BlobBody {
@@ -29,3 +43,15 @@ string CSV
 
 @mediaType("image/png")
 blob PNG
+
+
+enum StringEnum {
+    STRING = "string"
+    INTERESTING = "interesting"
+}
+
+@mediaType("audio/mpeg3")
+enum AudioEnum {
+   GUITAR = "guitar"
+   BASS = "bass"
+}


### PR DESCRIPTION
A string enum should be treated like a string and therefore when providing a special string codec supporting media type , string enum case should be included