### PR TITLE
fix: sync enum trait rendering with enum shape as possible

### DIFF
--- a/modules/codegen/src/smithy4s/codegen/internals/SmithyToIR.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/SmithyToIR.scala
@@ -312,20 +312,11 @@ private[codegen] class SmithyToIR(model: Model, namespace: String) {
       override def stringShape(shape: StringShape): Option[Decl] =
         (shape match {
           case T.enumeration(e) => {
-            val enumTrait = shape
-              .findTrait(ShapeId.from("smithy.api#enum"))
-              .asScala
-              .getOrElse(
-                throw new Exception(
-                  "smithy.api#enum shape is missing for enum trait"
-                )
-              )
             val pseudoEnumShape =
               EnumShape.fromStringShape(shape, true).asScala match {
                 case Some(shape) =>
                   shape
                     .toBuilder()
-                    .addTrait(enumTrait)
                     .asInstanceOf[EnumShape.Builder]
                     .build()
                 case None => {
@@ -354,7 +345,6 @@ private[codegen] class SmithyToIR(model: Model, namespace: String) {
                   }
                   EnumShape
                     .builder()
-                    .addTrait(enumTrait)
                     .id(shape.getId())
                     .source(shape.getSourceLocation())
                     .addTraits(

--- a/modules/codegen/src/smithy4s/codegen/internals/SmithyToIR.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/SmithyToIR.scala
@@ -312,37 +312,45 @@ private[codegen] class SmithyToIR(model: Model, namespace: String) {
       override def stringShape(shape: StringShape): Option[Decl] =
         (shape match {
           case T.enumeration(e) => {
-            val namedEnumTrait =
-              if (e.hasNames()) e
-              else {
-                val defs = e.getValues().asScala.zipWithIndex.map {
-                  case (enumDef, idx) =>
-                    enumDef.getName().asScala match {
-                      case Some(_) => enumDef
-                      case None =>
-                        enumDef
-                          .toBuilder()
-                          .name(
-                            EnumUtil
-                              .enumValueClassName(None, enumDef.getValue, idx)
-                          )
-                          .build()
+            val pseudoEnumShape =
+              EnumShape.fromStringShape(shape).asScala match {
+                case Some(shape) => shape
+                case None => {
+                  val namedEnumTrait = {
+                    val defs = e.getValues().asScala.zipWithIndex.map {
+                      case (enumDef, idx) =>
+                        enumDef.getName().asScala match {
+                          case Some(_) => enumDef
+                          case None =>
+                            enumDef
+                              .toBuilder()
+                              .name(
+                                EnumUtil
+                                  .enumValueClassName(
+                                    None,
+                                    enumDef.getValue,
+                                    idx
+                                  )
+                              )
+                              .build()
+                        }
                     }
+                    val builder = e.toBuilder().clearEnums()
+                    defs.foreach(builder.addEnum)
+                    builder.build()
+                  }
+                  EnumShape
+                    .builder()
+                    .source(shape.getSourceLocation())
+                    .addTraits(
+                      shape.getAllTraits().values()
+                    )
+                    .asInstanceOf[EnumShape.Builder]
+                    .id(shape.getId())
+                    .setMembersFromEnumTrait(namedEnumTrait)
+                    .build()
                 }
-                val builder = e.toBuilder().clearEnums()
-                defs.foreach(builder.addEnum)
-                builder.build()
               }
-            val pseudoEnumShape = EnumShape
-              .builder()
-              .source(shape.getSourceLocation())
-              .addTraits(
-                shape.getAllTraits().values()
-              )
-              .asInstanceOf[EnumShape.Builder]
-              .id(shape.getId())
-              .setMembersFromEnumTrait(namedEnumTrait)
-              .build()
             enumShape(pseudoEnumShape)
           }
           case _ => this.getDefault(shape)

--- a/modules/codegen/src/smithy4s/codegen/internals/SmithyToIR.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/SmithyToIR.scala
@@ -352,6 +352,9 @@ private[codegen] class SmithyToIR(model: Model, namespace: String) {
                         .getAllTraits()
                         .values()
                         .asScala
+                        .filterNot(
+                          _.toShapeId() == ShapeId.from("smithy.api#enum")
+                        )
                         .asJavaCollection
                     )
                     .asInstanceOf[EnumShape.Builder]

--- a/modules/codegen/src/smithy4s/codegen/internals/SmithyToIR.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/SmithyToIR.scala
@@ -341,12 +341,19 @@ private[codegen] class SmithyToIR(model: Model, namespace: String) {
                   }
                   EnumShape
                     .builder()
+                    .id(shape.getId())
                     .source(shape.getSourceLocation())
                     .addTraits(
-                      shape.getAllTraits().values()
+                      shape
+                        .getAllTraits()
+                        .values()
+                        .asScala
+                        .filterNot(
+                          _.toShapeId() == ShapeId.from("smithy.api#enum")
+                        )
+                        .asJavaCollection
                     )
                     .asInstanceOf[EnumShape.Builder]
-                    .id(shape.getId())
                     .setMembersFromEnumTrait(namedEnumTrait)
                     .build()
                 }
@@ -961,9 +968,6 @@ private[codegen] class SmithyToIR(model: Model, namespace: String) {
         .filterNot(_.toShapeId().getNamespace() == "smithy.synthetic")
         // enumValue can be derived from enum schemas anyway, so we're removing it from hints
         .filterNot(_.toShapeId() == EnumValueTrait.ID)
-        .filterNot(
-          _.toShapeId() == ShapeId.from("smithy.api#enum")
-        ) // filter out enum trait using literal to avoid deprecation warning from `EnumTrait.ID`
 
     val nonConstraintNonMetaTraits = nonMetaTraits.collect {
       case t if ConstraintTrait.unapply(t).isEmpty => t

--- a/modules/codegen/src/smithy4s/codegen/internals/SmithyToIR.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/SmithyToIR.scala
@@ -313,7 +313,7 @@ private[codegen] class SmithyToIR(model: Model, namespace: String) {
         (shape match {
           case T.enumeration(e) => {
             val pseudoEnumShape =
-              EnumShape.fromStringShape(shape).asScala match {
+              EnumShape.fromStringShape(shape, true).asScala match {
                 case Some(shape) => shape
                 case None => {
                   val namedEnumTrait = {
@@ -348,9 +348,6 @@ private[codegen] class SmithyToIR(model: Model, namespace: String) {
                         .getAllTraits()
                         .values()
                         .asScala
-                        .filterNot(
-                          _.toShapeId() == ShapeId.from("smithy.api#enum")
-                        )
                         .asJavaCollection
                     )
                     .asInstanceOf[EnumShape.Builder]

--- a/modules/codegen/test/src/smithy4s/codegen/internals/RendererSpec.scala
+++ b/modules/codegen/test/src/smithy4s/codegen/internals/RendererSpec.scala
@@ -161,8 +161,8 @@ final class RendererSpec extends munit.FunSuite {
       "variants generated from `@enum` trait must hold hints, but deprecation hint cannot support message and since properties."
     )
     assert(
-      definition.contains("smithy.api.Enum"),
-      "smithy.api.Enum must be preserved"
+      !definition.contains("smithy.api.Enum"),
+      "smithy.api.Enum must be discarded"
     )
 
   }

--- a/modules/codegen/test/src/smithy4s/codegen/internals/RendererSpec.scala
+++ b/modules/codegen/test/src/smithy4s/codegen/internals/RendererSpec.scala
@@ -144,10 +144,12 @@ final class RendererSpec extends munit.FunSuite {
     val diamondWithDocRendered =
       """case object DIAMOND extends Suit("DIAMOND", "DIAMOND", 0, Hints(smithy.api.Documentation("this is a DIAMOND")))"""
     // NOTE: enum trait and enum shape are not 100% compatible. For example, enum trait doesn't support deprecated$since and deprecated$message.
-    val haertWithDeprecationAndDocRendered =
-      """|  /** this is a HAERT */
-         |  @deprecated
-         |  case object HAERT extends Suit("HAERT", "HAERT", 1, Hints(smithy.api.Documentation("this is a HAERT"), smithy.api.Deprecated(message = None, since = None))""".stripMargin
+    val haertWithDeprecationAndDocRendered = List(
+      "/** this is a HAERT */",
+      "@deprecated",
+      """case object HAERT extends Suit("HAERT", "HAERT", 1, Hints(smithy.api.Documentation("this is a HAERT"), smithy.api.Deprecated(message = None, since = None))"""
+    )
+
     assert(
       definition.contains(classDoc),
       "generated class must hold documentation"
@@ -157,7 +159,7 @@ final class RendererSpec extends munit.FunSuite {
       "DIAMOND variant must hold hints from `@enum` trait"
     )
     assert(
-      definition.contains(haertWithDeprecationAndDocRendered),
+      haertWithDeprecationAndDocRendered.forall(definition.contains),
       "variants generated from `@enum` trait must hold hints, but deprecation hint cannot support message and since properties."
     )
     assert(

--- a/modules/codegen/test/src/smithy4s/codegen/internals/RendererSpec.scala
+++ b/modules/codegen/test/src/smithy4s/codegen/internals/RendererSpec.scala
@@ -85,6 +85,144 @@ final class RendererSpec extends munit.FunSuite {
       s"""val underlyingSchema: Schema[Map[String, Int]] = map($keySchemaString, $valueSchemaString)"""
     assert(definition.contains(requiredString))
   }
+  test("enum trait hints should be preserved") {
+    val smithy = s"""
+                    |$$version: "2.0"
+                    |namespace smithy4s
+                    |
+                    |@documentation("this is an enum Suit")
+                    |@enum([
+                    |{
+                    |  value: "DIAMOND",
+                    |  name: "DIAMOND",
+                    |  documentation: "this is a DIAMOND"
+                    |},
+                    |{
+                    |  value: "HAERT",
+                    |  name: "HAERT",
+                    |  documentation: "this is a HAERT",
+                    |  deprecated: true
+                    |},
+                    |{
+                    |  value: "HEART",
+                    |  name: "HEART",
+                    |  documentation: "this is a HEART"
+                    |},
+                    |{
+                    |  value: "CLUB",
+                    |  name: "CLUB"
+                    |},
+                    |{
+                    |  value: "SPADE"
+                    |  name: "SPADE"
+                    |}
+                    |])
+                    |string Suit
+                    |
+                    |""".stripMargin
+    val contents = generateScalaCode(smithy).values
+    val definition =
+      contents.find(content =>
+        content.contains("sealed abstract class Suit") && content.contains(
+          "object Suit extends Enumeration[Suit]"
+        )
+      ) match {
+        case None =>
+          fail(
+            "enum must be rendered as a sealed abstract class and its companion object"
+          )
+        case Some(code) => code
+      }
+    val classDoc = """/** this is an enum Suit
+                     |  * @param DIAMOND
+                     |  *   this is a DIAMOND
+                     |  * @param HAERT
+                     |  *   this is a HAERT
+                     |  * @param HEART
+                     |  *   this is a HEART
+                     |  */""".stripMargin
+    val diamondWithDocRendered =
+      """case object DIAMOND extends Suit("DIAMOND", "DIAMOND", 0, Hints(smithy.api.Documentation("this is a DIAMOND")))"""
+    // NOTE: enum trait and enum shape are not 100% compatible. For example, enum trait doesn't support deprecated$since and deprecated$message.
+    val haertWithDeprecationAndDocRendered =
+      """|  /** this is a HAERT */
+         |  @deprecated
+         |  case object HAERT extends Suit("HAERT", "HAERT", 1, Hints(smithy.api.Documentation("this is a HAERT"), smithy.api.Deprecated(message = None, since = None))""".stripMargin
+    assert(
+      definition.contains(classDoc),
+      "generated class must hold documentation"
+    )
+    assert(
+      definition.contains(diamondWithDocRendered),
+      "DIAMOND variant must hold hints from `@enum` trait"
+    )
+    assert(
+      definition.contains(haertWithDeprecationAndDocRendered),
+      "variants generated from `@enum` trait must hold hints, but deprecation hint cannot support message and since properties."
+    )
+    println(definition)
+  }
+  test("enum hints should be preserved") {
+    val smithy = """
+                   |$version: "2.0"
+                   |
+                   |namespace smithy4s
+                   |
+                   |@documentation("this is an enum Suit")
+                   |enum Suit {
+                   |  @documentation("this is a DIAMOND")
+                   |  DIAMOND
+                   |  /// this is a HAERT
+                   |  @deprecated(since:"0.0.0", message: "typo")
+                   |  HAERT
+                   |  /// this is a HEART
+                   |  HEART
+                   |  CLUB
+                   |  SPADE
+                   |}
+                   |
+                   |""".stripMargin
+    val contents = generateScalaCode(smithy).values
+    val definition =
+      contents.find(content =>
+        content.contains("sealed abstract class Suit") && content.contains(
+          "object Suit extends Enumeration[Suit]"
+        )
+      ) match {
+        case None =>
+          fail(
+            "enum must be rendered as a sealed abstract class and its companion object"
+          )
+        case Some(code) => code
+      }
+    val classDoc = """/** this is an enum Suit
+                     |  * @param DIAMOND
+                     |  *   this is a DIAMOND
+                     |  * @param HAERT
+                     |  *   this is a HAERT
+                     |  * @param HEART
+                     |  *   this is a HEART
+                     |  */""".stripMargin
+    val diamondWithDocRendered =
+      """case object DIAMOND extends Suit("DIAMOND", "DIAMOND", 0, Hints(smithy.api.Documentation("this is a DIAMOND")))"""
+    val haertWithDeprecationAndDocRendered =
+      """|  /** this is a HAERT */
+         |  @deprecated(message = "typo", since = "0.0.0")
+         |  case object HAERT extends Suit("HAERT", "HAERT", 1, Hints(smithy.api.Documentation("this is a HAERT"), smithy.api.Deprecated(message = Some("typo"), since = Some("0.0.0")))""".stripMargin
+    assert(
+      definition.contains(classDoc),
+      "generated class must hold documentation for itself and variants with doc hint."
+    )
+    assert(
+      definition.contains(diamondWithDocRendered),
+      "DIAMOND variant must hold hints from `@enum` trait"
+    )
+    assert(
+      definition.contains(haertWithDeprecationAndDocRendered),
+      "variants generated from enum shape must hold hints and deprecation hint must keep message and since properties."
+    )
+    println(definition)
+  }
 
   test("structure must generate final case class") {
     val smithy =

--- a/modules/codegen/test/src/smithy4s/codegen/internals/RendererSpec.scala
+++ b/modules/codegen/test/src/smithy4s/codegen/internals/RendererSpec.scala
@@ -160,7 +160,6 @@ final class RendererSpec extends munit.FunSuite {
       definition.contains(haertWithDeprecationAndDocRendered),
       "variants generated from `@enum` trait must hold hints, but deprecation hint cannot support message and since properties."
     )
-    println(definition)
   }
   test("enum hints should be preserved") {
     val smithy = """
@@ -221,7 +220,6 @@ final class RendererSpec extends munit.FunSuite {
       definition.contains(haertWithDeprecationAndDocRendered),
       "variants generated from enum shape must hold hints and deprecation hint must keep message and since properties."
     )
-    println(definition)
   }
 
   test("structure must generate final case class") {

--- a/modules/codegen/test/src/smithy4s/codegen/internals/RendererSpec.scala
+++ b/modules/codegen/test/src/smithy4s/codegen/internals/RendererSpec.scala
@@ -161,8 +161,8 @@ final class RendererSpec extends munit.FunSuite {
       "variants generated from `@enum` trait must hold hints, but deprecation hint cannot support message and since properties."
     )
     assert(
-      !definition.contains("smithy.api.Enum"),
-      "smithy.api.Enum must be erased"
+      definition.contains("smithy.api.Enum"),
+      "smithy.api.Enum must be preserved"
     )
 
   }

--- a/modules/codegen/test/src/smithy4s/codegen/internals/RendererSpec.scala
+++ b/modules/codegen/test/src/smithy4s/codegen/internals/RendererSpec.scala
@@ -160,6 +160,11 @@ final class RendererSpec extends munit.FunSuite {
       definition.contains(haertWithDeprecationAndDocRendered),
       "variants generated from `@enum` trait must hold hints, but deprecation hint cannot support message and since properties."
     )
+    assert(
+      !definition.contains("smithy.api.Enum"),
+      "smithy.api.Enum must be erased"
+    )
+
   }
   test("enum hints should be preserved") {
     val smithy = """

--- a/modules/example/src/smithy4s/example/LowHigh.scala
+++ b/modules/example/src/smithy4s/example/LowHigh.scala
@@ -25,7 +25,9 @@ sealed abstract class LowHigh(_value: String, _name: String, _intValue: Int, _hi
 object LowHigh extends Enumeration[LowHigh] with ShapeTag.Companion[LowHigh] {
   val id: ShapeId = ShapeId("smithy4s.example", "LowHigh")
 
-  val hints: Hints = Hints.empty
+  val hints: Hints = Hints(
+    smithy.api.Enum(List(smithy.api.EnumDefinition(value = smithy.api.NonEmptyString("Low"), name = Some(smithy.api.EnumConstantBodyName("LOW")), documentation = Some("low"), tags = None, deprecated = None), smithy.api.EnumDefinition(value = smithy.api.NonEmptyString("High"), name = Some(smithy.api.EnumConstantBodyName("HIGH")), documentation = Some("high"), tags = None, deprecated = None))),
+  )
 
   /** low */
   case object LOW extends LowHigh("Low", "LOW", 0, Hints(smithy.api.Documentation("low")))

--- a/modules/example/src/smithy4s/example/LowHigh.scala
+++ b/modules/example/src/smithy4s/example/LowHigh.scala
@@ -8,6 +8,11 @@ import smithy4s.ShapeTag
 import smithy4s.schema.EnumTag
 import smithy4s.schema.Schema.enumeration
 
+/** @param LOW
+  *   low
+  * @param HIGH
+  *   high
+  */
 sealed abstract class LowHigh(_value: String, _name: String, _intValue: Int, _hints: Hints) extends Enumeration.Value {
   override type EnumType = LowHigh
   override val value: String = _value
@@ -22,8 +27,10 @@ object LowHigh extends Enumeration[LowHigh] with ShapeTag.Companion[LowHigh] {
 
   val hints: Hints = Hints.empty
 
-  case object LOW extends LowHigh("Low", "LOW", 0, Hints())
-  case object HIGH extends LowHigh("High", "HIGH", 1, Hints())
+  /** low */
+  case object LOW extends LowHigh("Low", "LOW", 0, Hints(smithy.api.Documentation("low")))
+  /** high */
+  case object HIGH extends LowHigh("High", "HIGH", 1, Hints(smithy.api.Documentation("high")))
 
   val values: List[LowHigh] = List(
     LOW,

--- a/modules/example/src/smithy4s/example/LowHigh.scala
+++ b/modules/example/src/smithy4s/example/LowHigh.scala
@@ -20,9 +20,7 @@ sealed abstract class LowHigh(_value: String, _name: String, _intValue: Int, _hi
 object LowHigh extends Enumeration[LowHigh] with ShapeTag.Companion[LowHigh] {
   val id: ShapeId = ShapeId("smithy4s.example", "LowHigh")
 
-  val hints: Hints = Hints(
-    smithy.api.Enum(List(smithy.api.EnumDefinition(value = smithy.api.NonEmptyString("Low"), name = Some(smithy.api.EnumConstantBodyName("LOW")), documentation = None, tags = None, deprecated = None), smithy.api.EnumDefinition(value = smithy.api.NonEmptyString("High"), name = Some(smithy.api.EnumConstantBodyName("HIGH")), documentation = None, tags = None, deprecated = None))),
-  )
+  val hints: Hints = Hints.empty
 
   case object LOW extends LowHigh("Low", "LOW", 0, Hints())
   case object HIGH extends LowHigh("High", "HIGH", 1, Hints())

--- a/modules/example/src/smithy4s/example/LowHigh.scala
+++ b/modules/example/src/smithy4s/example/LowHigh.scala
@@ -25,9 +25,7 @@ sealed abstract class LowHigh(_value: String, _name: String, _intValue: Int, _hi
 object LowHigh extends Enumeration[LowHigh] with ShapeTag.Companion[LowHigh] {
   val id: ShapeId = ShapeId("smithy4s.example", "LowHigh")
 
-  val hints: Hints = Hints(
-    smithy.api.Enum(List(smithy.api.EnumDefinition(value = smithy.api.NonEmptyString("Low"), name = Some(smithy.api.EnumConstantBodyName("LOW")), documentation = Some("low"), tags = None, deprecated = None), smithy.api.EnumDefinition(value = smithy.api.NonEmptyString("High"), name = Some(smithy.api.EnumConstantBodyName("HIGH")), documentation = Some("high"), tags = None, deprecated = None))),
-  )
+  val hints: Hints = Hints.empty
 
   /** low */
   case object LOW extends LowHigh("Low", "LOW", 0, Hints(smithy.api.Documentation("low")))

--- a/sampleSpecs/example.smithy
+++ b/sampleSpecs/example.smithy
@@ -119,7 +119,7 @@ union Foo {
   bDec: BigDecimal
 }
 
-@enum([{value: "Low", name: "LOW"}, {value: "High", name: "HIGH"}])
+@enum([{value: "Low", name: "LOW", documentation: "low"}, {value: "High", name: "HIGH", documentation: "high"}])
 string LowHigh
 
 @uuidFormat


### PR DESCRIPTION
Previously, rendering result of [enum trait](https://smithy.io/2.0/spec/constraint-traits.html#enum-trait) was much different from that of [enum shape](https://smithy.io/2.0/spec/simple-types.html#enum) in that
1. smithy4s dropped enum variant hints
2. sealed abstract classes generated from enum trait held `smithy.api#enum` hints
3. sealed abstract classes from enum trait didn't have `@param` properties generated.


For example, the following smithy definition generated the Scala code below.

```smithy
@enum([
{
    value: "HEAD",
    name: "HEAD",
    documentation: "head"
},
{
    value: "TAIL",
    name: "TAIL",
    documentation: "tail",
    deprecated: true
}
])

string Coin
```

```scala
// When Coin is generated from enum shape and enum variant has
// documentation, here are `@param` properties for each variant with doc.
sealed abstract class Coin ...

...

object Coin extends Enumeration[Suit] with ...
  ...
  val hints: Hints = Hints(
    smithy.api.Enum(...) // <- When Coin is generated from enum shape, smithy.api.Enum does not exist here.
  )

  /** head */
  case object HEAD extends Coin("HEAD", "HEAD", 0, Hints()) // <- Hints is not empty when Coin is enum shape.
  /** tail  */
  @deprecated
  case object TAIL extends Coin("TAIL", "TAIL", 1, Hints()) // too

```

After this commits, enum variants generated from enum trait also hold hints such as documentation or deprecation. In addition, sealed abstract classes generated from enum trait no longer have redundant `smithy.api#enum hints`.

See https://github.com/disneystreaming/smithy4s/pull/980/files#diff-1374f8e9776053385d67f4bc78d81b77bd7730a72ebd38801479005fba548fa0 for instance.

Note that enum trait and enum shape are not 100% compatible.
For example, enum trait support neither `deprecated$since` nor `deprecated$message`.