### PR TITLE
improve: fallback unspecified members of deprecated trait to N/A

### DIFF
--- a/modules/codegen/src/smithy4s/codegen/internals/Renderer.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/Renderer.scala
@@ -183,12 +183,13 @@ private[internals] class Renderer(compilationUnit: CompilationUnit) { self =>
     hints
       .collectFirst { case h: Hint.Deprecated => h }
       .foldMap { dep =>
-        val messagePart = dep.message
-          .map(msg => line"message = ${renderStringLiteral(msg)}")
-        val versionPart =
-          dep.since.map(v => line"since = ${renderStringLiteral(v)}")
+        val messagePart =
+          line"message = ${renderStringLiteral(dep.message.getOrElse("N/A"))}"
 
-        val args = List(messagePart, versionPart).flatten.intercalate(comma)
+        val versionPart =
+          line"since = ${renderStringLiteral(dep.since.getOrElse("N/A"))}"
+
+        val args = List(messagePart, versionPart).intercalate(comma)
 
         val argListOrEmpty = if (args.nonEmpty) line"($args)" else line""
 

--- a/modules/codegen/test/src/smithy4s/codegen/internals/RendererSpec.scala
+++ b/modules/codegen/test/src/smithy4s/codegen/internals/RendererSpec.scala
@@ -126,4 +126,38 @@ final class RendererSpec extends munit.FunSuite {
     assert(contents.exists(_.contains(requiredIntCase)))
     assert(contents.exists(_.contains(requiredStrCase)))
   }
+  test("unspecified members of deprecated trait are rendered as N/A") {
+    val smithy =
+      """
+        |$version: "2.0"
+        |
+        |namespace smithy4s
+        |
+        |@deprecated
+        |integer MyInt
+        |
+        |@deprecated(message: "msg")
+        |string MyString
+        |
+        |@deprecated(since: "0.0.0")
+        |boolean MyBool
+        |""".stripMargin
+
+    val contents = generateScalaCode(smithy).values
+    assert(
+      contents.exists(
+        _.contains("""@deprecated(message = "N/A", since = "N/A")""")
+      )
+    )
+    assert(
+      contents.exists(
+        _.contains("""@deprecated(message = "msg", since = "N/A")""")
+      )
+    )
+    assert(
+      contents.exists(
+        _.contains("""@deprecated(message = "N/A", since = "0.0.0")""")
+      )
+    )
+  }
 }

--- a/modules/example/src/smithy4s/example/DeprecatedService.scala
+++ b/modules/example/src/smithy4s/example/DeprecatedService.scala
@@ -11,11 +11,11 @@ import smithy4s.kinds.PolyFunction5
 import smithy4s.kinds.toPolyFunction5.const5
 import smithy4s.schema.Schema.unit
 
-@deprecated
+@deprecated(message = "N/A", since = "N/A")
 trait DeprecatedServiceGen[F[_, _, _, _, _]] {
   self =>
 
-  @deprecated
+  @deprecated(message = "N/A", since = "N/A")
   def deprecatedOperation(): F[Unit, Nothing, Unit, Nothing, Nothing]
 
   def transform: Transformation.PartiallyApplied[DeprecatedServiceGen[F]] = Transformation.of[DeprecatedServiceGen[F]](this)

--- a/modules/example/src/smithy4s/example/DeprecatedString.scala
+++ b/modules/example/src/smithy4s/example/DeprecatedString.scala
@@ -7,7 +7,7 @@ import smithy4s.ShapeId
 import smithy4s.schema.Schema.bijection
 import smithy4s.schema.Schema.string
 
-@deprecated
+@deprecated(message = "N/A", since = "N/A")
 object DeprecatedString extends Newtype[String] {
   val id: ShapeId = ShapeId("smithy4s.example", "DeprecatedString")
   val hints: Hints = Hints(

--- a/modules/example/src/smithy4s/example/DeprecatedStructure.scala
+++ b/modules/example/src/smithy4s/example/DeprecatedStructure.scala
@@ -8,7 +8,7 @@ import smithy4s.schema.Schema.string
 import smithy4s.schema.Schema.struct
 
 @deprecated(message = "A compelling reason", since = "0.0.1")
-final case class DeprecatedStructure(@deprecated name: Option[String] = None, nameV2: Option[String] = None, strings: Option[List[String]] = None)
+final case class DeprecatedStructure(@deprecated(message = "N/A", since = "N/A") name: Option[String] = None, nameV2: Option[String] = None, strings: Option[List[String]] = None)
 object DeprecatedStructure extends ShapeTag.Companion[DeprecatedStructure] {
   val id: ShapeId = ShapeId("smithy4s.example", "DeprecatedStructure")
 

--- a/modules/example/src/smithy4s/example/DeprecatedUnion.scala
+++ b/modules/example/src/smithy4s/example/DeprecatedUnion.scala
@@ -20,10 +20,10 @@ object DeprecatedUnion extends ShapeTag.Companion[DeprecatedUnion] {
     smithy.api.Deprecated(message = Some("A compelling reason"), since = Some("0.0.1")),
   )
 
-  @deprecated
+  @deprecated(message = "N/A", since = "N/A")
   final case class SCase(s: String) extends DeprecatedUnion
   final case class S_V2Case(s_V2: String) extends DeprecatedUnion
-  @deprecated
+  @deprecated(message = "N/A", since = "N/A")
   final case class DeprecatedUnionProductCase() extends DeprecatedUnion
   object DeprecatedUnionProductCase extends ShapeTag.Companion[DeprecatedUnionProductCase] {
     val id: ShapeId = ShapeId("smithy4s.example", "DeprecatedUnionProductCase")
@@ -36,7 +36,7 @@ object DeprecatedUnion extends ShapeTag.Companion[DeprecatedUnion] {
 
     val alt = schema.oneOf[DeprecatedUnion]("p")
   }
-  @deprecated
+  @deprecated(message = "N/A", since = "N/A")
   final case class UnionProductCaseDeprecatedAtCallSite() extends DeprecatedUnion
   object UnionProductCaseDeprecatedAtCallSite extends ShapeTag.Companion[UnionProductCaseDeprecatedAtCallSite] {
     val id: ShapeId = ShapeId("smithy4s.example", "UnionProductCaseDeprecatedAtCallSite")

--- a/modules/example/src/smithy4s/example/EnumWithDeprecations.scala
+++ b/modules/example/src/smithy4s/example/EnumWithDeprecations.scala
@@ -9,7 +9,7 @@ import smithy4s.schema.EnumTag
 import smithy4s.schema.Schema.enumeration
 
 /** some docs here */
-@deprecated
+@deprecated(message = "N/A", since = "N/A")
 sealed abstract class EnumWithDeprecations(_value: String, _name: String, _intValue: Int, _hints: Hints) extends Enumeration.Value {
   override type EnumType = EnumWithDeprecations
   override val value: String = _value
@@ -27,7 +27,7 @@ object EnumWithDeprecations extends Enumeration[EnumWithDeprecations] with Shape
     smithy.api.Deprecated(message = None, since = None),
   )
 
-  @deprecated
+  @deprecated(message = "N/A", since = "N/A")
   case object OLD extends EnumWithDeprecations("OLD", "OLD", 0, Hints(smithy.api.Deprecated(message = None, since = None)))
   case object NEW extends EnumWithDeprecations("NEW", "NEW", 1, Hints())
 

--- a/modules/example/src/smithy4s/example/Strings.scala
+++ b/modules/example/src/smithy4s/example/Strings.scala
@@ -8,7 +8,7 @@ import smithy4s.schema.Schema.bijection
 import smithy4s.schema.Schema.list
 import smithy4s.schema.Schema.string
 
-@deprecated
+@deprecated(message = "N/A", since = "N/A")
 object Strings extends Newtype[List[String]] {
   val id: ShapeId = ShapeId("smithy4s.example", "Strings")
   val hints: Hints = Hints(

--- a/modules/example/src/smithy4s/example/package.scala
+++ b/modules/example/src/smithy4s/example/package.scala
@@ -11,7 +11,7 @@ package object example {
   val ObjectService = ObjectServiceGen
   type NameCollision[F[_]] = smithy4s.kinds.FunctorAlgebra[NameCollisionGen, F]
   val NameCollision = NameCollisionGen
-  @deprecated
+  @deprecated(message = "N/A", since = "N/A")
   type DeprecatedService[F[_]] = smithy4s.kinds.FunctorAlgebra[DeprecatedServiceGen, F]
   val DeprecatedService = DeprecatedServiceGen
 
@@ -36,10 +36,10 @@ package object example {
   type PersonPhoneNumber = smithy4s.example.PersonPhoneNumber.Type
   type FancyList = smithy4s.example.FancyList.Type
   type DefaultStringMap = smithy4s.example.DefaultStringMap.Type
-  @deprecated
+  @deprecated(message = "N/A", since = "N/A")
   type Strings = smithy4s.example.Strings.Type
   type PersonAge = smithy4s.example.PersonAge.Type
-  @deprecated
+  @deprecated(message = "N/A", since = "N/A")
   type DeprecatedString = smithy4s.example.DeprecatedString.Type
   type ObjectSize = smithy4s.example.ObjectSize.Type
   type PersonEmail = smithy4s.example.PersonEmail.Type


### PR DESCRIPTION
Scala compiler raises warning for deprecated annotation without message and/or since fields.

close https://github.com/disneystreaming/smithy4s/issues/948

Perhaps, should we warn or inform users to encourage them to use deprecated trait with message and since fields via smithy language server?