### PR TITLE
Header test multiple fixes

### DIFF
--- a/modules/compliance-tests/test/src/ComplianceUtilsSpec.scala
+++ b/modules/compliance-tests/test/src/ComplianceUtilsSpec.scala
@@ -41,13 +41,17 @@ object ComplianceUtilsSpec extends FunSuite {
   test(
     "comma between quotes is not used as delimiter and comma is included to the entry"
   ) {
-    val s = "a,\",b\" ,c"
-    expect(parseList(s) == List("a", "\",b\" ", "c"))
+    val s = "a, \"\\\",b\\\"\" ,c"
+    val expected = List("a", "\",b\"", "c")
+    val result = parseList(s)
+    expect(result == expected) && expect(result.size == expected.size)
   }
 
   test("more complex scenario with quotes and commas") {
-    val s = "a,\",b\",c,,,\"d,e,f\",g"
-    expect(parseList(s) == List("a", "\",b\"", "c", "\"d,e,f\"", "g"))
+    val s = "a,\"\\\",b\\\"\",c,,,\"\\\"d,e,f\\\"\",g"
+    val expected = List("a", "\",b\"", "c", "\"d,e,f\"", "g")
+    val result = parseList(s)
+    expect(result == expected) && expect(result.size == expected.size)
   }
 
 }

--- a/modules/http4s-kernel/src/smithy4s/http4s/kernel/package.scala
+++ b/modules/http4s-kernel/src/smithy4s/http4s/kernel/package.scala
@@ -65,7 +65,7 @@ package object kernel {
 
   private[smithy4s] def toHeaders(mp: Map[CaseInsensitive, Seq[String]]) =
     Headers(mp.flatMap { case (k, v) =>
-      v.filterNot(_.isEmpty).map(Header.Raw(CIString(k.toString), _))
+      v.map(Header.Raw(CIString(k.toString), _))
     }.toList)
 
   private[smithy4s] def getFirstHeader[F[_]](

--- a/modules/http4s-kernel/src/smithy4s/http4s/kernel/package.scala
+++ b/modules/http4s-kernel/src/smithy4s/http4s/kernel/package.scala
@@ -65,7 +65,7 @@ package object kernel {
 
   private[smithy4s] def toHeaders(mp: Map[CaseInsensitive, Seq[String]]) =
     Headers(mp.flatMap { case (k, v) =>
-      v.map(Header.Raw(CIString(k.toString), _))
+      v.filterNot(_.isEmpty).map(Header.Raw(CIString(k.toString), _))
     }.toList)
 
   private[smithy4s] def getFirstHeader[F[_]](


### PR DESCRIPTION
This PR addresses what I believe were inaccuracies in the parsing of multiple headers from a string that is encoded as a smithy string.
The tests too were inaccurate.
This introduces a different method plus changes the tests , in addition to applying the parsing to both client and server.

Therefore the tests will fail as a few additional compliance tests are passing and we need to update the allow list

There is one additional problem that arises and that is the parsing of a date which allows for unescaped commas.
So this change now causes to tests with dates in the header to fail

Other than , running a date parser first with a fallback to the multi-value header parser , I am not sure how to solve this problem in a generic fashion
