### PR TITLE
Filter for CLIENT test cases

### DIFF
--- a/modules/compliance-tests/src/smithy4s/compliancetests/internals/ClientHttpComplianceTestCase.scala
+++ b/modules/compliance-tests/src/smithy4s/compliancetests/internals/ClientHttpComplianceTestCase.scala
@@ -249,7 +249,7 @@ private[compliancetests] class ClientHttpComplianceTestCase[
               .toList
               .flatMap(_.value)
               .filter(_.protocol == protocolTag.id.toString())
-              .filter(tc => tc.appliesTo.forall(_ == AppliesTo.SERVER))
+              .filter(tc => tc.appliesTo.forall(_ == AppliesTo.CLIENT))
               .map(tc =>
                 clientResponseTest(
                   endpoint,


### PR DESCRIPTION
While working on a PR, I noticed that and I think this is a mistake. Assigned you because I know you're familiar with the compliance tests.

The CI fails because now a bunch of test succeeds that are not in the allowList. Would the next step to update the list in disneystreaming/alloy ?