### PR TITLE
fix: avoid baking error metadata into status code

### DIFF
--- a/modules/http4s-kernel/src/smithy4s/http4s/kernel/MessageEncoder.scala
+++ b/modules/http4s-kernel/src/smithy4s/http4s/kernel/MessageEncoder.scala
@@ -73,6 +73,11 @@ object MessageEncoder {
       val headers = toHeaders(metadata.headers)
       val status = metadata.statusCode
         .flatMap(Status.fromInt(_).toOption)
+        .filter(_.responseClass match {
+          case Status.Successful | Status.Redirection =>
+            true
+          case _ => false
+        })
         .getOrElse(response.status)
       response.withHeaders(response.headers ++ headers).withStatus(status)
     }

--- a/modules/http4s-kernel/src/smithy4s/http4s/kernel/MessageEncoder.scala
+++ b/modules/http4s-kernel/src/smithy4s/http4s/kernel/MessageEncoder.scala
@@ -74,6 +74,8 @@ object MessageEncoder {
       val status = metadata.statusCode
         .flatMap(Status.fromInt(_).toOption)
         .filter(_.responseClass match {
+          // This allows only Successful(2xx) and Redirection(3xx) values for response status code.
+          // see https://github.com/disneystreaming/smithy4s/issues/916#issuecomment-1516512415 for reference.
           case Status.Successful | Status.Redirection =>
             true
           case _ => false

--- a/modules/http4s-kernel/src/smithy4s/http4s/kernel/MessageEncoder.scala
+++ b/modules/http4s-kernel/src/smithy4s/http4s/kernel/MessageEncoder.scala
@@ -73,13 +73,7 @@ object MessageEncoder {
       val headers = toHeaders(metadata.headers)
       val status = metadata.statusCode
         .flatMap(Status.fromInt(_).toOption)
-        .filter(_.responseClass match {
-          // This allows only Successful(2xx) and Redirection(3xx) values for response status code.
-          // see https://github.com/disneystreaming/smithy4s/issues/916#issuecomment-1516512415 for reference.
-          case Status.Successful | Status.Redirection =>
-            true
-          case _ => false
-        })
+        .filter(_.responseClass.isSuccess)
         .getOrElse(response.status)
       response.withHeaders(response.headers ++ headers).withStatus(status)
     }


### PR DESCRIPTION
This commit updates MessageEncoder to avoid copying status code from metadata into response status when status code is not successful value. This change allows service to keep response status set by the endpoint.

See https://github.com/disneystreaming/smithy4s/issues/916#issuecomment-1516512415 for reference.