### PR TITLE
Add support for the notion of sparse collection

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -873,7 +873,8 @@ lazy val example = projectMatrix
       (ThisBuild / baseDirectory).value / "sampleSpecs" / "quoted_string.smithy",
       (ThisBuild / baseDirectory).value / "sampleSpecs" / "numeric.smithy",
       (ThisBuild / baseDirectory).value / "sampleSpecs" / "structure_pattern.smithy",
-      (ThisBuild / baseDirectory).value / "sampleSpecs" / "typeclass.smithy"
+      (ThisBuild / baseDirectory).value / "sampleSpecs" / "typeclass.smithy",
+      (ThisBuild / baseDirectory).value / "sampleSpecs" / "sparse.smithy"
     ),
     Compile / resourceDirectory := (ThisBuild / baseDirectory).value / "modules" / "example" / "resources",
     libraryDependencies += Dependencies.Http4s.emberServer.value,

--- a/modules/aws-http4s/src/smithy4s/aws/query/AwsSchemaVisitorAwsQueryCodec.scala
+++ b/modules/aws-http4s/src/smithy4s/aws/query/AwsSchemaVisitorAwsQueryCodec.scala
@@ -198,7 +198,7 @@ private[aws] class AwsSchemaVisitorAwsQueryCodec(
       override def apply(a: A): FormData = { underlying(a) }
     }
 
-  override def sparse[A](schema: Schema[A]): AwsQueryCodec[Option[A]] =
+  override def nullable[A](schema: Schema[A]): AwsQueryCodec[Option[A]] =
     new AwsQueryCodec[Option[A]] {
       val encoder = compile(schema)
       def apply(a: Option[A]): FormData = a match {

--- a/modules/aws-http4s/src/smithy4s/aws/query/AwsSchemaVisitorAwsQueryCodec.scala
+++ b/modules/aws-http4s/src/smithy4s/aws/query/AwsSchemaVisitorAwsQueryCodec.scala
@@ -198,6 +198,15 @@ private[aws] class AwsSchemaVisitorAwsQueryCodec(
       override def apply(a: A): FormData = { underlying(a) }
     }
 
+  override def sparse[A](schema: Schema[A]): AwsQueryCodec[Option[A]] =
+    new AwsQueryCodec[Option[A]] {
+      val encoder = compile(schema)
+      def apply(a: Option[A]): FormData = a match {
+        case None        => FormData.Empty
+        case Some(value) => encoder(value)
+      }
+    }
+
   /**
     * @todo Pay more attention to the AWS Query annotations
    */

--- a/modules/aws-http4s/test/src/smithy4s/aws/compliancetests/AwsJsonProtocolComplianceTests.scala
+++ b/modules/aws-http4s/test/src/smithy4s/aws/compliancetests/AwsJsonProtocolComplianceTests.scala
@@ -43,12 +43,10 @@ object AwsJsonProtocolComplianceTests
     val all: DynamicSchemaIndex => List[ComplianceTest[IO]] = dsi =>
       awsJson1_1(dsi) ++ awsJson1_0(dsi)
 
-    // filtering out Null operation as we dont support sparse yet
     // filtering out HostWithPathOperation as this would be taken-care of by middleware.
     // filtering PutWithContentEncoding until we implement compression
     fs2.Stream
       .evals(dynamicSchemaIndexLoader.map(all(_)))
-      .filterNot(_.endpoint.name.contains("NullOperation"))
       .filterNot(_.endpoint.name.contains("HostWithPathOperation"))
       .filterNot(_.endpoint.name.contains("PutWithContentEncoding"))
       .parEvalMapUnbounded(runInWeaver)

--- a/modules/cats/src/smithy4s/interopcats/SchemaVisitorHash.scala
+++ b/modules/cats/src/smithy4s/interopcats/SchemaVisitorHash.scala
@@ -216,7 +216,7 @@ final class SchemaVisitorHash(
     }
   }
 
-  override def sparse[A](schema: Schema[A]): Hash[Option[A]] =
+  override def nullable[A](schema: Schema[A]): Hash[Option[A]] =
     cats.instances.option.catsKernelStdHashForOption(self(schema))
 
 }

--- a/modules/cats/src/smithy4s/interopcats/SchemaVisitorHash.scala
+++ b/modules/cats/src/smithy4s/interopcats/SchemaVisitorHash.scala
@@ -216,4 +216,7 @@ final class SchemaVisitorHash(
     }
   }
 
+  override def sparse[A](schema: Schema[A]): Hash[Option[A]] =
+    cats.instances.option.catsKernelStdHashForOption(self(schema))
+
 }

--- a/modules/cats/src/smithy4s/interopcats/SchemaVisitorShow.scala
+++ b/modules/cats/src/smithy4s/interopcats/SchemaVisitorShow.scala
@@ -172,7 +172,7 @@ final class SchemaVisitorShow(
   override def sparse[A](schema: Schema[A]): Show[Option[A]] = {
     val showA = self(schema)
     locally {
-      case None        => "null"
+      case None        => "N/A"
       case Some(value) => showA.show(value)
     }
   }

--- a/modules/cats/src/smithy4s/interopcats/SchemaVisitorShow.scala
+++ b/modules/cats/src/smithy4s/interopcats/SchemaVisitorShow.scala
@@ -169,7 +169,7 @@ final class SchemaVisitorShow(
     a => ss.value.show(a)
   }
 
-  override def sparse[A](schema: Schema[A]): Show[Option[A]] = {
+  override def nullable[A](schema: Schema[A]): Show[Option[A]] = {
     val showA = self(schema)
     locally {
       case None        => "N/A"

--- a/modules/cats/src/smithy4s/interopcats/SchemaVisitorShow.scala
+++ b/modules/cats/src/smithy4s/interopcats/SchemaVisitorShow.scala
@@ -169,4 +169,12 @@ final class SchemaVisitorShow(
     a => ss.value.show(a)
   }
 
+  override def sparse[A](schema: Schema[A]): Show[Option[A]] = {
+    val showA = self(schema)
+    locally {
+      case None        => "null"
+      case Some(value) => showA.show(value)
+    }
+  }
+
 }

--- a/modules/cats/src/smithy4s/interopcats/SchemaVisitorShow.scala
+++ b/modules/cats/src/smithy4s/interopcats/SchemaVisitorShow.scala
@@ -172,8 +172,8 @@ final class SchemaVisitorShow(
   override def nullable[A](schema: Schema[A]): Show[Option[A]] = {
     val showA = self(schema)
     locally {
-      case None        => "N/A"
-      case Some(value) => showA.show(value)
+      case None        => "None"
+      case Some(value) => s"Some(${showA.show(value)})"
     }
   }
 

--- a/modules/codegen/src/smithy4s/codegen/internals/CollisionAvoidance.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/CollisionAvoidance.scala
@@ -23,6 +23,7 @@ import Type.PrimitiveType
 import TypedNode._
 import Type.ExternalType
 import LineSegment._
+import smithy4s.codegen.internals.Type.Sparse
 
 private[internals] object CollisionAvoidance {
   def apply(compilationUnit: CompilationUnit): CompilationUnit = {
@@ -131,6 +132,7 @@ private[internals] object CollisionAvoidance {
         modType(under),
         modNativeHint(refinementHint)
       )
+    case Sparse(underlying) => Sparse(modType(underlying))
   }
 
   private def modField(field: Field): Field = {

--- a/modules/codegen/src/smithy4s/codegen/internals/CollisionAvoidance.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/CollisionAvoidance.scala
@@ -23,7 +23,7 @@ import Type.PrimitiveType
 import TypedNode._
 import Type.ExternalType
 import LineSegment._
-import smithy4s.codegen.internals.Type.Sparse
+import smithy4s.codegen.internals.Type.Nullable
 
 private[internals] object CollisionAvoidance {
   def apply(compilationUnit: CompilationUnit): CompilationUnit = {
@@ -132,7 +132,7 @@ private[internals] object CollisionAvoidance {
         modType(under),
         modNativeHint(refinementHint)
       )
-    case Sparse(underlying) => Sparse(modType(underlying))
+    case Nullable(underlying) => Nullable(modType(underlying))
   }
 
   private def modField(field: Field): Field = {

--- a/modules/codegen/src/smithy4s/codegen/internals/IR.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/IR.scala
@@ -226,6 +226,11 @@ private[internals] object Type {
       member: Type,
       memberHints: List[Hint]
   ) extends Type
+
+  case class Sparse(
+      underlying: Type
+  ) extends Type
+
   case class Map(
       key: Type,
       keyHints: List[Hint],

--- a/modules/codegen/src/smithy4s/codegen/internals/IR.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/IR.scala
@@ -227,7 +227,7 @@ private[internals] object Type {
       memberHints: List[Hint]
   ) extends Type
 
-  case class Sparse(
+  case class Nullable(
       underlying: Type
   ) extends Type
 

--- a/modules/codegen/src/smithy4s/codegen/internals/Renderer.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/Renderer.scala
@@ -34,6 +34,7 @@ import LineSyntax.LineInterpolator
 import ToLines.lineToLines
 import smithy4s.codegen.internals.EnumTag.IntEnum
 import smithy4s.codegen.internals.EnumTag.StringEnum
+import smithy4s.codegen.internals.Type.Sparse
 
 private[internals] object Renderer {
 
@@ -1066,6 +1067,7 @@ private[internals] class Renderer(compilationUnit: CompilationUnit) { self =>
         line"${underlyingTpe.schemaRef}.refined[${e: Type}](${renderNativeHint(hint)})${maybeProviderImport
           .map { providerImport => Import(providerImport).toLine }
           .getOrElse(Line.empty)}"
+      case Sparse(underlying) => line"${underlying.schemaRef}.sparse"
     }
 
     private def schemaRefP(primitive: Primitive): String = primitive match {

--- a/modules/codegen/src/smithy4s/codegen/internals/Renderer.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/Renderer.scala
@@ -34,7 +34,7 @@ import LineSyntax.LineInterpolator
 import ToLines.lineToLines
 import smithy4s.codegen.internals.EnumTag.IntEnum
 import smithy4s.codegen.internals.EnumTag.StringEnum
-import smithy4s.codegen.internals.Type.Sparse
+import smithy4s.codegen.internals.Type.Nullable
 
 private[internals] object Renderer {
 
@@ -1067,7 +1067,7 @@ private[internals] class Renderer(compilationUnit: CompilationUnit) { self =>
         line"${underlyingTpe.schemaRef}.refined[${e: Type}](${renderNativeHint(hint)})${maybeProviderImport
           .map { providerImport => Import(providerImport).toLine }
           .getOrElse(Line.empty)}"
-      case Sparse(underlying) => line"${underlying.schemaRef}.sparse"
+      case Nullable(underlying) => line"${underlying.schemaRef}.nullable"
     }
 
     private def schemaRefP(primitive: Primitive): String = primitive match {

--- a/modules/codegen/src/smithy4s/codegen/internals/SmithyToIR.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/SmithyToIR.scala
@@ -682,7 +682,9 @@ private[codegen] class SmithyToIR(model: Model, namespace: String) {
 
       def mapShape(x: MapShape): Option[Type] = (for {
         k <- x.getKey().accept(this)
-        v <- x.getValue().accept(this)
+        v <- x.getValue().accept(this).map { tpe =>
+          if (x.hasTrait(classOf[SparseTrait])) Type.Sparse(tpe) else tpe
+        }
       } yield Type.Map(k, hints(x.getKey()), v, hints(x.getValue()))).map {
         tpe =>
           val externalOrBase =

--- a/modules/codegen/src/smithy4s/codegen/internals/SmithyToIR.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/SmithyToIR.scala
@@ -639,7 +639,7 @@ private[codegen] class SmithyToIR(model: Model, namespace: String) {
           .accept(this)
           .map { tpe =>
             if (x.hasTrait(classOf[SparseTrait])) {
-              Type.Sparse(tpe)
+              Type.Nullable(tpe)
             } else tpe
           }
           .map { tpe =>
@@ -683,7 +683,7 @@ private[codegen] class SmithyToIR(model: Model, namespace: String) {
       def mapShape(x: MapShape): Option[Type] = (for {
         k <- x.getKey().accept(this)
         v <- x.getValue().accept(this).map { tpe =>
-          if (x.hasTrait(classOf[SparseTrait])) Type.Sparse(tpe) else tpe
+          if (x.hasTrait(classOf[SparseTrait])) Type.Nullable(tpe) else tpe
         }
       } yield Type.Map(k, hints(x.getKey()), v, hints(x.getValue()))).map {
         tpe =>

--- a/modules/codegen/src/smithy4s/codegen/internals/ToLine.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/ToLine.scala
@@ -70,6 +70,10 @@ private[internals] object ToLine {
       case Type.PrimitiveType(prim)  => primitiveLine(prim)
       case e: Type.ExternalType =>
         NameRef(e.fullyQualifiedName, e.typeParameters.map(typeToNameRef))
+      case Type.Sparse(underlying) =>
+        NameRef("scala", "Option").copy(typeParams =
+          List(typeToNameRef(underlying))
+        )
     }
   }
 

--- a/modules/codegen/src/smithy4s/codegen/internals/ToLine.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/ToLine.scala
@@ -70,7 +70,7 @@ private[internals] object ToLine {
       case Type.PrimitiveType(prim)  => primitiveLine(prim)
       case e: Type.ExternalType =>
         NameRef(e.fullyQualifiedName, e.typeParameters.map(typeToNameRef))
-      case Type.Sparse(underlying) =>
+      case Type.Nullable(underlying) =>
         NameRef("scala", "Option").copy(typeParams =
           List(typeToNameRef(underlying))
         )

--- a/modules/compliance-tests/src/smithy4s/compliancetests/internals/DefaultSchemaVisitor.scala
+++ b/modules/compliance-tests/src/smithy4s/compliancetests/internals/DefaultSchemaVisitor.scala
@@ -114,6 +114,6 @@ private[compliancetests] object DefaultSchemaVisitor extends SchemaVisitor[Id] {
     suspend.map(apply).value
   }
 
-  override def sparse[A](schema: Schema[A]): Id[Option[A]] = None
+  override def nullable[A](schema: Schema[A]): Id[Option[A]] = None
 
 }

--- a/modules/compliance-tests/src/smithy4s/compliancetests/internals/DefaultSchemaVisitor.scala
+++ b/modules/compliance-tests/src/smithy4s/compliancetests/internals/DefaultSchemaVisitor.scala
@@ -114,4 +114,6 @@ private[compliancetests] object DefaultSchemaVisitor extends SchemaVisitor[Id] {
     suspend.map(apply).value
   }
 
+  override def sparse[A](schema: Schema[A]): Id[Option[A]] = None
+
 }

--- a/modules/compliance-tests/src/smithy4s/compliancetests/internals/eq/EqSchemaVisitor.scala
+++ b/modules/compliance-tests/src/smithy4s/compliancetests/internals/eq/EqSchemaVisitor.scala
@@ -174,7 +174,7 @@ object EqSchemaVisitor extends SchemaVisitor[Eq] { self =>
     (x: A, y: A) => eq.value.eqv(x, y)
   }
 
-  override def sparse[A](schema: Schema[A]): Eq[Option[A]] = {
+  override def nullable[A](schema: Schema[A]): Eq[Option[A]] = {
     Eq.catsKernelEqForOption(self(schema))
   }
 

--- a/modules/compliance-tests/src/smithy4s/compliancetests/internals/eq/EqSchemaVisitor.scala
+++ b/modules/compliance-tests/src/smithy4s/compliancetests/internals/eq/EqSchemaVisitor.scala
@@ -174,6 +174,10 @@ object EqSchemaVisitor extends SchemaVisitor[Eq] { self =>
     (x: A, y: A) => eq.value.eqv(x, y)
   }
 
+  override def sparse[A](schema: Schema[A]): Eq[Option[A]] = {
+    Eq.catsKernelEqForOption(self(schema))
+  }
+
   def primitiveEq[P](primitive: Primitive[P]): Eq[P] = {
     primitive match {
       case Primitive.PShort      => Eq[Short]

--- a/modules/core/src/smithy4s/http/internals/HttpResponseCodeSchemaVisitor.scala
+++ b/modules/core/src/smithy4s/http/internals/HttpResponseCodeSchemaVisitor.scala
@@ -112,6 +112,7 @@ class HttpResponseCodeSchemaVisitor()
     }
     fields.flatMap(f => compileField(f)).headOption.getOrElse(NoResponseCode)
   }
+
 }
 
 object HttpResponseCodeSchemaVisitor {

--- a/modules/core/src/smithy4s/http/internals/SchemaVisitorMetadataReader.scala
+++ b/modules/core/src/smithy4s/http/internals/SchemaVisitorMetadataReader.scala
@@ -248,6 +248,6 @@ private[http] class SchemaVisitorMetadataReader(
   override def lazily[A](suspend: Lazy[Schema[A]]): MetaDecode[A] =
     EmptyMetaDecode
 
-  override def sparse[A](schema: Schema[A]): MetaDecode[Option[A]] =
+  override def nullable[A](schema: Schema[A]): MetaDecode[Option[A]] =
     EmptyMetaDecode
 }

--- a/modules/core/src/smithy4s/http/internals/SchemaVisitorMetadataReader.scala
+++ b/modules/core/src/smithy4s/http/internals/SchemaVisitorMetadataReader.scala
@@ -247,4 +247,7 @@ private[http] class SchemaVisitorMetadataReader(
 
   override def lazily[A](suspend: Lazy[Schema[A]]): MetaDecode[A] =
     EmptyMetaDecode
+
+  override def sparse[A](schema: Schema[A]): MetaDecode[Option[A]] =
+    EmptyMetaDecode
 }

--- a/modules/core/src/smithy4s/http/internals/SchemaVisitorMetadataWriter.scala
+++ b/modules/core/src/smithy4s/http/internals/SchemaVisitorMetadataWriter.scala
@@ -31,7 +31,6 @@ import smithy4s.schema.{
   SchemaField,
   SchemaVisitor
 }
-
 import smithy4s.schema.Alt
 import smithy4s.schema.CompilationCache
 
@@ -75,6 +74,9 @@ class SchemaVisitorMetadataWriter(
       case _ => MetaEncode.empty
     }
   }
+
+  override def sparse[A](schema: Schema[A]): MetaEncode[Option[A]] =
+    EmptyMetaEncode
 
   override def map[K, V](
       shapeId: ShapeId,

--- a/modules/core/src/smithy4s/http/internals/SchemaVisitorMetadataWriter.scala
+++ b/modules/core/src/smithy4s/http/internals/SchemaVisitorMetadataWriter.scala
@@ -75,7 +75,7 @@ class SchemaVisitorMetadataWriter(
     }
   }
 
-  override def sparse[A](schema: Schema[A]): MetaEncode[Option[A]] =
+  override def nullable[A](schema: Schema[A]): MetaEncode[Option[A]] =
     EmptyMetaEncode
 
   override def map[K, V](

--- a/modules/core/src/smithy4s/internals/DocumentDecoderSchemaVisitor.scala
+++ b/modules/core/src/smithy4s/internals/DocumentDecoderSchemaVisitor.scala
@@ -215,7 +215,7 @@ class DocumentDecoderSchemaVisitor(
     }
   }
 
-  def sparse[A](schema: Schema[A]): DocumentDecoder[Option[A]] =
+  def nullable[A](schema: Schema[A]): DocumentDecoder[Option[A]] =
     new DocumentDecoder[Option[A]] {
       val decoder = schema.compile(self)
       def expected = decoder.expected

--- a/modules/core/src/smithy4s/internals/DocumentDecoderSchemaVisitor.scala
+++ b/modules/core/src/smithy4s/internals/DocumentDecoderSchemaVisitor.scala
@@ -97,7 +97,7 @@ object DocumentDecoder {
 
 class DocumentDecoderSchemaVisitor(
     val cache: CompilationCache[DocumentDecoder]
-) extends SchemaVisitor.Cached[DocumentDecoder] {
+) extends SchemaVisitor.Cached[DocumentDecoder] { self =>
 
   override def primitive[P](
       shapeId: ShapeId,
@@ -205,7 +205,7 @@ class DocumentDecoderSchemaVisitor(
       tag: CollectionTag[C],
       member: Schema[A]
   ): DocumentDecoder[C[A]] = {
-    val fa = apply(member)
+    val fa = self(member)
     DocumentDecoder.instance(tag.name, "Array") { case (pp, DArray(value)) =>
       tag.fromIterator(value.iterator.zipWithIndex.map {
         case (document, index) =>
@@ -215,6 +215,18 @@ class DocumentDecoderSchemaVisitor(
     }
   }
 
+  def sparse[A](schema: Schema[A]): DocumentDecoder[Option[A]] =
+    new DocumentDecoder[Option[A]] {
+      val decoder = schema.compile(self)
+      def expected = decoder.expected
+
+      def apply(
+          history: List[smithy4s.PayloadPath.Segment],
+          document: smithy4s.Document
+      ): Option[A] = if (document == Document.DNull) None
+      else Some(decoder(history, document))
+    }
+
   override def map[K, V](
       shapeId: ShapeId,
       hints: Hints,
@@ -222,7 +234,7 @@ class DocumentDecoderSchemaVisitor(
       value: Schema[V]
   ): DocumentDecoder[Map[K, V]] = {
     val maybeKeyDecoder = DocumentKeyDecoder.trySchemaVisitor(key)
-    val valueDecoder = apply(value)
+    val valueDecoder = self(value)
     maybeKeyDecoder match {
       case Some(keyDecoder) =>
         DocumentDecoder.instance("Map", "Object") { case (pp, DObject(map)) =>

--- a/modules/core/src/smithy4s/internals/DocumentEncoderSchemaVisitor.scala
+++ b/modules/core/src/smithy4s/internals/DocumentEncoderSchemaVisitor.scala
@@ -119,7 +119,7 @@ class DocumentEncoderSchemaVisitor(
     from[C[A]](c => DArray(tag.iterator(c).map(encoderS.apply).toIndexedSeq))
   }
 
-  override def sparse[A](schema: Schema[A]): DocumentEncoder[Option[A]] = {
+  override def nullable[A](schema: Schema[A]): DocumentEncoder[Option[A]] = {
     val encoder = self(schema)
     locally {
       case Some(a) => encoder.apply(a)

--- a/modules/core/src/smithy4s/internals/DocumentEncoderSchemaVisitor.scala
+++ b/modules/core/src/smithy4s/internals/DocumentEncoderSchemaVisitor.scala
@@ -49,15 +49,15 @@ import alloy.Untagged
 
 trait DocumentEncoder[A] { self =>
 
-  def apply: A => Document
+  def apply(a: A): Document
   final def contramap[B](f: B => A): DocumentEncoder[B] =
     new DocumentEncoder[B] {
-      def apply: B => Document = f andThen self.apply
+      def apply(b: B): Document = self.apply(f(b))
     }
 
   final def mapDocument(f: Document => Document): DocumentEncoder[A] =
     new DocumentEncoder[A] {
-      def apply: A => Document = self.apply andThen f
+      def apply(a: A): Document = f(self(a))
     }
 
 }
@@ -69,7 +69,7 @@ object DocumentEncoder {
       def apply[A](fa: DocumentEncoder[A], a: A): Document = fa.apply(a)
       def absorb[A](f: A => Document): DocumentEncoder[A] =
         new DocumentEncoder[A] {
-          def apply: A => Document = f
+          def apply(a: A): Document = f(a)
         }
     }
 
@@ -94,15 +94,12 @@ class DocumentEncoderSchemaVisitor(
       from(bytes => DString(Base64.getEncoder().encodeToString(bytes.array)))
     case PUnit => from(_ => DObject(Map.empty))
     case PTimestamp =>
-      new DocumentEncoder[Timestamp] {
-        def apply: Timestamp => Document =
-          hints
-            .get(TimestampFormat)
-            .getOrElse(TimestampFormat.EPOCH_SECONDS) match {
-            case DATE_TIME     => ts => DString(ts.format(DATE_TIME))
-            case HTTP_DATE     => ts => DString(ts.format(HTTP_DATE))
-            case EPOCH_SECONDS => ts => DNumber(BigDecimal(ts.epochSecond))
-          }
+      hints
+        .get(TimestampFormat)
+        .getOrElse(TimestampFormat.EPOCH_SECONDS) match {
+        case DATE_TIME     => ts => DString(ts.format(DATE_TIME))
+        case HTTP_DATE     => ts => DString(ts.format(HTTP_DATE))
+        case EPOCH_SECONDS => ts => DNumber(BigDecimal(ts.epochSecond))
       }
     case PDocument => from(identity)
     case PFloat    => from(float => DNumber(BigDecimal(float.toDouble)))
@@ -118,8 +115,16 @@ class DocumentEncoderSchemaVisitor(
       tag: CollectionTag[C],
       member: Schema[A]
   ): DocumentEncoder[C[A]] = {
-    val encoderS = apply(member)
+    val encoderS = self(member)
     from[C[A]](c => DArray(tag.iterator(c).map(encoderS.apply).toIndexedSeq))
+  }
+
+  override def sparse[A](schema: Schema[A]): DocumentEncoder[Option[A]] = {
+    val encoder = self(schema)
+    locally {
+      case Some(a) => encoder.apply(a)
+      case None    => Document.DNull
+    }
   }
 
   override def map[K, V](
@@ -129,7 +134,7 @@ class DocumentEncoderSchemaVisitor(
       value: Schema[V]
   ): DocumentEncoder[Map[K, V]] = {
     val maybeKeyEncoder = DocumentKeyEncoder.trySchemaVisitor(key)
-    val valueEncoder = apply(value)
+    val valueEncoder = self(value)
     maybeKeyEncoder match {
       case Some(keyEncoder) =>
         from[Map[K, V]] { map =>
@@ -203,7 +208,7 @@ class DocumentEncoderSchemaVisitor(
 
     val encoders = fields.map(field => fieldEncoder(field))
     new DocumentEncoder[S] {
-      def apply: S => Document = { s =>
+      def apply(s: S): Document = {
         val builder = Map.newBuilder[String, Document]
         encoders.foreach(_(s, builder))
         DObject(builder.result() ++ discriminator)
@@ -251,12 +256,12 @@ class DocumentEncoderSchemaVisitor(
   override def lazily[A](suspend: Lazy[Schema[A]]): DocumentEncoder[A] = {
     lazy val underlying = apply(suspend.value)
     new DocumentEncoder[A] {
-      def apply: A => Document = underlying.apply
+      def apply(a: A): Document = underlying(a)
     }
   }
 
   def from[A](f: A => Document): DocumentEncoder[A] =
     new DocumentEncoder[A] {
-      def apply: A => Document = f
+      def apply(a: A): Document = f(a)
     }
 }

--- a/modules/core/src/smithy4s/internals/SchemaDescription.scala
+++ b/modules/core/src/smithy4s/internals/SchemaDescription.scala
@@ -17,16 +17,7 @@
 package smithy4s
 package internals
 
-import smithy4s.schema.{
-  EnumTag,
-  Primitive,
-  EnumValue,
-  SchemaField,
-  SchemaAlt,
-  Alt,
-  SchemaVisitor,
-  CollectionTag
-}
+import smithy4s.schema._
 import smithy4s.schema.Primitive.PTimestamp
 
 object SchemaDescription extends SchemaVisitor[SchemaDescription] {
@@ -60,6 +51,10 @@ object SchemaDescription extends SchemaVisitor[SchemaDescription] {
     SchemaDescription.of(apply(schema))
   override def refine[A, B](schema: Schema[A], refinement: Refinement[A,B]): SchemaDescription[B] =
     SchemaDescription.of(apply(schema))
+
+  override def sparse[A](schema: Schema[A]): SchemaDescription[Option[A]] =
+    SchemaDescription.of("Sparse")
+
   override def lazily[A](suspend: Lazy[Schema[A]]): SchemaDescription[A] =
     suspend.map(s => SchemaDescription.of(apply(s))).value
   // format: on

--- a/modules/core/src/smithy4s/internals/SchemaDescription.scala
+++ b/modules/core/src/smithy4s/internals/SchemaDescription.scala
@@ -52,8 +52,8 @@ object SchemaDescription extends SchemaVisitor[SchemaDescription] {
   override def refine[A, B](schema: Schema[A], refinement: Refinement[A,B]): SchemaDescription[B] =
     SchemaDescription.of(apply(schema))
 
-  override def sparse[A](schema: Schema[A]): SchemaDescription[Option[A]] =
-    SchemaDescription.of("Sparse")
+  override def nullable[A](schema: Schema[A]): SchemaDescription[Option[A]] =
+    SchemaDescription.of("Nullable")
 
   override def lazily[A](suspend: Lazy[Schema[A]]): SchemaDescription[A] =
     suspend.map(s => SchemaDescription.of(apply(s))).value

--- a/modules/core/src/smithy4s/internals/SchemaDescriptionDetailed.scala
+++ b/modules/core/src/smithy4s/internals/SchemaDescriptionDetailed.scala
@@ -17,17 +17,7 @@
 package smithy4s
 package internals
 
-import smithy4s.schema.{
-  Primitive,
-  EnumValue,
-  EnumTag,
-  SchemaField,
-  SchemaAlt,
-  Alt,
-  SchemaVisitor,
-  CollectionTag
-}
-
+import smithy4s.schema._
 private[internals] trait SchemaDescriptionDetailedImpl[A]
     extends (Set[ShapeId] => (Set[ShapeId], String)) {
   def mapResult[B](f: String => String): SchemaDescriptionDetailedImpl[B] = {
@@ -161,10 +151,16 @@ private[internals] object SchemaDescriptionDetailedImpl
     }
   }
 
+  override def sparse[A](
+      schema: Schema[A]
+  ): SchemaDescriptionDetailedImpl[Option[A]] =
+    apply(schema).mapResult { desc => s"Sparse[$desc]" }
+
   val conversion: SchemaDescriptionDetailedImpl ~> SchemaDescription =
     new (SchemaDescriptionDetailedImpl ~> SchemaDescription) {
       def apply[A](
           fa: SchemaDescriptionDetailedImpl[A]
       ): SchemaDescription[A] = fa(Set.empty)._2
     }
+
 }

--- a/modules/core/src/smithy4s/internals/SchemaDescriptionDetailed.scala
+++ b/modules/core/src/smithy4s/internals/SchemaDescriptionDetailed.scala
@@ -151,7 +151,7 @@ private[internals] object SchemaDescriptionDetailedImpl
     }
   }
 
-  override def sparse[A](
+  override def nullable[A](
       schema: Schema[A]
   ): SchemaDescriptionDetailedImpl[Option[A]] =
     apply(schema).mapResult { desc => s"Sparse[$desc]" }

--- a/modules/core/src/smithy4s/schema/CollectionTag.scala
+++ b/modules/core/src/smithy4s/schema/CollectionTag.scala
@@ -144,6 +144,7 @@ object CollectionTag {
     }
     def refine[A, B](schema: Schema[A], refinement: Refinement[A,B]): MaybeCT[B] = None
     def lazily[A](suspend: Lazy[Schema[A]]): MaybeCT[A] = None
+    def sparse[A](schema: Schema[A]) = Some(implicitly[ClassTag[Option[A]]])
   }
   // format: off
 }

--- a/modules/core/src/smithy4s/schema/CollectionTag.scala
+++ b/modules/core/src/smithy4s/schema/CollectionTag.scala
@@ -144,7 +144,7 @@ object CollectionTag {
     }
     def refine[A, B](schema: Schema[A], refinement: Refinement[A,B]): MaybeCT[B] = None
     def lazily[A](suspend: Lazy[Schema[A]]): MaybeCT[A] = None
-    def sparse[A](schema: Schema[A]) = Some(implicitly[ClassTag[Option[A]]])
+    def nullable[A](schema: Schema[A]) = Some(implicitly[ClassTag[Option[A]]])
   }
   // format: off
 }

--- a/modules/core/src/smithy4s/schema/DefaultValueSchemaVisitor.scala
+++ b/modules/core/src/smithy4s/schema/DefaultValueSchemaVisitor.scala
@@ -94,4 +94,6 @@ private[schema] object DefaultValueSchemaVisitor extends SchemaVisitor[Option] {
 
   def lazily[A](suspend: Lazy[Schema[A]]): Option[A] =
     suspend.map(_.compile(this)).value
+
+  def sparse[A](schema: Schema[A]): Option[Option[A]] = Some(None)
 }

--- a/modules/core/src/smithy4s/schema/DefaultValueSchemaVisitor.scala
+++ b/modules/core/src/smithy4s/schema/DefaultValueSchemaVisitor.scala
@@ -95,5 +95,5 @@ private[schema] object DefaultValueSchemaVisitor extends SchemaVisitor[Option] {
   def lazily[A](suspend: Lazy[Schema[A]]): Option[A] =
     suspend.map(_.compile(this)).value
 
-  def sparse[A](schema: Schema[A]): Option[Option[A]] = Some(None)
+  def nullable[A](schema: Schema[A]): Option[Option[A]] = Some(None)
 }

--- a/modules/core/src/smithy4s/schema/Field.scala
+++ b/modules/core/src/smithy4s/schema/Field.scala
@@ -17,8 +17,6 @@
 package smithy4s
 package schema
 
-import smithy4s.kinds.PolyFunction
-
 /**
   * Represents a member of product type (case class)
   */
@@ -36,7 +34,7 @@ sealed abstract class Field[F[_], S, A] {
     * Grabs the instance associated to this field, applying a polymorphic
     * function when the field is optional
     */
-  def instanceA(onOptional: Field.ToOptional[F]): F[A]
+  def instanceA(onOptional: ToOptional[F]): F[A]
 
   /**
     * Fold a field into a value independant of the type indexed by the field.
@@ -149,9 +147,6 @@ object Field {
   trait LeftFolder[F[_], B] {
     def compile[T](label: String, instance: F[T]): (B, T) => B
   }
-
-  type Wrapped[F[_], G[_], A] = F[G[A]]
-  type ToOptional[F[_]] = PolyFunction[F, Wrapped[F, Option, *]]
 
   // format: on
 

--- a/modules/core/src/smithy4s/schema/Field.scala
+++ b/modules/core/src/smithy4s/schema/Field.scala
@@ -17,6 +17,8 @@
 package smithy4s
 package schema
 
+import smithy4s.kinds.PolyFunction
+
 /**
   * Represents a member of product type (case class)
   */
@@ -34,7 +36,7 @@ sealed abstract class Field[F[_], S, A] {
     * Grabs the instance associated to this field, applying a polymorphic
     * function when the field is optional
     */
-  def instanceA(onOptional: ToOptional[F]): F[A]
+  def instanceA(onOptional: Field.ToOptional[F]): F[A]
 
   /**
     * Fold a field into a value independant of the type indexed by the field.
@@ -147,6 +149,9 @@ object Field {
   trait LeftFolder[F[_], B] {
     def compile[T](label: String, instance: F[T]): (B, T) => B
   }
+
+  type Wrapped[F[_], G[_], A] = F[G[A]]
+  type ToOptional[F[_]] = PolyFunction[F, Wrapped[F, Option, *]]
 
   // format: on
 

--- a/modules/core/src/smithy4s/schema/Schema.scala
+++ b/modules/core/src/smithy4s/schema/Schema.scala
@@ -83,6 +83,7 @@ sealed trait Schema[A]{
 
   final def biject[B](bijection: Bijection[A, B]) : Schema[B] = Schema.bijection(this, bijection)
   final def biject[B](to: A => B, from: B => A) : Schema[B] = Schema.bijection(this, to, from)
+  final def sparse: Schema[Option[A]] = Schema.sparse(this)
 
   final def getDefault: Option[Document] =
     this.hints.get(smithy.api.Default).map(_.value)

--- a/modules/core/src/smithy4s/schema/Schema.scala
+++ b/modules/core/src/smithy4s/schema/Schema.scala
@@ -43,6 +43,7 @@ sealed trait Schema[A]{
     case BijectionSchema(schema, bijection) => BijectionSchema(schema.withId(newId), bijection)
     case RefinementSchema(schema, refinement) => RefinementSchema(schema.withId(newId), refinement)
     case LazySchema(suspend) => LazySchema(suspend.map(_.withId(newId)))
+    case s: SparseSchema[a] => SparseSchema(s.underlying.withId(newId)).asInstanceOf[Schema[A]]
   }
 
   final def withId(namespace: String, name: String): Schema[A] = withId(ShapeId(namespace, name))
@@ -57,6 +58,7 @@ sealed trait Schema[A]{
     case BijectionSchema(schema, bijection) => BijectionSchema(schema.transformHintsLocally(f), bijection)
     case RefinementSchema(schema, refinement) => RefinementSchema(schema.transformHintsLocally(f), refinement)
     case LazySchema(suspend) => LazySchema(suspend.map(_.transformHintsLocally(f)))
+    case s: SparseSchema[a] => SparseSchema(s.underlying.transformHintsLocally(f)).asInstanceOf[Schema[A]]
   }
 
   final def transformHintsTransitively(f: Hints => Hints): Schema[A] = this match {
@@ -69,6 +71,7 @@ sealed trait Schema[A]{
     case BijectionSchema(schema, bijection) => BijectionSchema(schema.transformHintsTransitively(f), bijection)
     case RefinementSchema(schema, refinement) => RefinementSchema(schema.transformHintsTransitively(f), refinement)
     case LazySchema(suspend) => LazySchema(suspend.map(_.transformHintsTransitively(f)))
+    case s: SparseSchema[a] => SparseSchema(s.underlying.transformHintsTransitively(f)).asInstanceOf[Schema[A]]
   }
 
   final def validated[C](c: C)(implicit constraint: RefinementProvider.Simple[C, A]): Schema[A] = {
@@ -124,6 +127,10 @@ object Schema {
   final case class EnumerationSchema[E](shapeId: ShapeId, hints: Hints, tag: EnumTag, values: List[EnumValue[E]], total: E => EnumValue[E]) extends Schema[E]
   final case class StructSchema[S](shapeId: ShapeId, hints: Hints, fields: Vector[SchemaField[S, _]], make: IndexedSeq[Any] => S) extends Schema[S]
   final case class UnionSchema[U](shapeId: ShapeId, hints: Hints, alternatives: Vector[SchemaAlt[U, _]], dispatch: U => Alt.SchemaAndValue[U, _]) extends Schema[U]
+  final case class SparseSchema[A](underlying: Schema[A]) extends Schema[Option[A]]{
+    def hints: Hints = underlying.hints
+    def shapeId: ShapeId = underlying.shapeId
+  }
   final case class BijectionSchema[A, B](underlying: Schema[A], bijection: Bijection[A, B]) extends Schema[B]{
     def shapeId = underlying.shapeId
     def hints = underlying.hints
@@ -173,8 +180,16 @@ object Schema {
   def vector[A](a: Schema[A]): Schema[Vector[A]] = Schema.CollectionSchema[Vector, A](placeholder, Hints.empty, CollectionTag.VectorTag, a)
   def indexedSeq[A](a: Schema[A]): Schema[IndexedSeq[A]] = Schema.CollectionSchema[IndexedSeq, A](placeholder, Hints.empty, CollectionTag.IndexedSeqTag, a)
 
+  def sparseList[A](a: Schema[A]): Schema[List[Option[A]]] = list(sparse(a))
+  def sparseSet[A](a: Schema[A]): Schema[Set[Option[A]]] = set(sparse(a))
+  def sparseVector[A](a: Schema[A]): Schema[Vector[Option[A]]] = vector(sparse(a))
+  def sparseIndexedSeq[A](a: Schema[A]): Schema[IndexedSeq[Option[A]]] = indexedSeq(sparse(a))
+
   def map[K, V](k: Schema[K], v: Schema[V]): Schema[Map[K, V]] = Schema.MapSchema(placeholder, Hints.empty, k, v)
+  def sparseMap[K, V](k: Schema[K], v: Schema[V]): Schema[Map[K, Option[V]]] = Schema.MapSchema(placeholder, Hints.empty, k, sparse(v))
+
   def recursive[A](s: => Schema[A]): Schema[A] = Schema.LazySchema(Lazy(s))
+  def sparse[A](s: Schema[A]): Schema[Option[A]] = Schema.SparseSchema(s)
 
   def union[U](alts: SchemaAlt[U, _]*)(dispatch: U => Alt.SchemaAndValue[U, _]): Schema.UnionSchema[U] =
     Schema.UnionSchema(placeholder, Hints.empty, alts.toVector, dispatch)

--- a/modules/core/src/smithy4s/schema/SchemaVisitor.scala
+++ b/modules/core/src/smithy4s/schema/SchemaVisitor.scala
@@ -30,6 +30,7 @@ trait SchemaVisitor[F[_]] extends (Schema ~> F) { self =>
   def biject[A, B](schema: Schema[A], bijection: Bijection[A, B]): F[B]
   def refine[A, B](schema: Schema[A], refinement: Refinement[A, B]): F[B]
   def lazily[A](suspend: Lazy[Schema[A]]): F[A]
+  def sparse[A](schema: Schema[A]): F[Option[A]]
 
   def apply[A](schema: Schema[A]): F[A] = schema match {
     case PrimitiveSchema(shapeId, hints, tag) => primitive(shapeId, hints, tag)
@@ -38,6 +39,7 @@ trait SchemaVisitor[F[_]] extends (Schema ~> F) { self =>
     case EnumerationSchema(shapeId, hints, tag, values, total) => enumeration(shapeId, hints, tag, values, total)
     case StructSchema(shapeId, hints, fields, make) => struct(shapeId, hints, fields, make)
     case u@UnionSchema(shapeId, hints, alts, _) => union(shapeId, hints, alts, Alt.Dispatcher.fromUnion(u))
+    case SparseSchema(a) => sparse(a)
     case BijectionSchema(schema, bijection) => biject(schema, bijection)
     case RefinementSchema(schema, refinement) => refine(schema, refinement)
     case LazySchema(make) => lazily(make)
@@ -60,6 +62,7 @@ object SchemaVisitor {
     override def biject[A, B](schema: Schema[A], bijection: Bijection[A, B]): F[B] = default
     override def refine[A, B](schema: Schema[A], refinement: Refinement[A, B]): F[B] = default
     override def lazily[A](suspend: Lazy[Schema[A]]): F[A] = default
+    override def sparse[A](schema: Schema[A]): F[Option[A]] = default
   }
 
   abstract class Cached[F[_]] extends SchemaVisitor[F] {

--- a/modules/core/src/smithy4s/schema/SchemaVisitor.scala
+++ b/modules/core/src/smithy4s/schema/SchemaVisitor.scala
@@ -30,7 +30,7 @@ trait SchemaVisitor[F[_]] extends (Schema ~> F) { self =>
   def biject[A, B](schema: Schema[A], bijection: Bijection[A, B]): F[B]
   def refine[A, B](schema: Schema[A], refinement: Refinement[A, B]): F[B]
   def lazily[A](suspend: Lazy[Schema[A]]): F[A]
-  def sparse[A](schema: Schema[A]): F[Option[A]]
+  def nullable[A](schema: Schema[A]): F[Option[A]]
 
   def apply[A](schema: Schema[A]): F[A] = schema match {
     case PrimitiveSchema(shapeId, hints, tag) => primitive(shapeId, hints, tag)
@@ -39,10 +39,10 @@ trait SchemaVisitor[F[_]] extends (Schema ~> F) { self =>
     case EnumerationSchema(shapeId, hints, tag, values, total) => enumeration(shapeId, hints, tag, values, total)
     case StructSchema(shapeId, hints, fields, make) => struct(shapeId, hints, fields, make)
     case u@UnionSchema(shapeId, hints, alts, _) => union(shapeId, hints, alts, Alt.Dispatcher.fromUnion(u))
-    case SparseSchema(a) => sparse(a)
     case BijectionSchema(schema, bijection) => biject(schema, bijection)
     case RefinementSchema(schema, refinement) => refine(schema, refinement)
     case LazySchema(make) => lazily(make)
+    case NullableSchema(a) => nullable(a)
   }
 
 }
@@ -62,7 +62,7 @@ object SchemaVisitor {
     override def biject[A, B](schema: Schema[A], bijection: Bijection[A, B]): F[B] = default
     override def refine[A, B](schema: Schema[A], refinement: Refinement[A, B]): F[B] = default
     override def lazily[A](suspend: Lazy[Schema[A]]): F[A] = default
-    override def sparse[A](schema: Schema[A]): F[Option[A]] = default
+    override def nullable[A](schema: Schema[A]): F[Option[A]] = default
   }
 
   abstract class Cached[F[_]] extends SchemaVisitor[F] {

--- a/modules/core/src/smithy4s/schema/package.scala
+++ b/modules/core/src/smithy4s/schema/package.scala
@@ -16,14 +16,10 @@
 
 package smithy4s
 
-import smithy4s.kinds.PolyFunction
-
 package object schema {
 
   type SchemaField[S, A] = Field[Schema, S, A]
   type SchemaAlt[U, A] = Alt[Schema, U, A]
   type Repr[A] = String
-  type Wrapped[F[_], G[_], A] = F[G[A]]
-  type ToOptional[F[_]] = PolyFunction[F, Wrapped[F, Option, *]]
 
 }

--- a/modules/core/src/smithy4s/schema/package.scala
+++ b/modules/core/src/smithy4s/schema/package.scala
@@ -16,10 +16,14 @@
 
 package smithy4s
 
+import smithy4s.kinds.PolyFunction
+
 package object schema {
 
   type SchemaField[S, A] = Field[Schema, S, A]
   type SchemaAlt[U, A] = Alt[Schema, U, A]
   type Repr[A] = String
+  type Wrapped[F[_], G[_], A] = F[G[A]]
+  type ToOptional[F[_]] = PolyFunction[F, Wrapped[F, Option, *]]
 
 }

--- a/modules/core/test/src/smithy4s/CachedSchemaVisitorSpec.scala
+++ b/modules/core/test/src/smithy4s/CachedSchemaVisitorSpec.scala
@@ -125,7 +125,7 @@ class CachedSchemaVisitorSpec() extends FunSuite {
       }
     }
 
-    def sparse[A](schema: Schema[A]): ConstUnit[Option[A]] = discard {
+    def nullable[A](schema: Schema[A]): ConstUnit[Option[A]] = discard {
       self(schema)
       counter.incrementAndGet()
     }

--- a/modules/core/test/src/smithy4s/CachedSchemaVisitorSpec.scala
+++ b/modules/core/test/src/smithy4s/CachedSchemaVisitorSpec.scala
@@ -124,6 +124,11 @@ class CachedSchemaVisitorSpec() extends FunSuite {
         lazyTracker.remove(shapeId)
       }
     }
+
+    def sparse[A](schema: Schema[A]): ConstUnit[Option[A]] = discard {
+      self(schema)
+      counter.incrementAndGet()
+    }
   }
 
   def checkSchema[A](schema: Schema[A]): Unit = {

--- a/modules/core/test/src/smithy4s/schema/HintsTransformationSpec.scala
+++ b/modules/core/test/src/smithy4s/schema/HintsTransformationSpec.scala
@@ -136,6 +136,12 @@ class HintsTransformationSpec() extends FunSuite {
     checkSchema(Foo(Some(Foo(Some(Foo(None))))), 3)
   }
 
+  test(header("sparse")) {
+    implicit val schema: Schema[Option[Int]] = int.sparse
+    checkSchema(1.some, 1)
+    checkSchema(none[Int], expectedTransitive = 0, expectedLocal = 0)
+  }
+
   case class Mark()
   object Mark extends ShapeTag.Companion[Mark] {
     implicit val schema: Schema[Mark] =
@@ -148,7 +154,11 @@ class HintsTransformationSpec() extends FunSuite {
   //
   // It is important that we test against runtime values, to ensure that
   // the transformation works correctly with unions (which is the trickiest)
-  def checkSchema[A: Schema](value: A, expected: Int)(implicit
+  def checkSchema[A: Schema](
+      value: A,
+      expectedTransitive: Int,
+      expectedLocal: Int = 1
+  )(implicit
       loc: Location
   ): Unit = {
     val countLocal = implicitly[Schema[A]]
@@ -160,10 +170,10 @@ class HintsTransformationSpec() extends FunSuite {
       .compile(CountVisitor)
 
     val localMsg = "Unexpected count of marks after local transformation"
-    assertEquals(countLocal(value), 1, localMsg)
+    assertEquals(countLocal(value), expectedLocal, localMsg)
     val transitiveMsg =
       "Unexpected count of marks after transitive transformation"
-    assertEquals(countTransitive(value), expected, transitiveMsg)
+    assertEquals(countTransitive(value), expectedTransitive, transitiveMsg)
   }
 
   private def count(hints: Hints): Int = if (hints.has[Mark]) 1 else 0
@@ -259,6 +269,14 @@ class HintsTransformationSpec() extends FunSuite {
     def lazily[A](suspend: Lazy[Schema[A]]): Count[A] = {
       lazy val underlying = compile(suspend.value)
       a => underlying(a)
+    }
+
+    def sparse[A](schema: Schema[A]): Count[Option[A]] = {
+      val count = compile(schema)
+      locally {
+        case Some(a) => count(a)
+        case None    => 0
+      }
     }
 
   }

--- a/modules/core/test/src/smithy4s/schema/HintsTransformationSpec.scala
+++ b/modules/core/test/src/smithy4s/schema/HintsTransformationSpec.scala
@@ -271,7 +271,7 @@ class HintsTransformationSpec() extends FunSuite {
       a => underlying(a)
     }
 
-    def sparse[A](schema: Schema[A]): Count[Option[A]] = {
+    def nullable[A](schema: Schema[A]): Count[Option[A]] = {
       val count = compile(schema)
       locally {
         case Some(a) => count(a)

--- a/modules/core/test/src/smithy4s/schema/HintsTransformationSpec.scala
+++ b/modules/core/test/src/smithy4s/schema/HintsTransformationSpec.scala
@@ -136,8 +136,8 @@ class HintsTransformationSpec() extends FunSuite {
     checkSchema(Foo(Some(Foo(Some(Foo(None))))), 3)
   }
 
-  test(header("sparse")) {
-    implicit val schema: Schema[Option[Int]] = int.sparse
+  test(header("nullable")) {
+    implicit val schema: Schema[Option[Int]] = int.nullable
     checkSchema(1.some, 1)
     checkSchema(none[Int], expectedTransitive = 0, expectedLocal = 0)
   }

--- a/modules/decline/src/core/OptsVisitor.scala
+++ b/modules/decline/src/core/OptsVisitor.scala
@@ -243,7 +243,7 @@ object OptsVisitor extends SchemaVisitor[Opts] { self =>
 
       case _: StructSchema[_] | _: Schema.CollectionSchema[_, _] |
           _: Schema.UnionSchema[_] | _: Schema.LazySchema[_] |
-          _: Schema.MapSchema[_, _] =>
+          _: Schema.MapSchema[_, _] | _: Schema.NullableSchema[_] =>
         jsonFieldPlural(member.addHints(hints))
 
     }
@@ -343,4 +343,7 @@ object OptsVisitor extends SchemaVisitor[Opts] { self =>
       .mapValidated(a =>
         Validated.fromEither(refinement(a).leftMap(NonEmptyList.one))
       )
+
+  override def nullable[A](schema: Schema[A]): Opts[Option[A]] =
+    schema.compile(this).orNone
 }

--- a/modules/dynamic/src/smithy4s/dynamic/internals/DynamicModelCompiler.scala
+++ b/modules/dynamic/src/smithy4s/dynamic/internals/DynamicModelCompiler.scala
@@ -349,7 +349,11 @@ private[dynamic] object Compiler {
         for {
           k <- schema(shape.key.target)
           v <- schema(shape.value.target)
-        } yield map(k, v)
+        } yield {
+          if (shape.traits.contains(IdRef("smithy.api#sparse"))) {
+            sparseMap(k, v).asInstanceOf[Schema[Map[Any, Any]]]
+          } else map(k, v)
+        }
       )
 
     override def operationShape(id: ShapeId, x: OperationShape): Unit = {}

--- a/modules/dynamic/src/smithy4s/dynamic/internals/DynamicModelCompiler.scala
+++ b/modules/dynamic/src/smithy4s/dynamic/internals/DynamicModelCompiler.scala
@@ -331,8 +331,13 @@ private[dynamic] object Compiler {
       }
     }
 
-    override def listShape(id: ShapeId, shape: ListShape): Unit =
-      update(id, shape.traits, schema(shape.member.target).map(s => list(s)))
+    override def listShape(id: ShapeId, shape: ListShape): Unit = {
+      if (shape.traits.contains(IdRef("smithy.api#sparse"))) {
+        update(id, shape.traits, schema(shape.member.target).map(sparseList))
+      } else {
+        update(id, shape.traits, schema(shape.member.target).map(list))
+      }
+    }
 
     override def setShape(id: ShapeId, shape: SetShape): Unit =
       update(id, shape.traits, schema(shape.member.target).map(s => set(s)))

--- a/modules/dynamic/test/src-jvm/smithy4s/dynamic/DynamicStabilitySpec.scala
+++ b/modules/dynamic/test/src-jvm/smithy4s/dynamic/DynamicStabilitySpec.scala
@@ -228,6 +228,10 @@ class DynamicStabilitySpec extends FunSuite {
         self(underlying)
       }
     }
+
+    def nullable[A](schema: Schema[A]): ConstUnit[Option[A]] = {
+      self(schema)
+    }
   }
 
 }

--- a/modules/example/src/smithy4s/example/SparseStringList.scala
+++ b/modules/example/src/smithy4s/example/SparseStringList.scala
@@ -8,11 +8,11 @@ import smithy4s.schema.Schema.bijection
 import smithy4s.schema.Schema.list
 import smithy4s.schema.Schema.string
 
-object SparseStrings extends Newtype[List[Option[String]]] {
-  val id: ShapeId = ShapeId("smithy4s.example", "SparseStrings")
+object SparseStringList extends Newtype[List[Option[String]]] {
+  val id: ShapeId = ShapeId("smithy4s.example", "SparseStringList")
   val hints: Hints = Hints(
     smithy.api.Sparse(),
   )
   val underlyingSchema: Schema[List[Option[String]]] = list(string.sparse).withId(id).addHints(hints)
-  implicit val schema: Schema[SparseStrings] = bijection(underlyingSchema, asBijection)
+  implicit val schema: Schema[SparseStringList] = bijection(underlyingSchema, asBijection)
 }

--- a/modules/example/src/smithy4s/example/SparseStringList.scala
+++ b/modules/example/src/smithy4s/example/SparseStringList.scala
@@ -13,6 +13,6 @@ object SparseStringList extends Newtype[List[Option[String]]] {
   val hints: Hints = Hints(
     smithy.api.Sparse(),
   )
-  val underlyingSchema: Schema[List[Option[String]]] = list(string.sparse).withId(id).addHints(hints)
+  val underlyingSchema: Schema[List[Option[String]]] = list(string.nullable).withId(id).addHints(hints)
   implicit val schema: Schema[SparseStringList] = bijection(underlyingSchema, asBijection)
 }

--- a/modules/example/src/smithy4s/example/SparseStringMap.scala
+++ b/modules/example/src/smithy4s/example/SparseStringMap.scala
@@ -1,0 +1,18 @@
+package smithy4s.example
+
+import smithy4s.Hints
+import smithy4s.Newtype
+import smithy4s.Schema
+import smithy4s.ShapeId
+import smithy4s.schema.Schema.bijection
+import smithy4s.schema.Schema.map
+import smithy4s.schema.Schema.string
+
+object SparseStringMap extends Newtype[Map[String, Option[String]]] {
+  val id: ShapeId = ShapeId("smithy4s.example", "SparseStringMap")
+  val hints: Hints = Hints(
+    smithy.api.Sparse(),
+  )
+  val underlyingSchema: Schema[Map[String, Option[String]]] = map(string, string.sparse).withId(id).addHints(hints)
+  implicit val schema: Schema[SparseStringMap] = bijection(underlyingSchema, asBijection)
+}

--- a/modules/example/src/smithy4s/example/SparseStringMap.scala
+++ b/modules/example/src/smithy4s/example/SparseStringMap.scala
@@ -13,6 +13,6 @@ object SparseStringMap extends Newtype[Map[String, Option[String]]] {
   val hints: Hints = Hints(
     smithy.api.Sparse(),
   )
-  val underlyingSchema: Schema[Map[String, Option[String]]] = map(string, string.sparse).withId(id).addHints(hints)
+  val underlyingSchema: Schema[Map[String, Option[String]]] = map(string, string.nullable).withId(id).addHints(hints)
   implicit val schema: Schema[SparseStringMap] = bijection(underlyingSchema, asBijection)
 }

--- a/modules/example/src/smithy4s/example/SparseStrings.scala
+++ b/modules/example/src/smithy4s/example/SparseStrings.scala
@@ -1,0 +1,18 @@
+package smithy4s.example
+
+import smithy4s.Hints
+import smithy4s.Newtype
+import smithy4s.Schema
+import smithy4s.ShapeId
+import smithy4s.schema.Schema.bijection
+import smithy4s.schema.Schema.list
+import smithy4s.schema.Schema.string
+
+object SparseStrings extends Newtype[List[Option[String]]] {
+  val id: ShapeId = ShapeId("smithy4s.example", "SparseStrings")
+  val hints: Hints = Hints(
+    smithy.api.Sparse(),
+  )
+  val underlyingSchema: Schema[List[Option[String]]] = list(string.sparse).withId(id).addHints(hints)
+  implicit val schema: Schema[SparseStrings] = bijection(underlyingSchema, asBijection)
+}

--- a/modules/example/src/smithy4s/example/package.scala
+++ b/modules/example/src/smithy4s/example/package.scala
@@ -31,6 +31,7 @@ package object example {
   type UnwrappedFancyList = smithy4s.example.UnwrappedFancyList.Type
   type TestStructurePattern = smithy4s.example.TestStructurePattern.Type
   type ArbitraryData = smithy4s.example.ArbitraryData.Type
+  type SparseStrings = smithy4s.example.SparseStrings.Type
   type DogName = smithy4s.example.DogName.Type
   type SomeVector = smithy4s.example.SomeVector.Type
   type PersonPhoneNumber = smithy4s.example.PersonPhoneNumber.Type

--- a/modules/example/src/smithy4s/example/package.scala
+++ b/modules/example/src/smithy4s/example/package.scala
@@ -29,9 +29,9 @@ package object example {
   type ObjectKey = smithy4s.example.ObjectKey.Type
   type OrderNumber = smithy4s.example.OrderNumber.Type
   type UnwrappedFancyList = smithy4s.example.UnwrappedFancyList.Type
+  type SparseStringList = smithy4s.example.SparseStringList.Type
   type TestStructurePattern = smithy4s.example.TestStructurePattern.Type
   type ArbitraryData = smithy4s.example.ArbitraryData.Type
-  type SparseStrings = smithy4s.example.SparseStrings.Type
   type DogName = smithy4s.example.DogName.Type
   type SomeVector = smithy4s.example.SomeVector.Type
   type PersonPhoneNumber = smithy4s.example.PersonPhoneNumber.Type
@@ -39,6 +39,7 @@ package object example {
   type DefaultStringMap = smithy4s.example.DefaultStringMap.Type
   @deprecated(message = "N/A", since = "N/A")
   type Strings = smithy4s.example.Strings.Type
+  type SparseStringMap = smithy4s.example.SparseStringMap.Type
   type PersonAge = smithy4s.example.PersonAge.Type
   @deprecated(message = "N/A", since = "N/A")
   type DeprecatedString = smithy4s.example.DeprecatedString.Type

--- a/modules/http4s/test/src-jvm/smithy4s/http4s/Http4sEmberPizzaClientSpec.scala
+++ b/modules/http4s/test/src-jvm/smithy4s/http4s/Http4sEmberPizzaClientSpec.scala
@@ -71,7 +71,7 @@ object Http4sEmberPizzaClientSpec extends IOSuite {
       }
 
   test("empty body") { client =>
-    (client.book("name") *> client.book("name2")).as(success)
+    (client.reservation("name") *> client.reservation("name2")).as(success)
   }
 
   private val dummyImpl: PizzaAdminService[IO] =
@@ -79,7 +79,7 @@ object Http4sEmberPizzaClientSpec extends IOSuite {
     // format: off
     override def health(query: Option[String]): IO[HealthResponse] = IO.pure(HealthResponse("good"))
     override def roundTrip(label: String, header: Option[String], query: Option[String], body: Option[String]): IO[RoundTripData] = IO.stub
-    override def book(name: String, town: Option[String]): IO[BookOutput] = IO.pure(BookOutput("name"))
+    override def reservation(name: String, town: Option[String]): IO[ReservationOutput] = IO.pure(ReservationOutput("name"))
     // format: on
     }
 

--- a/modules/json/src/smithy4s/http/json/SchemaVisitorJCodec.scala
+++ b/modules/json/src/smithy4s/http/json/SchemaVisitorJCodec.scala
@@ -1080,7 +1080,7 @@ private[smithy4s] class SchemaVisitorJCodec(
       out.writeKey(total(x).intValue)
   }
 
-  override def sparse[A](schema: Schema[A]): JCodec[Option[A]] =
+  override def nullable[A](schema: Schema[A]): JCodec[Option[A]] =
     new JCodec[Option[A]] {
       val underlying: JCodec[A] = self(schema)
       def expecting: String = s"JsNull or ${underlying.expecting}"

--- a/modules/json/src/smithy4s/http/json/SchemaVisitorJCodec.scala
+++ b/modules/json/src/smithy4s/http/json/SchemaVisitorJCodec.scala
@@ -1080,6 +1080,26 @@ private[smithy4s] class SchemaVisitorJCodec(
       out.writeKey(total(x).intValue)
   }
 
+  override def sparse[A](schema: Schema[A]): JCodec[Option[A]] =
+    new JCodec[Option[A]] {
+      val underlying: JCodec[A] = self(schema)
+      def expecting: String = s"JsNull or ${underlying.expecting}"
+      def decodeKey(in: JsonReader): Option[A] = ???
+      def encodeKey(x: Option[A], out: JsonWriter): Unit = ???
+      def encodeValue(x: Option[A], out: JsonWriter): Unit = x match {
+        case None        => out.writeNull()
+        case Some(value) => underlying.encodeValue(value, out)
+      }
+
+      def decodeValue(cursor: Cursor, in: JsonReader): Option[A] =
+        if (in.isNextToken('n'))
+          in.readNullOrError[Option[A]](None, "Expected null")
+        else {
+          in.rollbackToken()
+          Some(underlying.decodeValue(cursor, in))
+        }
+    }
+
   private def jsonLabel[A, Z](field: Field[Schema, Z, A]): String =
     field.hints.get(JsonName) match {
       case None    => field.label

--- a/modules/scalacheck/src/smithy4s/scalacheck/SchemaVisitorGen.scala
+++ b/modules/scalacheck/src/smithy4s/scalacheck/SchemaVisitorGen.scala
@@ -124,6 +124,8 @@ abstract class SchemaVisitorGen extends SchemaVisitor[Gen] { self =>
   def lazily[A](suspend: Lazy[Schema[A]]): Gen[A] =
     Gen.lzy(suspend.map(_.compile(this)).value)
 
+  def nullable[A](schema: Schema[A]): Gen[Option[A]] = Gen.option(this(schema))
+
   // //////////////////////////////////////////////////////////////////////////////////////
   // // HELPER FUNCTIONS
   // //////////////////////////////////////////////////////////////////////////////////////

--- a/modules/test-utils/src/smithy4s/tests/DefaultSchemaVisitor.scala
+++ b/modules/test-utils/src/smithy4s/tests/DefaultSchemaVisitor.scala
@@ -130,4 +130,5 @@ object DefaultSchemaVisitor extends SchemaVisitor[Id] {
 
   override def lazily[A](suspend: Lazy[Schema[A]]): Id[A] = ???
 
+  override def sparse[A](schema: Schema[A]): Id[Option[A]] = None
 }

--- a/modules/test-utils/src/smithy4s/tests/DefaultSchemaVisitor.scala
+++ b/modules/test-utils/src/smithy4s/tests/DefaultSchemaVisitor.scala
@@ -130,5 +130,5 @@ object DefaultSchemaVisitor extends SchemaVisitor[Id] {
 
   override def lazily[A](suspend: Lazy[Schema[A]]): Id[A] = ???
 
-  override def sparse[A](schema: Schema[A]): Id[Option[A]] = None
+  override def nullable[A](schema: Schema[A]): Id[Option[A]] = None
 }

--- a/modules/tests/src/smithy4s/tests/PizzaAdminServiceImpl.scala
+++ b/modules/tests/src/smithy4s/tests/PizzaAdminServiceImpl.scala
@@ -36,8 +36,8 @@ object PizzaAdminServiceImpl {
 
 class PizzaAdminServiceImpl(ref: Ref[IO, State]) extends PizzaAdminService[IO] {
 
-  def book(name: String, town: Option[String]): IO[BookOutput] =
-    IO.pure(BookOutput(message = s"Booked for $name"))
+  def reservation(name: String, town: Option[String]): IO[ReservationOutput] =
+    IO.pure(ReservationOutput(message = s"Booked for $name"))
 
   def getEnum(theEnum: TheEnum): IO[GetEnumOutput] =
     IO.pure(GetEnumOutput(result = Some(theEnum.value)))

--- a/modules/xml/src/smithy4s/xml/internals/XmlDecoderSchemaVisitor.scala
+++ b/modules/xml/src/smithy4s/xml/internals/XmlDecoderSchemaVisitor.scala
@@ -197,6 +197,15 @@ private[smithy4s] abstract class XmlDecoderSchemaVisitor
     }
   }
 
+  def sparse[A](schema: Schema[A]): XmlDecoder[Option[A]] =
+    new XmlDecoder[Option[A]] {
+      val decoder = compile(schema)
+      def decode(cursor: XmlCursor): Either[XmlDecodeError, Option[A]] =
+        // not taking sparse into account for xml : we're just attempting to decode
+        // the value, mapping to Some in case of success.
+        decoder.decode(cursor).map(Some(_))
+    }
+
   private def getXmlName(hints: Hints, default: String): XmlDocument.XmlQName =
     hints
       .get(XmlName)

--- a/modules/xml/src/smithy4s/xml/internals/XmlDecoderSchemaVisitor.scala
+++ b/modules/xml/src/smithy4s/xml/internals/XmlDecoderSchemaVisitor.scala
@@ -197,7 +197,7 @@ private[smithy4s] abstract class XmlDecoderSchemaVisitor
     }
   }
 
-  def sparse[A](schema: Schema[A]): XmlDecoder[Option[A]] =
+  def nullable[A](schema: Schema[A]): XmlDecoder[Option[A]] =
     new XmlDecoder[Option[A]] {
       val decoder = compile(schema)
       def decode(cursor: XmlCursor): Either[XmlDecodeError, Option[A]] =

--- a/modules/xml/src/smithy4s/xml/internals/XmlEncoderSchemaVisitor.scala
+++ b/modules/xml/src/smithy4s/xml/internals/XmlEncoderSchemaVisitor.scala
@@ -179,6 +179,15 @@ private[smithy4s] abstract class XmlEncoderSchemaVisitor
     def encode(value: A): List[XmlContent] = underlying.encode(value)
   }
 
+  def sparse[A](schema: Schema[A]): XmlEncoder[Option[A]] =
+    new XmlEncoder[Option[A]] {
+      val encoder = compile(schema)
+      def encode(value: Option[A]): List[XmlContent] = value match {
+        case None        => List.empty
+        case Some(value) => encoder.encode(value)
+      }
+    }
+
   private def getXmlName(hints: Hints, default: String): XmlDocument.XmlQName =
     hints
       .get(XmlName)

--- a/modules/xml/src/smithy4s/xml/internals/XmlEncoderSchemaVisitor.scala
+++ b/modules/xml/src/smithy4s/xml/internals/XmlEncoderSchemaVisitor.scala
@@ -179,7 +179,7 @@ private[smithy4s] abstract class XmlEncoderSchemaVisitor
     def encode(value: A): List[XmlContent] = underlying.encode(value)
   }
 
-  def sparse[A](schema: Schema[A]): XmlEncoder[Option[A]] =
+  def nullable[A](schema: Schema[A]): XmlEncoder[Option[A]] =
     new XmlEncoder[Option[A]] {
       val encoder = compile(schema)
       def encode(value: Option[A]): List[XmlContent] = value match {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -29,7 +29,7 @@ object Dependencies {
 
   val Alloy = new {
     val org = "com.disneystreaming.alloy"
-    val alloyVersion = "dev-SNAPSHOT"
+    val alloyVersion = "0.1.22"
     val core = org % "alloy-core" % alloyVersion
     val openapi = org %% "alloy-openapi" % alloyVersion
     val `protocol-tests` = org % "alloy-protocol-tests" % alloyVersion

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -29,7 +29,7 @@ object Dependencies {
 
   val Alloy = new {
     val org = "com.disneystreaming.alloy"
-    val alloyVersion = "0.1.20"
+    val alloyVersion = "dev-SNAPSHOT"
     val core = org % "alloy-core" % alloyVersion
     val openapi = org %% "alloy-openapi" % alloyVersion
     val `protocol-tests` = org % "alloy-protocol-tests" % alloyVersion

--- a/sampleSpecs/misc.smithy
+++ b/sampleSpecs/misc.smithy
@@ -112,4 +112,3 @@ structure RangeCheck {
 // face with sunglasses emoji
 @pattern("^\\uD83D\\uDE0E$")
 string UnicodeRegexString
-

--- a/sampleSpecs/pizza.smithy
+++ b/sampleSpecs/pizza.smithy
@@ -7,7 +7,7 @@ use alloy#simpleRestJson
 @simpleRestJson
 service PizzaAdminService {
   version: "1.0.0",
-  operations: [AddMenuItem, GetMenu, Version, Health, HeaderEndpoint, RoundTrip, GetEnum, GetIntEnum, CustomCode, Book, Echo]
+  operations: [AddMenuItem, GetMenu, Version, Health, HeaderEndpoint, RoundTrip, GetEnum, GetIntEnum, CustomCode, Reservation, Echo]
 }
 
 @http(method: "POST", uri: "/restaurant/{restaurant}/menu/item", code: 201)
@@ -297,7 +297,7 @@ structure CustomCodeOutput {
 }
 
 @http(method: "POST", uri: "/book/{name}", code: 200)
-operation Book {
+operation Reservation {
   input := {
     @httpLabel
     @required

--- a/sampleSpecs/sparse.smithy
+++ b/sampleSpecs/sparse.smithy
@@ -1,0 +1,6 @@
+namespace smithy4s.example
+
+@sparse
+list SparseStrings {
+    member: String
+}

--- a/sampleSpecs/sparse.smithy
+++ b/sampleSpecs/sparse.smithy
@@ -1,6 +1,12 @@
 namespace smithy4s.example
 
 @sparse
-list SparseStrings {
+list SparseStringList {
     member: String
+}
+
+@sparse
+map SparseStringMap {
+    key: String
+    value: String
 }


### PR DESCRIPTION
Closes https://github.com/disneystreaming/smithy4s/issues/990

This adds support for sparse collections by : 

1. modifying the `Schema` GADT to have a new concept, `sparse` that turns a `Schema[A]` into a `Schema[Option[A]]`. I may rename it, but this concept is somewhat orthogonal to the notion of optional field, and didn't want to name it in such a way that would mislead implementors of `SchemaVisitor`. I reached the conclusion that a new member needed to be added after experimenting with changing the Collection and Map members of the `Schema` GADT, which was making the implementation of Visitors more confusing than with this current version. 
2. Render sparse collections to make use of `SparseSchema` to wrap their members. 
3. Compile sparse collections to the correct schema in the dynamic module. 

This PR needs to be accompanied with a change to Alloy to tweak the list of tests, as new tests that were failing are now passing. 