### PR TITLE
[Json] Handle empty body

### DIFF
--- a/modules/json/src/smithy4s/http/json/JsonCodecAPI.scala
+++ b/modules/json/src/smithy4s/http/json/JsonCodecAPI.scala
@@ -26,18 +26,18 @@ import smithy4s.schema.SchemaVisitor
 import smithy4s.schema.CompilationCache
 
 abstract class JsonCodecAPI(
-                             makeVisitor: CompilationCache[JCodec] => SchemaVisitor[JCodec],
-                             hintMask: Option[HintMask],
-                             readerConfig: ReaderConfig = JsonCodecAPI.defaultReaderConfig,
-                             writerConfig: WriterConfig = WriterConfig
-                           ) extends CodecAPI {
+    makeVisitor: CompilationCache[JCodec] => SchemaVisitor[JCodec],
+    hintMask: Option[HintMask],
+    readerConfig: ReaderConfig = JsonCodecAPI.defaultReaderConfig,
+    writerConfig: WriterConfig = WriterConfig
+) extends CodecAPI {
 
   def this(
-            schemaVisitorJCodec: SchemaVisitor[JCodec],
-            hintMask: Option[HintMask],
-            readerConfig: ReaderConfig,
-            writerConfig: WriterConfig
-          ) = this(_ => schemaVisitorJCodec, hintMask, readerConfig, writerConfig)
+      schemaVisitorJCodec: SchemaVisitor[JCodec],
+      hintMask: Option[HintMask],
+      readerConfig: ReaderConfig,
+      writerConfig: WriterConfig
+  ) = this(_ => schemaVisitorJCodec, hintMask, readerConfig, writerConfig)
 
   type Cache = CompilationCache[JCodec]
   type Codec[A] = JCodec[A]
@@ -56,9 +56,9 @@ abstract class JsonCodecAPI(
     HttpMediaType("application/json")
 
   override def decodeFromByteArrayPartial[A](
-                                              codec: Codec[A],
-                                              bytes: Array[Byte]
-                                            ): Either[PayloadError, BodyPartial[A]] = {
+      codec: Codec[A],
+      bytes: Array[Byte]
+  ): Either[PayloadError, BodyPartial[A]] = {
     val nonEmpty = if (bytes.isEmpty) "{}".getBytes else bytes
     try {
       Right {
@@ -73,10 +73,11 @@ abstract class JsonCodecAPI(
   }
 
   override def decodeFromByteBufferPartial[A](
-                                               codec: Codec[A],
-                                               bytes: ByteBuffer
-                                             ): Either[PayloadError, BodyPartial[A]] = {
-    val nonEmpty = if(bytes.remaining() == 0) bytes.put("{}".getBytes) else bytes
+      codec: Codec[A],
+      bytes: ByteBuffer
+  ): Either[PayloadError, BodyPartial[A]] = {
+    val nonEmpty =
+      if (bytes.remaining() == 0) bytes.put("{}".getBytes) else bytes
     try {
       Right {
         BodyPartial(

--- a/modules/json/test/src/smithy4s/http/json/JsonCodecApiTests.scala
+++ b/modules/json/test/src/smithy4s/http/json/JsonCodecApiTests.scala
@@ -61,4 +61,37 @@ class JsonCodecApiTests extends FunSuite {
 
     assert(decoded.isLeft)
   }
+
+  test("passing empty string to codec should not fail decoding") {
+    case class A(a: Option[String])
+    val schemaWithOptionalField =
+      Schema
+        .struct[A]
+        .apply(
+          Schema.string
+            .optional[A]("a", _.a)
+        )(A.apply(_))
+    val capi = codecs(HintMask.empty)
+    val codec = capi.compileCodec(schemaWithOptionalField)
+    val decoded = capi.decodeFromByteArray(codec, "".getBytes())
+    assert(decoded.isRight)
+  }
+
+  test("if all fields are empty , an empty json object should be written") {
+    case class A(a: Option[String], b: Option[String])
+    val schemaWithOptionalField =
+      Schema
+        .struct[A]
+        .apply(
+          Schema.string
+            .optional[A]("a", _.a),
+          Schema.string
+            .optional[A]("b", _.b)
+        )(A.apply(_, _))
+    val capi = codecs(HintMask.empty)
+    val codec = capi.compileCodec(schemaWithOptionalField)
+    val encoded = capi.writeToArray(codec, A(None, None))
+    assertEquals(new String(encoded), "{}")
+  }
+
 }


### PR DESCRIPTION
JsonCodecApi defaults to empty json object when decoding when the http body is empty
closes #973 