### PR TITLE
misc: update endpoint-middleware.md

### DIFF
--- a/modules/docs/markdown/06-guides/endpoint-middleware.md
+++ b/modules/docs/markdown/06-guides/endpoint-middleware.md
@@ -253,7 +253,7 @@ object Middleware {
   private def middleware(bearerToken: String): Client[IO] => Client[IO] = { // 1
     inputClient =>
       Client[IO] { request =>
-        val newRequest = request.withHeaders( // 2
+        val newRequest = request.putHeaders( // 2
           Authorization(Credentials.Token(AuthScheme.Bearer, bearerToken))
         )
 


### PR DESCRIPTION
use `putHeaders` in example because `withHeaders` replaces whole headers