### PR TITLE
ECS provider fix

### DIFF
--- a/modules/aws-http4s/src/smithy4s/aws/AwsCredentialsProvider.scala
+++ b/modules/aws-http4s/src/smithy4s/aws/AwsCredentialsProvider.scala
@@ -31,6 +31,7 @@ import scala.concurrent.duration._
 import org.http4s.EntityDecoder
 import org.http4s.client.Client
 import org.http4s.syntax.all._
+import org.http4s.Uri
 
 object AwsCredentialsProvider {
 
@@ -111,6 +112,9 @@ class AwsCredentialsProvider[F[_]](implicit F: Temporal[F]) {
   val AWS_EC2_METADATA_URI =
     uri"http://169.254.169.254/latest/meta-data/iam/security-credentials/"
 
+  val AWS_ECS_METADATA_BASE_URI =
+    uri"http://169.254.170.2"
+
   def fromEC2(httpClient: Client[F]): F[AwsTemporaryCredentials] =
     for {
       roleName <- httpClient.expect[String](AWS_EC2_METADATA_URI)
@@ -120,7 +124,12 @@ class AwsCredentialsProvider[F[_]](implicit F: Temporal[F]) {
     } yield metadataRes
 
   def fromECS(httpClient: Client[F]): F[AwsTemporaryCredentials] =
-    httpClient.expect[AwsInstanceMetadata](AWS_EC2_METADATA_URI).widen
+    for {
+      path <- SysEnv.envValue(AWS_CONTAINER_CREDENTIALS_RELATIVE_URI).liftTo[F]
+      metadataRes <- httpClient.expect[AwsInstanceMetadata](
+        AWS_ECS_METADATA_BASE_URI.withPath(Uri.Path.unsafeFromString(path))
+      )
+    } yield metadataRes
 
   def refreshing(
       get: F[AwsTemporaryCredentials]


### PR DESCRIPTION
In ECS, to obtain credentials the following has to be used:

https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html

Applying the fix on the `0.18`, as it requires this change https://github.com/disneystreaming/smithy4s/commit/7c468ad99c6dff14d5b0c89c66893b63204a61c4 