### PR TITLE
Initial gzip encoder/decoder implementation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -666,7 +666,8 @@ lazy val `http4s-kernel` = projectMatrix
   .settings(
     isMimaEnabled := true,
     libraryDependencies ++= Seq(
-      Dependencies.Http4s.core.value
+      Dependencies.Http4s.core.value,
+      Dependencies.Weaver.cats.value % Test
     )
   )
   .http4sPlatform(allJvmScalaVersions, jvmDimSettings)

--- a/modules/http4s-kernel/src/smithy4s/http4s/kernel/GzipRequestDecoder.scala
+++ b/modules/http4s-kernel/src/smithy4s/http4s/kernel/GzipRequestDecoder.scala
@@ -1,0 +1,78 @@
+/*
+ *  Copyright 2021-2022 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package smithy4s.http4s.kernel
+
+import cats.effect.MonadCancelThrow
+import fs2.Pipe
+import fs2.Pull
+import fs2.Stream
+import fs2.compression.Compression
+import org.http4s.ContentCoding
+import org.http4s.Header
+import org.http4s.Request
+import org.http4s.headers.`Content-Encoding`
+import org.http4s.headers.`Content-Length`
+
+import scala.util.control.NoStackTrace
+
+// inspired from:
+// https://github.com/http4s/http4s/blob/v0.23.19/server/shared/src/main/scala/org/http4s/server/middleware/GZip.scala
+object GzipRequestDecoder {
+  val DefaultBufferSize = 32 * 1024
+
+  def make[F[_]: MonadCancelThrow: Compression, A](bufferSize: Int)(
+      nextDecoder: RequestDecoder[F, A]
+  ): RequestDecoder[F, A] = {
+
+    def decompressWith(bufferSize: Int): Pipe[F, Byte, Byte] =
+      _.pull.peek1
+        .flatMap {
+          case None                  => Pull.raiseError(EmptyBodyException)
+          case Some((_, fullStream)) => Pull.output1(fullStream)
+        }
+        .stream
+        .flatten
+        .through(Compression[F].gunzip(bufferSize))
+        .flatMap(_.content)
+        .handleErrorWith {
+          case EmptyBodyException => Stream.empty
+          case error              => Stream.raiseError(error)
+        }
+
+    new RequestDecoder[F, A] {
+      def decodeRequest(request: Request[F]): F[A] =
+        request.headers.get[`Content-Encoding`] match {
+          case Some(`Content-Encoding`(ContentCoding.gzip)) =>
+            val updatedRequest =
+              request
+                .filterHeaders(nonCompressionHeader)
+                .withBodyStream(
+                  request.body.through(decompressWith(bufferSize))
+                )
+            nextDecoder.decodeRequest(updatedRequest)
+          case Some(_) | None =>
+            nextDecoder.decodeRequest(request)
+        }
+    }
+  }
+
+  private def nonCompressionHeader(header: Header.Raw): Boolean =
+    header.name != `Content-Length`.headerInstance.name &&
+      header.name != `Content-Encoding`.headerInstance.name
+
+  private object EmptyBodyException extends Throwable with NoStackTrace
+}

--- a/modules/http4s-kernel/src/smithy4s/http4s/kernel/GzipRequestEncoder.scala
+++ b/modules/http4s-kernel/src/smithy4s/http4s/kernel/GzipRequestEncoder.scala
@@ -1,0 +1,58 @@
+/*
+ *  Copyright 2021-2022 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package smithy4s.http4s.kernel
+
+import org.http4s.Request
+import org.http4s.ContentCoding
+import org.http4s.headers.`Content-Encoding`
+import org.http4s.headers.`Content-Length`
+import fs2.compression.Compression
+import fs2.compression.DeflateParams
+import fs2.compression.ZLibParams
+
+// inspired from:
+// https://github.com/http4s/http4s/blob/v0.23.19/client/shared/src/main/scala/org/http4s/client/middleware/GZip.scala
+object GzipRequestEncoder {
+  val DefaultBufferSize = 32 * 1024
+
+  def make[F[_]: Compression, A](
+      bufferSize: Int,
+      level: DeflateParams.Level
+  ): RequestEncoder[F, A] =
+    new RequestEncoder[F, A] {
+      def addToRequest(request: Request[F], a: A): Request[F] =
+        request.headers.get[`Content-Encoding`] match {
+          case None =>
+            val compressPipe =
+              Compression[F].gzip(
+                fileName = None,
+                modificationTime = None,
+                comment = None,
+                DeflateParams(
+                  bufferSize = bufferSize,
+                  level = level,
+                  header = ZLibParams.Header.GZIP
+                )
+              )
+            request
+              .removeHeader[`Content-Length`]
+              .putHeaders(`Content-Encoding`(ContentCoding.gzip))
+              .withBodyStream(request.body.through(compressPipe))
+          case Some(_) => request
+        }
+    }
+}

--- a/modules/http4s-kernel/test/src-js/smithy4s/http4s/kernel/Compat.scala
+++ b/modules/http4s-kernel/test/src-js/smithy4s/http4s/kernel/Compat.scala
@@ -1,0 +1,25 @@
+/*
+ *  Copyright 2021-2022 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package smithy4s.http4s.kernel
+
+import fs2.compression.Compression
+import fs2.io.compression._
+import cats.effect.IO
+
+trait Compat {
+  implicit val fs2ioCompressionForIO: Compression[IO] =
+    fs2ioCompressionForLiftIO
+}

--- a/modules/http4s-kernel/test/src-jvm/smithy4s/http4s/kernel/Compat.scala
+++ b/modules/http4s-kernel/test/src-jvm/smithy4s/http4s/kernel/Compat.scala
@@ -1,0 +1,19 @@
+/*
+ *  Copyright 2021-2022 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package smithy4s.http4s.kernel
+
+trait Compat

--- a/modules/http4s-kernel/test/src-native/smithy4s/http4s/kernel/Compat.scala
+++ b/modules/http4s-kernel/test/src-native/smithy4s/http4s/kernel/Compat.scala
@@ -1,0 +1,19 @@
+/*
+ *  Copyright 2021-2022 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package smithy4s.http4s.kernel
+
+trait Compat

--- a/modules/http4s-kernel/test/src/smithy4s/http4s/kernel/GzipRequestCodecSpec.scala
+++ b/modules/http4s-kernel/test/src/smithy4s/http4s/kernel/GzipRequestCodecSpec.scala
@@ -1,0 +1,110 @@
+package smithy4s.http4s.kernel
+
+import weaver._
+import cats.implicits._
+import org.http4s.HttpRoutes
+import cats.effect.IO
+import cats.effect.kernel.Deferred
+import org.http4s.Response
+import fs2.compression.DeflateParams
+import org.http4s.Method
+import org.http4s.Request
+
+object GzipRequestCodecSpec extends SimpleIOSuite {
+  private val stringCodecs = {
+    val encoder =
+      GzipRequestEncoder.make[IO, String](
+        GzipRequestEncoder.DefaultBufferSize,
+        DeflateParams.Level.DEFAULT
+      )
+    val internal: RequestDecoder[IO, String] =
+      new RequestDecoder[IO, String]() {
+        def decodeRequest(request: Request[IO]): IO[String] = {
+          request.as[String]
+        }
+      }
+    val decoder =
+      GzipRequestDecoder.make[IO, String](
+        GzipRequestDecoder.DefaultBufferSize
+      )(internal)
+    (encoder, decoder)
+  }
+
+  test("codecs roundtrip - encoder compress and decoder decompress") {
+    val (encoder, decoder) = stringCodecs
+    Deferred[IO, String].flatMap { received =>
+      val routes = HttpRoutes.of[IO] { case req =>
+        req.toStrict(None).flatMap { strict =>
+          val record: IO[Unit] =
+            strict.body
+              .through(fs2.text.base64.encode)
+              .compile
+              .foldMonoid
+              .flatMap { received.complete(_).void }
+          val answer = decoder.decodeRequest(strict).map { payload =>
+            Response[IO]().withEntity(payload)
+          }
+          record *> answer
+        }
+      }
+      val originalPayload = "data"
+      val request =
+        Request[IO](method = Method.POST).withEntity(originalPayload)
+      routes
+        .run(encoder.addToRequest(request, ""))
+        .value
+        .flatMap {
+          case None => IO.pure(failure("expected a response"))
+          case Some(fa) =>
+            val checkResponse = fa
+              .as[String]
+              .map { payload => expect(payload == "data") }
+            // echo "data" | gzip | base64
+            // H4sIAAAAAAAAA0tJLEnkAgCCxcHmBQAAAA==
+            // trailing equals are padding
+            val checkRecordedBody = received.get.map { payload =>
+              expect(payload == "H4sIAAAAAAAAB0tJLEkEAGPz860EAAAA")
+            }
+            List(checkRecordedBody, checkResponse).combineAll
+        }
+    }
+  }
+
+  test("codecs roundtrip - works on empty body") {
+    val (encoder, decoder) = stringCodecs
+    Deferred[IO, String].flatMap { received =>
+      val routes = HttpRoutes.of[IO] { case req =>
+        req.toStrict(None).flatMap { strict =>
+          val record: IO[Unit] =
+            strict.body
+              .through(fs2.text.base64.encode)
+              .compile
+              .foldMonoid
+              .flatMap { received.complete(_).void }
+          val answer = decoder.decodeRequest(strict).map { payload =>
+            Response[IO]().withEntity(payload)
+          }
+          record *> answer
+        }
+      }
+      val request =
+        Request[IO](method = Method.POST)
+      routes
+        .run(encoder.addToRequest(request, ""))
+        .value
+        .flatMap {
+          case None => IO.pure(failure("expected a response"))
+          case Some(fa) =>
+            val checkResponse = fa
+              .as[String]
+              .map { payload => expect(payload == "") }
+            // echo "" | gzip | base64
+            // H4sIAAAAAAAAA+MCAJMG1zIBAAAA
+            val checkRecordedBody = received.get.map { payload =>
+              expect(payload == "H4sIAAAAAAAABwMAAAAAAAAAAAA=")
+            }
+            List(checkRecordedBody, checkResponse).combineAll
+        }
+    }
+  }
+}

--- a/modules/http4s-kernel/test/src/smithy4s/http4s/kernel/GzipRequestCodecSpec.scala
+++ b/modules/http4s-kernel/test/src/smithy4s/http4s/kernel/GzipRequestCodecSpec.scala
@@ -1,16 +1,31 @@
+/*
+ *  Copyright 2021-2022 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
 package smithy4s.http4s.kernel
 
-import weaver._
-import cats.implicits._
-import org.http4s.HttpRoutes
 import cats.effect.IO
 import cats.effect.kernel.Deferred
-import org.http4s.Response
+import cats.implicits._
 import fs2.compression.DeflateParams
+import org.http4s.HttpRoutes
 import org.http4s.Method
 import org.http4s.Request
+import org.http4s.Response
+import weaver._
 
-object GzipRequestCodecSpec extends SimpleIOSuite {
+object GzipRequestCodecSpec extends SimpleIOSuite with Compat {
   private val stringCodecs = {
     val encoder =
       GzipRequestEncoder.make[IO, String](
@@ -61,7 +76,8 @@ object GzipRequestCodecSpec extends SimpleIOSuite {
               .map { payload => expect(payload == "data") }
             // local:   "H4sIAAAAAAAAB0tJLEkEAGPz860EAAAA"
             // ci:      "H4sIAAAAAAAAA0tJLEkEAGPz860EAAAA"
-            val check = "^H4sIAAAAAAAA[AB]0tJLEkEAGPz860EAAAA=*$".r
+            // js:      "H4sIAAAAAAAAE0tJLEkEAGPz860EAAAA"
+            val check = "^H4sIAAAAAAAA[ABE]0tJLEkEAGPz860EAAAA=*$".r
             val checkRecordedBody = received.get.map { payload =>
               expect(check.findFirstIn(payload) == Some(payload))
             }
@@ -100,7 +116,8 @@ object GzipRequestCodecSpec extends SimpleIOSuite {
               .map { payload => expect(payload == "") }
             // local:   "H4sIAAAAAAAABwMAAAAAAAAAAAA"
             // ci:      "H4sIAAAAAAAAAwMAAAAAAAAAAAA="
-            val check = "^H4sIAAAAAAAA[AB]wMAAAAAAAAAAAA=*$".r
+            // js:      "H4sIAAAAAAAAEwMAAAAAAAAAAAA="
+            val check = "^H4sIAAAAAAAA[ABE]wMAAAAAAAAAAAA=*$".r
             val checkRecordedBody = received.get.map { payload =>
               expect(check.findFirstIn(payload) == Some(payload))
             }

--- a/modules/http4s-kernel/test/src/smithy4s/http4s/kernel/GzipRequestCodecSpec.scala
+++ b/modules/http4s-kernel/test/src/smithy4s/http4s/kernel/GzipRequestCodecSpec.scala
@@ -59,11 +59,11 @@ object GzipRequestCodecSpec extends SimpleIOSuite {
             val checkResponse = fa
               .as[String]
               .map { payload => expect(payload == "data") }
-            // echo "data" | gzip | base64
-            // H4sIAAAAAAAAA0tJLEnkAgCCxcHmBQAAAA==
-            // trailing equals are padding
+            // local:   "H4sIAAAAAAAAB0tJLEkEAGPz860EAAAA"
+            // ci:      "H4sIAAAAAAAAA0tJLEkEAGPz860EAAAA"
+            val check = "^H4sIAAAAAAAA[AB]0tJLEkEAGPz860EAAAA=*$".r
             val checkRecordedBody = received.get.map { payload =>
-              expect(payload == "H4sIAAAAAAAAB0tJLEkEAGPz860EAAAA")
+              expect(check.findFirstIn(payload) == Some(payload))
             }
             List(checkRecordedBody, checkResponse).combineAll
         }
@@ -98,10 +98,11 @@ object GzipRequestCodecSpec extends SimpleIOSuite {
             val checkResponse = fa
               .as[String]
               .map { payload => expect(payload == "") }
-            // echo "" | gzip | base64
-            // H4sIAAAAAAAAA+MCAJMG1zIBAAAA
+            // local:   "H4sIAAAAAAAABwMAAAAAAAAAAAA"
+            // ci:      "H4sIAAAAAAAAAwMAAAAAAAAAAAA="
+            val check = "^H4sIAAAAAAAA[AB]wMAAAAAAAAAAAA=*$".r
             val checkRecordedBody = received.get.map { payload =>
-              expect(payload == "H4sIAAAAAAAABwMAAAAAAAAAAAA=")
+              expect(check.findFirstIn(payload) == Some(payload))
             }
             List(checkRecordedBody, checkResponse).combineAll
         }


### PR DESCRIPTION
Some protocol support `requestCompression` and this is the gzip implementation for this: https://smithy.io/2.0/spec/behavior-traits.html?highlight=compression#requestcompression-trait

Currently, it is not wired to anything, but I'll do that on another PR that's already open for `restJson1`