### PR TITLE
Support for mill 0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Behavioural changes
 
+### Mill
+
+The `mill` plugin is build for version `0.11.0`. The changes to the API are solely results of this migration.
+
+The most important migration bits:
+
+1. Change from `def smithy4sInputDirs: mill.define.Sources` to `def smithy4sInputDirs: mill.define.Target[Seq[PathRef]]`
+2. Change from `def manifest: T[mill.modules.Jvm.JarManifest]` to `def manifest: T[mill.api.JarManifest]`
+3. Change from `def smithy4sAllExternalDependencies: T[Agg[Dep]]` to `def smithy4sAllExternalDependencies: T[Agg[BoundDep]]`
+
 ### Cats Module
 
 Addition of a cats module to contain `SchemaVisitor` implementations of commonly-used cats typeclasses. Currently included are `cats.Show` and `cats.Hash` (note that `cats.Eq` is provided by the `cats.Hash` implementation).

--- a/build.sbt
+++ b/build.sbt
@@ -411,7 +411,7 @@ lazy val codegen = projectMatrix
       Dependencies.Smithy.build,
       Dependencies.Alloy.core,
       Dependencies.Alloy.openapi,
-      "com.lihaoyi" %% "os-lib" % "0.8.1",
+      "com.lihaoyi" %% "os-lib" % "0.9.1",
       Dependencies.collectionsCompat.value,
       "org.scala-lang" % "scala-reflect" % scalaVersion.value,
       "io.get-coursier" %% "coursier" % "2.1.4"
@@ -498,6 +498,7 @@ lazy val millCodegenPlugin = projectMatrix
       Dependencies.Mill.scalalib,
       Dependencies.Mill.mainTestkit
     ),
+    libraryDependencySchemes += "com.lihaoyi" %% "geny" % VersionScheme.Always,
     publishLocal := {
       // make sure that core and codegen are published before the
       // plugin is published

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -68,7 +68,7 @@ object Dependencies {
   }
 
   object Mill {
-    val millVersion = "0.10.12"
+    val millVersion = "0.11.0"
 
     val scalalib = "com.lihaoyi" %% "mill-scalalib" % millVersion
     val main = "com.lihaoyi" %% "mill-main" % millVersion

--- a/project/Smithy4sBuildPlugin.scala
+++ b/project/Smithy4sBuildPlugin.scala
@@ -552,7 +552,7 @@ object Smithy4sBuildPlugin extends AutoPlugin {
   }
 
   def millPlatform(millVersion: String): String = millVersion match {
-    case mv if mv.startsWith("0.10") => "0.10"
+    case mv if mv.startsWith("0.11") => "0.11"
     case _                           => sys.error("Unsupported mill platform.")
   }
 


### PR DESCRIPTION
Should we cross-compile or we go with `0.11.0` along the 0.18 release ?