### PR TITLE
hints are not passed down to primitive from Collections when reading and writing headers

### DIFF
--- a/modules/core/src/smithy4s/http/internals/SchemaVisitorMetadataReader.scala
+++ b/modules/core/src/smithy4s/http/internals/SchemaVisitorMetadataReader.scala
@@ -54,7 +54,7 @@ private[http] class SchemaVisitorMetadataReader(
       tag: CollectionTag[C],
       member: Schema[A]
   ): MetaDecode[C[A]] = {
-    self(member.addHints(hints)) match {
+    self(member.addHints(httpHints(hints))) match {
       case MetaDecode.StringValueMetaDecode(f) =>
         MetaDecode.StringCollectionMetaDecode[C[A]] { it =>
           tag.fromIterator(it.map(f))
@@ -69,7 +69,7 @@ private[http] class SchemaVisitorMetadataReader(
       key: Schema[K],
       value: Schema[V]
   ): MetaDecode[Map[K, V]] = {
-    (self(key.addHints(hints)), self(value.addHints(hints))) match {
+    (self(key), self(value.addHints(httpHints(hints)))) match {
       case (StringValueMetaDecode(readK), StringValueMetaDecode(readV)) =>
         StringMapMetaDecode[Map[K, V]](map =>
           map.map { case (k, v) => (readK(k), readV(v)) }.toMap

--- a/modules/core/src/smithy4s/http/internals/SchemaVisitorMetadataReader.scala
+++ b/modules/core/src/smithy4s/http/internals/SchemaVisitorMetadataReader.scala
@@ -54,7 +54,7 @@ private[http] class SchemaVisitorMetadataReader(
       tag: CollectionTag[C],
       member: Schema[A]
   ): MetaDecode[C[A]] = {
-    self(member) match {
+    self(member.addHints(hints)) match {
       case MetaDecode.StringValueMetaDecode(f) =>
         MetaDecode.StringCollectionMetaDecode[C[A]] { it =>
           tag.fromIterator(it.map(f))
@@ -69,7 +69,7 @@ private[http] class SchemaVisitorMetadataReader(
       key: Schema[K],
       value: Schema[V]
   ): MetaDecode[Map[K, V]] = {
-    (self(key), self(value)) match {
+    (self(key.addHints(hints)), self(value.addHints(hints))) match {
       case (StringValueMetaDecode(readK), StringValueMetaDecode(readV)) =>
         StringMapMetaDecode[Map[K, V]](map =>
           map.map { case (k, v) => (readK(k), readV(v)) }.toMap

--- a/modules/core/src/smithy4s/http/internals/SchemaVisitorMetadataWriter.scala
+++ b/modules/core/src/smithy4s/http/internals/SchemaVisitorMetadataWriter.scala
@@ -50,7 +50,6 @@ class SchemaVisitorMetadataWriter(
     val cache: CompilationCache[MetaEncode]
 ) extends SchemaVisitor.Cached[MetaEncode] {
   self =>
-
   override def primitive[P](
       shapeId: ShapeId,
       hints: Hints,
@@ -68,7 +67,7 @@ class SchemaVisitorMetadataWriter(
       tag: CollectionTag[C],
       member: Schema[A]
   ): MetaEncode[C[A]] = {
-    self(member.addHints(hints)) match {
+    self(member.addHints(httpHints(hints))) match {
       case StringValueMetaEncode(f) =>
         StringListMetaEncode[C[A]](c => tag.iterator(c).map(f).toList)
       case _ => MetaEncode.empty
@@ -84,7 +83,7 @@ class SchemaVisitorMetadataWriter(
       key: Schema[K],
       value: Schema[V]
   ): MetaEncode[Map[K, V]] = {
-    (self(key), self(value)) match {
+    (self(key), self(value.addHints(httpHints(hints)))) match {
       case (StringValueMetaEncode(keyF), StringValueMetaEncode(valueF)) =>
         StringMapMetaEncode(map =>
           map.map { case (k, v) =>

--- a/modules/core/src/smithy4s/http/internals/SchemaVisitorMetadataWriter.scala
+++ b/modules/core/src/smithy4s/http/internals/SchemaVisitorMetadataWriter.scala
@@ -68,7 +68,7 @@ class SchemaVisitorMetadataWriter(
       tag: CollectionTag[C],
       member: Schema[A]
   ): MetaEncode[C[A]] = {
-    self(member) match {
+    self(member.addHints(hints)) match {
       case StringValueMetaEncode(f) =>
         StringListMetaEncode[C[A]](c => tag.iterator(c).map(f).toList)
       case _ => MetaEncode.empty

--- a/modules/core/src/smithy4s/http/internals/package.scala
+++ b/modules/core/src/smithy4s/http/internals/package.scala
@@ -20,6 +20,7 @@ package http
 package object internals {
 
   private[http] type HttpCode[A] = A => Option[Int]
+  private[http] val httpHints = HintMask(HttpBinding)
 
   private[internals] implicit class vectorOps[A](val vector: Vector[A])
       extends AnyVal {
@@ -90,4 +91,5 @@ package object internals {
       Some(PathSegment.label(str.substring(1, str.length() - 1)))
     else Some(PathSegment.static(str))
   }
+
 }


### PR DESCRIPTION
Currently, if a header hint targets a list, the hint is not passed down in the SchemaVisitors resulting in losing the HttpBinding context when processing the primitive targeted by the list. 
The case I bumped into was a header targeting a list of timestamps. The timestamp format used was the default one as opposed to the one meant for a header.

Test case : https://github.com/awslabs/smithy/blob/ad6d20b190d739aa9f83c5ef40a1e6c3ffe53ba5/smithy-aws-protocol-tests/model/restJson1/http-headers.smithy#L110