### PR TITLE
Adding a comment in flatMapErrors

### DIFF
--- a/modules/http4s/src/smithy4s/http4s/SimpleProtocolBuilder.scala
+++ b/modules/http4s/src/smithy4s/http4s/SimpleProtocolBuilder.scala
@@ -129,6 +129,11 @@ abstract class SimpleProtocolBuilder[P](
     ): RouterBuilder[Alg, F] =
       new RouterBuilder(service, impl, fe andThen (e => F.pure(e)), middleware)
 
+    /**
+      * Applies the error transformation to the errors that are not in the smithy spec (has no effect on errors from spec).
+      * Transformed errors raised in endpoint implementation will be observable from [[middleware]].
+      * Errors raised in the [[middleware]] will be transformed too. 
+      */
     def flatMapErrors(
         fe: PartialFunction[Throwable, F[Throwable]]
     ): RouterBuilder[Alg, F] =


### PR DESCRIPTION
Actually, on `0.18` the comment is not fully true. This is because the errors from transformations, are not piped through the `errorTransformer`. 