### PR TITLE
Revert original behavior where middleware get all errors

### DIFF
--- a/modules/http4s/test/src/smithy4s/http4s/ServerEndpointMiddlewareSpec.scala
+++ b/modules/http4s/test/src/smithy4s/http4s/ServerEndpointMiddlewareSpec.scala
@@ -80,6 +80,39 @@ object ServerEndpointMiddlewareSpec extends SimpleIOSuite {
     List(throwCheck, pureCheck).combineAll
   }
 
+  test("server - middleware can catch spec error") {
+    val catchSpecErrorMiddleware = new ServerEndpointMiddleware.Simple[IO]() {
+      def prepareWithHints(
+          serviceHints: Hints,
+          endpointHints: Hints
+      ): HttpApp[IO] => HttpApp[IO] = { inputApp =>
+        HttpApp[IO] { req =>
+          inputApp(req).handleError { case _: SpecificServerError =>
+            Response[IO]()
+          }
+        }
+      }
+    }
+
+    SimpleRestJsonBuilder
+      .routes(new HelloWorldService[IO] {
+        def hello(name: String, town: Option[String]): IO[Greeting] =
+          IO.raiseError(
+            SpecificServerError(Some("to be caught in middleware"))
+          )
+      })
+      .middleware(catchSpecErrorMiddleware)
+      .make
+      .toOption
+      .get
+      .apply(Request[IO](Method.POST, Uri.unsafeFromString("/bob")))
+      // would be 599 w/o the middleware
+      .flatMap(res => OptionT.pure(expect.eql(res.status.code, 200)))
+      .getOrElse(
+        failure("unable to run request")
+      )
+  }
+
   test("server - middleware is applied") {
     serverMiddlewareTest(
       shouldFailInMiddleware = true,


### PR DESCRIPTION
When merging https://github.com/disneystreaming/smithy4s/pull/877, I introduced a behaviour change that I had not anticipated: the errors defined in the smithy specs were turned into http response before users had a chance to react to them in the middleware they provide

this is problematic and this fix reverts that

this PR is an alternative to this one: https://github.com/disneystreaming/smithy4s/pull/1029