### PR TITLE
fix header test

### DIFF
--- a/modules/compliance-tests/src/smithy4s/compliancetests/internals/Assertions.scala
+++ b/modules/compliance-tests/src/smithy4s/compliancetests/internals/Assertions.scala
@@ -129,6 +129,11 @@ private[internals] object assert {
       .combineAll
   }
 
+  /**
+   * A list of header field names that must appear in the serialized HTTP message, but no assertion is made on the value.
+   * Headers listed in headers do not need to appear in this list.
+    */
+
   private def headersExistenceCheck(
       headers: Headers,
       requiredHeaders: Option[List[String]],
@@ -144,6 +149,7 @@ private[internals] object assert {
     }.combineAll
     checkRequired |+| checkForbidden
   }
+
   private def headerValuesCheck(
       headers: Map[String, String],
       expected: Option[Map[String, String]]
@@ -157,7 +163,7 @@ private[internals] object assert {
             case Some(v) =>
               assert.fail(s"Header $key has value `$v` but expected `$value`")
             case None =>
-              success // the presence of the value is checked in `headersExistenceCheck`
+              fail(s"Header $key is missing in the request.")
           }
         }.combineAll
       }

--- a/modules/compliance-tests/src/smithy4s/compliancetests/internals/Assertions.scala
+++ b/modules/compliance-tests/src/smithy4s/compliancetests/internals/Assertions.scala
@@ -150,7 +150,7 @@ private[internals] object assert {
     checkRequired |+| checkForbidden
   }
 
-  private def headerValuesCheck(
+  private def headerKeyValueCheck(
       headers: Map[String, String],
       expected: Option[Map[String, String]]
   ) = {
@@ -200,7 +200,7 @@ private[internals] object assert {
         forbiddenHeaders = tc.forbidHeaders
       )
       val valueChecks =
-        assert.headerValuesCheck(collapseHeaders(headers), tc.headers)
+        assert.headerKeyValueCheck(collapseHeaders(headers), tc.headers)
       existenceChecks |+| valueChecks
     }
 
@@ -214,7 +214,7 @@ private[internals] object assert {
         forbiddenHeaders = tc.forbidHeaders
       )
       val valueChecks =
-        assert.headerValuesCheck(collapseHeaders(headers), tc.headers)
+        assert.headerKeyValueCheck(collapseHeaders(headers), tc.headers)
       existenceChecks |+| valueChecks
     }
   }


### PR DESCRIPTION
The false positive tests noted over [here](https://github.com/disneystreaming/smithy4s/pull/1036#issue-1759032380) , are the result of not testing correctly.
The required headers and forbid headers is for testing keys only while allowing the value to vary
The headers is for testing **both** key and value, not **just** the value .
All header tests defined in restJson dont have a required headers field as every case has value requirements too.
Please see [docs](https://smithy.io/2.0/additional-specs/http-protocol-compliance-tests.html#httprequesttests-trait)

> requireHeaders | [string] | A list of header field names that must appear in the serialized HTTP message, but no assertion is made on the value. Headers listed in headers do not need to appear in this list.
-- | -- | --
  