### PR TITLE
Addressing SimpleRestJson tests :

### DIFF
--- a/modules/core/src/smithy4s/http/HttpDiscriminator.scala
+++ b/modules/core/src/smithy4s/http/HttpDiscriminator.scala
@@ -29,21 +29,23 @@ object HttpDiscriminator {
   // format: on
 
   def fromMetadata(
-      discriminatingHeaderName: String,
+      discriminatingHeaderNames: List[String],
       metadata: Metadata
   ): Option[HttpDiscriminator] = {
     metadata.statusCode.map(code =>
-      fromStatusOrHeader(discriminatingHeaderName, code, metadata.headers)
+      fromStatusOrHeader(discriminatingHeaderNames, code, metadata.headers)
     )
   }
 
   def fromStatusOrHeader(
-      discriminatingHeaderName: String,
+      discriminatingHeaderNames: List[String],
       statusCode: Int,
       headers: Map[CaseInsensitive, Seq[String]]
   ): HttpDiscriminator = {
-    headers
-      .get(CaseInsensitive(discriminatingHeaderName))
+    discriminatingHeaderNames.iterator
+      .map(CaseInsensitive(_))
+      .map(headers.get)
+      .collectFirst { case Some(h) => h }
       .flatMap(_.headOption)
       .map(errorType =>
         ShapeId

--- a/modules/core/src/smithy4s/http/package.scala
+++ b/modules/core/src/smithy4s/http/package.scala
@@ -18,6 +18,9 @@ package smithy4s
 
 package object http {
 
+  val errorTypeHeader = "X-Error-Type"
+  val amazonErrorTypeHeader = "X-Amzn-Errortype"
+
   type PathParams = Map[String, String]
   type HttpMediaType = HttpMediaType.Type
 

--- a/modules/core/src/smithy4s/package.scala
+++ b/modules/core/src/smithy4s/package.scala
@@ -22,8 +22,6 @@ package object smithy4s {
 
   type ~>[F[_], G[_]] = kinds.PolyFunction[F, G]
 
-  val errorTypeHeader = "X-Error-Type"
-
   def checkProtocol[Alg[_[_, _, _, _, _]]](
       service: Service[Alg],
       protocolTag: ShapeTag[_]

--- a/modules/http4s-kernel/src/smithy4s/http4s/kernel/ResponseEncoder.scala
+++ b/modules/http4s-kernel/src/smithy4s/http4s/kernel/ResponseEncoder.scala
@@ -33,17 +33,17 @@ import smithy4s.schema.Schema
 object ResponseEncoder {
 
   def forError[F[_], E](
-      errorTypeHeader: String,
+      errorTypeHeaders: List[String],
       maybeErrorable: Option[Errorable[E]],
       encoderCompiler: CachedSchemaCompiler[ResponseEncoder[F, *]]
   ): ResponseEncoder[F, E] = maybeErrorable match {
     case Some(errorable) =>
-      forErrorAux(errorTypeHeader, errorable, encoderCompiler)
+      forErrorAux(errorTypeHeaders, errorable, encoderCompiler)
     case None => Encoder.noop
   }
 
   private def forErrorAux[F[_], E](
-      errorTypeHeader: String,
+      errorTypeHeaders: List[String],
       errorable: Errorable[E],
       encoderCompiler: CachedSchemaCompiler[ResponseEncoder[F, *]]
   ): ResponseEncoder[F, E] = {
@@ -65,7 +65,7 @@ object ResponseEncoder {
           val encodedResponse = errorEncoder.encode(response, err)
           encodedResponse
             .withStatus(status)
-            .withHeaders(encodedResponse.headers.put(errorTypeHeader -> label))
+            .putHeaders(errorTypeHeaders.map(_ -> label))
         }
       }
     }

--- a/modules/http4s-kernel/src/smithy4s/http4s/kernel/UnaryServerCodecs.scala
+++ b/modules/http4s-kernel/src/smithy4s/http4s/kernel/UnaryServerCodecs.scala
@@ -39,7 +39,8 @@ object UnaryServerCodecs {
   def make[F[_]](
       input: CachedSchemaCompiler[RequestDecoder[F, *]],
       output: CachedSchemaCompiler[ResponseEncoder[F, *]],
-      error: CachedSchemaCompiler[ResponseEncoder[F, *]]
+      error: CachedSchemaCompiler[ResponseEncoder[F, *]],
+      errorHeaders: List[String]
   ): Make[F] = new Make[F] {
     val requestDecoderCache: input.Cache = input.createCache()
     val responseEncoderCache: output.Cache = output.createCache()
@@ -54,12 +55,7 @@ object UnaryServerCodecs {
         output.fromSchema(endpoint.output, responseEncoderCache)
       val errorEncoder: ResponseEncoder[F, E] =
         ResponseEncoder.forError(
-          // Adding X-Amzn-Errortype as well to facilitate interop
-          // with Amazon-issued code-generators.
-          List(
-            smithy4s.http.errorTypeHeader,
-            smithy4s.http.amazonErrorTypeHeader
-          ),
+          errorHeaders,
           endpoint.errorable,
           error
         )

--- a/modules/http4s-kernel/src/smithy4s/http4s/kernel/UnaryServerCodecs.scala
+++ b/modules/http4s-kernel/src/smithy4s/http4s/kernel/UnaryServerCodecs.scala
@@ -54,7 +54,12 @@ object UnaryServerCodecs {
         output.fromSchema(endpoint.output, responseEncoderCache)
       val errorEncoder: ResponseEncoder[F, E] =
         ResponseEncoder.forError(
-          smithy4s.errorTypeHeader,
+          // Adding X-Amzn-Errortype as well to facilitate interop
+          // with Amazon-issued code-generators.
+          List(
+            smithy4s.http.errorTypeHeader,
+            smithy4s.http.amazonErrorTypeHeader
+          ),
           endpoint.errorable,
           error
         )


### PR DESCRIPTION
* Using the Amazon discriminator as well as the current one, in order to improve compatibility with AWS-issued code-generators that target the AWS restJson protocol
* Adding a content-type when forcing an empty json object in the body of http responses.