### PR TITLE
endpoint trait implementation along with hostLabel trait

### DIFF
--- a/modules/bootstrapped/src/generated/smithy4s/example/DummyService.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/DummyService.scala
@@ -19,6 +19,7 @@ trait DummyServiceGen[F[_, _, _, _, _]] {
   self =>
 
   def dummy(str: Option[String] = None, int: Option[Int] = None, ts1: Option[Timestamp] = None, ts2: Option[Timestamp] = None, ts3: Option[Timestamp] = None, ts4: Option[Timestamp] = None, b: Option[Boolean] = None, sl: Option[List[String]] = None, ie: Option[Numbers] = None, slm: Option[Map[String, String]] = None): F[Queries, Nothing, Unit, Nothing, Nothing]
+  def dummyHostPrefix(label1: String, label2: String, label3: HostLabelEnum): F[HostLabelInput, Nothing, Unit, Nothing, Nothing]
   def dummyPath(str: String, int: Int, ts1: Timestamp, ts2: Timestamp, ts3: Timestamp, ts4: Timestamp, b: Boolean, ie: Numbers): F[PathParams, Nothing, Unit, Nothing, Nothing]
 
   def transform: Transformation.PartiallyApplied[DummyServiceGen[F]] = Transformation.of[DummyServiceGen[F]](this)
@@ -42,6 +43,7 @@ object DummyServiceGen extends Service.Mixin[DummyServiceGen, DummyServiceOperat
 
   val endpoints: List[smithy4s.Endpoint[DummyServiceOperation, _, _, _, _, _]] = List(
     DummyServiceOperation.Dummy,
+    DummyServiceOperation.DummyHostPrefix,
     DummyServiceOperation.DummyPath,
   )
 
@@ -64,10 +66,12 @@ object DummyServiceOperation {
 
   object reified extends DummyServiceGen[DummyServiceOperation] {
     def dummy(str: Option[String] = None, int: Option[Int] = None, ts1: Option[Timestamp] = None, ts2: Option[Timestamp] = None, ts3: Option[Timestamp] = None, ts4: Option[Timestamp] = None, b: Option[Boolean] = None, sl: Option[List[String]] = None, ie: Option[Numbers] = None, slm: Option[Map[String, String]] = None) = Dummy(Queries(str, int, ts1, ts2, ts3, ts4, b, sl, ie, slm))
+    def dummyHostPrefix(label1: String, label2: String, label3: HostLabelEnum) = DummyHostPrefix(HostLabelInput(label1, label2, label3))
     def dummyPath(str: String, int: Int, ts1: Timestamp, ts2: Timestamp, ts3: Timestamp, ts4: Timestamp, b: Boolean, ie: Numbers) = DummyPath(PathParams(str, int, ts1, ts2, ts3, ts4, b, ie))
   }
   class Transformed[P[_, _, _, _, _], P1[_ ,_ ,_ ,_ ,_]](alg: DummyServiceGen[P], f: PolyFunction5[P, P1]) extends DummyServiceGen[P1] {
     def dummy(str: Option[String] = None, int: Option[Int] = None, ts1: Option[Timestamp] = None, ts2: Option[Timestamp] = None, ts3: Option[Timestamp] = None, ts4: Option[Timestamp] = None, b: Option[Boolean] = None, sl: Option[List[String]] = None, ie: Option[Numbers] = None, slm: Option[Map[String, String]] = None) = f[Queries, Nothing, Unit, Nothing, Nothing](alg.dummy(str, int, ts1, ts2, ts3, ts4, b, sl, ie, slm))
+    def dummyHostPrefix(label1: String, label2: String, label3: HostLabelEnum) = f[HostLabelInput, Nothing, Unit, Nothing, Nothing](alg.dummyHostPrefix(label1, label2, label3))
     def dummyPath(str: String, int: Int, ts1: Timestamp, ts2: Timestamp, ts3: Timestamp, ts4: Timestamp, b: Boolean, ie: Numbers) = f[PathParams, Nothing, Unit, Nothing, Nothing](alg.dummyPath(str, int, ts1, ts2, ts3, ts4, b, ie))
   }
 
@@ -89,6 +93,23 @@ object DummyServiceOperation {
       smithy.api.Readonly(),
     )
     def wrap(input: Queries) = Dummy(input)
+    override val errorable: Option[Nothing] = None
+  }
+  final case class DummyHostPrefix(input: HostLabelInput) extends DummyServiceOperation[HostLabelInput, Nothing, Unit, Nothing, Nothing] {
+    def run[F[_, _, _, _, _]](impl: DummyServiceGen[F]): F[HostLabelInput, Nothing, Unit, Nothing, Nothing] = impl.dummyHostPrefix(input.label1, input.label2, input.label3)
+    def endpoint: (HostLabelInput, smithy4s.Endpoint[DummyServiceOperation,HostLabelInput, Nothing, Unit, Nothing, Nothing]) = (input, DummyHostPrefix)
+  }
+  object DummyHostPrefix extends smithy4s.Endpoint[DummyServiceOperation,HostLabelInput, Nothing, Unit, Nothing, Nothing] {
+    val id: ShapeId = ShapeId("smithy4s.example", "DummyHostPrefix")
+    val input: Schema[HostLabelInput] = HostLabelInput.schema.addHints(smithy4s.internals.InputOutput.Input.widen)
+    val output: Schema[Unit] = unit.addHints(smithy4s.internals.InputOutput.Output.widen)
+    val streamedInput: StreamingSchema[Nothing] = StreamingSchema.nothing
+    val streamedOutput: StreamingSchema[Nothing] = StreamingSchema.nothing
+    val hints: Hints = Hints(
+      smithy.api.Http(method = smithy.api.NonEmptyString("GET"), uri = smithy.api.NonEmptyString("/dummy"), code = 200),
+      smithy.api.Endpoint(hostPrefix = smithy.api.NonEmptyString("foo.{label1}--abc{label2}.{label3}.secure.")),
+    )
+    def wrap(input: HostLabelInput) = DummyHostPrefix(input)
     override val errorable: Option[Nothing] = None
   }
   final case class DummyPath(input: PathParams) extends DummyServiceOperation[PathParams, Nothing, Unit, Nothing, Nothing] {

--- a/modules/bootstrapped/test/src/smithy4s/http/uri/HostPrefixSpec.scala
+++ b/modules/bootstrapped/test/src/smithy4s/http/uri/HostPrefixSpec.scala
@@ -1,0 +1,51 @@
+/*
+ *  Copyright 2021-2022 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package smithy4s.http.uri
+
+import smithy4s.example.DummyServiceOperation.DummyHostPrefix
+import smithy4s.example.HostLabelInput
+
+class HostPrefixSpec() extends munit.FunSuite {
+
+  test("Parse host prefix pattern into host prefix segments") {
+    val result = hostPrefixSegments("{head}--foo{tail}")
+    expect(
+      result == Option(
+        Vector(
+          HostPrefixSegment.label("head"),
+          HostPrefixSegment.static("--foo"),
+          HostPrefixSegment.label("tail")
+        )
+      )
+    )
+  }
+
+  // "foo.{label1}--abc{label2}.{label3}.secure
+  test("Write a valid Host Prefix    for DummyHostPrefix") {
+    val result = HostEndpoint(DummyHostPrefix).get
+    HostLabelInput(
+      "mabeline",
+      "virgo",
+      smithy4s.example.Thing1
+    )
+
+    val expected =
+      "foo." :: "mabeline" :: "--abc" :: "virgo" :: "." :: "smithy4s.example.Thing1" :: ".secure" :: Nil
+    expect.eql(result, expected)
+  }
+
+}

--- a/modules/bootstrapped/test/src/smithy4s/http/uri/HostPrefixSpec.scala
+++ b/modules/bootstrapped/test/src/smithy4s/http/uri/HostPrefixSpec.scala
@@ -36,7 +36,7 @@ class HostPrefixSpec() extends munit.FunSuite {
 
   // "foo.{label1}--abc{label2}.{label3}.secure
   test("Write a valid Host Prefix    for DummyHostPrefix") {
-    val result = HostEndpoint(DummyHostPrefix).get
+    val result = HostPrefixInjector(DummyHostPrefix).get
     HostLabelInput(
       "mabeline",
       "virgo",

--- a/modules/compliance-tests/src/smithy4s/compliancetests/internals/Assertions.scala
+++ b/modules/compliance-tests/src/smithy4s/compliancetests/internals/Assertions.scala
@@ -51,6 +51,21 @@ private[internals] object assert {
     }
   }
 
+  def contains(
+      result: String,
+      expected: String,
+      prefix: String = ""
+  ): ComplianceResult = {
+    if (result.contains(expected)) {
+      success
+    } else {
+      fail(
+        s"$prefix the result value: ${pprint.apply(result)} did not contain the expected TestCase value ${pprint
+          .apply(expected)}."
+      )
+    }
+  }
+
   def eql[A: Eq](
       result: A,
       testCase: A,

--- a/modules/compliance-tests/src/smithy4s/compliancetests/internals/ClientHttpComplianceTestCase.scala
+++ b/modules/compliance-tests/src/smithy4s/compliancetests/internals/ClientHttpComplianceTestCase.scala
@@ -62,6 +62,20 @@ private[compliancetests] class ClientHttpComplianceTestCase[
       )
     }
 
+    val resolvedHostPrefix =
+      testCase.resolvedHost
+        .zip(testCase.host)
+        .map { case (resolved, host) => resolved.split(host)(0) }
+
+    val resolvedHostAssert =
+      request.uri.host
+        .map(_.value)
+        .zip(resolvedHostPrefix)
+        .map { case (a, b) =>
+          assert.contains(a, b, "resolved host test :").pure[F]
+        }
+        .toList
+
     val receivedPathSegments =
       request.uri.path.segments.map(_.decoded())
     val expectedPathSegments =
@@ -87,8 +101,9 @@ private[compliancetests] class ClientHttpComplianceTestCase[
       testCase.method.toLowerCase(),
       "method test :"
     )
-    val ioAsserts: List[F[ComplianceResult]] = bodyAssert +:
-      List(
+
+    val ioAsserts: List[F[ComplianceResult]] =
+      bodyAssert +: resolvedHostAssert ::: List(
         assert.testCase.checkHeaders(testCase, request.headers),
         pathAssert,
         queryAssert,

--- a/modules/core/src/smithy4s/Writer.scala
+++ b/modules/core/src/smithy4s/Writer.scala
@@ -60,6 +60,8 @@ trait Writer[Message, A] { self =>
       def write(message: Message, a: A): Message =
         other.write(self.write(message, a), a)
     }
+  def combineOpt(other: Option[Writer[Message, A]]): Writer[Message, A] =
+    other.fold(this)(combine(_))
 
 }
 

--- a/modules/core/src/smithy4s/http/internals/package.scala
+++ b/modules/core/src/smithy4s/http/internals/package.scala
@@ -24,7 +24,7 @@ package object internals {
   private[http] type HttpCode[A] = A => Option[Int]
   private[http] val httpHints = HintMask(HttpBinding)
 
-  private[internals] implicit class vectorOps[A](val vector: Vector[A])
+  private[http] implicit class vectorOps[A](val vector: Vector[A])
       extends AnyVal {
     def traverse[B](f: A => Option[B]): Option[Vector[B]] =
       vector.foldLeft[Option[Vector[B]]](Some(Vector.empty)) { (result, a) =>

--- a/modules/core/src/smithy4s/http/uri/HostEndpoint.scala
+++ b/modules/core/src/smithy4s/http/uri/HostEndpoint.scala
@@ -1,0 +1,43 @@
+/*
+ *  Copyright 2021-2022 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package smithy4s.http.uri
+
+import smithy4s.Endpoint
+
+trait HostEndpoint[I] {
+  def hostPrefix(input: I): List[String]
+}
+
+object HostEndpoint {
+  def apply[I, E, O, SI, SO](
+      endpoint: Endpoint.Base[I, E, O, SI, SO]
+  ): Option[HostEndpoint[I]] = {
+    for {
+      endpointHint <- endpoint.hints.get(smithy.api.Endpoint)
+      hostPrefixEncoder = HostPrefixSchemaVisitor(
+        endpoint.input.addHints(endpointHint)
+      )
+
+    } yield {
+      new HostEndpoint[I] {
+        def hostPrefix(input: I): List[String] =
+          hostPrefixEncoder.map(_.encode(input)).getOrElse(List.empty)
+      }
+    }
+  }
+
+}

--- a/modules/core/src/smithy4s/http/uri/HostPrefixEncode.scala
+++ b/modules/core/src/smithy4s/http/uri/HostPrefixEncode.scala
@@ -1,0 +1,31 @@
+/*
+ *  Copyright 2021-2022 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package smithy4s.http.uri
+
+trait HostPrefixEncode[A] { self =>
+  def encode(a: A): List[String]
+
+  def contramap[B](f: B => A): HostPrefixEncode[B] =
+    b => self.encode(f(b))
+}
+
+object HostPrefixEncode {
+  type MaybeHostPrefixEncode[A] = Option[HostPrefixEncode[A]]
+
+  val str: HostPrefixEncode[String] = (a: String) => List(a)
+  val maybeStr: MaybeHostPrefixEncode[String] = Some(str)
+}

--- a/modules/core/src/smithy4s/http/uri/HostPrefixInjector.scala
+++ b/modules/core/src/smithy4s/http/uri/HostPrefixInjector.scala
@@ -18,14 +18,14 @@ package smithy4s.http.uri
 
 import smithy4s.Endpoint
 
-trait HostEndpoint[I] {
-  def hostPrefix(input: I): List[String]
+trait HostPrefixInjector[I] {
+  def inject(input: I): List[String]
 }
 
-object HostEndpoint {
+object HostPrefixInjector {
   def apply[I, E, O, SI, SO](
       endpoint: Endpoint.Base[I, E, O, SI, SO]
-  ): Option[HostEndpoint[I]] = {
+  ): Option[HostPrefixInjector[I]] = {
     for {
       endpointHint <- endpoint.hints.get(smithy.api.Endpoint)
       hostPrefixEncoder = HostPrefixSchemaVisitor(
@@ -33,8 +33,8 @@ object HostEndpoint {
       )
 
     } yield {
-      new HostEndpoint[I] {
-        def hostPrefix(input: I): List[String] =
+      new HostPrefixInjector[I] {
+        def inject(input: I): List[String] =
           hostPrefixEncoder.map(_.encode(input)).getOrElse(List.empty)
       }
     }

--- a/modules/core/src/smithy4s/http/uri/HostPrefixSchemaVisitor.scala
+++ b/modules/core/src/smithy4s/http/uri/HostPrefixSchemaVisitor.scala
@@ -1,0 +1,124 @@
+/*
+ *  Copyright 2021-2022 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package smithy4s.http.uri
+
+import smithy4s.http.uri.HostPrefixEncode.{MaybeHostPrefixEncode, maybeStr}
+import smithy4s.{Schema, _}
+import smithy4s.schema._
+import HostPrefixSegment._
+import smithy4s.http.internals.vectorOps
+
+object HostPrefixSchemaVisitor
+    extends SchemaVisitor[MaybeHostPrefixEncode]
+    with SchemaVisitor.Default[MaybeHostPrefixEncode] {
+  self =>
+
+  def default[A]: MaybeHostPrefixEncode[A] = None
+
+  override def primitive[P](
+      shapeId: ShapeId,
+      hints: Hints,
+      tag: Primitive[P]
+  ): MaybeHostPrefixEncode[P] = {
+    tag match {
+      case Primitive.PString => maybeStr
+      case _                 => default
+    }
+  }
+
+  override def enumeration[E](
+      shapeId: ShapeId,
+      hints: Hints,
+      tag: EnumTag,
+      values: List[EnumValue[E]],
+      total: E => EnumValue[E]
+  ): MaybeHostPrefixEncode[E] =
+    tag match {
+      case EnumTag.IntEnum    => default
+      case EnumTag.StringEnum => maybeStr.map(_.contramap(total(_).stringValue))
+    }
+
+  override def struct[S](
+      shapeId: ShapeId,
+      hints: Hints,
+      fields: Vector[SchemaField[S, _]],
+      make: IndexedSeq[Any] => S
+  ): MaybeHostPrefixEncode[S] = {
+    type Writer = S => List[String]
+
+    def toHostPrefixEncoder[A](
+        field: Field[Schema, S, A]
+    ): Option[Writer] = {
+      field.fold(new Field.Folder[Schema, S, Option[Writer]] {
+        def onRequired[AA](
+            label: String,
+            instance: Schema[AA],
+            get: S => AA
+        ): Option[Writer] = {
+          self(instance).map(_.contramap(get).encode)
+        }
+        def onOptional[AA](
+            label: String,
+            instance: Schema[AA],
+            get: S => Option[AA]
+        ): Option[Writer] = None
+      })
+    }
+    def compile1(path: HostPrefixSegment): Option[Writer] = path match {
+      case Static(value) => Some(Function.const(List(value)))
+      case HostLabel(value) =>
+        fields
+          .find(_.label == value)
+          .flatMap(field => toHostPrefixEncoder(field))
+    }
+
+    def compileHostPrefix(
+        path: Vector[HostPrefixSegment]
+    ): Option[Vector[Writer]] =
+      path.traverse(compile1(_))
+
+    for {
+      endpointHint <- hints.get[smithy.api.Endpoint]
+      writers <- compileHostPrefix(
+        hostPrefixSegments(endpointHint.hostPrefix.value)
+      )
+    } yield new HostPrefixEncode[S] {
+      def encode(s: S): List[String] = writers.flatMap(_.apply(s)).toList
+    }
+  }
+
+  override def biject[A, B](
+      schema: Schema[A],
+      bijection: Bijection[A, B]
+  ): MaybeHostPrefixEncode[B] = {
+    self(schema).map(_.contramap(bijection.from))
+  }
+
+  override def refine[A, B](
+      schema: Schema[A],
+      refinement: Refinement[A, B]
+  ): MaybeHostPrefixEncode[B] = {
+    self(schema).map(_.contramap(refinement.from))
+  }
+
+  override def lazily[A](suspend: Lazy[Schema[A]]): MaybeHostPrefixEncode[A] = {
+    // "safe" because the `structure` implementation will not exercise any recursion
+    // due to the fact that httpLabel can only be applied on members targeting
+    // simple shapes.
+    suspend.map(this.apply(_)).value
+  }
+}

--- a/modules/core/src/smithy4s/http/uri/HostPrefixSchemaVisitor.scala
+++ b/modules/core/src/smithy4s/http/uri/HostPrefixSchemaVisitor.scala
@@ -87,9 +87,9 @@ object HostPrefixSchemaVisitor
     }
 
     def compileHostPrefix(
-        path: Vector[HostPrefixSegment]
+        hostPrefixSegments: Vector[HostPrefixSegment]
     ): Option[Vector[Writer]] =
-      path.traverse(compile1(_))
+      hostPrefixSegments.traverse(compile1(_))
 
     for {
       endpointHint <- hints.get[smithy.api.Endpoint]

--- a/modules/core/src/smithy4s/http/uri/HostPrefixSegment.scala
+++ b/modules/core/src/smithy4s/http/uri/HostPrefixSegment.scala
@@ -1,0 +1,27 @@
+/*
+ *  Copyright 2021-2022 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package smithy4s.http.uri
+
+sealed trait HostPrefixSegment
+
+object HostPrefixSegment {
+
+  def static(value: String): HostPrefixSegment = Static(value)
+  def label(value: String): HostPrefixSegment = HostLabel(value)
+  case class Static(value: String) extends HostPrefixSegment
+  case class HostLabel(name: String) extends HostPrefixSegment
+}

--- a/modules/core/src/smithy4s/http/uri/package.scala
+++ b/modules/core/src/smithy4s/http/uri/package.scala
@@ -1,0 +1,39 @@
+/*
+ *  Copyright 2021-2022 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package smithy4s.http
+
+import smithy4s.http.internals.vectorOps
+
+package object uri {
+  private def extractHostLabels(str: String): Option[HostPrefixSegment] = {
+    if (str == null || str.isEmpty) None
+    else if (str.startsWith("{") && str.endsWith("}"))
+      Some(HostPrefixSegment.label(str.substring(1, str.length() - 1)))
+    else Some(HostPrefixSegment.static(str))
+  }
+
+  private[smithy4s] def hostPrefixSegments(
+      str: String
+  ): Vector[HostPrefixSegment] = {
+    str
+      .split('.')
+      .toVector
+      .filterNot(_.isEmpty())
+      .traverse(extractHostLabels(_))
+      .getOrElse(Vector.empty)
+  }
+}

--- a/modules/http4s-kernel/src/smithy4s/http4s/kernel/RequestEncoder.scala
+++ b/modules/http4s-kernel/src/smithy4s/http4s/kernel/RequestEncoder.scala
@@ -21,6 +21,7 @@ import org.http4s.EntityEncoder
 import org.http4s.Method
 import org.http4s.Request
 import org.http4s.Uri
+import org.http4s.Uri.Authority
 import smithy4s.http.HttpEndpoint
 import smithy4s.http.HttpRestSchema
 import smithy4s.http.Metadata
@@ -128,7 +129,7 @@ object RequestEncoder {
     HttpRestSchema.combineWriterCompilers(metadataCompiler, bodyCompiler)
   }
 
-  def prefixHost(u: Uri, prefix: List[String]): Option[Authority] =
+  private def prefixHost(u: Uri, prefix: List[String]): Option[Authority] =
     u.authority.map {
       case auth @ Authority(_, Uri.RegName(hostName), _) =>
         auth.copy(host =

--- a/modules/http4s-kernel/src/smithy4s/http4s/kernel/RequestEncoder.scala
+++ b/modules/http4s-kernel/src/smithy4s/http4s/kernel/RequestEncoder.scala
@@ -25,7 +25,7 @@ import org.http4s.Uri.Authority
 import smithy4s.http.HttpEndpoint
 import smithy4s.http.HttpRestSchema
 import smithy4s.http.Metadata
-import smithy4s.http.uri.HostEndpoint
+import smithy4s.http.uri.HostPrefixInjector
 import smithy4s.kinds.FunctorK
 import smithy4s.kinds.PolyFunction
 import smithy4s.schema._
@@ -69,10 +69,10 @@ object RequestEncoder {
     }
 
   def fromHostEndpoint[F[_]: Concurrent, I](
-      hostEndpoint: HostEndpoint[I]
+      hostEndpoint: HostPrefixInjector[I]
   ): RequestEncoder[F, I] = new RequestEncoder[F, I] {
     def write(request: Request[F], input: I): Request[F] = {
-      val hostPrefix = hostEndpoint.hostPrefix(input)
+      val hostPrefix = hostEndpoint.inject(input)
       val oldUri = request.uri
       val newAuth = prefixHost(oldUri, hostPrefix)
       val newUri = oldUri.copy(authority = newAuth)

--- a/modules/http4s-kernel/src/smithy4s/http4s/kernel/RequestEncoder.scala
+++ b/modules/http4s-kernel/src/smithy4s/http4s/kernel/RequestEncoder.scala
@@ -134,7 +134,7 @@ object RequestEncoder {
       case auth @ Authority(_, Uri.RegName(hostName), _) =>
         auth.copy(host =
           Uri.RegName(
-            hostName.transform(value => s"${prefix.mkString(".")}.$value")
+            hostName.transform(value => s"${prefix.mkString("")}.$value")
           )
         )
       case other => other

--- a/modules/http4s/src/smithy4s/http4s/SimpleRestJsonBuilder.scala
+++ b/modules/http4s/src/smithy4s/http4s/SimpleRestJsonBuilder.scala
@@ -17,7 +17,7 @@
 package smithy4s
 package http4s
 
-object SimpleRestJsonBuilder extends SimpleRestJsonBuilder(1024, false)
+object SimpleRestJsonBuilder extends SimpleRestJsonBuilder(1024, false, true)
 
 class SimpleRestJsonBuilder private (
     simpleRestJsonCodecs: internals.SimpleRestJsonCodecs
@@ -25,13 +25,24 @@ class SimpleRestJsonBuilder private (
       simpleRestJsonCodecs
     ) {
 
-  def this(maxArity: Int, explicitNullEncoding: Boolean) =
-    this(new internals.SimpleRestJsonCodecs(maxArity, explicitNullEncoding))
+  def this(
+      maxArity: Int,
+      explicitNullEncoding: Boolean,
+      hostPrefixInjection: Boolean
+  ) =
+    this(
+      new internals.SimpleRestJsonCodecs(
+        maxArity,
+        explicitNullEncoding,
+        hostPrefixInjection
+      )
+    )
 
   def withMaxArity(maxArity: Int): SimpleRestJsonBuilder =
     new SimpleRestJsonBuilder(
       maxArity,
-      simpleRestJsonCodecs.explicitNullEncoding
+      simpleRestJsonCodecs.explicitNullEncoding,
+      simpleRestJsonCodecs.hostPrefixInjectionEnabled
     )
 
   def withExplicitNullEncoding(
@@ -39,6 +50,13 @@ class SimpleRestJsonBuilder private (
   ): SimpleRestJsonBuilder =
     new SimpleRestJsonBuilder(
       simpleRestJsonCodecs.maxArity,
-      explicitNullEncoding
+      explicitNullEncoding,
+      simpleRestJsonCodecs.hostPrefixInjectionEnabled
+    )
+  def disableHostPrefixInjection(): SimpleRestJsonBuilder =
+    new SimpleRestJsonBuilder(
+      simpleRestJsonCodecs.maxArity,
+      simpleRestJsonCodecs.explicitNullEncoding,
+      false
     )
 }

--- a/modules/http4s/src/smithy4s/http4s/internals/SimpleRestJsonCodecs.scala
+++ b/modules/http4s/src/smithy4s/http4s/internals/SimpleRestJsonCodecs.scala
@@ -29,7 +29,8 @@ import org.http4s.syntax.all._
 
 private[http4s] class SimpleRestJsonCodecs(
     val maxArity: Int,
-    val explicitNullEncoding: Boolean
+    val explicitNullEncoding: Boolean,
+    val hostPrefixInjectionEnabled: Boolean
 ) extends SimpleProtocolCodecs {
   private val hintMask =
     alloy.SimpleRestJson.protocol.hintMask ++ HintMask(IntEnum)
@@ -109,7 +110,8 @@ private[http4s] class SimpleRestJsonCodecs(
             errorHeaders,
             getResponseMetadata(response)
           )
-        )
+        ),
+      hostPrefixInjectionEnabled
     )
   }
 

--- a/sampleSpecs/metadata.smithy
+++ b/sampleSpecs/metadata.smithy
@@ -6,7 +6,7 @@ namespace smithy4s.example
 /// when testing core
 service DummyService {
   version: "0.0",
-  operations: [Dummy, DummyPath]
+  operations: [Dummy,DummyHostPrefix,  DummyPath]
 }
 
 @http(method: "GET", uri: "/dummy")
@@ -19,6 +19,29 @@ operation Dummy {
 @readonly
 operation DummyPath {
   input: PathParams
+}
+
+@http(method: "GET", uri: "/dummy")
+@endpoint(hostPrefix:"foo.{label1}--abc{label2}.{label3}.secure.")
+operation DummyHostPrefix{
+input: HostLabelInput
+}
+
+structure HostLabelInput {
+  @required
+  @hostLabel
+  label1: String,
+  @required
+  @hostLabel
+  label2: String,
+  @required
+  @hostLabel
+  label3:HostLabelEnum
+}
+
+enum HostLabelEnum {
+  THING1
+  THING2
 }
 
 structure Queries {


### PR DESCRIPTION
- This is a first run at implementing client-side endpoint and hostLabel traits
   -  since hostLabel has no effect on the protocol serialization, I see no reason for there to be a server-side implementation , since the interpreter only matches on Path, not the hostname
- this passes restJson1 and AwsJson0 and AwsJson1 endpoint related tests
- Naming and file location are not great

#### currently failing due to OpenApi conversion as the hostLabel trait is unsupported 

~~TODO~~
- ~~add the ability for the client to disable host prefix rendering per https://smithy.io/2.0/spec/endpoint-traits.html#smithy-api-endpoint-trait~~
> Clients SHOULD provide a way for users to disable the hostPrefix injection behavior. If a user sets this flag, the client MUST NOT perform any hostPrefix expansion and MUST NOT prepend the prefix to the client derived host. The client MUST serialize members to any modeled target location regardless of this flag.

UPDATE
- added ability to disable hostPrefix injection
- included it in rest json builder
