### PR TITLE
Add a version command to the CLI

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -377,9 +377,11 @@ lazy val codegen = projectMatrix
  */
 lazy val `codegen-cli` = projectMatrix
   .in(file("modules/codegen-cli"))
+  .enablePlugins(BuildInfoPlugin)
   .dependsOn(codegen)
   .jvmPlatform(List(Scala213), jvmDimSettings)
   .settings(
+    buildInfoPackage := "smithy4s.codegen.cli",
     libraryDependencies ++= Seq(
       Dependencies.Decline.core.value,
       Dependencies.Weaver.cats.value % Test

--- a/modules/codegen-cli/src/smithy4s/codegen/cli/Main.scala
+++ b/modules/codegen-cli/src/smithy4s/codegen/cli/Main.scala
@@ -29,7 +29,8 @@ object Main {
       NonEmptyList
         .of(
           CodegenCommand.command,
-          DumpModelCommand.command
+          DumpModelCommand.command,
+          VersionCommand.command
         )
         .reduceMapK(Opts.subcommand(_))
     )
@@ -58,6 +59,9 @@ object Main {
 
           case Smithy4sCommand.DumpModel(args) =>
             out.println(Codegen.dumpModel(args))
+
+          case Smithy4sCommand.Version =>
+            out.println(BuildInfo.version)
         }
         .leftMap { help =>
           System.err.println(help.show)

--- a/modules/codegen-cli/src/smithy4s/codegen/cli/Options.scala
+++ b/modules/codegen-cli/src/smithy4s/codegen/cli/Options.scala
@@ -15,6 +15,7 @@
  */
 
 package smithy4s.codegen.cli
+
 import cats.data.Validated
 import cats.data.ValidatedNel
 import cats.syntax.all._

--- a/modules/codegen-cli/src/smithy4s/codegen/cli/VersionCommand.scala
+++ b/modules/codegen-cli/src/smithy4s/codegen/cli/VersionCommand.scala
@@ -16,12 +16,12 @@
 
 package smithy4s.codegen.cli
 
-import smithy4s.codegen.CodegenArgs
-import smithy4s.codegen.DumpModelArgs
+import com.monovore.decline.Command
+import com.monovore.decline.Opts
 
-sealed trait Smithy4sCommand extends Product with Serializable
-object Smithy4sCommand {
-  final case class Generate(args: CodegenArgs) extends Smithy4sCommand
-  final case class DumpModel(args: DumpModelArgs) extends Smithy4sCommand
-  final case object Version extends Smithy4sCommand
+object VersionCommand {
+  val command: Command[Smithy4sCommand.Version.type] =
+    Command("version", "Output the version of the CLI.")(
+      Opts(Smithy4sCommand.Version)
+    )
 }


### PR DESCRIPTION
I've interacted with users that had installed an old version of the CLI and they had issues. Turns out the issue were version related and I could not know what version they were using.

```bash
> sbt -error "codegen-cli/run version"
0.18.1-SNAPSHOT
```