### PR TITLE
[aws] Keep casing in file credential provider

### DIFF
--- a/modules/aws/src/smithy4s/aws/AwsCredentialsFile.scala
+++ b/modules/aws/src/smithy4s/aws/AwsCredentialsFile.scala
@@ -85,7 +85,7 @@ object AwsCredentialsFile {
         case head :: next =>
           val parts = head.split("=")
           val key = parts(0).trim().toLowerCase
-          val value = parts(1).trim().toLowerCase()
+          val value = parts(1).trim()
           val updated = data + (key -> value)
           inProfile(next, currentProfile, updated)
       }

--- a/modules/aws/test/src/smithy4s/aws/AwsCredentialsFileTest.scala
+++ b/modules/aws/test/src/smithy4s/aws/AwsCredentialsFileTest.scala
@@ -48,6 +48,24 @@ object AwsCredentialsFileTest extends FunSuite {
     }
   }
 
+  test("be case sensitive") {
+    expectRight(
+      AwsCredentialsFile.processFileLines(
+        asLines(
+          """|[default]
+             |aws_secret_access_key = DeF_SeC
+             |aws_access_key_id     = dEf_KEy
+             |aws_session_token     = dEF_TokEn""".stripMargin
+        )
+      )
+    ) { res =>
+      expect.same(
+        Some(AwsCredentials.Default("dEf_KEy", "DeF_SeC", Some("dEF_TokEn"))),
+        res.default
+      )
+    }
+  }
+
   test("parse comments") {
     expectRight(
       AwsCredentialsFile.processFileLines(


### PR DESCRIPTION
Resolves part 2 of #1075 for 0.17. We'll get this ported to 0.18 later on.