### PR TITLE
[RestXML Support] Various fixes

### DIFF
--- a/modules/aws-http4s/test/src/smithy4s/aws/ClientPrepareTest.scala
+++ b/modules/aws-http4s/test/src/smithy4s/aws/ClientPrepareTest.scala
@@ -33,7 +33,8 @@ object ClientPrepareTest extends FunSuite {
               aws.protocols.AwsJson1_0.getTag,
               aws.protocols.AwsJson1_1.getTag,
               aws.protocols.AwsQuery.getTag,
-              aws.protocols.RestJson1.getTag
+              aws.protocols.RestJson1.getTag,
+              aws.protocols.RestXml.getTag
             )
           )
         )

--- a/modules/aws-http4s/test/src/smithy4s/aws/compliancetests/AwsComplianceSuite.scala
+++ b/modules/aws-http4s/test/src/smithy4s/aws/compliancetests/AwsComplianceSuite.scala
@@ -67,7 +67,9 @@ object AwsComplianceSuite extends ProtocolComplianceSuite {
   private val modelDump = fileFromEnv("MODEL_DUMP")
 
   val jsonPayloadCodecs =
-    smithy4s.aws.internals.AwsJsonCodecs.jsonPayloadCodecs
+    smithy4s.json.Json.payloadCodecs.withJsoniterCodecCompiler {
+      smithy4s.json.Json.jsoniter.withMapOrderPreservation(true)
+    }
 
   override def dynamicSchemaIndexLoader: IO[DynamicSchemaIndex] = {
     for {

--- a/modules/aws-http4s/test/src/smithy4s/aws/compliancetests/AwsComplianceSuite.scala
+++ b/modules/aws-http4s/test/src/smithy4s/aws/compliancetests/AwsComplianceSuite.scala
@@ -44,8 +44,7 @@ object AwsComplianceSuite extends ProtocolComplianceSuite {
 
     val disallowed = Set(
       // this would be taken-care of by middleware
-      "HostWithPathOperation",
-      "XmlUnionsWith" // TODO: fix
+      "HostWithPathOperation"
     )
     (complianceTest: ComplianceTest[IO]) =>
       if (disallowed.exists(complianceTest.show.contains(_))) ShouldRun.No

--- a/modules/compliance-tests/src/smithy4s/compliancetests/HttpProtocolCompliance.scala
+++ b/modules/compliance-tests/src/smithy4s/compliancetests/HttpProtocolCompliance.scala
@@ -16,7 +16,7 @@
 
 package smithy4s.compliancetests
 
-import cats.effect.Temporal
+import cats.effect.Async
 import smithy4s.Service
 
 /**
@@ -32,7 +32,7 @@ object HttpProtocolCompliance {
   def clientTests[F[_], Alg[_[_, _, _, _, _]]](
       reverseRouter: ReverseRouter[F],
       service: Service[Alg]
-  )(implicit ce: Temporal[F]): List[ComplianceTest[F]] =
+  )(implicit ce: Async[F]): List[ComplianceTest[F]] =
     new internals.ClientHttpComplianceTestCase[F, Alg](
       reverseRouter,
       service
@@ -41,7 +41,7 @@ object HttpProtocolCompliance {
   def serverTests[F[_], Alg[_[_, _, _, _, _]]](
       router: Router[F],
       service: Service[Alg]
-  )(implicit ce: Temporal[F]): List[ComplianceTest[F]] =
+  )(implicit ce: Async[F]): List[ComplianceTest[F]] =
     new internals.ServerHttpComplianceTestCase[F, Alg](
       router,
       service
@@ -50,7 +50,7 @@ object HttpProtocolCompliance {
   def clientAndServerTests[F[_], Alg[_[_, _, _, _, _]]](
       router: Router[F] with ReverseRouter[F],
       service: Service[Alg]
-  )(implicit ce: Temporal[F]): List[ComplianceTest[F]] =
+  )(implicit ce: Async[F]): List[ComplianceTest[F]] =
     clientTests(router, service) ++ serverTests(router, service)
 
 }

--- a/modules/compliance-tests/src/smithy4s/compliancetests/internals/Assertions.scala
+++ b/modules/compliance-tests/src/smithy4s/compliancetests/internals/Assertions.scala
@@ -34,6 +34,9 @@ private[internals] object assert {
   private def isJson(bodyMediaType: Option[String]) =
     bodyMediaType.exists(_.equalsIgnoreCase("application/json"))
 
+  private def isXml(bodyMediaType: Option[String]) =
+    bodyMediaType.exists(_.equalsIgnoreCase("application/xml"))
+
   private def jsonEql(result: String, testCase: String): ComplianceResult = {
     (result.isEmpty, testCase.isEmpty) match {
       case (true, true) => success
@@ -49,6 +52,14 @@ private[internals] object assert {
             fail(s"JSONs are not equal: result json: $a \n testcase json:  $b")
         }
     }
+  }
+
+  private def xmlEql(result: String, testCase: String): ComplianceResult = {
+    // TODO fix this poor man's attempt at standardising the xml payloads with actual xml parsing
+    eql(
+      result,
+      testCase.replace(">\n", ">").replaceAll("(\\s)*<", "<")
+    )
   }
 
   def eql[A: Eq](
@@ -74,6 +85,8 @@ private[internals] object assert {
     if (testCase.isDefined)
       if (isJson(bodyMediaType)) {
         jsonEql(result, testCase.getOrElse(""))
+      } else if (isXml(bodyMediaType)) {
+        xmlEql(result, testCase.getOrElse(""))
       } else {
         eql(result, testCase.getOrElse(""))
       }

--- a/modules/compliance-tests/src/smithy4s/compliancetests/internals/ClientHttpComplianceTestCase.scala
+++ b/modules/compliance-tests/src/smithy4s/compliancetests/internals/ClientHttpComplianceTestCase.scala
@@ -18,7 +18,7 @@ package smithy4s.compliancetests
 package internals
 
 import cats.implicits._
-import cats.effect.Temporal
+import cats.effect.Async
 import cats.effect.syntax.all._
 import org.http4s.HttpApp
 import org.http4s.Headers
@@ -42,7 +42,7 @@ private[compliancetests] class ClientHttpComplianceTestCase[
 ](
     reverseRouter: ReverseRouter[F],
     serviceInstance: Service[Alg]
-)(implicit ce: Temporal[F]) {
+)(implicit ce: Async[F]) {
   import ce._
   import org.http4s.implicits._
   import reverseRouter._
@@ -110,7 +110,7 @@ private[compliancetests] class ClientHttpComplianceTestCase[
       endpoint.id,
       testCase.documentation,
       clientReq,
-      run = {
+      run = ce.defer {
         val input = inputFromDocument
           .decode(testCase.params.getOrElse(Document.obj()))
           .liftTo[F]
@@ -156,7 +156,7 @@ private[compliancetests] class ClientHttpComplianceTestCase[
       endpoint.id,
       testCase.documentation,
       clientRes,
-      run = {
+      run = ce.defer {
         implicit val outputEq: Eq[O] =
           smithy4s.compliancetests.internals.eq.EqSchemaVisitor(endpoint.output)
         val buildResult = {

--- a/modules/compliance-tests/src/smithy4s/compliancetests/internals/ServerHttpComplianceTestCase.scala
+++ b/modules/compliance-tests/src/smithy4s/compliancetests/internals/ServerHttpComplianceTestCase.scala
@@ -18,7 +18,7 @@ package smithy4s.compliancetests
 package internals
 
 import cats.implicits._
-import cats.effect.Temporal
+import cats.effect.Async
 import cats.effect.syntax.all._
 import cats.kernel.Eq
 import org.http4s._
@@ -40,7 +40,7 @@ private[compliancetests] class ServerHttpComplianceTestCase[
     router: Router[F],
     serviceInstance: Service[Alg]
 )(implicit
-    ce: Temporal[F]
+    ce: Async[F]
 ) {
 
   import ce._
@@ -102,7 +102,7 @@ private[compliancetests] class ServerHttpComplianceTestCase[
       endpoint.id,
       testCase.documentation,
       serverReq,
-      run = {
+      run = ce.defer {
         deferred[I].flatMap { inputDeferred =>
           val fakeImpl: FunctorAlgebra[Alg, F] =
             originalService.fromPolyFunction[Kind1[F]#toKind5](
@@ -179,7 +179,7 @@ private[compliancetests] class ServerHttpComplianceTestCase[
       endpoint.id,
       testCase.documentation,
       serverRes,
-      run = {
+      run = ce.defer {
         val (amendedService, syntheticRequest) = prepareService(endpoint)
 
         val buildResult: Either[Document => F[Throwable], Document => F[O]] = {

--- a/modules/json/src/smithy4s/json/JsoniterCodecCompiler.scala
+++ b/modules/json/src/smithy4s/json/JsoniterCodecCompiler.scala
@@ -63,6 +63,11 @@ trait JsoniterCodecCompiler extends CachedSchemaCompiler[JsonCodec] {
   def withInfinitySupport(infinitySupport: Boolean): JsoniterCodecCompiler
 
   /**
+    * Changes the behaviour of Json decoders so that the preserve the ordering of maps.
+    */
+  def withMapOrderPreservation(preserveMapOrder: Boolean): JsoniterCodecCompiler
+
+  /**
     * Changes the hint mask with which the decoder works. Depending on the hint mask, some
     * smithy traits may be overlooked during encoding/decoding. For instance, `@jsonName`.
     */

--- a/modules/json/src/smithy4s/json/internals/JsoniterCodecCompilerImpl.scala
+++ b/modules/json/src/smithy4s/json/internals/JsoniterCodecCompilerImpl.scala
@@ -25,6 +25,7 @@ private[smithy4s] case class JsoniterCodecCompilerImpl(
     explicitNullEncoding: Boolean,
     flexibleCollectionsSupport: Boolean,
     infinitySupport: Boolean,
+    preserveMapOrder: Boolean,
     hintMask: Option[HintMask]
 ) extends CachedSchemaCompiler.Impl[JCodec]
     with JsoniterCodecCompiler {
@@ -49,12 +50,18 @@ private[smithy4s] case class JsoniterCodecCompilerImpl(
   def withInfinitySupport(infinitySupport: Boolean): JsoniterCodecCompiler =
     copy(infinitySupport = infinitySupport)
 
+  def withMapOrderPreservation(
+      preserveMapOrder: Boolean
+  ): JsoniterCodecCompiler =
+    copy(preserveMapOrder = preserveMapOrder)
+
   def fromSchema[A](schema: Schema[A], cache: Cache): JCodec[A] = {
     val visitor = new SchemaVisitorJCodec(
       maxArity,
       explicitNullEncoding,
       infinitySupport,
       flexibleCollectionsSupport,
+      preserveMapOrder,
       cache
     )
     val amendedSchema =
@@ -74,6 +81,7 @@ private[smithy4s] object JsoniterCodecCompilerImpl {
       explicitNullEncoding = false,
       infinitySupport = false,
       flexibleCollectionsSupport = false,
+      preserveMapOrder = false,
       hintMask = Some(JsoniterCodecCompiler.defaultHintMask)
     )
 

--- a/modules/xml/src/smithy4s/xml/XPath.scala
+++ b/modules/xml/src/smithy4s/xml/XPath.scala
@@ -19,6 +19,7 @@ import smithy4s.xml.XPath.Segment.Attr
 import smithy4s.xml.XPath.Segment.Index
 import smithy4s.xml.XPath.Segment.Tag
 import smithy4s.xml.XmlDocument.XmlQName
+import smithy4s.codecs.PayloadPath
 
 /**
   * Represents a path in the XML payload. Segments can be either tags, indexes (when dealing with collections), or attributes.
@@ -27,6 +28,15 @@ import smithy4s.xml.XmlDocument.XmlQName
   */
 case class XPath(reversedSegments: List[XPath.Segment]) {
   def render: String = reversedSegments.reverse.map(_.render).mkString(".")
+  def toPayloadPath: PayloadPath = PayloadPath {
+    reversedSegments.reverse.map { xpathSegment =>
+      xpathSegment match {
+        case Index(index) => PayloadPath.Segment(index)
+        case Tag(tag)     => PayloadPath.Segment(tag.name)
+        case Attr(attr)   => PayloadPath.Segment("attr:" + attr)
+      }
+    }
+  }
 
   def appendIndex(index: Int): XPath = XPath(
     XPath.Segment.Index(index) :: reversedSegments

--- a/modules/xml/src/smithy4s/xml/XmlDocument.scala
+++ b/modules/xml/src/smithy4s/xml/XmlDocument.scala
@@ -127,29 +127,14 @@ object XmlDocument {
     def fromSchema[A](schema: Schema[A]): Encoder[A] = {
       val rootName: XmlQName = getRootName(schema)
       val xmlEncoder = XmlEncoderSchemaVisitor(schema)
-      if (xmlEncoder.encodesUnion) {
-        // The union encoder should always return a single XML element
-        new Encoder[A] {
-          def encode(value: A): XmlDocument = {
-            xmlEncoder
-              .encode(value)
-              .collectFirst { case elem @ XmlElem(_, _, _) =>
-                elem
-              }
-              .map(XmlDocument(_))
-              .getOrElse(XmlDocument(XmlElem(rootName, Nil, Nil)))
-          }
-        }
-      } else {
-        new Encoder[A] {
-          def encode(value: A): XmlDocument = {
-            val (attributes, children) =
-              xmlEncoder.encode(value).partitionEither {
-                case attr @ XmlAttr(_, _) => Left(attr)
-                case other                => Right(other)
-              }
-            XmlDocument(XmlElem(rootName, attributes, children))
-          }
+      new Encoder[A] {
+        def encode(value: A): XmlDocument = {
+          val (attributes, children) =
+            xmlEncoder.encode(value).partitionEither {
+              case attr @ XmlAttr(_, _) => Left(attr)
+              case other                => Right(other)
+            }
+          XmlDocument(XmlElem(rootName, attributes, children))
         }
       }
     }

--- a/modules/xml/src/smithy4s/xml/internals/XmlDecoder.scala
+++ b/modules/xml/src/smithy4s/xml/internals/XmlDecoder.scala
@@ -82,7 +82,7 @@ private[smithy4s] object XmlDecoder {
     * This is the method that is used to define primitive decoders, as all primitives
     * are decoded from text content, whether it's in elements or in attributes.
     */
-  def fromStringParser[A](expectedType: String)(
+  def fromStringParser[A](expectedType: String, trim: Boolean)(
       f: String => Option[A]
   ): XmlDecoder[A] =
     new XmlDecoder[A] {
@@ -90,7 +90,7 @@ private[smithy4s] object XmlDecoder {
         case Nodes(history, NonEmptyList(node, Nil)) =>
           node.children match {
             case XmlDocument.XmlText(value) :: Nil =>
-              f(value.trim()).toRight(
+              f(if (trim) value.trim() else value).toRight(
                 XmlDecodeError(
                   history,
                   s"Could not extract $expectedType from $value"

--- a/modules/xml/src/smithy4s/xml/internals/XmlDecoder.scala
+++ b/modules/xml/src/smithy4s/xml/internals/XmlDecoder.scala
@@ -90,7 +90,7 @@ private[smithy4s] object XmlDecoder {
         case Nodes(history, NonEmptyList(node, Nil)) =>
           node.children match {
             case XmlDocument.XmlText(value) :: Nil =>
-              f(value).toRight(
+              f(value.trim()).toRight(
                 XmlDecodeError(
                   history,
                   s"Could not extract $expectedType from $value"

--- a/modules/xml/src/smithy4s/xml/internals/XmlDecoderSchemaVisitor.scala
+++ b/modules/xml/src/smithy4s/xml/internals/XmlDecoderSchemaVisitor.scala
@@ -40,8 +40,9 @@ private[smithy4s] abstract class XmlDecoderSchemaVisitor
       tag: Primitive[P]
   ): XmlDecoder[P] = {
     val desc = SchemaDescription.primitive(shapeId, hints, tag)
+    val trim = (tag != Primitive.PString && tag != Primitive.PBlob)
     Primitive.stringParser(tag, hints) match {
-      case Some(parser) => XmlDecoder.fromStringParser(desc)(parser)
+      case Some(parser) => XmlDecoder.fromStringParser(desc, trim)(parser)
       case None => XmlDecoder.alwaysFailing(s"Cannot decode $desc from XML")
     }
   }
@@ -105,11 +106,13 @@ private[smithy4s] abstract class XmlDecoderSchemaVisitor
     if (isIntEnum) {
       val desc = s"enum[${values.map(_.intValue).mkString(", ")}]"
       val valueMap = values.map(ev => ev.intValue -> ev.value).toMap
-      XmlDecoder.fromStringParser(desc)(_.toIntOption.flatMap(valueMap.get))
+      XmlDecoder.fromStringParser(desc, trim = true)(
+        _.toIntOption.flatMap(valueMap.get)
+      )
     } else {
       val desc = s"enum[${values.map(_.stringValue).mkString(", ")}]"
       val valueMap = values.map(ev => ev.stringValue -> ev.value).toMap
-      XmlDecoder.fromStringParser(desc)(valueMap.get)
+      XmlDecoder.fromStringParser(desc, trim = false)(valueMap.get)
     }
   }
 

--- a/modules/xml/test/src/smithy4s/xml/XmlCodecSpec.scala
+++ b/modules/xml/test/src/smithy4s/xml/XmlCodecSpec.scala
@@ -332,12 +332,57 @@ object XmlCodecSpec extends SimpleIOSuite {
       union(left, right) {
         case Left(int)     => left(int)
         case Right(string) => right(string)
-      }
+      }.n
     }
-    val xmlLeft = """<left>1</left>"""
-    val xmlRight = """<right>hello</right>""".stripMargin
+    val xmlLeft = """<Foo><left>1</left></Foo>"""
+    val xmlRight = """<Foo><right>hello</right></Foo>""".stripMargin
     checkContent[Foo](xmlLeft, Left(1)) |+|
       checkContent[Foo](xmlRight, Right("hello"))
+  }
+
+  test("union") {
+    type Foo = Either[Int, String]
+    implicit val schema: Schema[Foo] = {
+      val left = int.oneOf[Foo]("left", Left(_))
+      val right = string.oneOf[Foo]("right", Right(_))
+      union(left, right) {
+        case Left(int)     => left(int)
+        case Right(string) => right(string)
+      }.n
+    }
+    val xmlLeft = """<Foo><left>1</left></Foo>"""
+    val xmlRight = """<Foo><right>hello</right></Foo>""".stripMargin
+    checkContent[Foo](xmlLeft, Left(1)) |+|
+      checkContent[Foo](xmlRight, Right("hello"))
+  }
+
+  test("recursiveUnion") {
+
+    sealed trait Foo
+    object Foo {
+      case class Bar(foo: Foo) extends Foo
+      case class Baz(int: Int) extends Foo
+
+      implicit val schema: Schema[Foo] = Schema.recursive {
+        val bar =
+          Foo.schema
+            .biject[Foo.Bar](Foo.Bar(_), (_: Foo.Bar).foo)
+            .oneOf[Foo]("bar")
+        val baz =
+          int.biject[Foo.Baz](Foo.Baz(_), (_: Foo.Baz).int).oneOf[Foo]("baz")
+        union(bar, baz) {
+          case b: Foo.Bar => bar(b)
+          case b: Foo.Baz => baz(b)
+        }.n
+      }
+    }
+    val xml = """|<Foo>
+                 |   <bar>
+                 |      <baz>1</baz>
+                 |   </bar>
+                 |</Foo>
+                 |""".stripMargin
+    checkContent[Foo](xml, Foo.Bar(Foo.Baz(1)))
   }
 
   test("union: custom names") {
@@ -348,10 +393,10 @@ object XmlCodecSpec extends SimpleIOSuite {
       union(left, right) {
         case Left(int)     => left(int)
         case Right(string) => right(string)
-      }
+      }.n
     }
-    val xmlLeft = """<foo>1</foo>"""
-    val xmlRight = """<bar>hello</bar>""".stripMargin
+    val xmlLeft = """<Foo><foo>1</foo></Foo>"""
+    val xmlRight = """<Foo><bar>hello</bar></Foo>""".stripMargin
     checkContent[Foo](xmlLeft, Left(1)) |+|
       checkContent[Foo](xmlRight, Right("hello"))
   }


### PR DESCRIPTION
* Fix union decoding/encoding (at least avoids stack-overflows) 
* Defer test scenarios of compliance tests. This facilitates debugging 
* Ensures that Xml decoders are erroring with `HttpContractError` when connected to the AWS interpreters
* Adds a poor-man's way of comparing xml payloads against ones that are prettified. This is a temporary hack and should be replaced with proper xml parsing. 