### PR TITLE
Rework xml decoding to start from an arbitrary XPath 

### DIFF
--- a/modules/aws-http4s/src/smithy4s/aws/AwsErrorTypeDecoder.scala
+++ b/modules/aws-http4s/src/smithy4s/aws/AwsErrorTypeDecoder.scala
@@ -80,8 +80,11 @@ object AwsErrorTypeDecoder {
     protected[aws] val schema: smithy4s.Schema[AwsErrorType] = {
       import smithy4s.schema.Schema._
 
-      val __typeField = string.optional[AwsErrorType]("__type", _.__type)
-      val codeField = string.optional[AwsErrorType]("code", _.code)
+      val __typeField = string
+        .optional[AwsErrorType]("__type", _.__type)
+      val codeField = string
+        .optional[AwsErrorType]("code", _.code)
+        .addHints(smithy.api.XmlName("Code"))
       val typeHeader =
         string
           .optional[AwsErrorType]("typeHeader", _.typeHeader)

--- a/modules/compliance-tests/src/smithy4s/compliancetests/internals/ClientHttpComplianceTestCase.scala
+++ b/modules/compliance-tests/src/smithy4s/compliancetests/internals/ClientHttpComplianceTestCase.scala
@@ -210,6 +210,7 @@ private[compliancetests] class ClientHttpComplianceTestCase[
                   val res: F[O] = service
                     .toPolyFunction[R](client)
                     .apply(endpoint.wrap(dummyInput))
+
                   res.map { output =>
                     assert.eql(
                       output,
@@ -237,22 +238,19 @@ private[compliancetests] class ClientHttpComplianceTestCase[
               .flatMap(_.value)
               .filter(_.protocol == protocolTag.id.toString())
               .filter(tc => tc.appliesTo.forall(_ == AppliesTo.SERVER))
-              .map(tc =>
+              .map { tc =>
                 clientResponseTest(
                   endpoint,
                   tc,
                   errorSchema = Some(
-                    ErrorResponseTest
-                      .from(
-                        errorAlt,
-                        Alt.Dispatcher.fromUnion(
-                          errorable.error
-                        ),
-                        errorable
-                      )
+                    ErrorResponseTest.from(
+                      errorAlt,
+                      Alt.Dispatcher.fromUnion(errorable.error),
+                      errorable
+                    )
                   )
                 )
-              )
+              }
           }
         }
     }

--- a/modules/compliance-tests/src/smithy4s/compliancetests/internals/ErrorResponseTest.scala
+++ b/modules/compliance-tests/src/smithy4s/compliancetests/internals/ErrorResponseTest.scala
@@ -53,7 +53,10 @@ private[compliancetests] final case class ErrorResponseTest[A, E](
           (dispatcher(e), dispatchThrowable(throwable)) match {
             case (Some(expected), Some(result)) =>
               assert.eql(result, expected)
-            case _ => assert.fail("")
+            case _ =>
+              assert.fail(
+                s"Could not decode error response to known model: $throwable"
+              )
           }
         }
         .liftTo[F]

--- a/modules/core/src/smithy4s/schema/CachedSchemaCompiler.scala
+++ b/modules/core/src/smithy4s/schema/CachedSchemaCompiler.scala
@@ -39,6 +39,19 @@ trait CachedSchemaCompiler[+F[_]] { self =>
       )
     }
 
+  final def contramapSchema(
+      fk: PolyFunction[Schema, Schema]
+  ): CachedSchemaCompiler[F] = new CachedSchemaCompiler[F] {
+    type Cache = self.Cache
+    def createCache(): Cache = self.createCache()
+
+    def fromSchema[A](schema: Schema[A]): F[A] = self.fromSchema(fk(schema))
+
+    def fromSchema[A](schema: Schema[A], cache: Cache): F[A] =
+      self.fromSchema(fk(schema), cache)
+
+  }
+
 }
 
 object CachedSchemaCompiler { outer =>

--- a/modules/tests/src/smithy4s/tests/ProtocolComplianceSuite.scala
+++ b/modules/tests/src/smithy4s/tests/ProtocolComplianceSuite.scala
@@ -141,7 +141,7 @@ abstract class ProtocolComplianceSuite
       if (shouldRun == ShouldRun.Yes) {
         Stream {
           tc.run
-            .map(res => expectSuccess(res))
+            .map(res => { println(res); expectSuccess(res) })
             .attempt
             .map {
               case Right(expectations) => expectations
@@ -172,8 +172,9 @@ abstract class ProtocolComplianceSuite
       res: ComplianceTest.ComplianceResult
   ): Expectations = {
     res.toEither match {
-      case Left(failures) => failures.foldMap(Expectations.Helpers.failure(_))
-      case Right(_)       => Expectations.Helpers.success
+      case Left(failures) =>
+        failures.foldMap(Expectations.Helpers.failure(_))
+      case Right(_) => Expectations.Helpers.success
     }
   }
 

--- a/modules/tests/src/smithy4s/tests/ProtocolComplianceSuite.scala
+++ b/modules/tests/src/smithy4s/tests/ProtocolComplianceSuite.scala
@@ -141,7 +141,7 @@ abstract class ProtocolComplianceSuite
       if (shouldRun == ShouldRun.Yes) {
         Stream {
           tc.run
-            .map(res => { println(res); expectSuccess(res) })
+            .map(res => expectSuccess(res))
             .attempt
             .map {
               case Right(expectations) => expectations

--- a/modules/xml/src/smithy4s/xml/XPath.scala
+++ b/modules/xml/src/smithy4s/xml/XPath.scala
@@ -44,6 +44,9 @@ case class XPath(reversedSegments: List[XPath.Segment]) {
   def appendTag(tag: XmlQName): XPath = XPath(
     XPath.Segment.Tag(tag) :: reversedSegments
   )
+  def appendTag(tag: String): XPath = XPath(
+    XPath.Segment.Tag(XmlQName.parse(tag)) :: reversedSegments
+  )
   def appendAttr(name: XmlQName): XPath = XPath(
     XPath.Segment.Attr(name) :: reversedSegments
   )

--- a/modules/xml/src/smithy4s/xml/XmlDocument.scala
+++ b/modules/xml/src/smithy4s/xml/XmlDocument.scala
@@ -104,26 +104,29 @@ object XmlDocument {
       .getOrElse(XmlQName.fromShapeId(schema.shapeId))
   }
 
+  private def getStartingPath[A](schema: Schema[A]): List[XmlQName] = {
+    schema.hints
+      .get(internals.XmlStartingPath)
+      .map(_.path.map(XmlQName.parse))
+      .getOrElse(List(getRootName(schema)))
+  }
+
   /**
     * A Decoder aims at decoding documents. As such, it is not meant to be a compositional construct, because
     * documents cannot be nested under other documents. This aims at decoding top-level XML payloads.
     */
   trait Decoder[A] {
-    def root: List[XmlQName]
-
     def decode(xmlDocument: XmlDocument): Either[XmlDecodeError, A]
   }
 
   object Decoder extends CachedSchemaCompiler.Impl[Decoder] {
     def fromSchema[A](schema: Schema[A], cache: Cache): Decoder[A] = {
-      val expectedRootName: XmlQName = getRootName(schema)
-      val expectedRoot = List(expectedRootName)
+      val startingPath: List[XmlQName] = getStartingPath(schema)
       new Decoder[A] {
-        def root = expectedRoot
         val decoder = XmlDecoderSchemaVisitor(schema)
         def decode(xmlDocument: XmlDocument): Either[XmlDecodeError, A] = {
           val documentCursor = XmlCursor.fromDocument(xmlDocument)
-          val updatedCursor = root.foldLeft(documentCursor)(_.down(_))
+          val updatedCursor = startingPath.foldLeft(documentCursor)(_.down(_))
           decoder.decode(updatedCursor)
         }
       }

--- a/modules/xml/src/smithy4s/xml/internals/XmlDecoder.scala
+++ b/modules/xml/src/smithy4s/xml/internals/XmlDecoder.scala
@@ -17,14 +17,10 @@
 package smithy4s.xml
 package internals
 
-import cats.data.NonEmptyList
 import smithy4s.ConstraintError
 import smithy4s.xml.XmlDocument
 import smithy4s.xml.XmlDocument.XmlQName
-import smithy4s.xml.internals.XmlCursor.AttrNode
-import smithy4s.xml.internals.XmlCursor.FailedNode
-import smithy4s.xml.internals.XmlCursor.NoNode
-import smithy4s.xml.internals.XmlCursor.Nodes
+import smithy4s.xml.internals.XmlCursor._
 
 /**
   * This constructs allow for decoding XML data. It is not limited to top-level
@@ -87,7 +83,7 @@ private[smithy4s] object XmlDecoder {
   ): XmlDecoder[A] =
     new XmlDecoder[A] {
       def decode(cursor: XmlCursor): Either[XmlDecodeError, A] = cursor match {
-        case Nodes(history, NonEmptyList(node, Nil)) =>
+        case SingleNode(history, node) =>
           node.children match {
             case XmlDocument.XmlText(value) :: Nil =>
               f(if (trim) value.trim() else value).toRight(

--- a/modules/xml/src/smithy4s/xml/internals/XmlDecoderSchemaVisitor.scala
+++ b/modules/xml/src/smithy4s/xml/internals/XmlDecoderSchemaVisitor.scala
@@ -17,7 +17,6 @@
 package smithy4s.xml
 package internals
 
-import cats.data.NonEmptyList
 import cats.syntax.all._
 import smithy.api.XmlAttribute
 import smithy.api.XmlFlattened
@@ -29,9 +28,7 @@ import smithy4s.schema._
 
 import XmlDocument.XmlQName
 
-private[smithy4s] object XmlDecoderSchemaVisitor extends XmlDecoderSchemaVisitor
-
-private[smithy4s] abstract class XmlDecoderSchemaVisitor
+private[smithy4s] object XmlDecoderSchemaVisitor
     extends SchemaVisitor[XmlDecoder]
     with smithy4s.ScalaCompat { compile =>
   def primitive[P](
@@ -64,8 +61,7 @@ private[smithy4s] abstract class XmlDecoderSchemaVisitor
             nodes.zipWithIndex
               .traverse { case (elem, index) =>
                 memberReader.decode(
-                  XmlCursor
-                    .Nodes(history.appendIndex(index), NonEmptyList.one(elem))
+                  XmlCursor.SingleNode(history.appendIndex(index), elem)
                 )
               }
               .map(list => tag.fromIterator(list.iterator))
@@ -152,7 +148,7 @@ private[smithy4s] abstract class XmlDecoderSchemaVisitor
     new XmlDecoder[U] {
       def decode(cursor: XmlCursor): Either[XmlDecodeError, U] = {
         cursor match {
-          case s @ XmlCursor.Nodes(history, NonEmptyList(node, Nil)) =>
+          case s @ XmlCursor.SingleNode(history, node) =>
             val children = node.children.flatMap {
               case text @ XmlDocument.XmlText(value) =>
                 // Remove newlines or other blank text nodes at this level

--- a/modules/xml/src/smithy4s/xml/internals/XmlDecoderSchemaVisitor.scala
+++ b/modules/xml/src/smithy4s/xml/internals/XmlDecoderSchemaVisitor.scala
@@ -57,6 +57,12 @@ private[smithy4s] object XmlDecoderSchemaVisitor
       def decode(cursor: XmlCursor): Either[XmlDecodeError, C[A]] = {
         val realCursor = if (isFlattened) cursor else cursor.down(xmlName)
         realCursor match {
+          case XmlCursor.SingleNode(history, node) =>
+            memberReader
+              .decode(
+                XmlCursor.SingleNode(history.appendIndex(0), node)
+              )
+              .map(value => tag.fromIterator(Iterator.single(value)))
           case XmlCursor.Nodes(history, nodes) =>
             nodes.zipWithIndex
               .traverse { case (elem, index) =>

--- a/modules/xml/src/smithy4s/xml/internals/XmlEncoderSchemaVisitor.scala
+++ b/modules/xml/src/smithy4s/xml/internals/XmlEncoderSchemaVisitor.scala
@@ -86,8 +86,6 @@ private[smithy4s] abstract class XmlEncoderSchemaVisitor
         if (isFlattened) compile(member) else compile(member).down(xmlName)
 
       def encode(value: C[A]): List[XmlContent] = {
-        println(isFlattened)
-        println(xmlName)
         tag.iterator(value).toList.foldMap(memberWriter.encode)
       }
 

--- a/modules/xml/src/smithy4s/xml/internals/XmlStartingPath.scala
+++ b/modules/xml/src/smithy4s/xml/internals/XmlStartingPath.scala
@@ -1,0 +1,21 @@
+package smithy4s.xml.internals
+
+import smithy4s.schema.Schema
+import Schema._
+import smithy4s.ShapeTag
+import smithy4s.ShapeId
+
+case class XmlStartingPath(path: List[String])
+
+object XmlStartingPath extends ShapeTag.Companion[XmlStartingPath] {
+
+  val id: ShapeId = ShapeId("smithy4s.xml.internals", "XmlStartingPath")
+
+  val schema: Schema[XmlStartingPath] =
+    list(string)
+      .biject[XmlStartingPath](
+        XmlStartingPath(_),
+        (_: XmlStartingPath).path
+      )
+
+}

--- a/modules/xml/test/src/smithy4s/xml/XmlCodecSpec.scala
+++ b/modules/xml/test/src/smithy4s/xml/XmlCodecSpec.scala
@@ -25,8 +25,9 @@ import smithy.api.XmlAttribute
 import smithy.api.XmlFlattened
 import smithy.api.XmlName
 import smithy4s.ByteArray
-import smithy4s.Hints
+// import smithy4s.Hints
 import smithy4s.ShapeId
+import smithy4s.Hints
 import smithy4s.schema.Schema
 import smithy4s.schema.Schema._
 import smithy4s.xml.internals.XmlCursor
@@ -339,22 +340,6 @@ object XmlCodecSpec extends SimpleIOSuite {
       checkContent[Foo](xmlRight, Right("hello"))
   }
 
-  test("union") {
-    type Foo = Either[Int, String]
-    implicit val schema: Schema[Foo] = {
-      val left = int.oneOf[Foo]("left", Left(_))
-      val right = string.oneOf[Foo]("right", Right(_))
-      union(left, right) {
-        case Left(int)     => left(int)
-        case Right(string) => right(string)
-      }.n
-    }
-    val xmlLeft = """<Foo><left>1</left></Foo>"""
-    val xmlRight = """<Foo><right>hello</right></Foo>""".stripMargin
-    checkContent[Foo](xmlLeft, Left(1)) |+|
-      checkContent[Foo](xmlRight, Right("hello"))
-  }
-
   test("recursiveUnion") {
 
     sealed trait Foo
@@ -503,7 +488,7 @@ object XmlCodecSpec extends SimpleIOSuite {
     checkContent(xml, Foo(Map("a" -> 1, "b" -> 2)))
   }
 
-  test("Document decoding") {
+  test("XMLDocument decoding") {
     case class Foo(x: Int)
     object Foo {
       implicit val schema: Schema[Foo] = {
@@ -518,7 +503,7 @@ object XmlCodecSpec extends SimpleIOSuite {
     checkDocument(xml, Foo(1))
   }
 
-  test("Document decoding: custom name") {
+  test("XMLDocument decoding: custom name") {
     case class Foo(x: Int)
     object Foo {
       implicit val schema: Schema[Foo] = {
@@ -533,7 +518,7 @@ object XmlCodecSpec extends SimpleIOSuite {
     checkDocument(xml, Foo(1))
   }
 
-  test("Document decoding: failure") {
+  test("XMLDocument decoding: failure") {
     case class Foo(x: Int)
     object Foo {
       implicit val schema: Schema[Foo] = {
@@ -552,7 +537,10 @@ object XmlCodecSpec extends SimpleIOSuite {
         expect.same(
           result,
           Left(
-            XmlDecodeError(XPath.root, "Expected Foo XML root element, got Bar")
+            XmlDecodeError(
+              XPath.root.appendTag("Foo"),
+              "Could not decode failed node"
+            )
           )
         )
       }
@@ -609,7 +597,7 @@ object XmlCodecSpec extends SimpleIOSuite {
 
   private def decodeContent[A: Schema](document: XmlDocument): IO[A] = {
     val decoder = implicitly[Schema[A]].compile(XmlDecoderSchemaVisitor)
-    val cursor = XmlCursor.fromDocument(document)
+    val cursor = XmlCursor.SingleNode(XPath.root, document.root)
     decoder.decode(cursor).leftWiden[Throwable].liftTo[IO]
   }
 


### PR DESCRIPTION
* Rework the XML internals to facilitate starting the decoding from an arbitrary path. 
* Create a new ShapeTag to inject arbitrary paths to be able to start the decoding somewhere. 
* Wire layers such that errors can be decoded from nested XML, as per the RestXML spec