### PR TITLE
Add zlib to flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -16,7 +16,7 @@
       {
         devShells.default = pkgs.mkShell {
           buildInputs = map (pkgName: pkgs.${pkgName}) shellPackages;
-          nativeBuildInputs = [ pkgs.openssl ];
+          nativeBuildInputs = [ pkgs.openssl pkgs.zlib ];
           welcomeMessage = ''
             Welcome to the smithy4s Nix shell! 👋
             Available packages:


### PR DESCRIPTION
For my fellow Nix users, if you want to run Native tests, you now need libz - here's an addition to the flake that enables it.