### PR TITLE
empty response content-type

### DIFF
--- a/modules/bootstrapped/resources/smithy4s.example.PizzaAdminService.json
+++ b/modules/bootstrapped/resources/smithy4s.example.PizzaAdminService.json
@@ -284,6 +284,23 @@
                 }
             }
         },
+        "/optional-output": {
+            "get": {
+                "operationId": "OptionalOutput",
+                "responses": {
+                    "200": {
+                        "description": "OptionalOutput 200 response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/OptionalOutputOutputPayload"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/restaurant/{restaurant}/menu": {
             "get": {
                 "operationId": "GetMenu",
@@ -647,6 +664,9 @@
                 "required": [
                     "name"
                 ]
+            },
+            "OptionalOutputOutputPayload": {
+                "type": "string"
             },
             "Pizza": {
                 "type": "object",

--- a/modules/bootstrapped/resources/smithy4s.example.PizzaAdminService.json
+++ b/modules/bootstrapped/resources/smithy4s.example.PizzaAdminService.json
@@ -293,7 +293,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/OptionalOutputOutputPayload"
+                                    "$ref": "#/components/schemas/EchoBody"
                                 }
                             }
                         }
@@ -664,9 +664,6 @@
                 "required": [
                     "name"
                 ]
-            },
-            "OptionalOutputOutputPayload": {
-                "type": "string"
             },
             "Pizza": {
                 "type": "object",

--- a/modules/bootstrapped/src/generated/smithy4s/example/OptionalOutputOutput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/OptionalOutputOutput.scala
@@ -1,0 +1,23 @@
+package smithy4s.example
+
+import smithy4s.Hints
+import smithy4s.Schema
+import smithy4s.ShapeId
+import smithy4s.ShapeTag
+import smithy4s.schema.Schema.string
+import smithy4s.schema.Schema.struct
+
+final case class OptionalOutputOutput(body: Option[String] = None)
+object OptionalOutputOutput extends ShapeTag.Companion[OptionalOutputOutput] {
+  val id: ShapeId = ShapeId("smithy4s.example", "OptionalOutputOutput")
+
+  val hints: Hints = Hints(
+    smithy.api.Output(),
+  )
+
+  implicit val schema: Schema[OptionalOutputOutput] = struct(
+    string.optional[OptionalOutputOutput]("body", _.body).addHints(smithy.api.HttpPayload()),
+  ){
+    OptionalOutputOutput.apply
+  }.withId(id).addHints(hints)
+}

--- a/modules/bootstrapped/src/generated/smithy4s/example/OptionalOutputOutput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/OptionalOutputOutput.scala
@@ -4,10 +4,9 @@ import smithy4s.Hints
 import smithy4s.Schema
 import smithy4s.ShapeId
 import smithy4s.ShapeTag
-import smithy4s.schema.Schema.string
 import smithy4s.schema.Schema.struct
 
-final case class OptionalOutputOutput(body: Option[String] = None)
+final case class OptionalOutputOutput(body: Option[EchoBody] = None)
 object OptionalOutputOutput extends ShapeTag.Companion[OptionalOutputOutput] {
   val id: ShapeId = ShapeId("smithy4s.example", "OptionalOutputOutput")
 
@@ -16,7 +15,7 @@ object OptionalOutputOutput extends ShapeTag.Companion[OptionalOutputOutput] {
   )
 
   implicit val schema: Schema[OptionalOutputOutput] = struct(
-    string.optional[OptionalOutputOutput]("body", _.body).addHints(smithy.api.HttpPayload()),
+    EchoBody.schema.optional[OptionalOutputOutput]("body", _.body).addHints(smithy.api.HttpPayload()),
   ){
     OptionalOutputOutput.apply
   }.withId(id).addHints(hints)

--- a/modules/bootstrapped/src/generated/smithy4s/example/PizzaAdminService.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/PizzaAdminService.scala
@@ -30,6 +30,7 @@ trait PizzaAdminServiceGen[F[_, _, _, _, _]] {
   def customCode(code: Int): F[CustomCodeInput, PizzaAdminServiceOperation.CustomCodeError, CustomCodeOutput, Nothing, Nothing]
   def reservation(name: String, town: Option[String] = None): F[ReservationInput, Nothing, ReservationOutput, Nothing, Nothing]
   def echo(pathParam: String, body: EchoBody, queryParam: Option[String] = None): F[EchoInput, Nothing, Unit, Nothing, Nothing]
+  def optionalOutput(): F[Unit, Nothing, OptionalOutputOutput, Nothing, Nothing]
 
   def transform: Transformation.PartiallyApplied[PizzaAdminServiceGen[F]] = Transformation.of[PizzaAdminServiceGen[F]](this)
 }
@@ -62,6 +63,7 @@ object PizzaAdminServiceGen extends Service.Mixin[PizzaAdminServiceGen, PizzaAdm
     PizzaAdminServiceOperation.CustomCode,
     PizzaAdminServiceOperation.Reservation,
     PizzaAdminServiceOperation.Echo,
+    PizzaAdminServiceOperation.OptionalOutput,
   )
 
   def endpoint[I, E, O, SI, SO](op: PizzaAdminServiceOperation[I, E, O, SI, SO]) = op.endpoint
@@ -105,6 +107,7 @@ object PizzaAdminServiceOperation {
     def customCode(code: Int) = CustomCode(CustomCodeInput(code))
     def reservation(name: String, town: Option[String] = None) = Reservation(ReservationInput(name, town))
     def echo(pathParam: String, body: EchoBody, queryParam: Option[String] = None) = Echo(EchoInput(pathParam, body, queryParam))
+    def optionalOutput() = OptionalOutput()
   }
   class Transformed[P[_, _, _, _, _], P1[_ ,_ ,_ ,_ ,_]](alg: PizzaAdminServiceGen[P], f: PolyFunction5[P, P1]) extends PizzaAdminServiceGen[P1] {
     def addMenuItem(restaurant: String, menuItem: MenuItem) = f[AddMenuItemRequest, PizzaAdminServiceOperation.AddMenuItemError, AddMenuItemResult, Nothing, Nothing](alg.addMenuItem(restaurant, menuItem))
@@ -118,6 +121,7 @@ object PizzaAdminServiceOperation {
     def customCode(code: Int) = f[CustomCodeInput, PizzaAdminServiceOperation.CustomCodeError, CustomCodeOutput, Nothing, Nothing](alg.customCode(code))
     def reservation(name: String, town: Option[String] = None) = f[ReservationInput, Nothing, ReservationOutput, Nothing, Nothing](alg.reservation(name, town))
     def echo(pathParam: String, body: EchoBody, queryParam: Option[String] = None) = f[EchoInput, Nothing, Unit, Nothing, Nothing](alg.echo(pathParam, body, queryParam))
+    def optionalOutput() = f[Unit, Nothing, OptionalOutputOutput, Nothing, Nothing](alg.optionalOutput())
   }
 
   def toPolyFunction[P[_, _, _, _, _]](impl: PizzaAdminServiceGen[P]): PolyFunction5[PizzaAdminServiceOperation, P] = new PolyFunction5[PizzaAdminServiceOperation, P] {
@@ -533,6 +537,23 @@ object PizzaAdminServiceOperation {
       smithy.api.Http(method = smithy.api.NonEmptyString("POST"), uri = smithy.api.NonEmptyString("/echo/{pathParam}"), code = 200),
     )
     def wrap(input: EchoInput) = Echo(input)
+    override val errorable: Option[Nothing] = None
+  }
+  final case class OptionalOutput() extends PizzaAdminServiceOperation[Unit, Nothing, OptionalOutputOutput, Nothing, Nothing] {
+    def run[F[_, _, _, _, _]](impl: PizzaAdminServiceGen[F]): F[Unit, Nothing, OptionalOutputOutput, Nothing, Nothing] = impl.optionalOutput()
+    def endpoint: (Unit, smithy4s.Endpoint[PizzaAdminServiceOperation,Unit, Nothing, OptionalOutputOutput, Nothing, Nothing]) = ((), OptionalOutput)
+  }
+  object OptionalOutput extends smithy4s.Endpoint[PizzaAdminServiceOperation,Unit, Nothing, OptionalOutputOutput, Nothing, Nothing] {
+    val id: ShapeId = ShapeId("smithy4s.example", "OptionalOutput")
+    val input: Schema[Unit] = unit.addHints(smithy4s.internals.InputOutput.Input.widen)
+    val output: Schema[OptionalOutputOutput] = OptionalOutputOutput.schema.addHints(smithy4s.internals.InputOutput.Output.widen)
+    val streamedInput: StreamingSchema[Nothing] = StreamingSchema.nothing
+    val streamedOutput: StreamingSchema[Nothing] = StreamingSchema.nothing
+    val hints: Hints = Hints(
+      smithy.api.Http(method = smithy.api.NonEmptyString("GET"), uri = smithy.api.NonEmptyString("/optional-output"), code = 200),
+      smithy.api.Readonly(),
+    )
+    def wrap(input: Unit) = OptionalOutput()
     override val errorable: Option[Nothing] = None
   }
 }

--- a/modules/json/src/smithy4s/json/internals/JsonPayloadCodecCompilerImpl.scala
+++ b/modules/json/src/smithy4s/json/internals/JsonPayloadCodecCompilerImpl.scala
@@ -53,25 +53,11 @@ private[json] case class JsonPayloadCodecCompilerImpl(
   def fromSchema[A](schema: Schema[A], cache: Cache): PayloadCodec[A] = {
     val jcodec = jsoniterCodecCompiler.fromSchema(schema, cache)
     val reader: PayloadReader[A] = new JsonPayloadReader(jcodec)
-    val writer: PayloadWriter[A] =
-      schema.hints.get(smithy.api.HttpPayload) match {
-        case Some(_) =>
-          Writer.encodeBy { (value: A) =>
-            val intermediate = Blob(
-              writeToArray(value, jsoniterWriterConfig)(jcodec)
-            )
-            if (intermediate.sameBytesAs(Blob("null"))) Blob("")
-            else intermediate
-          }
-        case None =>
-          Writer.encodeBy { (value: A) =>
-            val intermediate = Blob(
-              writeToArray(value, jsoniterWriterConfig)(jcodec)
-            )
-            if (intermediate.sameBytesAs(Blob("null"))) Blob("{}")
-            else intermediate
-          }
-      }
+    val writer: PayloadWriter[A] = Writer.encodeBy { (value: A) =>
+      Blob(
+        writeToArray(value, jsoniterWriterConfig)(jcodec)
+      )
+    }
     ReaderWriter(reader, writer)
   }
 

--- a/modules/tests/src/smithy4s/tests/PizzaAdminServiceImpl.scala
+++ b/modules/tests/src/smithy4s/tests/PizzaAdminServiceImpl.scala
@@ -116,4 +116,7 @@ class PizzaAdminServiceImpl(ref: Ref[IO, State]) extends PizzaAdminService[IO] {
       body: EchoBody,
       queryParam: Option[String]
   ): IO[Unit] = IO.unit
+
+  def optionalOutput(): IO[OptionalOutputOutput] =
+    IO.pure(OptionalOutputOutput(None))
 }

--- a/modules/tests/src/smithy4s/tests/PizzaSpec.scala
+++ b/modules/tests/src/smithy4s/tests/PizzaSpec.scala
@@ -295,7 +295,7 @@ abstract class PizzaSpec
 
   routerTest("Empty output body") { (client, uri, log) =>
     for {
-      res <- client.send[Json](
+      res <- client.send[String](
         GET(uri / "optional-output"),
         log
       )

--- a/modules/tests/src/smithy4s/tests/PizzaSpec.scala
+++ b/modules/tests/src/smithy4s/tests/PizzaSpec.scala
@@ -293,6 +293,26 @@ abstract class PizzaSpec
         .map(assert.eql(_, 400))
   }
 
+  routerTest("Empty output body") { (client, uri, log) =>
+    for {
+      res <- client.send[Json](
+        GET(uri / "optional-output"),
+        log
+      )
+    } yield {
+      val (code, headers, _) = res
+      expect(code == 200)
+      expect(
+        headers.get("Content-Length").exists(_ == List("0")),
+        "Content-Length should be 0"
+      )
+      expect(
+        headers.get("Content-Type").isEmpty,
+        "Content-Type header should not be defined when content length is 0"
+      )
+    }
+  }
+
   // note: these aren't really part of the pizza suite
 
   pureTest("Happy path: httpMatch") {

--- a/sampleSpecs/pizza.smithy
+++ b/sampleSpecs/pizza.smithy
@@ -19,6 +19,7 @@ service PizzaAdminService {
         CustomCode
         Reservation
         Echo
+        OptionalOutput
     ]
 }
 
@@ -351,4 +352,13 @@ operation Echo {
 structure EchoBody {
     @length(min: 10)
     data: String
+}
+
+@http(method: "GET", uri: "/optional-output")
+@readonly
+operation OptionalOutput {
+    output := {
+        @httpPayload
+        body: String
+    }
 }

--- a/sampleSpecs/pizza.smithy
+++ b/sampleSpecs/pizza.smithy
@@ -359,6 +359,6 @@ structure EchoBody {
 operation OptionalOutput {
     output := {
         @httpPayload
-        body: String
+        body: EchoBody
     }
 }


### PR DESCRIPTION
Before any changes, the response was coming in as `{}` with `content-length: 2` and `content-type: application/json`. After changes, it is now an empty body with `content-length: 0`, but still has `content-type: application/json`. Currently it looks like the content type is set globally on all operations in simpleRestJson. I'm not sure what the best way would be to remove it when the body is empty.

Closes #1072.