### PR TITLE
SimpleRestJson empty optional payloads == null

### DIFF
--- a/modules/aws-http4s/src/smithy4s/aws/internals/AwsRestJsonCodecs.scala
+++ b/modules/aws-http4s/src/smithy4s/aws/internals/AwsRestJsonCodecs.scala
@@ -17,6 +17,7 @@
 package smithy4s.aws
 package internals
 
+import smithy4s.Blob
 import smithy4s.codecs._
 import smithy4s.http._
 import smithy4s.json.Json
@@ -52,8 +53,13 @@ private[aws] object AwsRestJsonCodecs {
           .andThen[HttpMediaReader](HttpMediaTyped.mediaTypeK(mediaType))
       }
 
+    def nullToEmptyObject(blob: Blob): Blob =
+      if (blob.sameBytesAs(Blob("null"))) Blob("{}") else blob
+
     val jsonMediaWriters = jsonPayloadCodecs.mapK {
-      PayloadCodec.writerK.andThen[HttpMediaWriter](HttpMediaTyped.mediaTypeK(mediaType))
+      PayloadCodec.writerK
+        .andThen[PayloadWriter](Writer.andThenK(nullToEmptyObject))
+        .andThen[HttpMediaWriter](HttpMediaTyped.mediaTypeK(mediaType))
     }
 
     val mediaReaders =

--- a/modules/aws-http4s/src/smithy4s/aws/internals/AwsRestJsonCodecs.scala
+++ b/modules/aws-http4s/src/smithy4s/aws/internals/AwsRestJsonCodecs.scala
@@ -54,7 +54,7 @@ private[aws] object AwsRestJsonCodecs {
       }
 
     def nullToEmptyObject(blob: Blob): Blob =
-      if (blob.sameBytesAs(Blob("null"))) Blob("{}") else blob
+      if (blob.sameBytesAs(Json.NullBlob)) Json.EmptyObjectBlob else blob
 
     val jsonMediaWriters = jsonPayloadCodecs.mapK {
       PayloadCodec.writerK

--- a/modules/bootstrapped/resources/smithy4s.example.PizzaAdminService.json
+++ b/modules/bootstrapped/resources/smithy4s.example.PizzaAdminService.json
@@ -284,6 +284,23 @@
                 }
             }
         },
+        "/optional-output": {
+            "get": {
+                "operationId": "OptionalOutput",
+                "responses": {
+                    "200": {
+                        "description": "OptionalOutput 200 response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/OptionalOutputOutputPayload"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/restaurant/{restaurant}/menu": {
             "get": {
                 "operationId": "GetMenu",
@@ -647,6 +664,9 @@
                 "required": [
                     "name"
                 ]
+            },
+            "OptionalOutputOutputPayload": {
+                "type": "string"
             },
             "Pizza": {
                 "type": "object",

--- a/modules/bootstrapped/src/generated/smithy4s/example/OptionalOutputOutput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/OptionalOutputOutput.scala
@@ -1,0 +1,23 @@
+package smithy4s.example
+
+import smithy4s.Hints
+import smithy4s.Schema
+import smithy4s.ShapeId
+import smithy4s.ShapeTag
+import smithy4s.schema.Schema.string
+import smithy4s.schema.Schema.struct
+
+final case class OptionalOutputOutput(body: Option[String] = None)
+object OptionalOutputOutput extends ShapeTag.Companion[OptionalOutputOutput] {
+  val id: ShapeId = ShapeId("smithy4s.example", "OptionalOutputOutput")
+
+  val hints: Hints = Hints(
+    smithy.api.Output(),
+  )
+
+  implicit val schema: Schema[OptionalOutputOutput] = struct(
+    string.optional[OptionalOutputOutput]("body", _.body).addHints(smithy.api.HttpPayload()),
+  ){
+    OptionalOutputOutput.apply
+  }.withId(id).addHints(hints)
+}

--- a/modules/bootstrapped/src/generated/smithy4s/example/PizzaAdminService.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/PizzaAdminService.scala
@@ -30,6 +30,7 @@ trait PizzaAdminServiceGen[F[_, _, _, _, _]] {
   def customCode(code: Int): F[CustomCodeInput, PizzaAdminServiceOperation.CustomCodeError, CustomCodeOutput, Nothing, Nothing]
   def reservation(name: String, town: Option[String] = None): F[ReservationInput, Nothing, ReservationOutput, Nothing, Nothing]
   def echo(pathParam: String, body: EchoBody, queryParam: Option[String] = None): F[EchoInput, Nothing, Unit, Nothing, Nothing]
+  def optionalOutput(): F[Unit, Nothing, OptionalOutputOutput, Nothing, Nothing]
 
   def transform: Transformation.PartiallyApplied[PizzaAdminServiceGen[F]] = Transformation.of[PizzaAdminServiceGen[F]](this)
 }
@@ -62,6 +63,7 @@ object PizzaAdminServiceGen extends Service.Mixin[PizzaAdminServiceGen, PizzaAdm
     PizzaAdminServiceOperation.CustomCode,
     PizzaAdminServiceOperation.Reservation,
     PizzaAdminServiceOperation.Echo,
+    PizzaAdminServiceOperation.OptionalOutput,
   )
 
   def endpoint[I, E, O, SI, SO](op: PizzaAdminServiceOperation[I, E, O, SI, SO]) = op.endpoint
@@ -105,6 +107,7 @@ object PizzaAdminServiceOperation {
     def customCode(code: Int) = CustomCode(CustomCodeInput(code))
     def reservation(name: String, town: Option[String] = None) = Reservation(ReservationInput(name, town))
     def echo(pathParam: String, body: EchoBody, queryParam: Option[String] = None) = Echo(EchoInput(pathParam, body, queryParam))
+    def optionalOutput() = OptionalOutput()
   }
   class Transformed[P[_, _, _, _, _], P1[_ ,_ ,_ ,_ ,_]](alg: PizzaAdminServiceGen[P], f: PolyFunction5[P, P1]) extends PizzaAdminServiceGen[P1] {
     def addMenuItem(restaurant: String, menuItem: MenuItem) = f[AddMenuItemRequest, PizzaAdminServiceOperation.AddMenuItemError, AddMenuItemResult, Nothing, Nothing](alg.addMenuItem(restaurant, menuItem))
@@ -118,6 +121,7 @@ object PizzaAdminServiceOperation {
     def customCode(code: Int) = f[CustomCodeInput, PizzaAdminServiceOperation.CustomCodeError, CustomCodeOutput, Nothing, Nothing](alg.customCode(code))
     def reservation(name: String, town: Option[String] = None) = f[ReservationInput, Nothing, ReservationOutput, Nothing, Nothing](alg.reservation(name, town))
     def echo(pathParam: String, body: EchoBody, queryParam: Option[String] = None) = f[EchoInput, Nothing, Unit, Nothing, Nothing](alg.echo(pathParam, body, queryParam))
+    def optionalOutput() = f[Unit, Nothing, OptionalOutputOutput, Nothing, Nothing](alg.optionalOutput())
   }
 
   def toPolyFunction[P[_, _, _, _, _]](impl: PizzaAdminServiceGen[P]): PolyFunction5[PizzaAdminServiceOperation, P] = new PolyFunction5[PizzaAdminServiceOperation, P] {
@@ -533,6 +537,23 @@ object PizzaAdminServiceOperation {
       smithy.api.Http(method = smithy.api.NonEmptyString("POST"), uri = smithy.api.NonEmptyString("/echo/{pathParam}"), code = 200),
     )
     def wrap(input: EchoInput) = Echo(input)
+    override val errorable: Option[Nothing] = None
+  }
+  final case class OptionalOutput() extends PizzaAdminServiceOperation[Unit, Nothing, OptionalOutputOutput, Nothing, Nothing] {
+    def run[F[_, _, _, _, _]](impl: PizzaAdminServiceGen[F]): F[Unit, Nothing, OptionalOutputOutput, Nothing, Nothing] = impl.optionalOutput()
+    def endpoint: (Unit, smithy4s.Endpoint[PizzaAdminServiceOperation,Unit, Nothing, OptionalOutputOutput, Nothing, Nothing]) = ((), OptionalOutput)
+  }
+  object OptionalOutput extends smithy4s.Endpoint[PizzaAdminServiceOperation,Unit, Nothing, OptionalOutputOutput, Nothing, Nothing] {
+    val id: ShapeId = ShapeId("smithy4s.example", "OptionalOutput")
+    val input: Schema[Unit] = unit.addHints(smithy4s.internals.InputOutput.Input.widen)
+    val output: Schema[OptionalOutputOutput] = OptionalOutputOutput.schema.addHints(smithy4s.internals.InputOutput.Output.widen)
+    val streamedInput: StreamingSchema[Nothing] = StreamingSchema.nothing
+    val streamedOutput: StreamingSchema[Nothing] = StreamingSchema.nothing
+    val hints: Hints = Hints(
+      smithy.api.Http(method = smithy.api.NonEmptyString("GET"), uri = smithy.api.NonEmptyString("/optional-output"), code = 200),
+      smithy.api.Readonly(),
+    )
+    def wrap(input: Unit) = OptionalOutput()
     override val errorable: Option[Nothing] = None
   }
 }

--- a/modules/json/src/smithy4s/json/Json.scala
+++ b/modules/json/src/smithy4s/json/Json.scala
@@ -25,6 +25,9 @@ import com.github.plokhotnyuk.jsoniter_scala.core._
 
 object Json {
 
+  val NullBlob = Blob("null")
+  val EmptyObjectBlob = Blob("{}")
+
   /**
     * Reads an instance of `A` from a [[smithy4s.Blob]] holding a json payload.
     *

--- a/modules/json/src/smithy4s/json/internals/JsonPayloadCodecCompilerImpl.scala
+++ b/modules/json/src/smithy4s/json/internals/JsonPayloadCodecCompilerImpl.scala
@@ -54,11 +54,9 @@ private[json] case class JsonPayloadCodecCompilerImpl(
     val jcodec = jsoniterCodecCompiler.fromSchema(schema, cache)
     val reader: PayloadReader[A] = new JsonPayloadReader(jcodec)
     val writer: PayloadWriter[A] = Writer.encodeBy { (value: A) =>
-      val intermediate = Blob(
+      Blob(
         writeToArray(value, jsoniterWriterConfig)(jcodec)
       )
-      if (intermediate.sameBytesAs(Blob("null"))) Blob("{}")
-      else intermediate
     }
     ReaderWriter(reader, writer)
   }

--- a/modules/tests/src/smithy4s/tests/PizzaAdminServiceImpl.scala
+++ b/modules/tests/src/smithy4s/tests/PizzaAdminServiceImpl.scala
@@ -116,4 +116,7 @@ class PizzaAdminServiceImpl(ref: Ref[IO, State]) extends PizzaAdminService[IO] {
       body: EchoBody,
       queryParam: Option[String]
   ): IO[Unit] = IO.unit
+
+  def optionalOutput(): IO[OptionalOutputOutput] =
+    IO.pure(OptionalOutputOutput(None))
 }

--- a/modules/tests/src/smithy4s/tests/PizzaSpec.scala
+++ b/modules/tests/src/smithy4s/tests/PizzaSpec.scala
@@ -293,6 +293,27 @@ abstract class PizzaSpec
         .map(assert.eql(_, 400))
   }
 
+  routerTest("Optional payload set to empty") { (client, uri, log) =>
+    for {
+      res <- client.send[Json](
+        GET(uri / "optional-output"),
+        log
+      )
+    } yield {
+      val (code, headers, body) = res
+      expect.same(body, Json.Null) &&
+      expect.same(code, 200) &&
+      expect(
+        headers.get("Content-Length").exists(_ == List("4")),
+        "Content-Length should be 4"
+      ) &&
+      expect.same(
+        headers.get("Content-Type"),
+        Some(List("application/json"))
+      )
+    }
+  }
+
   // note: these aren't really part of the pizza suite
 
   pureTest("Happy path: httpMatch") {
@@ -349,7 +370,7 @@ abstract class PizzaSpec
           // If it was the case, these errors would be turned into a GenericServerError
           // and would fail.
           smithy4s.example.GenericServerError("CatchAll: " + t.getMessage())
-        case other => other.printStackTrace(); other
+        case other => other
       }
     )
   } yield res

--- a/sampleSpecs/pizza.smithy
+++ b/sampleSpecs/pizza.smithy
@@ -19,6 +19,7 @@ service PizzaAdminService {
         CustomCode
         Reservation
         Echo
+        OptionalOutput
     ]
 }
 
@@ -351,4 +352,13 @@ operation Echo {
 structure EchoBody {
     @length(min: 10)
     data: String
+}
+
+@http(method: "GET", uri: "/optional-output")
+@readonly
+operation OptionalOutput {
+    output := {
+        @httpPayload
+        body: String
+    }
 }


### PR DESCRIPTION
Closes https://github.com/disneystreaming/smithy4s/issues/1072.

Changes the logic so that the original json PayloadCodec compilers do not take the responsibility of turning `null` to `{}` as this is a protocol specific concern.

#### The case of SimpleRestJson

Moreover, in the context of SimpleRestJson (which literally has all payloads be json), it makes sense that an optional payload field set to empty should be serialised as json null. For instance, given this operation : 

```smithy
operation Foo {
  output: {
      @httpPayload 
      string: String
  } 
}
```

the only sensical translation for the case where `string == None` in scala is to serialise the value as json `null`. This is because the other side should rightfully expect for a payload to be present and for that payload to abide by `application/json`, since `simpleRestJson` aims at being a straightforward Json-in/Json-out RESTful protocol. 

Note that this case is different from an empty operation 

``` 
operation Foo {
} 
```

In this case, the `SimpleRestJson` protocol ought to consider that no-body should be serialised 

#### In the case of AWS Rest Json 

However, this PR ensures that the behaviour of turning `null` into `{}` in requests is kept for the AWS Rest Json protocol. Indeed, AWS seemingly doesn't care about having any coherence whatsoever, probably because of a desire to keep behaviour of their existing tools. 

I believe that this very situation is one of the few cases where a divergence from AWS is entirely justified, in particular because the behaviour is [unclear when the payload is a optional structure](https://github.com/smithy-lang/smithy/blob/main/smithy-aws-protocol-tests/model/restJson1/http-payload.smithy#L210-L270). 

If we ever get around to supporting AWSRestJson server-side, then we'll add a opt-in behaviour in the json codecs to allow for decoding empty options from `{}`. 