### PR TITLE
Allow throttled webjars update PRs

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,8 +1,11 @@
 updates.ignore = [
   { groupId = "org.scalameta" },
-  { groupId = "org.webjars" },
-  { groupId = "org.webjars.npm"},
   { groupId = "software.amazon.awssdk" }
+]
+
+dependencyOverrides = [
+  { pullRequests = { frequency = "@monthly" }, dependency = { groupId = "org.webjars" }},
+  { pullRequests = { frequency = "@monthly" }, dependency = { groupId = "org.webjars.npm" }}
 ]
 
 updates.limit = 4


### PR DESCRIPTION
Let Scala Steward sometimes send an update PR for the webjars so security findings are mitigated.

Closes #1069