### PR TITLE
Minor refactors for 0.18

### DIFF
--- a/modules/http4s-kernel/src/smithy4s/http4s/kernel/package.scala
+++ b/modules/http4s-kernel/src/smithy4s/http4s/kernel/package.scala
@@ -108,7 +108,7 @@ package object kernel {
       .groupBy(_._1)
       .map { case (k, v) => k -> v.map(_._2).toList }
 
-  private[smithy4s] def getRequestMetadata[F[_]](
+  def getRequestMetadata[F[_]](
       pathParams: PathParams,
       request: Request[F]
   ): Metadata =
@@ -119,7 +119,7 @@ package object kernel {
       statusCode = None
     )
 
-  private[smithy4s] def getResponseMetadata[F[_]](
+  def getResponseMetadata[F[_]](
       response: Response[F]
   ): Metadata =
     Metadata(

--- a/modules/http4s/src/smithy4s/http4s/internals/SmithyHttp4sClientEndpoint.scala
+++ b/modules/http4s/src/smithy4s/http4s/internals/SmithyHttp4sClientEndpoint.scala
@@ -30,8 +30,7 @@ import smithy4s.http4s.kernel._
 private[http4s] class SmithyHttp4sClientEndpoint[F[_], I, E, O, SI, SO](
   baseUri: Uri,
   client: Client[F],
-  endpoint: Endpoint.Base[I, E, O, SI, SO],
-  makeClientCodecs: UnaryClientCodecs.Make[F],
+  clientCodecs: UnaryClientCodecs[F, I, E, O],
   middleware: Client[F] => Client[F]
 )(implicit effect: Concurrent[F]) extends (I => F[O]) {
 // format: on
@@ -46,10 +45,7 @@ private[http4s] class SmithyHttp4sClientEndpoint[F[_], I, E, O, SI, SO](
       }
   }
 
-  // format: off
-  val clientCodecs = makeClientCodecs(endpoint)
   import clientCodecs._
-  // format: on
 
   // Method will be amended by inputEncoder
   val baseRequest = Request[F](org.http4s.Method.POST, baseUri).withEmptyBody

--- a/modules/http4s/src/smithy4s/http4s/internals/SmithyHttp4sReverseRouter.scala
+++ b/modules/http4s/src/smithy4s/http4s/internals/SmithyHttp4sReverseRouter.scala
@@ -39,8 +39,7 @@ private[http4s] object SmithyHttp4sReverseRouter {
         new SmithyHttp4sClientEndpoint(
           baseUri,
           client,
-          endpoint,
-          compilerContext,
+          compilerContext(endpoint),
           middleware.prepare(service)(endpoint)
         )
     }


### PR DESCRIPTION
Two changes, one of which is not strictly necessary:

1. visibility of metadata functions in the http4s-kernel
2. make the client codecs one level above to avoid dragging endpoint further down in the implementation

I have another one [that add a way to merge two readerwriter](https://github.com/disneystreaming/smithy4s/commit/2e6dbc5dc6e3298afcb6cd178e65e96b4b7a7470) but I'm not sure if you would want that or something more generic