### PR TITLE
Flatten AWS newtypes

### DIFF
--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/aws-newtype-flatten/build.sbt
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/aws-newtype-flatten/build.sbt
@@ -2,16 +2,8 @@ lazy val root = (project in file("."))
   .enablePlugins(Smithy4sCodegenPlugin)
   .settings(
     scalaVersion := "2.13.10",
-    Compile / smithy4sAllowedNamespaces := List(
-      "aws.api",
-      "aws.auth",
-      "aws.customizations",
-      "aws.protocols",
-      "com.amazonaws.dynamodb",
-    ),
     libraryDependencies ++= Seq(
-      "com.disneystreaming.smithy4s" %% "smithy4s-core" % smithy4sVersion.value,
-      "com.disneystreaming.smithy"   % "aws-dynamodb-spec" % "2023.02.10"
+      "com.disneystreaming.smithy4s" %% "smithy4s-aws-kernel" % smithy4sVersion.value
     ),
     Compile / smithy4sOutputDir := baseDirectory.value / "smithy_output"
   )

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/aws-newtype-flatten/build.sbt
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/aws-newtype-flatten/build.sbt
@@ -1,0 +1,17 @@
+lazy val root = (project in file("."))
+  .enablePlugins(Smithy4sCodegenPlugin)
+  .settings(
+    scalaVersion := "2.13.10",
+    Compile / smithy4sAllowedNamespaces := List(
+      "aws.api",
+      "aws.auth",
+      "aws.customizations",
+      "aws.protocols",
+      "com.amazonaws.dynamodb",
+    ),
+    libraryDependencies ++= Seq(
+      "com.disneystreaming.smithy4s" %% "smithy4s-core" % smithy4sVersion.value,
+      "com.disneystreaming.smithy"   % "aws-dynamodb-spec" % "2023.02.10"
+    ),
+    Compile / smithy4sOutputDir := baseDirectory.value / "smithy_output"
+  )

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/aws-newtype-flatten/project/build.properties
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/aws-newtype-flatten/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.8.2

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/aws-newtype-flatten/project/plugins.sbt
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/aws-newtype-flatten/project/plugins.sbt
@@ -1,0 +1,9 @@
+sys.props.get("plugin.version") match {
+  case Some(x) =>
+    addSbtPlugin("com.disneystreaming.smithy4s" % "smithy4s-sbt-codegen" % x)
+  case _ =>
+    sys.error(
+      """|The system property 'plugin.version' is not defined.
+         |Specify this property using the scriptedLaunchOpts -D.""".stripMargin
+    )
+}

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/aws-newtype-flatten/src/main/scala/Main.scala
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/aws-newtype-flatten/src/main/scala/Main.scala
@@ -1,0 +1,20 @@
+
+import com.amazonaws.dynamodb.ArchivalSummary
+import com.amazonaws.dynamodb.BackupArn
+import smithy4s.Timestamp
+
+object Main extends App {
+
+  val archivalSummary = new ArchivalSummary(
+    // archivalDateTime needs to be rewritten from a com.amazonaws.dynamodb.Date to a simple timestamp
+    archivalDateTime = Some(Timestamp.fromEpochSecond(java.time.Instant.now().getEpochSecond)),
+
+    // archivalReason needs to be rewritten from com.amazonaws.dynamodb.ArchivalReason to a String
+    archivalReason = Some("This is just a string"),
+
+    // archivalBackupArn remains as a newtype because com.amazonaws.dynamodb.BackupArn
+    // has the @length trait applied
+    archivalBackupArn = Some(BackupArn("this-is-a-back-up-arn-with-a-minimum-length"))
+  )
+
+}

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/aws-newtype-flatten/src/main/scala/Main.scala
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/aws-newtype-flatten/src/main/scala/Main.scala
@@ -1,20 +1,32 @@
-
-import com.amazonaws.dynamodb.ArchivalSummary
-import com.amazonaws.dynamodb.BackupArn
-import smithy4s.Timestamp
+import com.amazonaws.dynamodb.DescribeEndpointsResponse
+import com.amazonaws.dynamodb.Endpoint
+import com.amazonaws.dynamodb.ListTablesInput
+import com.amazonaws.dynamodb.ListTablesInputLimit
+import com.amazonaws.dynamodb.TableName
 
 object Main extends App {
 
-  val archivalSummary = new ArchivalSummary(
-    // archivalDateTime needs to be rewritten from a com.amazonaws.dynamodb.Date to a simple timestamp
-    archivalDateTime = Some(Timestamp.fromEpochSecond(java.time.Instant.now().getEpochSecond)),
+  val listTablesInput = new ListTablesInput(
+    // TableName is not flattened because it has
+    // @length and @pattern traits applied
+    exclusiveStartTableName = Some(TableName("example-table-name")),
 
-    // archivalReason needs to be rewritten from com.amazonaws.dynamodb.ArchivalReason to a String
-    archivalReason = Some("This is just a string"),
-
-    // archivalBackupArn remains as a newtype because com.amazonaws.dynamodb.BackupArn
-    // has the @length trait applied
-    archivalBackupArn = Some(BackupArn("this-is-a-back-up-arn-with-a-minimum-length"))
+    // ListTablesInputLimit is not flattened because it has
+    // a @range constraint
+    limit = Some(ListTablesInputLimit(5))
   )
+
+  val describeEndpointsResponse = List(
+    Endpoint(
+      // Endpoint address was flattened from a com.amazonaws.dynamodb#String
+      // to a standard String shape
+      address = "example-endpoint",
+
+      // CachePeriodInMinutes was flattened from a com.amazonaws.dynamodb#Long
+      // to a standard long
+      cachePeriodInMinutes = 5L
+    )
+  )
+
 
 }

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/aws-newtype-flatten/src/main/scala/Main.scala
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/aws-newtype-flatten/src/main/scala/Main.scala
@@ -1,3 +1,19 @@
+/*
+ *  Copyright 2021-2022 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 import com.amazonaws.dynamodb.DescribeEndpointsResponse
 import com.amazonaws.dynamodb.Endpoint
 import com.amazonaws.dynamodb.ListTablesInput

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/aws-newtype-flatten/src/main/smithy/dynamo-lightweight.json
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/aws-newtype-flatten/src/main/smithy/dynamo-lightweight.json
@@ -1,0 +1,230 @@
+{
+    "smithy": "2.0",
+    "shapes": {
+      "com.amazonaws.dynamodb#DynamoDB_20120810": {
+        "type": "service",
+        "version": "2012-08-10",
+        "operations": [
+          {
+            "target": "com.amazonaws.dynamodb#DescribeEndpoints"
+          },
+          {
+            "target": "com.amazonaws.dynamodb#ListTables"
+          }
+        ],
+        "traits": {
+          "aws.api#clientEndpointDiscovery": {
+            "operation": "com.amazonaws.dynamodb#DescribeEndpoints",
+            "error": "com.amazonaws.dynamodb#InvalidEndpointException"
+          },
+          "aws.api#service": {
+            "sdkId": "DynamoDB",
+            "arnNamespace": "dynamodb",
+            "cloudFormationName": "DynamoDB",
+            "cloudTrailEventSource": "dynamodb.amazonaws.com",
+            "endpointPrefix": "dynamodb"
+          },
+          "aws.auth#sigv4": {
+            "name": "dynamodb"
+          },
+          "aws.protocols#awsJson1_0": {},
+          "smithy.api#documentation": "<fullname>Amazon DynamoDB</fullname>\n\n\n         <p>Amazon DynamoDB is a fully managed NoSQL database service that provides fast and\n      predictable performance with seamless scalability. DynamoDB lets you offload the\n      administrative burdens of operating and scaling a distributed database, so that you don't have\n      to worry about hardware provisioning, setup and configuration, replication, software patching,\n      or cluster scaling.</p>\n\n         <p>With DynamoDB, you can create database tables that can store and retrieve any amount of\n      data, and serve any level of request traffic. You can scale up or scale down your tables'\n      throughput capacity without downtime or performance degradation, and use the AWS Management\n      Console to monitor resource utilization and performance metrics.</p>\n\n         <p>DynamoDB automatically spreads the data and traffic for your tables over a sufficient\n      number of servers to handle your throughput and storage requirements, while maintaining\n      consistent and fast performance. All of your data is stored on solid state disks (SSDs) and\n      automatically replicated across multiple Availability Zones in an AWS region, providing\n      built-in high availability and data durability. </p>",
+          "smithy.api#title": "Amazon DynamoDB",
+          "smithy.api#xmlNamespace": {
+            "uri": "http://dynamodb.amazonaws.com/doc/2012-08-10/"
+          }
+        }
+      },
+      "com.amazonaws.dynamodb#DescribeEndpoints": {
+        "type": "operation",
+        "input": {
+          "target": "com.amazonaws.dynamodb#DescribeEndpointsRequest"
+        },
+        "output": {
+          "target": "com.amazonaws.dynamodb#DescribeEndpointsResponse"
+        },
+        "traits": {
+          "smithy.api#documentation": "<p>Returns the regional endpoint information.</p>"
+        }
+      },
+      "com.amazonaws.dynamodb#DescribeEndpointsRequest": {
+        "type": "structure",
+        "members": {}
+      },
+      "com.amazonaws.dynamodb#DescribeEndpointsResponse": {
+        "type": "structure",
+        "members": {
+          "Endpoints": {
+            "target": "com.amazonaws.dynamodb#Endpoints",
+            "traits": {
+              "smithy.api#documentation": "<p>List of endpoints.</p>",
+              "smithy.api#required": {}
+            }
+          }
+        }
+      },
+      "com.amazonaws.dynamodb#Endpoint": {
+        "type": "structure",
+        "members": {
+          "Address": {
+            "target": "com.amazonaws.dynamodb#String",
+            "traits": {
+              "smithy.api#documentation": "<p>IP address of the endpoint.</p>",
+              "smithy.api#required": {}
+            }
+          },
+          "CachePeriodInMinutes": {
+            "target": "com.amazonaws.dynamodb#Long",
+            "traits": {
+              "smithy.api#default": 0,
+              "smithy.api#documentation": "<p>Endpoint cache time to live (TTL) value.</p>",
+              "smithy.api#required": {}
+            }
+          }
+        },
+        "traits": {
+          "smithy.api#documentation": "<p>An endpoint information details.</p>"
+        }
+      },
+      "com.amazonaws.dynamodb#Endpoints": {
+        "type": "list",
+        "member": {
+          "target": "com.amazonaws.dynamodb#Endpoint"
+        }
+      },
+      "com.amazonaws.dynamodb#Long": {
+        "type": "long",
+        "traits": {
+          "smithy.api#default": 0
+        }
+      },
+      "com.amazonaws.dynamodb#ErrorMessage": {
+        "type": "string"
+      },
+      "com.amazonaws.dynamodb#InternalServerError": {
+        "type": "structure",
+        "members": {
+          "message": {
+            "target": "com.amazonaws.dynamodb#ErrorMessage",
+            "traits": {
+              "smithy.api#documentation": "<p>The server encountered an internal error trying to fulfill the request.</p>"
+            }
+          }
+        },
+        "traits": {
+          "smithy.api#documentation": "<p>An error occurred on the server side.</p>",
+          "smithy.api#error": "server"
+        }
+      },
+      "com.amazonaws.dynamodb#InvalidEndpointException": {
+        "type": "structure",
+        "members": {
+          "Message": {
+            "target": "com.amazonaws.dynamodb#String"
+          }
+        },
+        "traits": {
+          "smithy.api#error": "client",
+          "smithy.api#httpError": 421
+        }
+      },
+      "com.amazonaws.dynamodb#ListTables": {
+        "type": "operation",
+        "input": {
+          "target": "com.amazonaws.dynamodb#ListTablesInput"
+        },
+        "output": {
+          "target": "com.amazonaws.dynamodb#ListTablesOutput"
+        },
+        "errors": [
+          {
+            "target": "com.amazonaws.dynamodb#InternalServerError"
+          },
+          {
+            "target": "com.amazonaws.dynamodb#InvalidEndpointException"
+          }
+        ],
+        "traits": {
+          "aws.api#clientDiscoveredEndpoint": {
+            "required": false
+          },
+          "smithy.api#documentation": "<p>Returns an array of table names associated with the current account and endpoint. The output\n      from <code>ListTables</code> is paginated, with each page returning a maximum of 100 table\n      names.</p>",
+          "smithy.api#paginated": {
+            "inputToken": "ExclusiveStartTableName",
+            "outputToken": "LastEvaluatedTableName",
+            "items": "TableNames",
+            "pageSize": "Limit"
+          }
+        }
+      },
+      "com.amazonaws.dynamodb#ListTablesInput": {
+        "type": "structure",
+        "members": {
+          "ExclusiveStartTableName": {
+            "target": "com.amazonaws.dynamodb#TableName",
+            "traits": {
+              "smithy.api#documentation": "<p>The first table name that this operation will evaluate. Use the value that was returned for\n        <code>LastEvaluatedTableName</code> in a previous operation, so that you can obtain the next page\n      of results.</p>"
+            }
+          },
+          "Limit": {
+            "target": "com.amazonaws.dynamodb#ListTablesInputLimit",
+            "traits": {
+              "smithy.api#documentation": "<p>A maximum number of table names to return. If this parameter is not specified, the limit is 100.</p>"
+            }
+          }
+        },
+        "traits": {
+          "smithy.api#documentation": "<p>Represents the input of a <code>ListTables</code> operation.</p>"
+        }
+      },
+      "com.amazonaws.dynamodb#ListTablesInputLimit": {
+        "type": "integer",
+        "traits": {
+          "smithy.api#range": {
+            "min": 1,
+            "max": 100
+          }
+        }
+      },
+      "com.amazonaws.dynamodb#ListTablesOutput": {
+        "type": "structure",
+        "members": {
+          "TableNames": {
+            "target": "com.amazonaws.dynamodb#TableNameList",
+            "traits": {
+              "smithy.api#documentation": "<p>The names of the tables associated with the current account at the current endpoint. The maximum size of this array is 100.</p>\n         <p>If <code>LastEvaluatedTableName</code> also appears in the output, you can use this value as the\n        <code>ExclusiveStartTableName</code> parameter in a subsequent <code>ListTables</code> request and\n      obtain the next page of results.</p>"
+            }
+          },
+          "LastEvaluatedTableName": {
+            "target": "com.amazonaws.dynamodb#TableName",
+            "traits": {
+              "smithy.api#documentation": "<p>The name of the last table in the current page of results. Use this value as the\n        <code>ExclusiveStartTableName</code> in a new request to obtain the next page of results, until\n      all the table names are returned.</p>\n         <p>If you do not receive a <code>LastEvaluatedTableName</code> value in the response, this means that\n      there are no more table names to be retrieved.</p>"
+            }
+          }
+        },
+        "traits": {
+          "smithy.api#documentation": "<p>Represents the output of a <code>ListTables</code> operation.</p>"
+        }
+      },
+      "com.amazonaws.dynamodb#String": {
+        "type": "string"
+      },
+      "com.amazonaws.dynamodb#TableName": {
+        "type": "string",
+        "traits": {
+          "smithy.api#length": {
+            "min": 3,
+            "max": 255
+          },
+          "smithy.api#pattern": "^[a-zA-Z0-9_.-]+$"
+        }
+      },
+      "com.amazonaws.dynamodb#TableNameList": {
+        "type": "list",
+        "member": {
+          "target": "com.amazonaws.dynamodb#TableName"
+        }
+      }
+    }
+  }
+  

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/aws-newtype-flatten/test
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/aws-newtype-flatten/test
@@ -1,8 +1,8 @@
 # check if smithy4sCodegen works
 > compile
 
-$ exists  smithy_output/com/amazonaws/dynamodb/ArchivalSummary.scala
+# This new type was not flattened because it has range constraints
+$ exists  smithy_output/com/amazonaws/dynamodb/ListTablesInputLimit.scala
 
-# This was a type alias to string `string ArchivalReason` and should be removed
-# by the AWS newtype flattener
--$ exists smithy_output/com/amazonaws/dynamodb/ArchivalReason.scala
+# Flattened and removed by the projection transformer
+-$ exists smithy_output/com/amazonaws/dynamodb/Long.scala

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/aws-newtype-flatten/test
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/aws-newtype-flatten/test
@@ -1,0 +1,8 @@
+# check if smithy4sCodegen works
+> compile
+
+$ exists  smithy_output/com/amazonaws/dynamodb/ArchivalSummary.scala
+
+# This was a type alias to string `string ArchivalReason` and should be removed
+# by the AWS newtype flattener
+-$ exists smithy_output/com/amazonaws/dynamodb/ArchivalReason.scala

--- a/modules/codegen/resources/META-INF/services/software.amazon.smithy.build.ProjectionTransformer
+++ b/modules/codegen/resources/META-INF/services/software.amazon.smithy.build.ProjectionTransformer
@@ -1,0 +1,1 @@
+smithy4s.codegen.transformers.AwsStandardTypesTransformer

--- a/modules/codegen/src/smithy4s/codegen/internals/CodegenImpl.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/CodegenImpl.scala
@@ -18,6 +18,7 @@ package smithy4s.codegen
 package internals
 
 import alloy.openapi._
+import smithy4s.codegen.transformers.AwsStandardTypesTransformer
 import software.amazon.smithy.model.Model
 
 import scala.jdk.CollectionConverters._
@@ -34,7 +35,7 @@ private[codegen] object CodegenImpl { self =>
       args.specs.map(_.toIO).toSet,
       args.dependencies,
       args.repositories,
-      args.transformers,
+      withAwsTypeTransformer(args.transformers),
       args.discoverModels,
       args.localJars
     )
@@ -148,12 +149,15 @@ private[codegen] object CodegenImpl { self =>
       args.specs.map(_.toIO).toSet,
       args.dependencies,
       args.repositories,
-      args.transformers,
+      withAwsTypeTransformer(args.transformers),
       discoverModels = false,
       args.localJars
     )
 
     Node.prettyPrintJson(ModelSerializer.builder().build.serialize(model))
   }
+
+  private def withAwsTypeTransformer(transformers: List[String]): List[String] =
+    transformers :+ AwsStandardTypesTransformer.name
 
 }

--- a/modules/codegen/src/smithy4s/codegen/transformers/AwsStandardTypesTransformer.scala
+++ b/modules/codegen/src/smithy4s/codegen/transformers/AwsStandardTypesTransformer.scala
@@ -22,11 +22,15 @@ class AwsStandardTypesTransformer extends ProjectionTransformer {
     )
   }
 
-  private def mapFunction(model: Model): java.util.function.Function[Shape, Shape] = shape => {
+  private def mapFunction(
+      model: Model
+  ): java.util.function.Function[Shape, Shape] = shape => {
     def replaceWith(shapeId: ShapeId): ShapeId = {
       val shapeType =
         model
-          .expectShape(shapeId) // this should be safe as we already did some filtering before calling the method
+          .expectShape(
+            shapeId
+          ) // this should be safe as we already did some filtering before calling the method
           .getType
 
       // Use the shape type instead of relying on the name
@@ -39,7 +43,7 @@ class AwsStandardTypesTransformer extends ProjectionTransformer {
 
     shape
       .asMemberShape()
-      .filter{ memberShape =>
+      .filter { memberShape =>
         model
           .getShape(memberShape.getTarget)
           .map[Boolean](canReplace)
@@ -68,7 +72,7 @@ class AwsStandardTypesTransformer extends ProjectionTransformer {
   }
 
   @annotation.nowarn
-  private def onlySupportedTraits(traits: java.util.Map[ShapeId, Trait]) = 
+  private def onlySupportedTraits(traits: java.util.Map[ShapeId, Trait]) =
     traits
       .values()
       .stream()
@@ -82,7 +86,9 @@ object AwsStandardTypesTransformer {
 
   val name: String = "AwsStandardTypesTransformer"
 
-  private[transformers] final implicit class MemberShapeBuilderOps(val builder: MemberShape.Builder) extends AnyVal {
+  private[transformers] final implicit class MemberShapeBuilderOps(
+      val builder: MemberShape.Builder
+  ) extends AnyVal {
     def copyDefaultTrait(shape: Shape): MemberShape.Builder = {
       val defaultTraitOpt = toOption(shape.getTrait(classOf[DefaultTrait]))
 

--- a/modules/codegen/src/smithy4s/codegen/transformers/AwsStandardTypesTransformer.scala
+++ b/modules/codegen/src/smithy4s/codegen/transformers/AwsStandardTypesTransformer.scala
@@ -1,0 +1,99 @@
+package smithy4s.codegen.transformers
+
+import smithy4s.codegen.transformers.AwsStandardTypesTransformer.MemberShapeBuilderOps
+import software.amazon.smithy.build.{ProjectionTransformer, TransformContext}
+import software.amazon.smithy.model.Model
+import software.amazon.smithy.model.shapes._
+import software.amazon.smithy.model.traits.{BoxTrait, DefaultTrait, Trait}
+
+class AwsStandardTypesTransformer extends ProjectionTransformer {
+
+  private val smithyStandardNamespace = "smithy.api"
+  private val awsNamespacePrefix = "com.amazonaws"
+
+  override def getName: String = AwsStandardTypesTransformer.name
+
+  override def transform(context: TransformContext): Model = {
+    val transformer = context.getTransformer
+
+    transformer.removeShapesIf(
+      transformer.mapShapes(context.getModel, mapFunction(context.getModel)),
+      canReplace
+    )
+  }
+
+  private def mapFunction(model: Model): java.util.function.Function[Shape, Shape] = shape => {
+    def replaceWith(shapeId: ShapeId): ShapeId = {
+      val shapeType =
+        model
+          .expectShape(shapeId) // this should be safe as we already did some filtering before calling the method
+          .getType
+
+      // Use the shape type instead of relying on the name
+      // because we want to be able to replace something
+      // com.amazonaws.dynamodb#Date with smithy.api#Timestamp
+      val shapeName = shapeType.getShapeClass.getSimpleName.replace("Shape", "")
+
+      ShapeId.fromParts(smithyStandardNamespace, shapeName)
+    }
+
+    shape.asMemberShape()
+      .filter{ memberShape =>
+        model.getShape(memberShape.getTarget)
+          .map[Boolean](canReplace)
+          .orElse(false)
+      }
+      .flatMap[Shape](shape => {
+        val replacementShape = replaceWith(shape.getTarget)
+        val target = model.expectShape(shape.getTarget)
+
+        val builder = MemberShape
+          .builder()
+          .id(shape.getId)
+          .source(shape.getSourceLocation)
+          .target(replacementShape)
+          .copyDefaultTrait(target, replacementShape)
+
+        java.util.Optional.of(builder.build().asInstanceOf[Shape])
+      })
+      .orElse(shape)
+  }
+
+  private def isAwsShape(shape: Shape): Boolean =
+    shape.getId.getNamespace.startsWith(awsNamespacePrefix)
+
+  private def canReplace(shape: Shape): Boolean = {
+    shape.isInstanceOf[SimpleShape] &&
+      isAwsShape(shape) &&
+      onlySupportedTraits(shape.getAllTraits)
+  }
+
+  @annotation.nowarn
+  private def onlySupportedTraits(traits: java.util.Map[ShapeId, Trait]) = traits.values().stream().allMatch(t => {
+      t.isInstanceOf[DefaultTrait] || t.isInstanceOf[BoxTrait]
+  })
+
+}
+
+object AwsStandardTypesTransformer {
+
+  val name: String = "AwsStandardTypesTransformer"
+
+  private[transformers] final implicit class MemberShapeBuilderOps(val builder: MemberShape.Builder) extends AnyVal {
+    def copyDefaultTrait(shape: Shape, replacementShape: ShapeId): MemberShape.Builder = {
+      val defaultTraitOpt = toOption(shape.getTrait(classOf[DefaultTrait]))
+
+      defaultTraitOpt.map { df =>
+        new DefaultTrait.Provider().createTrait(replacementShape, df.toNode)
+      }.fold(builder){defaultTrait => builder.addTrait(defaultTrait)}
+    }
+  }
+
+  private def toOption[A](o: java.util.Optional[A]): Option[A] = {
+    if (o.isPresent) {
+      Some(o.get())
+    } else {
+      None
+    }
+  }
+}

--- a/modules/codegen/src/smithy4s/codegen/transformers/AwsStandardTypesTransformer.scala
+++ b/modules/codegen/src/smithy4s/codegen/transformers/AwsStandardTypesTransformer.scala
@@ -1,3 +1,19 @@
+/*
+ *  Copyright 2021-2022 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 package smithy4s.codegen.transformers
 
 import smithy4s.codegen.transformers.AwsStandardTypesTransformer.MemberShapeBuilderOps

--- a/modules/codegen/test/src/smithy4s/codegen/internals/TestUtils.scala
+++ b/modules/codegen/test/src/smithy4s/codegen/internals/TestUtils.scala
@@ -30,6 +30,10 @@ object TestUtils {
       .addUnparsedModel("foo.smithy", smithySpec)
       .assemble()
       .unwrap()
+    generateScalaCode(model)
+  }
+
+  def generateScalaCode(model: Model): Map[String, String] = {
     CodegenImpl
       .generate(model, None, None)
       .map { case (_, result) =>

--- a/modules/codegen/test/src/smithy4s/codegen/transformers/AwsStandardTypesTransformerSpec.scala
+++ b/modules/codegen/test/src/smithy4s/codegen/transformers/AwsStandardTypesTransformerSpec.scala
@@ -38,7 +38,8 @@ final class AwsStandardTypesTransformerSpec extends munit.FunSuite {
 
     val transformedModel = transformer.transform(transformerContext)
 
-    val structureCode = generateScalaCode(transformedModel)("test.TestStructure")
+    val structureCode =
+      generateScalaCode(transformedModel)("test.TestStructure")
 
     assertEquals(
       structureCode,
@@ -88,9 +89,9 @@ final class AwsStandardTypesTransformerSpec extends munit.FunSuite {
         | @length(min:5, max:10)
         | s: com.amazonaws.kinesis#String
         |}
-        |""".stripMargin      
+        |""".stripMargin
 
-    val transformedModel = 
+    val transformedModel =
       new AwsStandardTypesTransformer()
         .transform(
           TransformContext
@@ -99,7 +100,8 @@ final class AwsStandardTypesTransformerSpec extends munit.FunSuite {
             .build()
         )
 
-    val structureCode = generateScalaCode(transformedModel)("test.TestStructure")
+    val structureCode =
+      generateScalaCode(transformedModel)("test.TestStructure")
 
     assertEquals(
       structureCode,
@@ -159,7 +161,8 @@ final class AwsStandardTypesTransformerSpec extends munit.FunSuite {
 
     val transformedModel = transformer.transform(transformerContext)
 
-    val structureCode = generateScalaCode(transformedModel)("test.TestStructure")
+    val structureCode =
+      generateScalaCode(transformedModel)("test.TestStructure")
 
     assertEquals(
       structureCode,
@@ -203,7 +206,11 @@ final class AwsStandardTypesTransformerSpec extends munit.FunSuite {
 
     val transformedModel = transformer.transform(transformerContext)
 
-    assert(!transformedModel.getShape(ShapeId.from("com.amazonaws.kinesis#Integer")).isPresent)
+    assert(
+      !transformedModel
+        .getShape(ShapeId.from("com.amazonaws.kinesis#Integer"))
+        .isPresent
+    )
   }
 
   test("Flattens AWS dates") {
@@ -222,7 +229,11 @@ final class AwsStandardTypesTransformerSpec extends munit.FunSuite {
 
     val transformedModel = transformer.transform(transformerContext)
 
-    assert(!transformedModel.getShape(ShapeId.from("com.amazonaws.kinesis#Date")).isPresent)
+    assert(
+      !transformedModel
+        .getShape(ShapeId.from("com.amazonaws.kinesis#Date"))
+        .isPresent
+    )
   }
 
   test("Does not flatten types with traits") {
@@ -242,9 +253,12 @@ final class AwsStandardTypesTransformerSpec extends munit.FunSuite {
 
     val transformedModel = transformer.transform(transformerContext)
 
-    assert(transformedModel.getShape(ShapeId.from("com.amazonaws.dynamodb#BackupArn")).isPresent)
+    assert(
+      transformedModel
+        .getShape(ShapeId.from("com.amazonaws.dynamodb#BackupArn"))
+        .isPresent
+    )
   }
-
 
   private def loadModel(namespaces: String*): Model = {
     val assembler = Model
@@ -252,9 +266,10 @@ final class AwsStandardTypesTransformerSpec extends munit.FunSuite {
       .disableValidation()
       .discoverModels()
 
-    namespaces.foldLeft(assembler) {case (a, model) =>
-      a.addUnparsedModel(s"test-${model.hashCode}.smithy", model)
-    }
+    namespaces
+      .foldLeft(assembler) { case (a, model) =>
+        a.addUnparsedModel(s"test-${model.hashCode}.smithy", model)
+      }
       .assemble()
       .unwrap()
   }

--- a/modules/codegen/test/src/smithy4s/codegen/transformers/AwsStandardTypesTransformerSpec.scala
+++ b/modules/codegen/test/src/smithy4s/codegen/transformers/AwsStandardTypesTransformerSpec.scala
@@ -1,3 +1,19 @@
+/*
+ *  Copyright 2021-2022 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 package smithy4s.codegen.transformers
 
 import software.amazon.smithy.build.TransformContext

--- a/modules/codegen/test/src/smithy4s/codegen/transformers/AwsStandardTypesTransformerSpec.scala
+++ b/modules/codegen/test/src/smithy4s/codegen/transformers/AwsStandardTypesTransformerSpec.scala
@@ -1,0 +1,208 @@
+package smithy4s.codegen.transformers
+
+import software.amazon.smithy.build.TransformContext
+import software.amazon.smithy.model.Model
+import software.amazon.smithy.model.node.Node
+import software.amazon.smithy.model.shapes.{ModelSerializer, ShapeId}
+
+final class AwsStandardTypesTransformerSpec extends munit.FunSuite {
+
+  import smithy4s.codegen.internals.TestUtils._
+
+  test("Flattens member shapes targeting AWS new-types") {
+    val kinesisNamespace =
+      """|namespace com.amazonaws.kinesis
+         |
+         |integer Integer
+         |timestamp Date
+         |""".stripMargin
+
+    val testNamespace =
+      """
+        |namespace test
+        |
+        |structure TestStructure {
+        | i: com.amazonaws.kinesis#Integer
+        | d: com.amazonaws.kinesis#Date
+        |}
+        |""".stripMargin
+
+    val rawModel = loadModel(kinesisNamespace, testNamespace)
+
+    val transformer = new AwsStandardTypesTransformer()
+    val transformerContext =
+      TransformContext
+        .builder()
+        .model(rawModel)
+        .build()
+
+    val transformedModel = transformer.transform(transformerContext)
+
+    val structureCode = generateScalaCode(transformedModel)("test.TestStructure")
+
+    assertEquals(
+      structureCode,
+      """package test
+        |
+        |import smithy4s.Hints
+        |import smithy4s.Schema
+        |import smithy4s.ShapeId
+        |import smithy4s.ShapeTag
+        |import smithy4s.Timestamp
+        |import smithy4s.schema.Schema.int
+        |import smithy4s.schema.Schema.struct
+        |import smithy4s.schema.Schema.timestamp
+        |
+        |case class TestStructure(i: Int = 0, d: Option[Timestamp] = None)
+        |object TestStructure extends ShapeTag.Companion[TestStructure] {
+        |  val id: ShapeId = ShapeId("test", "TestStructure")
+        |
+        |  val hints: Hints = Hints.empty
+        |
+        |  implicit val schema: Schema[TestStructure] = struct(
+        |    int.required[TestStructure]("i", _.i).addHints(smithy.api.Default(smithy4s.Document.fromDouble(0.0d))),
+        |    timestamp.optional[TestStructure]("d", _.d),
+        |  ){
+        |    TestStructure.apply
+        |  }.withId(id).addHints(hints)
+        |}""".stripMargin
+    )
+  }
+
+  test("Keeps default traits") {
+    val kinesisNamespace =
+      """|$version: "2"
+         |
+         |namespace com.amazonaws.kinesis
+         |
+         |@default(5)
+         |integer Integer
+         |""".stripMargin
+
+    val testNamespace =
+      """
+        |$version: "2"
+        |
+        |namespace test
+        |
+        |structure TestStructure {
+        | i: com.amazonaws.kinesis#Integer
+        |}
+        |""".stripMargin
+
+    val rawModel = loadModel(kinesisNamespace, testNamespace)
+
+    val transformer = new AwsStandardTypesTransformer()
+    val transformerContext =
+      TransformContext
+        .builder()
+        .model(rawModel)
+        .build()
+
+    val transformedModel = transformer.transform(transformerContext)
+
+    val structureCode = generateScalaCode(transformedModel)("test.TestStructure")
+
+    assertEquals(
+      structureCode,
+      """package test
+        |
+        |import smithy4s.Hints
+        |import smithy4s.Schema
+        |import smithy4s.ShapeId
+        |import smithy4s.ShapeTag
+        |import smithy4s.schema.Schema.int
+        |import smithy4s.schema.Schema.struct
+        |
+        |case class TestStructure(i: Int = 5)
+        |object TestStructure extends ShapeTag.Companion[TestStructure] {
+        |  val id: ShapeId = ShapeId("test", "TestStructure")
+        |
+        |  val hints: Hints = Hints.empty
+        |
+        |  implicit val schema: Schema[TestStructure] = struct(
+        |    int.required[TestStructure]("i", _.i).addHints(smithy.api.Default(smithy4s.Document.fromDouble(5.0d))),
+        |  ){
+        |    TestStructure.apply
+        |  }.withId(id).addHints(hints)
+        |}""".stripMargin
+    )
+  }
+
+  test("Removes AWS new types after flattening") {
+    val kinesisNamespace =
+      """|namespace com.amazonaws.kinesis
+         |
+         |integer Integer
+         |""".stripMargin
+
+    val transformer = new AwsStandardTypesTransformer()
+    val transformerContext =
+      TransformContext
+        .builder()
+        .model(loadModel(kinesisNamespace))
+        .build()
+
+    val transformedModel = transformer.transform(transformerContext)
+
+    assert(!transformedModel.getShape(ShapeId.from("com.amazonaws.kinesis#Integer")).isPresent)
+  }
+
+  test("Flattens AWS dates") {
+    val kinesisNamespace =
+      """|namespace com.amazonaws.kinesis
+         |
+         |timestamp Date
+         |""".stripMargin
+
+    val transformer = new AwsStandardTypesTransformer()
+    val transformerContext =
+      TransformContext
+        .builder()
+        .model(loadModel(kinesisNamespace))
+        .build()
+
+    val transformedModel = transformer.transform(transformerContext)
+
+    assert(!transformedModel.getShape(ShapeId.from("com.amazonaws.kinesis#Date")).isPresent)
+  }
+
+  test("Does not flatten types with traits") {
+    val kinesisNamespace =
+      """|namespace com.amazonaws.dynamodb
+         |
+         |@length(min: 1, max: 10)
+         |string BackupArn
+         |""".stripMargin
+
+    val transformer = new AwsStandardTypesTransformer()
+    val transformerContext =
+      TransformContext
+        .builder()
+        .model(loadModel(kinesisNamespace))
+        .build()
+
+    val transformedModel = transformer.transform(transformerContext)
+
+    assert(transformedModel.getShape(ShapeId.from("com.amazonaws.dynamodb#BackupArn")).isPresent)
+  }
+
+
+  private def loadModel(namespaces: String*): Model = {
+    val assembler = Model
+      .assembler()
+      .disableValidation()
+      .discoverModels()
+
+    namespaces.foldLeft(assembler) {case (a, model) =>
+      a.addUnparsedModel(s"test-${model.hashCode}.smithy", model)
+    }
+      .assemble()
+      .unwrap()
+  }
+
+  def prettyPrint(model: Model): String = {
+    Node.prettyPrintJson(ModelSerializer.builder().build.serialize(model))
+  }
+
+}


### PR DESCRIPTION
AWS in their smithy specs have a tendency to create newtypes for the smithy standard shapes. As part of this change, introduce a projection transformer that will run as a preprocessor before code generation and will replace the newtypes (if they match some criteria) with references to the standard smithy shapes.

For a newtype to be considered as being "replaceable" it has to match the following criteria:
- doesn't have any traits (other than @default)
- is a simple shape
- the name matches the smithy shape (one exception is Date, as it will be replaced with Timestamp even though it doesn't actually match).
- comes from an AWS namespace (i.e. starts with com.amazonaws)