### PR TITLE
add method to display json shape received when failing document decoder

### DIFF
--- a/modules/core/src/smithy4s/Document.scala
+++ b/modules/core/src/smithy4s/Document.scala
@@ -35,6 +35,17 @@ sealed trait Document extends Product with Serializable {
 
   override def toString(): String = this.show
 
+  def name: String = this match {
+    case DNumber(_)  => "number"
+    case DString(_)  => "string"
+    case DBoolean(_) => "boolean"
+    case DNull       => "null"
+    case DArray(value) =>
+      s"array[${value.headOption.map(_.name).getOrElse("null")}]"
+    case DObject(map) =>
+      s"object{${map.map { case (k, v) => s"$k=${v.name}" }.mkString(",")}}"
+  }
+
   /**
     * Toy renderer that does not comply the json specification :
     * strings aren't escaped and keys aren't quoted.

--- a/modules/core/src/smithy4s/Document.scala
+++ b/modules/core/src/smithy4s/Document.scala
@@ -36,14 +36,14 @@ sealed trait Document extends Product with Serializable {
   override def toString(): String = this.show
 
   def name: String = this match {
-    case DNumber(_)  => "number"
-    case DString(_)  => "string"
-    case DBoolean(_) => "boolean"
-    case DNull       => "null"
+    case DNumber(_)  => "Number"
+    case DString(_)  => "String"
+    case DBoolean(_) => "Boolean"
+    case DNull       => "Null"
     case DArray(value) =>
-      s"array[${value.headOption.map(_.name).getOrElse("null")}]"
+      s"Array[${value.headOption.map(_.name).getOrElse("Null")}]"
     case DObject(map) =>
-      s"object{${map.map { case (k, v) => s"$k=${v.name}" }.mkString(",")}}"
+      s"Object{${map.map { case (k, v) => s"$k=${v.name}" }.mkString(",")}}"
   }
 
   /**

--- a/modules/core/src/smithy4s/Document.scala
+++ b/modules/core/src/smithy4s/Document.scala
@@ -40,10 +40,8 @@ sealed trait Document extends Product with Serializable {
     case DString(_)  => "String"
     case DBoolean(_) => "Boolean"
     case DNull       => "Null"
-    case DArray(value) =>
-      s"Array[${value.headOption.map(_.name).getOrElse("Null")}]"
-    case DObject(map) =>
-      s"Object{${map.map { case (k, v) => s"$k=${v.name}" }.mkString(",")}}"
+    case DArray(_)   => "Array"
+    case DObject(_)  => "Object"
   }
 
   /**

--- a/modules/core/src/smithy4s/internals/DocumentDecoderSchemaVisitor.scala
+++ b/modules/core/src/smithy4s/internals/DocumentDecoderSchemaVisitor.scala
@@ -82,7 +82,7 @@ object DocumentDecoder {
         throw PayloadError(
           PayloadPath(history.reverse),
           expectedType,
-          s"Expected Json $expectedJsonShape"
+          s"Expected Json Shape: $expectedJsonShape but got the following Json Shape ${document.name}"
         )
     }
     def expected: String = expectedType


### PR DESCRIPTION
RE: #701
adds method to display shape of document received when failing due to unexpected json shape