### PR TITLE
Wire up EC2 Query codec based on Query codec, plus compliance tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -890,15 +890,18 @@ lazy val sandbox = projectMatrix
   .dependsOn(`aws-http4s`)
   .settings(
     Compile / allowedNamespaces := Seq(
-      "com.amazonaws.cloudwatch"
+      "com.amazonaws.cloudwatch",
+      "com.amazonaws.ec2"
     ),
     genSmithy(Compile),
     // Ignore deprecation warnings here - it's all generated code, anyway.
     scalacOptions ++= Seq(
       "-Wconf:cat=deprecation:silent"
     ) ++ scala3MigrationOption(scalaVersion.value),
-    smithy4sDependencies +=
+    smithy4sDependencies ++= Seq(
       "com.disneystreaming.smithy" % "aws-cloudwatch-spec" % "2023.02.10",
+      "com.disneystreaming.smithy" % "aws-ec2-spec" % "2023.02.10"
+    ),
     libraryDependencies ++= Seq(
       Dependencies.Http4s.emberClient.value,
       Dependencies.slf4jNop

--- a/build.sbt
+++ b/build.sbt
@@ -259,11 +259,10 @@ lazy val `aws-kernel` = projectMatrix
     genSmithy(Compile),
     Test / envVars ++= Map("TEST_VAR" -> "hello"),
     scalacOptions ++= Seq(
-      "-Wconf:msg=class AwsQuery in package (aws\\.)?protocols is deprecated:silent",
-      "-Wconf:msg=class RestXml in package aws.protocols is deprecated:silent",
-      "-Wconf:msg=value noErrorWrapping in class RestXml is deprecated:silent",
-      "-Wconf:msg=class Ec2Query in package aws.protocols is deprecated:silent",
-      "-Wconf:msg=class RestXml in package protocols is deprecated:silent"
+      "-Wconf:msg=class AwsQuery in package protocols is deprecated:silent",
+      "-Wconf:msg=class Ec2Query in package protocols is deprecated:silent",
+      "-Wconf:msg=class RestXml in package protocols is deprecated:silent",
+      "-Wconf:msg=value noErrorWrapping in class RestXml is deprecated:silent"
     )
   )
   .jvmPlatform(allJvmScalaVersions, jvmDimSettings)
@@ -309,11 +308,10 @@ lazy val `aws-http4s` = projectMatrix
       )
     },
     scalacOptions ++= Seq(
-      "-Wconf:msg=class AwsQuery in package (aws\\.)?protocols is deprecated:silent",
+      "-Wconf:msg=class AwsQuery in package protocols is deprecated:silent",
+      "-Wconf:msg=class Ec2Query in package protocols is deprecated:silent",
       "-Wconf:msg=class RestXml in package protocols is deprecated:silent",
-      "-Wconf:msg=class RestXml in package aws.protocols is deprecated:silent",
-      "-Wconf:msg=value noErrorWrapping in class RestXml is deprecated:silent",
-      "-Wconf:msg=class Ec2Query in package aws.protocols is deprecated:silent"
+      "-Wconf:msg=value noErrorWrapping in class RestXml is deprecated:silent"
     ),
     Test / complianceTestDependencies := Seq(
       Dependencies.Alloy.`protocol-tests`

--- a/build.sbt
+++ b/build.sbt
@@ -259,9 +259,9 @@ lazy val `aws-kernel` = projectMatrix
     genSmithy(Compile),
     Test / envVars ++= Map("TEST_VAR" -> "hello"),
     scalacOptions ++= Seq(
-      "-Wconf:msg=class AwsQuery in package protocols is deprecated:silent",
-      "-Wconf:msg=class Ec2Query in package protocols is deprecated:silent",
-      "-Wconf:msg=class RestXml in package protocols is deprecated:silent",
+      "-Wconf:msg=class AwsQuery in package (aws\\.)?protocols is deprecated:silent",
+      "-Wconf:msg=class Ec2Query in package (aws\\.)?protocols is deprecated:silent",
+      "-Wconf:msg=class RestXml in package (aws\\.)?protocols is deprecated:silent",
       "-Wconf:msg=value noErrorWrapping in class RestXml is deprecated:silent"
     )
   )
@@ -308,9 +308,9 @@ lazy val `aws-http4s` = projectMatrix
       )
     },
     scalacOptions ++= Seq(
-      "-Wconf:msg=class AwsQuery in package protocols is deprecated:silent",
-      "-Wconf:msg=class Ec2Query in package protocols is deprecated:silent",
-      "-Wconf:msg=class RestXml in package protocols is deprecated:silent",
+      "-Wconf:msg=class AwsQuery in package (aws\\.)?protocols is deprecated:silent",
+      "-Wconf:msg=class Ec2Query in package (aws\\.)?protocols is deprecated:silent",
+      "-Wconf:msg=class RestXml in package (aws\\.)?protocols is deprecated:silent",
       "-Wconf:msg=value noErrorWrapping in class RestXml is deprecated:silent"
     ),
     Test / complianceTestDependencies := Seq(

--- a/modules/aws-http4s/src/smithy4s/aws/AwsClient.scala
+++ b/modules/aws-http4s/src/smithy4s/aws/AwsClient.scala
@@ -23,6 +23,7 @@ import fs2.compression.Compression
 import smithy4s.http4s.kernel._
 import smithy4s.aws.internals._
 import _root_.aws.api.{Service => AwsService}
+import smithy4s.aws.internals.AwsQueryCodecs
 
 object AwsClient {
 
@@ -60,6 +61,9 @@ object AwsClient {
         awsEnv: AwsEnvironment[F]
     ): service.FunctorInterpreter[F] = {
       val clientCodecs: UnaryClientCodecs.Make[F] = awsProtocol match {
+        case AwsProtocol.AWS_EC2_QUERY(_) =>
+          AwsEcsQueryCodecs.make[F](version = service.version)
+
         case AwsProtocol.AWS_JSON_1_0(_) =>
           AwsJsonCodecs.make[F]("application/x-amz-json-1.0")
 

--- a/modules/aws-http4s/src/smithy4s/aws/AwsClient.scala
+++ b/modules/aws-http4s/src/smithy4s/aws/AwsClient.scala
@@ -16,14 +16,14 @@
 
 package smithy4s.aws
 
+import _root_.aws.api.{Service => AwsService}
 import cats.effect.Async
 import cats.effect.Resource
 import cats.syntax.all._
 import fs2.compression.Compression
-import smithy4s.http4s.kernel._
-import smithy4s.aws.internals._
-import _root_.aws.api.{Service => AwsService}
 import smithy4s.aws.internals.AwsQueryCodecs
+import smithy4s.aws.internals._
+import smithy4s.http4s.kernel._
 
 object AwsClient {
 

--- a/modules/aws-http4s/src/smithy4s/aws/AwsCredentialsProvider.scala
+++ b/modules/aws-http4s/src/smithy4s/aws/AwsCredentialsProvider.scala
@@ -18,20 +18,21 @@ package smithy4s.aws
 
 import cats.effect._
 import cats.syntax.all._
+import fs2.io.file.Files
+import org.http4s.EntityDecoder
+import org.http4s.Uri
+import org.http4s.client.Client
+import org.http4s.syntax.all._
 import smithy4s.aws.kernel.AWS_ACCESS_KEY_ID
+import smithy4s.aws.kernel.AWS_PROFILE
 import smithy4s.aws.kernel.AWS_SECRET_ACCESS_KEY
 import smithy4s.aws.kernel.AWS_SESSION_TOKEN
-import smithy4s.aws.kernel.AWS_PROFILE
 import smithy4s.aws.kernel.AwsInstanceMetadata
 import smithy4s.aws.kernel.AwsTemporaryCredentials
 import smithy4s.aws.kernel.SysEnv
 import smithy4s.http4s.kernel.EntityDecoders
-import fs2.io.file.Files
+
 import scala.concurrent.duration._
-import org.http4s.EntityDecoder
-import org.http4s.client.Client
-import org.http4s.syntax.all._
-import org.http4s.Uri
 
 object AwsCredentialsProvider {
 

--- a/modules/aws-http4s/src/smithy4s/aws/internals/AwsEc2QueryCodecs.scala
+++ b/modules/aws-http4s/src/smithy4s/aws/internals/AwsEc2QueryCodecs.scala
@@ -18,15 +18,15 @@ package smithy4s
 package aws
 package internals
 
-import smithy.api.XmlName
+import _root_.aws.protocols.AwsQueryError
+import _root_.aws.protocols.Ec2QueryName
 import cats.effect.Concurrent
 import cats.syntax.all._
 import fs2.compression.Compression
+import smithy.api.XmlName
 import smithy4s.Endpoint
 import smithy4s.http._
 import smithy4s.http4s.kernel._
-import _root_.aws.protocols.Ec2QueryName
-import _root_.aws.protocols.AwsQueryError
 
 private[aws] object AwsEcsQueryCodecs {
 

--- a/modules/aws-http4s/src/smithy4s/aws/internals/AwsEc2QueryCodecs.scala
+++ b/modules/aws-http4s/src/smithy4s/aws/internals/AwsEc2QueryCodecs.scala
@@ -71,7 +71,7 @@ private[aws] object AwsEcsQueryCodecs {
                         XmlName(xmlName.value.capitalize)
                       )
 
-                    case _ =>
+                    case None =>
                       hints
                   }
               }

--- a/modules/aws-http4s/src/smithy4s/aws/internals/AwsEc2QueryCodecs.scala
+++ b/modules/aws-http4s/src/smithy4s/aws/internals/AwsEc2QueryCodecs.scala
@@ -1,0 +1,131 @@
+/*
+ *  Copyright 2021-2022 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package smithy4s
+package aws
+package internals
+
+import cats.effect.Concurrent
+import cats.syntax.all._
+import fs2.compression.Compression
+import smithy4s.Endpoint
+import smithy4s.schema.CachedSchemaCompiler
+import smithy4s.http._
+import smithy4s.http4s.kernel._
+import smithy4s.http.Metadata
+import smithy4s.kinds.PolyFunction
+import smithy4s.codecs.PayloadPath
+import org.http4s.EntityEncoder
+import _root_.aws.protocols.AwsQueryError
+
+private[aws] object AwsEcsQueryCodecs {
+
+  def make[F[_]: Concurrent: Compression](
+      version: String
+  ): UnaryClientCodecs.Make[F] =
+    new UnaryClientCodecs.Make[F] {
+      def apply[I, E, O, SI, SO](
+          endpoint: Endpoint.Base[I, E, O, SI, SO]
+      ): UnaryClientCodecs[F, I, E, O] = {
+        val transformEncoders =
+          applyCompression[F](endpoint.hints, retainUserEncoding = false)
+        val requestEncoderCompilersWithCompression = transformEncoders(
+          requestEncoderCompilers[F](
+            action = endpoint.id.name,
+            version = version
+          )
+        )
+
+        val (xmlResponseDecoderCompilers, errorDecoderCompilers) =
+          AwsXmlCodecs.responseAndErrorDecoderCompilers[F]
+        val responseTag = endpoint.name + "Response"
+        val resultTag = endpoint.name + "Result"
+        val responseDecoderCompilers =
+          xmlResponseDecoderCompilers.contramapSchema(
+            smithy4s.schema.Schema.transformHintsLocallyK(
+              _ ++ smithy4s.Hints(
+                smithy4s.xml.internals.XmlStartingPath(
+                  List(responseTag, resultTag)
+                )
+              )
+            )
+          )
+        // Takes the `@awsQueryError` trait into consideration to decide how to
+        // discriminate error responses.
+        val errorNameMapping: (String => String) = endpoint.errorable match {
+          case None =>
+            identity[String]
+
+          case Some(err) =>
+            val mapping = err.error.alternatives.flatMap { alt =>
+              val shapeName = alt.schema.shapeId.name
+              alt.hints.get(AwsQueryError).map(_.code).map(_ -> shapeName)
+            }.toMap
+            (errorCode: String) => mapping.getOrElse(errorCode, errorCode)
+        }
+        val errorDiscriminator = AwsErrorTypeDecoder
+          .fromResponse(errorDecoderCompilers)
+          .andThen(_.map(_.map {
+            case HttpDiscriminator.NameOnly(name) =>
+              HttpDiscriminator.NameOnly(errorNameMapping(name))
+            case other => other
+          }))
+
+        val make = UnaryClientCodecs.Make[F](
+          input = requestEncoderCompilersWithCompression,
+          output = responseDecoderCompilers,
+          error = errorDecoderCompilers,
+          errorDiscriminator = errorDiscriminator
+        )
+        make.apply(endpoint)
+      }
+    }
+
+  private def requestEncoderCompilers[F[_]: Concurrent](
+      action: String,
+      version: String
+  ): CachedSchemaCompiler[RequestEncoder[F, *]] = {
+    val urlFormEntityEncoderCompilers = UrlForm.Encoder.mapK(
+      new PolyFunction[UrlForm.Encoder, EntityEncoder[F, *]] {
+        def apply[A](fa: UrlForm.Encoder[A]): EntityEncoder[F, A] =
+          urlFormEntityEncoder[F].contramap((a: A) =>
+            UrlForm(
+              formData = UrlForm.FormData.MultipleValues(
+                values = Vector(
+                  UrlForm.FormData.PathedValue(PayloadPath("Action"), action),
+                  UrlForm.FormData.PathedValue(PayloadPath("Version"), version)
+                ) ++ fa.encode(a).formData.values
+              )
+            )
+          )
+      }
+    )
+    RequestEncoder.restSchemaCompiler[F](
+      metadataEncoderCompiler = Metadata.AwsEncoder,
+      entityEncoderCompiler = urlFormEntityEncoderCompilers,
+      writeEmptyStructs = true
+    )
+  }
+
+  private def urlFormEntityEncoder[F[_]]: EntityEncoder[F, UrlForm] =
+    EntityEncoders.fromHttpMediaWriter(
+      HttpMediaTyped(
+        HttpMediaType("application/x-www-form-urlencoded"),
+        (_: Any, urlForm: UrlForm) => Blob(urlForm.render)
+      )
+    )
+
+}

--- a/modules/aws-http4s/src/smithy4s/aws/internals/AwsEc2QueryCodecs.scala
+++ b/modules/aws-http4s/src/smithy4s/aws/internals/AwsEc2QueryCodecs.scala
@@ -41,7 +41,7 @@ private[aws] object AwsEcsQueryCodecs {
           .requestEncoderCompilers[F](
             // These are set to fulfil the requirements of
             // https://smithy.io/2.0/aws/protocols/aws-ec2-query-protocol.html?highlight=ec2%20query%20protocol#query-key-resolution.
-            // without UrlFormDataEncoderSchemaVisitor having to have more aware
+            // without UrlFormDataEncoderSchemaVisitor having to be more aware
             // than necessary of these protocol quirks (having it be aware of
             // XmlName and XmlFlattened already feels like too much - perhaps in
             // a future change UrlFormDataEncoderSchemaVisitor can work with

--- a/modules/aws-http4s/src/smithy4s/aws/internals/AwsEc2QueryCodecs.scala
+++ b/modules/aws-http4s/src/smithy4s/aws/internals/AwsEc2QueryCodecs.scala
@@ -18,17 +18,15 @@ package smithy4s
 package aws
 package internals
 
+import smithy.api.XmlName
 import cats.effect.Concurrent
 import cats.syntax.all._
 import fs2.compression.Compression
 import smithy4s.Endpoint
-import smithy4s.schema.CachedSchemaCompiler
 import smithy4s.http._
 import smithy4s.http4s.kernel._
-import smithy4s.http.Metadata
-import smithy4s.kinds.PolyFunction
-import smithy4s.codecs.PayloadPath
-import org.http4s.EntityEncoder
+import smithy4s.schema._
+import _root_.aws.protocols.Ec2QueryName
 import _root_.aws.protocols.AwsQueryError
 
 private[aws] object AwsEcsQueryCodecs {
@@ -37,16 +35,123 @@ private[aws] object AwsEcsQueryCodecs {
       version: String
   ): UnaryClientCodecs.Make[F] =
     new UnaryClientCodecs.Make[F] {
+      // TODO: Caching?
+      object foo extends SchemaVisitor.Default[Schema] { self =>
+        override def default[A]: Schema[A] = ???
+        override def apply[A](schema: Schema[A]): Schema[A] =
+          schema.hints.get(Ec2QueryName) match {
+            case Some(ec2QueryName) =>
+              schema.addHints(XmlName(ec2QueryName.value))
+
+            case None =>
+              schema.hints.get(XmlName) match {
+                case Some(xmlName) =>
+                  schema.addHints(
+                    XmlName(xmlName.value.capitalize)
+                  )
+
+                case _ =>
+                  schema match {
+                    case s: Schema.CollectionSchema[_, _] =>
+                      s.copy(
+                        member = self(s.member)
+                      )
+
+                    case m: Schema.MapSchema[_, _] =>
+                      m.copy(
+                        key = self(m.key),
+                        value = self(m.value)
+                      )
+
+                    case struct: Schema.StructSchema[_] =>
+                      struct.copy(
+                        fields = struct.fields.map(field =>
+                          field.hints.get(Ec2QueryName) match {
+                            case Some(ec2QueryName) =>
+                              def transformField[S, B](
+                                  field: Field[S, B]
+                              ): Field[S, B] =
+                                field
+                                  .copy(
+                                    schema = self(field.schema)
+                                  )
+                                  .addHints(XmlName(ec2QueryName.value))
+                              transformField(field)
+                            case None =>
+                              def transformField[S, B](
+                                  field: Field[S, B]
+                              ): Field[S, B] =
+                                field.hints.get(XmlName) match {
+                                  case Some(xmlName) =>
+                                    field
+                                      .addHints(
+                                        XmlName(xmlName.value.capitalize)
+                                      )
+                                  case _ =>
+                                    println(s"transforming field ${field}")
+                                    field                                    
+                                      .copy(
+                                        schema = self(field.schema)
+                                      ).
+                                    addHints(
+                                      XmlName(field.label.capitalize)
+                                    )
+                                }
+                              transformField(field)
+                          }
+                        )
+                      )
+                    case union: Schema.UnionSchema[_] =>
+                      union.copy(
+                        alternatives = union.alternatives.map(field =>
+                          field.addHints(
+                            XmlName(field.label.capitalize)
+                          )
+                        )
+                      )
+                    case _ => schema
+                  }
+              }
+          }
+      }
       def apply[I, E, O, SI, SO](
           endpoint: Endpoint.Base[I, E, O, SI, SO]
       ): UnaryClientCodecs[F, I, E, O] = {
-        val transformEncoders =
-          applyCompression[F](endpoint.hints, retainUserEncoding = false)
-        val requestEncoderCompilersWithCompression = transformEncoders(
-          requestEncoderCompilers[F](
+        val requestEncoderCompilers = AwsQueryCodecs
+          .requestEncoderCompilers[F](
+            ignoreXmlFlattened = true,
             action = endpoint.id.name,
             version = version
           )
+          .contramapSchema(
+            foo
+            // smithy4s.schema.Schema.transformHintsTransitivelyK(hints =>
+            //   hints.get(Ec2QueryName) match {
+            //     case Some(ec2QueryName) =>
+            //       hints ++ smithy4s.Hints(
+            //         XmlName(ec2QueryName.value)
+            //       )
+
+            //     case None =>
+            //       hints.get(XmlName) match {
+            //         case Some(xmlName) if !xmlName.value.isEmpty =>
+            //           hints ++ smithy4s.Hints(
+            //             XmlName(xmlName.value.capitalize)
+            //           )
+
+            //         case _ =>
+            //           hints
+            //           //  ++ smithy4s.Hints(
+            //             // XmlName(s"${Character.toUpperCase(xmlName.value.charAt(0))}${xmlName.value.substring(1)}")
+            //           // )
+            //       }
+            //   }
+            // )
+          )
+        val transformEncoders =
+          applyCompression[F](endpoint.hints, retainUserEncoding = false)
+        val requestEncoderCompilersWithCompression = transformEncoders(
+          requestEncoderCompilers
         )
 
         val responseTag = endpoint.name + "Response"
@@ -104,46 +209,5 @@ private[aws] object AwsEcsQueryCodecs {
         make.apply(endpoint)
       }
     }
-
-  private def requestEncoderCompilers[F[_]: Concurrent](
-      action: String,
-      version: String
-  ): CachedSchemaCompiler[RequestEncoder[F, *]] = {
-    val urlFormEntityEncoderCompilers = UrlForm
-      .Encoder(
-        // Per
-        // https://github.com/smithy-lang/smithy/blob/0d7a26d4880cdb7b3c21ba414c2642d93245b19e/smithy-aws-protocol-tests/model/ec2Query/main.smithy#L5.
-        ignoreXmlFlattened = true
-      )
-      .mapK(
-        new PolyFunction[UrlForm.Encoder, EntityEncoder[F, *]] {
-          def apply[A](fa: UrlForm.Encoder[A]): EntityEncoder[F, A] =
-            urlFormEntityEncoder[F].contramap((a: A) =>
-              UrlForm(
-                formData = UrlForm.FormData.MultipleValues(
-                  values = Vector(
-                    UrlForm.FormData.PathedValue(PayloadPath("Action"), action),
-                    UrlForm.FormData
-                      .PathedValue(PayloadPath("Version"), version)
-                  ) ++ fa.encode(a).formData.values
-                )
-              )
-            )
-        }
-      )
-    RequestEncoder.restSchemaCompiler[F](
-      metadataEncoderCompiler = Metadata.AwsEncoder,
-      entityEncoderCompiler = urlFormEntityEncoderCompilers,
-      writeEmptyStructs = true
-    )
-  }
-
-  private def urlFormEntityEncoder[F[_]]: EntityEncoder[F, UrlForm] =
-    EntityEncoders.fromHttpMediaWriter(
-      HttpMediaTyped(
-        HttpMediaType("application/x-www-form-urlencoded"),
-        (_: Any, urlForm: UrlForm) => Blob(urlForm.render)
-      )
-    )
 
 }

--- a/modules/aws-http4s/src/smithy4s/aws/internals/AwsQueryCodecs.scala
+++ b/modules/aws-http4s/src/smithy4s/aws/internals/AwsQueryCodecs.scala
@@ -18,18 +18,18 @@ package smithy4s
 package aws
 package internals
 
+import _root_.aws.protocols.AwsQueryError
 import cats.effect.Concurrent
 import cats.syntax.all._
 import fs2.compression.Compression
+import org.http4s.EntityEncoder
 import smithy4s.Endpoint
-import smithy4s.schema.CachedSchemaCompiler
+import smithy4s.codecs.PayloadPath
+import smithy4s.http.Metadata
 import smithy4s.http._
 import smithy4s.http4s.kernel._
-import smithy4s.http.Metadata
 import smithy4s.kinds.PolyFunction
-import smithy4s.codecs.PayloadPath
-import org.http4s.EntityEncoder
-import _root_.aws.protocols.AwsQueryError
+import smithy4s.schema.CachedSchemaCompiler
 
 private[aws] object AwsQueryCodecs {
 

--- a/modules/aws-http4s/src/smithy4s/aws/internals/AwsQueryCodecs.scala
+++ b/modules/aws-http4s/src/smithy4s/aws/internals/AwsQueryCodecs.scala
@@ -44,6 +44,7 @@ private[aws] object AwsQueryCodecs {
           applyCompression[F](endpoint.hints, retainUserEncoding = false)
         val requestEncoderCompilersWithCompression = transformEncoders(
           requestEncoderCompilers[F](
+            ignoreXmlFlattened = false,
             action = endpoint.id.name,
             version = version
           )
@@ -105,12 +106,13 @@ private[aws] object AwsQueryCodecs {
       }
     }
 
-  private def requestEncoderCompilers[F[_]: Concurrent](
+  def requestEncoderCompilers[F[_]: Concurrent](
+      ignoreXmlFlattened: Boolean,
       action: String,
       version: String
   ): CachedSchemaCompiler[RequestEncoder[F, *]] = {
     val urlFormEntityEncoderCompilers = UrlForm
-      .Encoder()
+      .Encoder(ignoreXmlFlattened)
       .mapK(
         new PolyFunction[UrlForm.Encoder, EntityEncoder[F, *]] {
           def apply[A](fa: UrlForm.Encoder[A]): EntityEncoder[F, A] =

--- a/modules/aws-http4s/src/smithy4s/aws/internals/AwsQueryCodecs.scala
+++ b/modules/aws-http4s/src/smithy4s/aws/internals/AwsQueryCodecs.scala
@@ -45,6 +45,7 @@ private[aws] object AwsQueryCodecs {
         val requestEncoderCompilersWithCompression = transformEncoders(
           requestEncoderCompilers[F](
             ignoreXmlFlattened = false,
+            capitalizeStructAndUnionMemberNames = false,
             action = endpoint.id.name,
             version = version
           )
@@ -108,11 +109,12 @@ private[aws] object AwsQueryCodecs {
 
   def requestEncoderCompilers[F[_]: Concurrent](
       ignoreXmlFlattened: Boolean,
+      capitalizeStructAndUnionMemberNames: Boolean,
       action: String,
       version: String
   ): CachedSchemaCompiler[RequestEncoder[F, *]] = {
     val urlFormEntityEncoderCompilers = UrlForm
-      .Encoder(ignoreXmlFlattened)
+      .Encoder(ignoreXmlFlattened = ignoreXmlFlattened, capitalizeStructAndUnionMemberNames = capitalizeStructAndUnionMemberNames)
       .mapK(
         new PolyFunction[UrlForm.Encoder, EntityEncoder[F, *]] {
           def apply[A](fa: UrlForm.Encoder[A]): EntityEncoder[F, A] =

--- a/modules/aws-http4s/src/smithy4s/aws/internals/AwsQueryCodecs.scala
+++ b/modules/aws-http4s/src/smithy4s/aws/internals/AwsQueryCodecs.scala
@@ -49,16 +49,27 @@ private[aws] object AwsQueryCodecs {
           )
         )
 
-        val (xmlResponseDecoderCompilers, errorDecoderCompilers) =
-          AwsXmlCodecs.responseAndErrorDecoderCompilers[F]
         val responseTag = endpoint.name + "Response"
         val resultTag = endpoint.name + "Result"
         val responseDecoderCompilers =
-          xmlResponseDecoderCompilers.contramapSchema(
+          AwsXmlCodecs
+            .responseDecoderCompilers[F]
+            .contramapSchema(
+              smithy4s.schema.Schema.transformHintsLocallyK(
+                _ ++ smithy4s.Hints(
+                  smithy4s.xml.internals.XmlStartingPath(
+                    List(responseTag, resultTag)
+                  )
+                )
+              )
+            )
+        val errorDecoderCompilers = AwsXmlCodecs
+          .responseDecoderCompilers[F]
+          .contramapSchema(
             smithy4s.schema.Schema.transformHintsLocallyK(
               _ ++ smithy4s.Hints(
                 smithy4s.xml.internals.XmlStartingPath(
-                  List(responseTag, resultTag)
+                  List("ErrorResponse", "Error")
                 )
               )
             )

--- a/modules/aws-http4s/src/smithy4s/aws/internals/AwsQueryCodecs.scala
+++ b/modules/aws-http4s/src/smithy4s/aws/internals/AwsQueryCodecs.scala
@@ -109,21 +109,24 @@ private[aws] object AwsQueryCodecs {
       action: String,
       version: String
   ): CachedSchemaCompiler[RequestEncoder[F, *]] = {
-    val urlFormEntityEncoderCompilers = UrlForm.Encoder.mapK(
-      new PolyFunction[UrlForm.Encoder, EntityEncoder[F, *]] {
-        def apply[A](fa: UrlForm.Encoder[A]): EntityEncoder[F, A] =
-          urlFormEntityEncoder[F].contramap((a: A) =>
-            UrlForm(
-              formData = UrlForm.FormData.MultipleValues(
-                values = Vector(
-                  UrlForm.FormData.PathedValue(PayloadPath("Action"), action),
-                  UrlForm.FormData.PathedValue(PayloadPath("Version"), version)
-                ) ++ fa.encode(a).formData.values
+    val urlFormEntityEncoderCompilers = UrlForm
+      .Encoder()
+      .mapK(
+        new PolyFunction[UrlForm.Encoder, EntityEncoder[F, *]] {
+          def apply[A](fa: UrlForm.Encoder[A]): EntityEncoder[F, A] =
+            urlFormEntityEncoder[F].contramap((a: A) =>
+              UrlForm(
+                formData = UrlForm.FormData.MultipleValues(
+                  values = Vector(
+                    UrlForm.FormData.PathedValue(PayloadPath("Action"), action),
+                    UrlForm.FormData
+                      .PathedValue(PayloadPath("Version"), version)
+                  ) ++ fa.encode(a).formData.values
+                )
               )
             )
-          )
-      }
-    )
+        }
+      )
     RequestEncoder.restSchemaCompiler[F](
       metadataEncoderCompiler = Metadata.AwsEncoder,
       entityEncoderCompiler = urlFormEntityEncoderCompilers,

--- a/modules/aws-http4s/src/smithy4s/aws/internals/AwsSignatureClient.scala
+++ b/modules/aws-http4s/src/smithy4s/aws/internals/AwsSignatureClient.scala
@@ -17,17 +17,18 @@
 package smithy4s.aws
 package internals
 
-import java.net.URLEncoder
-import java.nio.charset.StandardCharsets
-import smithy4s._
+import cats.effect.Concurrent
+import cats.effect.Resource
+import cats.syntax.all._
+import fs2.Chunk
 import org.http4s._
 import org.http4s.client.Client
-import cats.effect.Resource
-import smithy4s.aws.kernel.AwsCrypto._
-import cats.effect.Concurrent
-import fs2.Chunk
-import cats.syntax.all._
 import org.typelevel.ci.CIString
+import smithy4s._
+import smithy4s.aws.kernel.AwsCrypto._
+
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
 
 /**
   * A Client middleware that signs http requests before they are sent to AWS.

--- a/modules/aws-http4s/src/smithy4s/aws/internals/AwsXmlCodecs.scala
+++ b/modules/aws-http4s/src/smithy4s/aws/internals/AwsXmlCodecs.scala
@@ -18,25 +18,24 @@ package smithy4s
 package aws
 package internals
 
+import cats.Applicative
+import cats.data.EitherT
 import cats.effect.Concurrent
 import cats.syntax.all._
-import cats.Applicative
 import fs2.compression.Compression
-import smithy4s.http4s.kernel._
-import smithy4s.Endpoint
-import smithy4s.schema.CachedSchemaCompiler
-import org.http4s.EntityDecoder
-import smithy4s.xml.XmlDocument
-import org.http4s.MediaRange
 import fs2.data.xml._
 import fs2.data.xml.dom._
-import cats.data.EitherT
-import smithy4s.kinds.PolyFunction
+import org.http4s.EntityDecoder
 import org.http4s.EntityEncoder
-import smithy4s.capability.Covariant
-
+import org.http4s.MediaRange
 import org.http4s.MediaType
+import smithy4s.Endpoint
+import smithy4s.capability.Covariant
 import smithy4s.http.Metadata
+import smithy4s.http4s.kernel._
+import smithy4s.kinds.PolyFunction
+import smithy4s.schema.CachedSchemaCompiler
+import smithy4s.xml.XmlDocument
 
 private[aws] object AwsXmlCodecs {
 

--- a/modules/aws-http4s/src/smithy4s/aws/internals/package.scala
+++ b/modules/aws-http4s/src/smithy4s/aws/internals/package.scala
@@ -16,10 +16,10 @@
 
 package smithy4s.aws
 
-import smithy4s.http4s.kernel.RequestEncoder
 import fs2.compression.Compression
-import smithy4s.schema.CachedSchemaCompiler
 import smithy4s.Hints
+import smithy4s.http4s.kernel.RequestEncoder
+import smithy4s.schema.CachedSchemaCompiler
 
 package object internals {
 

--- a/modules/aws-http4s/test/src/smithy4s/aws/compliancetests/AwsComplianceSuite.scala
+++ b/modules/aws-http4s/test/src/smithy4s/aws/compliancetests/AwsComplianceSuite.scala
@@ -57,19 +57,20 @@ object AwsComplianceSuite extends ProtocolComplianceSuite {
   }
 
   override def allTests(dsi: DynamicSchemaIndex): List[ComplianceTest[IO]] =
-    genClientTests(impl(Ec2Query), awsEc2Query)(dsi) ++
-      genClientTests(impl(AwsJson1_0), awsJson1_0)(dsi) ++
-      genClientTests(impl(AwsJson1_1), awsJson1_1)(dsi) ++
-      genClientTests(impl(AwsQuery), awsQuery)(dsi) ++
-      genClientTests(impl(RestJson1), restJson1)(dsi) ++
-      genClientTests(impl(RestXml), restXml)(dsi)
+    genClientTests(impl(Ec2Query), awsEc2Query)(dsi)
+    //  ++
+      // genClientTests(impl(AwsJson1_0), awsJson1_0)(dsi) ++
+      // genClientTests(impl(AwsJson1_1), awsJson1_1)(dsi) ++
+      // genClientTests(impl(AwsQuery), awsQuery)(dsi) ++
+      // genClientTests(impl(RestJson1), restJson1)(dsi) ++
+      // genClientTests(impl(RestXml), restXml)(dsi)
 
   private val awsEc2Query = ShapeId("aws.protocoltests.ec2", "AwsEc2")
-  private val awsJson1_0 = ShapeId("aws.protocoltests.json10", "JsonRpc10")
-  private val awsJson1_1 = ShapeId("aws.protocoltests.json", "JsonProtocol")
-  private val awsQuery = ShapeId("aws.protocoltests.query", "AwsQuery")
-  private val restJson1 = ShapeId("aws.protocoltests.restjson", "RestJson")
-  private val restXml = ShapeId("aws.protocoltests.restxml", "RestXml")
+  // private val awsJson1_0 = ShapeId("aws.protocoltests.json10", "JsonRpc10")
+  // private val awsJson1_1 = ShapeId("aws.protocoltests.json", "JsonProtocol")
+  // private val awsQuery = ShapeId("aws.protocoltests.query", "AwsQuery")
+  // private val restJson1 = ShapeId("aws.protocoltests.restjson", "RestJson")
+  // private val restXml = ShapeId("aws.protocoltests.restxml", "RestXml")
 
   private val modelDump = fileFromEnv("MODEL_DUMP")
 

--- a/modules/aws-http4s/test/src/smithy4s/aws/compliancetests/AwsComplianceSuite.scala
+++ b/modules/aws-http4s/test/src/smithy4s/aws/compliancetests/AwsComplianceSuite.scala
@@ -57,12 +57,14 @@ object AwsComplianceSuite extends ProtocolComplianceSuite {
   }
 
   override def allTests(dsi: DynamicSchemaIndex): List[ComplianceTest[IO]] =
-    genClientTests(impl(AwsJson1_0), awsJson1_0)(dsi) ++
+    genClientTests(impl(Ec2Query), awsEc2Query)(dsi) ++
+      genClientTests(impl(AwsJson1_0), awsJson1_0)(dsi) ++
       genClientTests(impl(AwsJson1_1), awsJson1_1)(dsi) ++
       genClientTests(impl(AwsQuery), awsQuery)(dsi) ++
       genClientTests(impl(RestJson1), restJson1)(dsi) ++
       genClientTests(impl(RestXml), restXml)(dsi)
 
+  private val awsEc2Query = ShapeId("aws.protocoltests.ec2", "AwsEc2")
   private val awsJson1_0 = ShapeId("aws.protocoltests.json10", "JsonRpc10")
   private val awsJson1_1 = ShapeId("aws.protocoltests.json", "JsonProtocol")
   private val awsQuery = ShapeId("aws.protocoltests.query", "AwsQuery")

--- a/modules/aws-http4s/test/src/smithy4s/aws/compliancetests/AwsComplianceSuite.scala
+++ b/modules/aws-http4s/test/src/smithy4s/aws/compliancetests/AwsComplianceSuite.scala
@@ -57,20 +57,19 @@ object AwsComplianceSuite extends ProtocolComplianceSuite {
   }
 
   override def allTests(dsi: DynamicSchemaIndex): List[ComplianceTest[IO]] =
-    genClientTests(impl(Ec2Query), awsEc2Query)(dsi)
-    //  ++
-      // genClientTests(impl(AwsJson1_0), awsJson1_0)(dsi) ++
-      // genClientTests(impl(AwsJson1_1), awsJson1_1)(dsi) ++
-      // genClientTests(impl(AwsQuery), awsQuery)(dsi) ++
-      // genClientTests(impl(RestJson1), restJson1)(dsi) ++
-      // genClientTests(impl(RestXml), restXml)(dsi)
+    genClientTests(impl(Ec2Query), awsEc2Query)(dsi) ++
+      genClientTests(impl(AwsJson1_0), awsJson1_0)(dsi) ++
+      genClientTests(impl(AwsJson1_1), awsJson1_1)(dsi) ++
+      genClientTests(impl(AwsQuery), awsQuery)(dsi) ++
+      genClientTests(impl(RestJson1), restJson1)(dsi) ++
+      genClientTests(impl(RestXml), restXml)(dsi)
 
   private val awsEc2Query = ShapeId("aws.protocoltests.ec2", "AwsEc2")
-  // private val awsJson1_0 = ShapeId("aws.protocoltests.json10", "JsonRpc10")
-  // private val awsJson1_1 = ShapeId("aws.protocoltests.json", "JsonProtocol")
-  // private val awsQuery = ShapeId("aws.protocoltests.query", "AwsQuery")
-  // private val restJson1 = ShapeId("aws.protocoltests.restjson", "RestJson")
-  // private val restXml = ShapeId("aws.protocoltests.restxml", "RestXml")
+  private val awsJson1_0 = ShapeId("aws.protocoltests.json10", "JsonRpc10")
+  private val awsJson1_1 = ShapeId("aws.protocoltests.json", "JsonProtocol")
+  private val awsQuery = ShapeId("aws.protocoltests.query", "AwsQuery")
+  private val restJson1 = ShapeId("aws.protocoltests.restjson", "RestJson")
+  private val restXml = ShapeId("aws.protocoltests.restxml", "RestXml")
 
   private val modelDump = fileFromEnv("MODEL_DUMP")
 

--- a/modules/aws-http4s/test/src/smithy4s/aws/compliancetests/AwsComplianceSuite.scala
+++ b/modules/aws-http4s/test/src/smithy4s/aws/compliancetests/AwsComplianceSuite.scala
@@ -18,11 +18,11 @@ package smithy4s.aws
 
 import aws.protocols._
 import cats.effect.IO
-import smithy4s.dynamic.DynamicSchemaIndex
-import smithy4s.ShapeId
 import cats.syntax.all._
+import smithy4s.ShapeId
 import smithy4s.aws.AwsJson.impl
 import smithy4s.compliancetests._
+import smithy4s.dynamic.DynamicSchemaIndex
 import smithy4s.tests.ProtocolComplianceSuite
 
 object AwsComplianceSuite extends ProtocolComplianceSuite {

--- a/modules/aws-kernel/src/smithy4s/aws/AwsProtocol.scala
+++ b/modules/aws-kernel/src/smithy4s/aws/AwsProtocol.scala
@@ -16,7 +16,7 @@
 
 package smithy4s.aws
 
-import aws.protocols.{AwsJson1_0, AwsJson1_1, AwsQuery, RestJson1, RestXml}
+import aws.protocols._
 import smithy4s.Hints
 import smithy4s.ShapeTag
 
@@ -28,8 +28,13 @@ private[aws] object AwsProtocol {
 
   def apply(hints: Hints): Option[AwsProtocol] =
     hints
-      .get(AwsJson1_0)
-      .map(AWS_JSON_1_0.apply)
+      .get(Ec2Query)
+      .map(AWS_EC2_QUERY.apply)
+      .orElse(
+        hints
+          .get(AwsJson1_0)
+          .map(AWS_JSON_1_0.apply)
+      )
       .orElse(
         hints
           .get(AwsJson1_1)
@@ -52,6 +57,7 @@ private[aws] object AwsProtocol {
       )
 
   // See https://awslabs.github.io/smithy/1.0/spec/aws/aws-json-1_0-protocol.html#differences-between-awsjson1-0-and-awsjson1-1
+  final case class AWS_EC2_QUERY(value: Ec2Query) extends AwsProtocol
   final case class AWS_JSON_1_0(value: AwsJson1_0) extends AwsProtocol
   final case class AWS_JSON_1_1(value: AwsJson1_1) extends AwsProtocol
   final case class AWS_QUERY(value: AwsQuery) extends AwsProtocol

--- a/modules/aws-kernel/src/smithy4s/aws/AwsProtocol.scala
+++ b/modules/aws-kernel/src/smithy4s/aws/AwsProtocol.scala
@@ -64,13 +64,13 @@ private[aws] object AwsProtocol {
   // https://smithy.io/2.0/aws/protocols/aws-json-1_0-protocol.html#differences-between-awsjson1-0-and-awsjson1-1.
   final case class AWS_JSON_1_0(value: AwsJson1_0) extends AwsProtocol
   final case class AWS_JSON_1_1(value: AwsJson1_1) extends AwsProtocol
-  
+
   // See https://smithy.io/2.0/aws/protocols/aws-query-protocol.html.
   final case class AWS_QUERY(value: AwsQuery) extends AwsProtocol
-  
+
   // See https://smithy.io/2.0/aws/protocols/aws-restjson1-protocol.html.
   final case class AWS_REST_JSON_1(value: RestJson1) extends AwsProtocol
-  
+
   // See https://smithy.io/2.0/aws/protocols/aws-restxml-protocol.html.
   final case class AWS_REST_XML(value: RestXml) extends AwsProtocol
 

--- a/modules/aws-kernel/src/smithy4s/aws/AwsProtocol.scala
+++ b/modules/aws-kernel/src/smithy4s/aws/AwsProtocol.scala
@@ -56,12 +56,22 @@ private[aws] object AwsProtocol {
           .map(AWS_REST_XML.apply)
       )
 
-  // See https://awslabs.github.io/smithy/1.0/spec/aws/aws-json-1_0-protocol.html#differences-between-awsjson1-0-and-awsjson1-1
+  // See https://smithy.io/2.0/aws/protocols/aws-ec2-query-protocol.html.
   final case class AWS_EC2_QUERY(value: Ec2Query) extends AwsProtocol
+
+  // See https://smithy.io/2.0/aws/protocols/aws-json-1_0-protocol.html,
+  // https://smithy.io/2.0/aws/protocols/aws-json-1_1-protocol.html, and
+  // https://smithy.io/2.0/aws/protocols/aws-json-1_0-protocol.html#differences-between-awsjson1-0-and-awsjson1-1.
   final case class AWS_JSON_1_0(value: AwsJson1_0) extends AwsProtocol
   final case class AWS_JSON_1_1(value: AwsJson1_1) extends AwsProtocol
+  
+  // See https://smithy.io/2.0/aws/protocols/aws-query-protocol.html.
   final case class AWS_QUERY(value: AwsQuery) extends AwsProtocol
+  
+  // See https://smithy.io/2.0/aws/protocols/aws-restjson1-protocol.html.
   final case class AWS_REST_JSON_1(value: RestJson1) extends AwsProtocol
+  
+  // See https://smithy.io/2.0/aws/protocols/aws-restxml-protocol.html.
   final case class AWS_REST_XML(value: RestXml) extends AwsProtocol
 
 }

--- a/modules/bootstrapped/src/generated/com/amazonaws/dynamodb/TableName.scala
+++ b/modules/bootstrapped/src/generated/com/amazonaws/dynamodb/TableName.scala
@@ -10,6 +10,6 @@ import smithy4s.schema.Schema.string
 object TableName extends Newtype[String] {
   val id: ShapeId = ShapeId("com.amazonaws.dynamodb", "TableName")
   val hints: Hints = Hints.empty
-  val underlyingSchema: Schema[String] = string.withId(id).addHints(hints).validated(smithy.api.Length(min = Some(3L), max = Some(255L))).validated(smithy.api.Pattern("^[a-zA-Z0-9_.-]+$"))
+  val underlyingSchema: Schema[String] = string.withId(id).addHints(hints).validated(smithy.api.Length(min = Some(3L), max = Some(255L))).validated(smithy.api.Pattern(s"^[a-zA-Z0-9_.-]+$$"))
   implicit val schema: Schema[TableName] = bijection(underlyingSchema, asBijection)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/CheckedOrUnchecked.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/CheckedOrUnchecked.scala
@@ -26,7 +26,7 @@ object CheckedOrUnchecked extends ShapeTag.Companion[CheckedOrUnchecked] {
 
   object CheckedCase {
     val hints: Hints = Hints.empty
-    val schema: Schema[CheckedCase] = bijection(string.addHints(hints).validated(smithy.api.Pattern("^\\w+$")), CheckedCase(_), _.checked)
+    val schema: Schema[CheckedCase] = bijection(string.addHints(hints).validated(smithy.api.Pattern(s"^\\w+$$")), CheckedCase(_), _.checked)
     val alt = schema.oneOf[CheckedOrUnchecked]("checked")
   }
   object RawCase {

--- a/modules/bootstrapped/src/generated/smithy4s/example/CheckedOrUnchecked2.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/CheckedOrUnchecked2.scala
@@ -28,7 +28,7 @@ object CheckedOrUnchecked2 extends ShapeTag.Companion[CheckedOrUnchecked2] {
 
   object CheckedCase {
     val hints: Hints = Hints.empty
-    val schema: Schema[CheckedCase] = bijection(string.addHints(hints).validated(smithy.api.Pattern("^\\w+$")), CheckedCase(_), _.checked)
+    val schema: Schema[CheckedCase] = bijection(string.addHints(hints).validated(smithy.api.Pattern(s"^\\w+$$")), CheckedCase(_), _.checked)
     val alt = schema.oneOf[CheckedOrUnchecked2]("checked")
   }
   object RawCase {

--- a/modules/bootstrapped/src/generated/smithy4s/example/CityId.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/CityId.scala
@@ -10,6 +10,6 @@ import smithy4s.schema.Schema.string
 object CityId extends Newtype[String] {
   val id: ShapeId = ShapeId("smithy4s.example", "CityId")
   val hints: Hints = Hints.empty
-  val underlyingSchema: Schema[String] = string.withId(id).addHints(hints).validated(smithy.api.Pattern("^[A-Za-z0-9 ]+$"))
+  val underlyingSchema: Schema[String] = string.withId(id).addHints(hints).validated(smithy.api.Pattern(s"^[A-Za-z0-9 ]+$$"))
   implicit val schema: Schema[CityId] = bijection(underlyingSchema, asBijection)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/UnicodeRegexString.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/UnicodeRegexString.scala
@@ -10,6 +10,6 @@ import smithy4s.schema.Schema.string
 object UnicodeRegexString extends Newtype[String] {
   val id: ShapeId = ShapeId("smithy4s.example", "UnicodeRegexString")
   val hints: Hints = Hints.empty
-  val underlyingSchema: Schema[String] = string.withId(id).addHints(hints).validated(smithy.api.Pattern("^\uD83D\uDE0E$"))
+  val underlyingSchema: Schema[String] = string.withId(id).addHints(hints).validated(smithy.api.Pattern(s"^\uD83D\uDE0E$$"))
   implicit val schema: Schema[UnicodeRegexString] = bijection(underlyingSchema, asBijection)
 }

--- a/modules/bootstrapped/test/src/smithy4s/http/internals/UrlFormDataEncoderSchemaVisitorSpec.scala
+++ b/modules/bootstrapped/test/src/smithy4s/http/internals/UrlFormDataEncoderSchemaVisitorSpec.scala
@@ -331,7 +331,11 @@ object UrlFormDataEncoderSchemaVisitorSpec extends SimpleIOSuite {
       loc: SourceLocation
   ): IO[Expectations] = {
     val cache = CompilationCache.make[UrlFormDataEncoder]
-    val schemaVisitor = new UrlFormDataEncoderSchemaVisitor(cache)
+    val schemaVisitor = new UrlFormDataEncoderSchemaVisitor(
+      cache,
+      ignoreXmlFlattened = false,
+      capitalizeStructAndUnionMemberNames = false
+    )
     val encoder = schemaVisitor(schema)
     val formData = encoder.encode(value)
     val builder = new mutable.StringBuilder

--- a/modules/bootstrapped/test/src/smithy4s/http/internals/UrlFormDataEncoderSchemaVisitorSpec.scala
+++ b/modules/bootstrapped/test/src/smithy4s/http/internals/UrlFormDataEncoderSchemaVisitorSpec.scala
@@ -20,15 +20,16 @@ package internals
 
 import cats.effect.IO
 import cats.syntax.all._
-import smithy4s.Blob
-import smithy4s.Hints
-import smithy4s.schema.Schema
-import scala.collection.mutable
-import smithy4s.schema.CompilationCache
-import smithy4s.schema.Schema._
-import weaver._
 import smithy.api.XmlFlattened
 import smithy.api.XmlName
+import smithy4s.Blob
+import smithy4s.Hints
+import smithy4s.schema.CompilationCache
+import smithy4s.schema.Schema
+import smithy4s.schema.Schema._
+import weaver._
+
+import scala.collection.mutable
 
 object UrlFormDataEncoderSchemaVisitorSpec extends SimpleIOSuite {
 

--- a/modules/codegen/src/smithy4s/codegen/internals/Renderer.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/Renderer.scala
@@ -20,8 +20,11 @@ package internals
 import cats.data.NonEmptyList
 import cats.data.Reader
 import cats.syntax.all._
+import smithy4s.codegen.internals.EnumTag.IntEnum
+import smithy4s.codegen.internals.EnumTag.StringEnum
 import smithy4s.codegen.internals.LineSegment._
 import smithy4s.codegen.internals.Primitive.Nothing
+import smithy4s.codegen.internals.Type.Nullable
 import smithy4s.codegen.internals.TypedNode._
 import software.amazon.smithy.model.node.Node
 import software.amazon.smithy.model.node._
@@ -32,9 +35,6 @@ import scala.jdk.CollectionConverters._
 import Line._
 import LineSyntax.LineInterpolator
 import ToLines.lineToLines
-import smithy4s.codegen.internals.EnumTag.IntEnum
-import smithy4s.codegen.internals.EnumTag.StringEnum
-import smithy4s.codegen.internals.Type.Nullable
 
 private[internals] object Renderer {
 

--- a/modules/codegen/src/smithy4s/codegen/internals/Renderer.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/Renderer.scala
@@ -1465,7 +1465,7 @@ private[internals] class Renderer(compilationUnit: CompilationUnit) { self =>
     // render any such strings as interpolated strings (even though that would
     // otherwise be unecessary) so that we can render "$" as "$$", which get
     // converted back to "$" during interpolation.
-    val escaped = if(str.contains('$')) s"s${str.replace("$", "$$")}" else str
+    val escaped = if (str.contains('$')) s"s${str.replace("$", "$$")}" else str
 
     line"$escaped"
   }

--- a/modules/codegen/src/smithy4s/codegen/internals/Renderer.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/Renderer.scala
@@ -1460,7 +1460,13 @@ private[internals] class Renderer(compilationUnit: CompilationUnit) { self =>
       // with unicode character escapes like "\uD83D" that can be parsed in the regex implementations on all platforms.
       // See https://github.com/disneystreaming/smithy4s/pull/499
       .replace("\\\\u", "\\u")
+    // If the string contains "$", the use of -Xlint:missing-interpolator when
+    // compiling the generated code will result in warnings. To prevent that we
+    // render any such strings as interpolated strings (even though that would
+    // otherwise be unecessary) so that we can render "$" as "$$", which get
+    // converted back to "$" during interpolation.
+    val escaped = if(str.contains('$')) s"s${str.replace("$", "$$")}" else str
 
-    line"$str"
+    line"$escaped"
   }
 }

--- a/modules/codegen/src/smithy4s/codegen/transformers/AwsStandardTypesTransformer.scala
+++ b/modules/codegen/src/smithy4s/codegen/transformers/AwsStandardTypesTransformer.scala
@@ -65,16 +65,20 @@ class AwsStandardTypesTransformer extends ProjectionTransformer {
           .map[Boolean](canReplace)
           .orElse(false)
       }
-      .map[Shape](shape => {
+      .map[Shape] { shape =>
         val target = model.expectShape(shape.getTarget)
         val replacementShape = replaceWith(shape.getTarget)
+        // Member shapes can only carry the `@default` trait IF
+        // their container is a structures
+        val canCarryDefault =
+          model.expectShape(shape.getContainer()).isStructureShape()
 
         shape
           .toBuilder()
           .target(replacementShape)
-          .copyDefaultTrait(target)
+          .when(canCarryDefault)(_.copyDefaultTrait(target))
           .build()
-      })
+      }
       .orElse(shape)
   }
 
@@ -105,11 +109,16 @@ object AwsStandardTypesTransformer {
   private[transformers] final implicit class MemberShapeBuilderOps(
       val builder: MemberShape.Builder
   ) extends AnyVal {
-    def copyDefaultTrait(shape: Shape): MemberShape.Builder = {
-      val defaultTraitOpt = toOption(shape.getTrait(classOf[DefaultTrait]))
+    def when(condition: Boolean)(
+        mutation: MemberShape.Builder => MemberShape.Builder
+    ): MemberShape.Builder =
+      if (condition)(mutation(builder)) else builder
 
-      defaultTraitOpt
-        .fold(builder)(builder.addTrait(_))
+    def copyDefaultTrait(
+        shape: Shape
+    ): MemberShape.Builder = {
+      val defaultTraitOpt = toOption(shape.getTrait(classOf[DefaultTrait]))
+      defaultTraitOpt.fold(builder)(builder.addTrait(_))
     }
   }
 

--- a/modules/codegen/src/smithy4s/codegen/transformers/AwsStandardTypesTransformer.scala
+++ b/modules/codegen/src/smithy4s/codegen/transformers/AwsStandardTypesTransformer.scala
@@ -17,10 +17,13 @@
 package smithy4s.codegen.transformers
 
 import smithy4s.codegen.transformers.AwsStandardTypesTransformer.MemberShapeBuilderOps
-import software.amazon.smithy.build.{ProjectionTransformer, TransformContext}
+import software.amazon.smithy.build.ProjectionTransformer
+import software.amazon.smithy.build.TransformContext
 import software.amazon.smithy.model.Model
 import software.amazon.smithy.model.shapes._
-import software.amazon.smithy.model.traits.{BoxTrait, DefaultTrait, Trait}
+import software.amazon.smithy.model.traits.BoxTrait
+import software.amazon.smithy.model.traits.DefaultTrait
+import software.amazon.smithy.model.traits.Trait
 
 class AwsStandardTypesTransformer extends ProjectionTransformer {
 

--- a/modules/codegen/test/src/smithy4s/codegen/internals/RendererSpec.scala
+++ b/modules/codegen/test/src/smithy4s/codegen/internals/RendererSpec.scala
@@ -394,4 +394,36 @@ final class RendererSpec extends munit.FunSuite {
 
     assert(!contents.exists(_.contains("ServiceProduct")))
   }
+  test(
+    "string literal not containing $ is rendered as an uninterpolated string"
+  ) {
+    val smithy = """
+                   |$version: "2.0"
+                   |
+                   |namespace smithy4s
+                   |
+                   |@documentation("foo bar")
+                   |string MyString
+                   |""".stripMargin
+
+    val contents = generateScalaCode(smithy).values
+
+    assert(contents.exists(_.contains("smithy.api.Documentation(\"foo bar\")")))
+  }
+  test(
+    "string literal containing $ is rendered as an interpolated string with $ escaped as $$"
+  ) {
+    val smithy = """
+                   |$version: "2.0"
+                   |
+                   |namespace smithy4s
+                   |
+                   |@documentation("foo $bar")
+                   |string MyString
+                   |""".stripMargin
+
+    val contents = generateScalaCode(smithy).values
+
+    assert(contents.exists(_.contains("smithy.api.Documentation(s\"foo $$bar\")")))
+  }
 }

--- a/modules/codegen/test/src/smithy4s/codegen/internals/RendererSpec.scala
+++ b/modules/codegen/test/src/smithy4s/codegen/internals/RendererSpec.scala
@@ -424,6 +424,8 @@ final class RendererSpec extends munit.FunSuite {
 
     val contents = generateScalaCode(smithy).values
 
-    assert(contents.exists(_.contains("smithy.api.Documentation(s\"foo $$bar\")")))
+    assert(
+      contents.exists(_.contains("smithy.api.Documentation(s\"foo $$bar\")"))
+    )
   }
 }

--- a/modules/core/src/smithy4s/http/HttpRestSchema.scala
+++ b/modules/core/src/smithy4s/http/HttpRestSchema.scala
@@ -17,15 +17,15 @@
 package smithy4s
 package http
 
-import smithy4s.PartialData
 import smithy.api.HttpPayload
-import smithy4s.schema._
+import smithy4s.PartialData
+import smithy4s.capability.Zipper
+import smithy4s.codecs.Reader
+import smithy4s.codecs.Writer
 import smithy4s.schema.SchemaPartition.NoMatch
 import smithy4s.schema.SchemaPartition.SplittingMatch
 import smithy4s.schema.SchemaPartition.TotalMatch
-import smithy4s.codecs.Writer
-import smithy4s.codecs.Reader
-import smithy4s.capability.Zipper
+import smithy4s.schema._
 
 /**
  * This construct indicates how a schema is split between http metadata

--- a/modules/core/src/smithy4s/http/HttpRestSchema.scala
+++ b/modules/core/src/smithy4s/http/HttpRestSchema.scala
@@ -54,6 +54,10 @@ object HttpRestSchema {
 
   def apply[A](
       fullSchema: Schema[A],
+      // This is used by AwsQueryCodecs and AwsEc2QueryCodecs to ensure that
+      // body producer is retained even in the case where a top-level struct
+      // input is empty. They need that to happen so that a body is produced to
+      // which the Action and Version metadata can be added.
       writeEmptyStructs: Boolean
   ): HttpRestSchema[A] = {
 
@@ -75,7 +79,7 @@ object HttpRestSchema {
           case NoMatch() =>
             fullSchema match {
               case Schema.StructSchema(_, _, fields, make)
-                  if !writeEmptyStructs && (fields.isEmpty) =>
+                  if !writeEmptyStructs && fields.isEmpty =>
                 Empty(make(IndexedSeq.empty))
               case _ => OnlyBody(fullSchema)
             }

--- a/modules/core/src/smithy4s/http/UrlForm.scala
+++ b/modules/core/src/smithy4s/http/UrlForm.scala
@@ -135,7 +135,10 @@ private[smithy4s] object UrlForm {
     def encode(a: A): UrlForm
   }
   object Encoder {
-    def apply(ignoreXmlFlattened: Boolean, capitalizeStructAndUnionMemberNames: Boolean): CachedSchemaCompiler[Encoder] =
+    def apply(
+        ignoreXmlFlattened: Boolean,
+        capitalizeStructAndUnionMemberNames: Boolean
+    ): CachedSchemaCompiler[Encoder] =
       new CachedSchemaCompiler.Impl[Encoder] {
         protected override type Aux[A] = UrlFormDataEncoder[A]
         override def fromSchema[A](
@@ -143,7 +146,11 @@ private[smithy4s] object UrlForm {
             cache: Cache
         ): Encoder[A] = {
           val schemaVisitor =
-            new UrlFormDataEncoderSchemaVisitor(cache, ignoreXmlFlattened, capitalizeStructAndUnionMemberNames)
+            new UrlFormDataEncoderSchemaVisitor(
+              cache,
+              ignoreXmlFlattened,
+              capitalizeStructAndUnionMemberNames
+            )
           val urlFormDataEncoder = schemaVisitor(schema)
           (value: A) =>
             UrlForm(

--- a/modules/core/src/smithy4s/http/UrlForm.scala
+++ b/modules/core/src/smithy4s/http/UrlForm.scala
@@ -135,24 +135,23 @@ private[smithy4s] object UrlForm {
     def encode(a: A): UrlForm
   }
   object Encoder {
-    def apply(
-        ignoreXmlFlattened: Boolean = false
-    ): CachedSchemaCompiler[Encoder] = new CachedSchemaCompiler.Impl[Encoder] {
-      protected override type Aux[A] = UrlFormDataEncoder[A]
-      override def fromSchema[A](
-          schema: Schema[A],
-          cache: Cache
-      ): Encoder[A] = {
-        val schemaVisitor =
-          new UrlFormDataEncoderSchemaVisitor(cache, ignoreXmlFlattened)
-        val urlFormDataEncoder = schemaVisitor(schema)
-        (value: A) =>
-          UrlForm(
-            UrlForm.FormData.MultipleValues(
-              urlFormDataEncoder.encode(value).toPathedValues
+    def apply(ignoreXmlFlattened: Boolean): CachedSchemaCompiler[Encoder] =
+      new CachedSchemaCompiler.Impl[Encoder] {
+        protected override type Aux[A] = UrlFormDataEncoder[A]
+        override def fromSchema[A](
+            schema: Schema[A],
+            cache: Cache
+        ): Encoder[A] = {
+          val schemaVisitor =
+            new UrlFormDataEncoderSchemaVisitor(cache, ignoreXmlFlattened)
+          val urlFormDataEncoder = schemaVisitor(schema)
+          (value: A) =>
+            UrlForm(
+              UrlForm.FormData.MultipleValues(
+                urlFormDataEncoder.encode(value).toPathedValues
+              )
             )
-          )
+        }
       }
-    }
   }
 }

--- a/modules/core/src/smithy4s/http/UrlForm.scala
+++ b/modules/core/src/smithy4s/http/UrlForm.scala
@@ -17,17 +17,16 @@
 package smithy4s
 package http
 
-import java.net.URLEncoder
-import java.nio.charset.StandardCharsets
-
 import smithy4s.codecs.PayloadPath
 import smithy4s.codecs.PayloadPath.Segment
-import scala.collection.mutable
-import smithy4s.schema.CachedSchemaCompiler
 import smithy4s.http.internals.UrlFormDataEncoder
 import smithy4s.http.internals.UrlFormDataEncoderSchemaVisitor
-
+import smithy4s.schema.CachedSchemaCompiler
 import smithy4s.schema.Schema
+
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
+import scala.collection.mutable
 
 private[smithy4s] final case class UrlForm(
     formData: UrlForm.FormData.MultipleValues

--- a/modules/core/src/smithy4s/http/UrlForm.scala
+++ b/modules/core/src/smithy4s/http/UrlForm.scala
@@ -135,7 +135,7 @@ private[smithy4s] object UrlForm {
     def encode(a: A): UrlForm
   }
   object Encoder {
-    def apply(ignoreXmlFlattened: Boolean): CachedSchemaCompiler[Encoder] =
+    def apply(ignoreXmlFlattened: Boolean, capitalizeStructAndUnionMemberNames: Boolean): CachedSchemaCompiler[Encoder] =
       new CachedSchemaCompiler.Impl[Encoder] {
         protected override type Aux[A] = UrlFormDataEncoder[A]
         override def fromSchema[A](
@@ -143,7 +143,7 @@ private[smithy4s] object UrlForm {
             cache: Cache
         ): Encoder[A] = {
           val schemaVisitor =
-            new UrlFormDataEncoderSchemaVisitor(cache, ignoreXmlFlattened)
+            new UrlFormDataEncoderSchemaVisitor(cache, ignoreXmlFlattened, capitalizeStructAndUnionMemberNames)
           val urlFormDataEncoder = schemaVisitor(schema)
           (value: A) =>
             UrlForm(

--- a/modules/core/src/smithy4s/http/UrlForm.scala
+++ b/modules/core/src/smithy4s/http/UrlForm.scala
@@ -134,17 +134,25 @@ private[smithy4s] object UrlForm {
   trait Encoder[A] {
     def encode(a: A): UrlForm
   }
-  object Encoder extends CachedSchemaCompiler.Impl[Encoder] {
-    protected override type Aux[A] = UrlFormDataEncoder[A]
-    def fromSchema[A](schema: Schema[A], cache: Cache): Encoder[A] = {
-      val schemaVisitor = new UrlFormDataEncoderSchemaVisitor(cache)
-      val urlFormDataEncoder = schemaVisitor(schema)
-      (value: A) =>
-        UrlForm(
-          UrlForm.FormData.MultipleValues(
-            urlFormDataEncoder.encode(value).toPathedValues
+  object Encoder {
+    def apply(
+        ignoreXmlFlattened: Boolean = false
+    ): CachedSchemaCompiler[Encoder] = new CachedSchemaCompiler.Impl[Encoder] {
+      protected override type Aux[A] = UrlFormDataEncoder[A]
+      override def fromSchema[A](
+          schema: Schema[A],
+          cache: Cache
+      ): Encoder[A] = {
+        val schemaVisitor =
+          new UrlFormDataEncoderSchemaVisitor(cache, ignoreXmlFlattened)
+        val urlFormDataEncoder = schemaVisitor(schema)
+        (value: A) =>
+          UrlForm(
+            UrlForm.FormData.MultipleValues(
+              urlFormDataEncoder.encode(value).toPathedValues
+            )
           )
-        )
+      }
     }
   }
 }

--- a/modules/core/src/smithy4s/http/internals/UrlFormDataEncoder.scala
+++ b/modules/core/src/smithy4s/http/internals/UrlFormDataEncoder.scala
@@ -19,8 +19,8 @@ package http
 package internals
 
 import smithy4s.capability.EncoderK
-import smithy4s.http.UrlForm
 import smithy4s.codecs.PayloadPath
+import smithy4s.http.UrlForm
 
 private[smithy4s] trait UrlFormDataEncoder[-A] { self =>
 

--- a/modules/core/src/smithy4s/http/internals/UrlFormDataEncoderSchemaVisitor.scala
+++ b/modules/core/src/smithy4s/http/internals/UrlFormDataEncoderSchemaVisitor.scala
@@ -18,10 +18,11 @@ package smithy4s
 package http
 package internals
 
-import smithy.api.{XmlFlattened, XmlName}
+import smithy.api.XmlFlattened
+import smithy.api.XmlName
+import smithy4s.codecs.PayloadPath
 import smithy4s.http._
 import smithy4s.schema._
-import smithy4s.codecs.PayloadPath
 
 private[smithy4s] class UrlFormDataEncoderSchemaVisitor(
     val cache: CompilationCache[UrlFormDataEncoder],

--- a/modules/core/src/smithy4s/http/internals/UrlFormDataEncoderSchemaVisitor.scala
+++ b/modules/core/src/smithy4s/http/internals/UrlFormDataEncoderSchemaVisitor.scala
@@ -25,7 +25,8 @@ import smithy4s.codecs.PayloadPath
 
 private[smithy4s] class UrlFormDataEncoderSchemaVisitor(
     val cache: CompilationCache[UrlFormDataEncoder],
-    ignoreXmlFlattened: Boolean
+    ignoreXmlFlattened: Boolean,
+    capitalizeStructAndUnionMemberNames: Boolean
 ) extends SchemaVisitor.Cached[UrlFormDataEncoder] { compile =>
 
   override def primitive[P](
@@ -180,6 +181,8 @@ private[smithy4s] class UrlFormDataEncoderSchemaVisitor(
       .get(XmlName)
       .map(_.value)
       .map(PayloadPath.Segment(_))
-      .getOrElse(default)
+      .getOrElse(
+        if (capitalizeStructAndUnionMemberNames) default.capitalize else default
+      )
 
 }

--- a/modules/core/src/smithy4s/http/internals/UrlFormDataEncoderSchemaVisitor.scala
+++ b/modules/core/src/smithy4s/http/internals/UrlFormDataEncoderSchemaVisitor.scala
@@ -25,6 +25,8 @@ import smithy4s.codecs.PayloadPath
 
 private[smithy4s] class UrlFormDataEncoderSchemaVisitor(
     val cache: CompilationCache[UrlFormDataEncoder],
+    // These are used by AwsEc2QueryCodecs to conform to the requirements of
+    // https://smithy.io/2.0/aws/protocols/aws-ec2-query-protocol.html?highlight=ec2%20query%20protocol#query-key-resolution.
     ignoreXmlFlattened: Boolean,
     capitalizeStructAndUnionMemberNames: Boolean
 ) extends SchemaVisitor.Cached[UrlFormDataEncoder] { compile =>
@@ -182,7 +184,8 @@ private[smithy4s] class UrlFormDataEncoderSchemaVisitor(
       .map(_.value)
       .map(PayloadPath.Segment(_))
       .getOrElse(
-        if (capitalizeStructAndUnionMemberNames) default.capitalize else default
+        if (capitalizeStructAndUnionMemberNames) default.capitalize
+        else default
       )
 
 }

--- a/modules/core/src/smithy4s/http/internals/UrlFormDataEncoderSchemaVisitor.scala
+++ b/modules/core/src/smithy4s/http/internals/UrlFormDataEncoderSchemaVisitor.scala
@@ -24,7 +24,8 @@ import smithy4s.schema._
 import smithy4s.codecs.PayloadPath
 
 private[smithy4s] class UrlFormDataEncoderSchemaVisitor(
-    val cache: CompilationCache[UrlFormDataEncoder]
+    val cache: CompilationCache[UrlFormDataEncoder],
+    ignoreXmlFlattened: Boolean
 ) extends SchemaVisitor.Cached[UrlFormDataEncoder] { compile =>
 
   override def primitive[P](
@@ -50,7 +51,7 @@ private[smithy4s] class UrlFormDataEncoderSchemaVisitor(
   ): UrlFormDataEncoder[C[A]] = {
     val memberEncoder = compile(member)
     val maybeKey =
-      if (hints.has[XmlFlattened]) None
+      if (ignoreXmlFlattened || hints.has[XmlFlattened]) None
       else Option(getKey(member.hints, "member"))
     val skipEmpty = hints.toMap.contains(SkipEmpty.keyId)
     (collection: C[A]) => {

--- a/modules/core/src/smithy4s/internals/DocumentDecoderSchemaVisitor.scala
+++ b/modules/core/src/smithy4s/internals/DocumentDecoderSchemaVisitor.scala
@@ -17,20 +17,20 @@
 package smithy4s
 package internals
 
-import java.util.Base64
-import java.util.UUID
-
+import alloy.Discriminated
 import smithy.api.JsonName
 import smithy.api.TimestampFormat
 import smithy.api.TimestampFormat.DATE_TIME
 import smithy.api.TimestampFormat.EPOCH_SECONDS
 import smithy.api.TimestampFormat.HTTP_DATE
-import alloy.Discriminated
-import smithy4s.codecs._
-import smithy4s.capability.Covariant
 import smithy4s.Document._
-import smithy4s.schema._
+import smithy4s.capability.Covariant
+import smithy4s.codecs._
 import smithy4s.schema.Primitive._
+import smithy4s.schema._
+
+import java.util.Base64
+import java.util.UUID
 import scala.collection.immutable.ListMap
 
 trait DocumentDecoder[A] { self =>

--- a/modules/http4s-kernel/src/smithy4s/http4s/kernel/GzipRequestCompression.scala
+++ b/modules/http4s-kernel/src/smithy4s/http4s/kernel/GzipRequestCompression.scala
@@ -30,6 +30,11 @@ object GzipRequestCompression {
   val DefaultBufferSize = 32 * 1024
 
   def apply[F[_]: Compression](
+      // This is used by AwsQueryCodecs and AwsEc2QueryCodecs to conform to the
+      // requirements of
+      // https://github.com/smithy-lang/smithy/blob/main/smithy-aws-protocol-tests/model/awsQuery/requestCompression.smithy#L152-L298
+      // and
+      // https://github.com/smithy-lang/smithy/blob/main/smithy-aws-protocol-tests/model/ec2Query/requestCompression.smithy#L152-L298.
       retainUserEncoding: Boolean,
       bufferSize: Int = DefaultBufferSize,
       level: DeflateParams.Level = DeflateParams.Level.DEFAULT

--- a/modules/json/test/src/smithy4s/json/SchemaVisitorJCodecTests.scala
+++ b/modules/json/test/src/smithy4s/json/SchemaVisitorJCodecTests.scala
@@ -17,30 +17,27 @@
 package smithy4s
 package json
 
+import alloy.Discriminated
 import com.github.plokhotnyuk.jsoniter_scala.core.{readFromString => _, _}
+import munit.FunSuite
+import smithy.api.Default
 import smithy.api.JsonName
-import smithy4s.schema.Schema._
-
 import smithy4s.codecs.PayloadError
 import smithy4s.codecs.PayloadPath
-import smithy4s.example.{
-  CheckedOrUnchecked,
-  CheckedOrUnchecked2,
-  FaceCard,
-  Four,
-  One,
-  PayloadData,
-  RangeCheck,
-  TestBiggerUnion,
-  Three,
-  UntaggedUnion
-}
-import alloy.Discriminated
+import smithy4s.example.CheckedOrUnchecked
+import smithy4s.example.CheckedOrUnchecked2
+import smithy4s.example.FaceCard
+import smithy4s.example.Four
+import smithy4s.example.One
+import smithy4s.example.PayloadData
+import smithy4s.example.RangeCheck
+import smithy4s.example.TestBiggerUnion
+import smithy4s.example.Three
+import smithy4s.example.UntaggedUnion
+import smithy4s.schema.Schema._
 
 import scala.collection.immutable.ListMap
 import scala.util.Try
-import munit.FunSuite
-import smithy.api.Default
 
 class SchemaVisitorJCodecTests() extends FunSuite {
 

--- a/modules/sandbox/src/Sandbox.scala
+++ b/modules/sandbox/src/Sandbox.scala
@@ -28,7 +28,11 @@ object Main extends IOApp.Simple {
     // https://disneystreaming.github.io/smithy4s/docs/protocols/aws/aws/#awsquery,
     // CloudWatch is one of a few services that use the awsQuery protocol.
     AwsClient(cloudwatch.CloudWatch, awsEnvironment).use(cloudWatchClient =>
-      listAll[cloudwatch.NextToken, cloudwatch.ListMetricsOutput, cloudwatch.Metric](
+      listAll[
+        cloudwatch.NextToken,
+        cloudwatch.ListMetricsOutput,
+        cloudwatch.Metric
+      ](
         listF = maybeNextToken =>
           cloudWatchClient.listMetrics(
             // This is just a simple way of reducing the size of the results while

--- a/modules/sandbox/src/Sandbox.scala
+++ b/modules/sandbox/src/Sandbox.scala
@@ -30,34 +30,34 @@ object Main extends IOApp.Simple {
     // https://disneystreaming.github.io/smithy4s/docs/protocols/aws/aws/#awsquery,
     // CloudWatch is one of a few services that use the awsQuery protocol.
     AwsClient(CloudWatch, awsEnvironment).use(cloudWatchClient =>
-    listAll[ListMetricsOutput, Metric](
-      listF = maybeNextToken =>
-        cloudWatchClient.listMetrics(
-          // This is just a simple way of reducing the size of the results while
-          // still exercising the pagination handler.
-          namespace = Some("AWS/S3"),
-          nextToken = maybeNextToken
-        ),
-      accessResults = _.metrics.toList.flatten,
-      accessNextToken = _.nextToken
-    )
-      .map(_.size)
-      .flatMap(size => IO.println(s"Found $size metrics"))
+      listAll[ListMetricsOutput, Metric](
+        listF = maybeNextToken =>
+          cloudWatchClient.listMetrics(
+            // This is just a simple way of reducing the size of the results while
+            // still exercising the pagination handler.
+            namespace = Some("AWS/S3"),
+            nextToken = maybeNextToken
+          ),
+        accessResults = _.metrics.toList.flatten,
+        accessNextToken = _.nextToken
+      )
+        .map(_.size)
+        .flatMap(size => IO.println(s"Found $size metrics"))
     )
     // Per
     // https://disneystreaming.github.io/smithy4s/docs/protocols/aws/aws/#ec2query,
     // EC2 is the only service that use the ec2Query protocol.
     AwsClient(EC2, awsEnvironment).use(ec2Client =>
-    listAll[DescribeInstancesOutput, Metric](
-      listF = maybeNextToken =>
-        ec2Client.describeInstanceTypes(
-          nextToken = maybeNextToken
-        ),
-      accessResults = _.reservationSet.toList.flatten,
-      accessNextToken = _.nextToken
-    )
-      .map(_.size)
-      .flatMap(size => IO.println(s"Found $size instance types"))
+      listAll[DescribeInstanceTypesResult, InstanceTypeInfo](
+        listF = maybeNextToken =>
+          ec2Client.describeInstanceTypes(
+            nextToken = maybeNextToken
+          ),
+        accessResults = _.instanceTypes.toList.flatten,
+        accessNextToken = _.nextToken
+      )
+        .map(_.size)
+        .flatMap(size => IO.println(s"Found $size instance types"))
     )
   }
 

--- a/modules/sandbox/src/Sandbox.scala
+++ b/modules/sandbox/src/Sandbox.scala
@@ -48,16 +48,17 @@ object Main extends IOApp.Simple {
     // https://disneystreaming.github.io/smithy4s/docs/protocols/aws/aws/#ec2query,
     // EC2 is the only service that use the ec2Query protocol.
     AwsClient(EC2, awsEnvironment).use(ec2Client =>
-      listAll[DescribeInstanceTypesResult, InstanceTypeInfo](
+      listAll[DescribeInstancesResult, Reservation](
         listF = maybeNextToken =>
-          ec2Client.describeInstanceTypes(
+          ec2Client.describeInstances(
+            maxResults = 100,
             nextToken = maybeNextToken
           ),
-        accessResults = _.instanceTypes.toList.flatten,
+        accessResults = _.reservations.toList.flatten,
         accessNextToken = _.nextToken
       )
         .map(_.size)
-        .flatMap(size => IO.println(s"Found $size instance types"))
+        .flatMap(size => IO.println(s"Found $size instances"))
     )
   }
 
@@ -67,7 +68,7 @@ object Main extends IOApp.Simple {
         .default[IO]
         .build
         .map(
-          RequestLogger.colored(
+          Logger(
             logHeaders = true,
             logBody = true,
             logAction = Some(IO.println _)

--- a/modules/sandbox/src/Sandbox.scala
+++ b/modules/sandbox/src/Sandbox.scala
@@ -23,8 +23,6 @@ import smithy4s.aws._
 
 object Main extends IOApp.Simple {
 
-  type NextToken = String
-
   override def run: IO[Unit] = awsEnvironmentResource.use { awsEnvironment =>
     // Per
     // https://disneystreaming.github.io/smithy4s/docs/protocols/aws/aws/#awsquery,

--- a/modules/sandbox/src/Sandbox.scala
+++ b/modules/sandbox/src/Sandbox.scala
@@ -14,12 +14,11 @@
  *  limitations under the License.
  */
 
-import smithy4s.aws._
 import cats.effect._
+import com.amazonaws.cloudwatch._
 import org.http4s.client.middleware._
 import org.http4s.ember.client.EmberClientBuilder
-
-import com.amazonaws.cloudwatch._
+import smithy4s.aws._
 
 object Main extends IOApp.Simple {
 

--- a/modules/sandbox/src/Sandbox.scala
+++ b/modules/sandbox/src/Sandbox.scala
@@ -48,17 +48,17 @@ object Main extends IOApp.Simple {
     // https://disneystreaming.github.io/smithy4s/docs/protocols/aws/aws/#ec2query,
     // EC2 is the only service that use the ec2Query protocol.
     AwsClient(EC2, awsEnvironment).use(ec2Client =>
-      listAll[DescribeInstancesResult, Reservation](
+      listAll[DescribeInstanceStatusResult, InstanceStatus](
         listF = maybeNextToken =>
-          ec2Client.describeInstances(
+          ec2Client.describeInstanceStatus(
             maxResults = 100,
             nextToken = maybeNextToken
           ),
-        accessResults = _.reservations.toList.flatten,
+        accessResults = _.instanceStatuses.toList.flatten,
         accessNextToken = _.nextToken
       )
         .map(_.size)
-        .flatMap(size => IO.println(s"Found $size instances"))
+        .flatMap(size => IO.println(s"Found $size instance statuses"))
     )
   }
 
@@ -68,7 +68,7 @@ object Main extends IOApp.Simple {
         .default[IO]
         .build
         .map(
-          Logger(
+          RequestLogger.colored(
             logHeaders = true,
             logBody = true,
             logAction = Some(IO.println _)

--- a/modules/sandbox/src/Sandbox.scala
+++ b/modules/sandbox/src/Sandbox.scala
@@ -15,8 +15,8 @@
  */
 
 import cats.effect._
-import com.amazonaws.cloudwatch._
-import com.amazonaws.ec2._
+import com.amazonaws.cloudwatch
+import com.amazonaws.ec2
 import org.http4s.client.middleware._
 import org.http4s.ember.client.EmberClientBuilder
 import smithy4s.aws._
@@ -27,8 +27,8 @@ object Main extends IOApp.Simple {
     // Per
     // https://disneystreaming.github.io/smithy4s/docs/protocols/aws/aws/#awsquery,
     // CloudWatch is one of a few services that use the awsQuery protocol.
-    AwsClient(CloudWatch, awsEnvironment).use(cloudWatchClient =>
-      listAll[ListMetricsOutput, Metric](
+    AwsClient(cloudwatch.CloudWatch, awsEnvironment).use(cloudWatchClient =>
+      listAll[cloudwatch.NextToken, cloudwatch.ListMetricsOutput, cloudwatch.Metric](
         listF = maybeNextToken =>
           cloudWatchClient.listMetrics(
             // This is just a simple way of reducing the size of the results while
@@ -45,8 +45,8 @@ object Main extends IOApp.Simple {
     // Per
     // https://disneystreaming.github.io/smithy4s/docs/protocols/aws/aws/#ec2query,
     // EC2 is the only service that use the ec2Query protocol.
-    AwsClient(EC2, awsEnvironment).use(ec2Client =>
-      listAll[DescribeInstanceStatusResult, InstanceStatus](
+    AwsClient(ec2.EC2, awsEnvironment).use(ec2Client =>
+      listAll[String, ec2.DescribeInstanceStatusResult, ec2.InstanceStatus](
         listF = maybeNextToken =>
           ec2Client.describeInstanceStatus(
             maxResults = 100,
@@ -87,7 +87,7 @@ object Main extends IOApp.Simple {
   // user-land. Perhaps we could use pagination hints from the specs to avoid
   // having to manually wire up the accessors, and to generate synthetic service
   // functions that handle pagination?
-  private def listAll[ListOutput, Result](
+  private def listAll[NextToken, ListOutput, Result](
       listF: Option[NextToken] => IO[ListOutput],
       accessResults: ListOutput => List[Result],
       accessNextToken: ListOutput => Option[NextToken],

--- a/modules/tests/src/smithy4s/tests/ProtocolComplianceSuite.scala
+++ b/modules/tests/src/smithy4s/tests/ProtocolComplianceSuite.scala
@@ -19,15 +19,19 @@ package smithy4s.tests
 import cats.effect.IO
 import cats.effect.std.Env
 import cats.syntax.all._
+import fs2.Stream
 import fs2.io.file.Path
-import smithy4s.{Blob, Document, Schema, ShapeId}
+import smithy4s.Blob
+import smithy4s.Document
+import smithy4s.Schema
+import smithy4s.ShapeId
+import smithy4s.codecs._
 import smithy4s.compliancetests._
 import smithy4s.dynamic.DynamicSchemaIndex
-import smithy4s.dynamic.model.Model
 import smithy4s.dynamic.DynamicSchemaIndex.load
-import smithy4s.codecs._
+import smithy4s.dynamic.model.Model
 import weaver._
-import fs2.Stream
+
 import java.util.regex.Pattern
 
 abstract class ProtocolComplianceSuite

--- a/modules/xml/src/smithy4s/xml/internals/XmlDecoderSchemaVisitor.scala
+++ b/modules/xml/src/smithy4s/xml/internals/XmlDecoderSchemaVisitor.scala
@@ -28,10 +28,11 @@ import smithy4s.schema._
 
 import XmlDocument.XmlQName
 
-// TODO: Caching
-private[smithy4s] object XmlDecoderSchemaVisitor
-    extends SchemaVisitor[XmlDecoder]
+private[smithy4s] class XmlDecoderSchemaVisitor(
+    val cache: CompilationCache[XmlDecoder]
+) extends SchemaVisitor.Cached[XmlDecoder]
     with smithy4s.ScalaCompat { compile =>
+
   def primitive[P](
       shapeId: ShapeId,
       hints: Hints,

--- a/modules/xml/src/smithy4s/xml/internals/XmlEncoderSchemaVisitor.scala
+++ b/modules/xml/src/smithy4s/xml/internals/XmlEncoderSchemaVisitor.scala
@@ -28,10 +28,9 @@ import smithy4s.{Schema => _, _}
 import XmlDocument._
 import cats.kernel.Monoid
 
-private[smithy4s] object XmlEncoderSchemaVisitor extends XmlEncoderSchemaVisitor
-
-private[smithy4s] abstract class XmlEncoderSchemaVisitor
-    extends SchemaVisitor[XmlEncoder]
+private[smithy4s] class XmlEncoderSchemaVisitor(
+    val cache: CompilationCache[XmlEncoder]
+) extends SchemaVisitor.Cached[XmlEncoder]
     with smithy4s.ScalaCompat { compile =>
 
   def primitive[P](

--- a/modules/xml/test/src/smithy4s/xml/XmlCodecSpec.scala
+++ b/modules/xml/test/src/smithy4s/xml/XmlCodecSpec.scala
@@ -184,8 +184,12 @@ object XmlCodecSpec extends SimpleIOSuite {
     case class Foo(x: String, y: Option[String])
     object Foo {
       implicit val schema: Schema[Foo] = {
-        val x = string.required[Foo]("x", _.x).addHints(Default(Document.fromString("bar")))
-        val y = string.optional[Foo]("y", _.y).addHints(Default(Document.fromString("baz")))
+        val x = string
+          .required[Foo]("x", _.x)
+          .addHints(Default(Document.fromString("bar")))
+        val y = string
+          .optional[Foo]("y", _.y)
+          .addHints(Default(Document.fromString("baz")))
         struct(x, y)(Foo.apply).n
       }
     }
@@ -200,7 +204,7 @@ object XmlCodecSpec extends SimpleIOSuite {
         expect.same(
           result,
           Right(
-             Foo("bar", Some("baz"))
+            Foo("bar", Some("baz"))
           )
         )
       }


### PR DESCRIPTION
Approach:

The compliance tests caught a few issues, fixes for which are included. I then used it in the sandbox module to call some EC2 APIs, and that found a few more issues, fixes for which are also included. The remaining issue not fixed in this PR is the need for optional open enum support. We're agree that's out of scope for this PR. The consequence is that there are a decent number of EC2 API responses which fail to decode due to AWS including enum values that are not present in the published spec. To get a good sandbox run for now I just used an EC2 endpoint that happens to not include any unknown enum values.

Summary of changes:

1. Wire up AWS EC2 Query codec based on AWS Query codec, plus compliance tests.
2. Add flags to `UrlFormDataEncoderSchemaVisitor` so it can accomodate the quirks of the AWS EC2 protocol without having to be aware of all the details. Instead, the relevant hints on the schema are transformed so that `UrlFormDataEncoderSchemaVisitor` can work only in terms of `XmlName`.
3. Add comments explaining quirks of both query protocols.
4. Sort imports in all files touched by #1112 and this branch.
5. Patch `AwsStandardTypesTransformer` to fix codgen error (thanks Oli for the patch).
6. Also fix sandbox compile errors.
7. Patch renderer to escape $ when rendering literal strings, necessary because the EC2 spec includes a documentation string with `<p>Specify the fields using the <code>${field-id}</code> format, separated by spaces.` in it.
8. Make `XmlDecoder` aware of default hint on structure members. Without this, sandbox runs failed with `HttpPayloadError(.DescribeInstancesResponse.reservationSet.item.0.instancesSet.item.0.placement.partitionNumber, expected = , message=Expected a single node with text content)` due to the use of `@default` in
https://raw.githubusercontent.com/aws/aws-sdk-js-v3/main/codegen/sdk-codegen/aws-models/ec2.json.
9. Make XML schema visitors use cache.

Merging:

Like #1112 and for the same reason, let's squash merge this, using the above summary of changes as the commit message.