### PR TITLE
JCodec Allocation Optimization

### DIFF
--- a/modules/bootstrapped/test/src/smithy4s/schema/FieldSpec.scala
+++ b/modules/bootstrapped/test/src/smithy4s/schema/FieldSpec.scala
@@ -1,0 +1,29 @@
+package smithy4s
+package schema
+
+import munit._
+import Schema._
+import smithy.api.Default
+import scala.collection.mutable.ListBuffer
+
+final class FieldSpec extends FunSuite {
+
+  test("foreachUnlessDefault") {
+    case class Foo(a: String)
+    val field = string
+      .required[Foo]("a", _.a)
+      .addHints(Default(Document.fromString("test")))
+
+    val result = ListBuffer.empty[String]
+    field.foreachUnlessDefault(Foo("test")) { foo =>
+      result += foo
+    }
+
+    field.foreachUnlessDefault(Foo("test2")) { foo =>
+      result += foo
+    }
+
+    assertEquals(result.toList, List("test2"))
+  }
+
+}

--- a/modules/core/src/smithy4s/schema/Field.scala
+++ b/modules/core/src/smithy4s/schema/Field.scala
@@ -54,6 +54,11 @@ final case class Field[S, A](
     }
   }
 
+  def foreachUnlessDefault(s: S)(f: A => Unit): Unit = {
+    val a = get(s)
+    if (isDefaultValue(a)) () else f(a)
+  }
+
   def hasDefaultValue: Boolean = getDefaultValue.isDefined
   def isStrictlyRequired: Boolean = !hasDefaultValue
 

--- a/modules/json/src/smithy4s/json/internals/SchemaVisitorJCodec.scala
+++ b/modules/json/src/smithy4s/json/internals/SchemaVisitorJCodec.scala
@@ -1276,7 +1276,7 @@ private[smithy4s] class SchemaVisitorJCodec(
         writeLabel(out)
         codec.encodeValue(field.get(z), out)
     } else { (z: Z, out: JsonWriter) =>
-      field.getUnlessDefault(z).foreach { (a: A) =>
+      field.foreachUnlessDefault(z) { (a: A) =>
         writeLabel(out)
         codec.encodeValue(a, out)
       }


### PR DESCRIPTION
small optimization by removing option allocation in jcodec by using a new function `foreachUnlessDefault` instead of relying on `getUnlessDefault` which adds an extra allocation of `Some(...)` or `None`