### PR TITLE
Union rendering tweaks

### DIFF
--- a/modules/bootstrapped/src/generated/com/amazonaws/dynamodb/DynamoDB.scala
+++ b/modules/bootstrapped/src/generated/com/amazonaws/dynamodb/DynamoDB.scala
@@ -164,7 +164,7 @@ object DynamoDBOperation {
   }
   sealed trait ListTablesError extends scala.Product with scala.Serializable {
     @inline final def widen: ListTablesError = this
-    def _ordinal: Int
+    def $ordinal: Int
   }
   object ListTablesError extends ShapeTag.Companion[ListTablesError] {
 
@@ -175,8 +175,8 @@ object DynamoDBOperation {
 
     val hints: Hints = Hints.empty
 
-    final case class InternalServerErrorCase(internalServerError: InternalServerError) extends ListTablesError { final def _ordinal: Int = 0 }
-    final case class InvalidEndpointExceptionCase(invalidEndpointException: InvalidEndpointException) extends ListTablesError { final def _ordinal: Int = 1 }
+    final case class InternalServerErrorCase(internalServerError: InternalServerError) extends ListTablesError { final def $ordinal: Int = 0 }
+    final case class InvalidEndpointExceptionCase(invalidEndpointException: InvalidEndpointException) extends ListTablesError { final def $ordinal: Int = 1 }
 
     object InternalServerErrorCase {
       val hints: Hints = Hints.empty
@@ -193,7 +193,7 @@ object DynamoDBOperation {
       InternalServerErrorCase.alt,
       InvalidEndpointExceptionCase.alt,
     ){
-      _._ordinal
+      _.$ordinal
     }
   }
 }

--- a/modules/bootstrapped/src/generated/com/amazonaws/dynamodb/DynamoDB.scala
+++ b/modules/bootstrapped/src/generated/com/amazonaws/dynamodb/DynamoDB.scala
@@ -167,14 +167,16 @@ object DynamoDBOperation {
     def _ordinal: Int
   }
   object ListTablesError extends ShapeTag.Companion[ListTablesError] {
+
+    def internalServerError(internalServerError:InternalServerError): ListTablesError = InternalServerErrorCase(internalServerError)
+    def invalidEndpointException(invalidEndpointException:InvalidEndpointException): ListTablesError = InvalidEndpointExceptionCase(invalidEndpointException)
+
     val id: ShapeId = ShapeId("com.amazonaws.dynamodb", "ListTablesError")
 
     val hints: Hints = Hints.empty
 
     final case class InternalServerErrorCase(internalServerError: InternalServerError) extends ListTablesError { final def _ordinal: Int = 0 }
-    def internalServerError(internalServerError:InternalServerError): ListTablesError = InternalServerErrorCase(internalServerError)
     final case class InvalidEndpointExceptionCase(invalidEndpointException: InvalidEndpointException) extends ListTablesError { final def _ordinal: Int = 1 }
-    def invalidEndpointException(invalidEndpointException:InvalidEndpointException): ListTablesError = InvalidEndpointExceptionCase(invalidEndpointException)
 
     object InternalServerErrorCase {
       val hints: Hints = Hints.empty

--- a/modules/bootstrapped/src/generated/smithy4s/example/CheckedOrUnchecked.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/CheckedOrUnchecked.scala
@@ -13,14 +13,16 @@ sealed trait CheckedOrUnchecked extends scala.Product with scala.Serializable {
   def _ordinal: Int
 }
 object CheckedOrUnchecked extends ShapeTag.Companion[CheckedOrUnchecked] {
+
+  def checked(checked:String): CheckedOrUnchecked = CheckedCase(checked)
+  def raw(raw:String): CheckedOrUnchecked = RawCase(raw)
+
   val id: ShapeId = ShapeId("smithy4s.example", "CheckedOrUnchecked")
 
   val hints: Hints = Hints.empty
 
   final case class CheckedCase(checked: String) extends CheckedOrUnchecked { final def _ordinal: Int = 0 }
-  def checked(checked:String): CheckedOrUnchecked = CheckedCase(checked)
   final case class RawCase(raw: String) extends CheckedOrUnchecked { final def _ordinal: Int = 1 }
-  def raw(raw:String): CheckedOrUnchecked = RawCase(raw)
 
   object CheckedCase {
     val hints: Hints = Hints.empty

--- a/modules/bootstrapped/src/generated/smithy4s/example/CheckedOrUnchecked.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/CheckedOrUnchecked.scala
@@ -10,7 +10,7 @@ import smithy4s.schema.Schema.union
 
 sealed trait CheckedOrUnchecked extends scala.Product with scala.Serializable {
   @inline final def widen: CheckedOrUnchecked = this
-  def _ordinal: Int
+  def $ordinal: Int
 }
 object CheckedOrUnchecked extends ShapeTag.Companion[CheckedOrUnchecked] {
 
@@ -21,8 +21,8 @@ object CheckedOrUnchecked extends ShapeTag.Companion[CheckedOrUnchecked] {
 
   val hints: Hints = Hints.empty
 
-  final case class CheckedCase(checked: String) extends CheckedOrUnchecked { final def _ordinal: Int = 0 }
-  final case class RawCase(raw: String) extends CheckedOrUnchecked { final def _ordinal: Int = 1 }
+  final case class CheckedCase(checked: String) extends CheckedOrUnchecked { final def $ordinal: Int = 0 }
+  final case class RawCase(raw: String) extends CheckedOrUnchecked { final def $ordinal: Int = 1 }
 
   object CheckedCase {
     val hints: Hints = Hints.empty
@@ -39,6 +39,6 @@ object CheckedOrUnchecked extends ShapeTag.Companion[CheckedOrUnchecked] {
     CheckedCase.alt,
     RawCase.alt,
   ){
-    _._ordinal
+    _.$ordinal
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/CheckedOrUnchecked2.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/CheckedOrUnchecked2.scala
@@ -13,6 +13,10 @@ sealed trait CheckedOrUnchecked2 extends scala.Product with scala.Serializable {
   def _ordinal: Int
 }
 object CheckedOrUnchecked2 extends ShapeTag.Companion[CheckedOrUnchecked2] {
+
+  def checked(checked:String): CheckedOrUnchecked2 = CheckedCase(checked)
+  def raw(raw:String): CheckedOrUnchecked2 = RawCase(raw)
+
   val id: ShapeId = ShapeId("smithy4s.example", "CheckedOrUnchecked2")
 
   val hints: Hints = Hints(
@@ -20,9 +24,7 @@ object CheckedOrUnchecked2 extends ShapeTag.Companion[CheckedOrUnchecked2] {
   )
 
   final case class CheckedCase(checked: String) extends CheckedOrUnchecked2 { final def _ordinal: Int = 0 }
-  def checked(checked:String): CheckedOrUnchecked2 = CheckedCase(checked)
   final case class RawCase(raw: String) extends CheckedOrUnchecked2 { final def _ordinal: Int = 1 }
-  def raw(raw:String): CheckedOrUnchecked2 = RawCase(raw)
 
   object CheckedCase {
     val hints: Hints = Hints.empty

--- a/modules/bootstrapped/src/generated/smithy4s/example/CheckedOrUnchecked2.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/CheckedOrUnchecked2.scala
@@ -10,7 +10,7 @@ import smithy4s.schema.Schema.union
 
 sealed trait CheckedOrUnchecked2 extends scala.Product with scala.Serializable {
   @inline final def widen: CheckedOrUnchecked2 = this
-  def _ordinal: Int
+  def $ordinal: Int
 }
 object CheckedOrUnchecked2 extends ShapeTag.Companion[CheckedOrUnchecked2] {
 
@@ -23,8 +23,8 @@ object CheckedOrUnchecked2 extends ShapeTag.Companion[CheckedOrUnchecked2] {
     alloy.Untagged(),
   )
 
-  final case class CheckedCase(checked: String) extends CheckedOrUnchecked2 { final def _ordinal: Int = 0 }
-  final case class RawCase(raw: String) extends CheckedOrUnchecked2 { final def _ordinal: Int = 1 }
+  final case class CheckedCase(checked: String) extends CheckedOrUnchecked2 { final def $ordinal: Int = 0 }
+  final case class RawCase(raw: String) extends CheckedOrUnchecked2 { final def $ordinal: Int = 1 }
 
   object CheckedCase {
     val hints: Hints = Hints.empty
@@ -41,6 +41,6 @@ object CheckedOrUnchecked2 extends ShapeTag.Companion[CheckedOrUnchecked2] {
     CheckedCase.alt,
     RawCase.alt,
   ){
-    _._ordinal
+    _.$ordinal
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/DeprecatedUnion.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/DeprecatedUnion.scala
@@ -12,7 +12,7 @@ import smithy4s.schema.Schema.union
 @deprecated(message = "A compelling reason", since = "0.0.1")
 sealed trait DeprecatedUnion extends scala.Product with scala.Serializable {
   @inline final def widen: DeprecatedUnion = this
-  def _ordinal: Int
+  def $ordinal: Int
 }
 object DeprecatedUnion extends ShapeTag.Companion[DeprecatedUnion] {
 
@@ -30,11 +30,11 @@ object DeprecatedUnion extends ShapeTag.Companion[DeprecatedUnion] {
   )
 
   @deprecated(message = "N/A", since = "N/A")
-  final case class SCase(s: String) extends DeprecatedUnion { final def _ordinal: Int = 0 }
-  final case class S_V2Case(s_V2: String) extends DeprecatedUnion { final def _ordinal: Int = 1 }
+  final case class SCase(s: String) extends DeprecatedUnion { final def $ordinal: Int = 0 }
+  final case class S_V2Case(s_V2: String) extends DeprecatedUnion { final def $ordinal: Int = 1 }
   @deprecated(message = "N/A", since = "N/A")
   final case class DeprecatedUnionProductCase() extends DeprecatedUnion {
-    def _ordinal: Int = 2
+    def $ordinal: Int = 2
   }
   object DeprecatedUnionProductCase extends ShapeTag.Companion[DeprecatedUnionProductCase] {
     val id: ShapeId = ShapeId("smithy4s.example", "DeprecatedUnionProductCase")
@@ -49,7 +49,7 @@ object DeprecatedUnion extends ShapeTag.Companion[DeprecatedUnion] {
   }
   @deprecated(message = "N/A", since = "N/A")
   final case class UnionProductCaseDeprecatedAtCallSite() extends DeprecatedUnion {
-    def _ordinal: Int = 3
+    def $ordinal: Int = 3
   }
   object UnionProductCaseDeprecatedAtCallSite extends ShapeTag.Companion[UnionProductCaseDeprecatedAtCallSite] {
     val id: ShapeId = ShapeId("smithy4s.example", "UnionProductCaseDeprecatedAtCallSite")
@@ -82,6 +82,6 @@ object DeprecatedUnion extends ShapeTag.Companion[DeprecatedUnion] {
     DeprecatedUnionProductCase.alt,
     UnionProductCaseDeprecatedAtCallSite.alt,
   ){
-    _._ordinal
+    _.$ordinal
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/DeprecatedUnion.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/DeprecatedUnion.scala
@@ -15,6 +15,14 @@ sealed trait DeprecatedUnion extends scala.Product with scala.Serializable {
   def _ordinal: Int
 }
 object DeprecatedUnion extends ShapeTag.Companion[DeprecatedUnion] {
+
+  @deprecated(message = "N/A", since = "N/A")
+  def s(s:String): DeprecatedUnion = SCase(s)
+  def s_V2(s_V2:String): DeprecatedUnion = S_V2Case(s_V2)
+  def deprecatedUnionProductCase():DeprecatedUnionProductCase = DeprecatedUnionProductCase()
+  @deprecated(message = "N/A", since = "N/A")
+  def unionProductCaseDeprecatedAtCallSite():UnionProductCaseDeprecatedAtCallSite = UnionProductCaseDeprecatedAtCallSite()
+
   val id: ShapeId = ShapeId("smithy4s.example", "DeprecatedUnion")
 
   val hints: Hints = Hints(
@@ -23,9 +31,7 @@ object DeprecatedUnion extends ShapeTag.Companion[DeprecatedUnion] {
 
   @deprecated(message = "N/A", since = "N/A")
   final case class SCase(s: String) extends DeprecatedUnion { final def _ordinal: Int = 0 }
-  def s(s:String): DeprecatedUnion = SCase(s)
   final case class S_V2Case(s_V2: String) extends DeprecatedUnion { final def _ordinal: Int = 1 }
-  def s_V2(s_V2:String): DeprecatedUnion = S_V2Case(s_V2)
   @deprecated(message = "N/A", since = "N/A")
   final case class DeprecatedUnionProductCase() extends DeprecatedUnion {
     def _ordinal: Int = 2

--- a/modules/bootstrapped/src/generated/smithy4s/example/ErrorHandlingService.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/ErrorHandlingService.scala
@@ -105,7 +105,7 @@ object ErrorHandlingServiceOperation {
   }
   sealed trait ErrorHandlingOperationError extends scala.Product with scala.Serializable {
     @inline final def widen: ErrorHandlingOperationError = this
-    def _ordinal: Int
+    def $ordinal: Int
   }
   object ErrorHandlingOperationError extends ShapeTag.Companion[ErrorHandlingOperationError] {
 
@@ -118,10 +118,10 @@ object ErrorHandlingServiceOperation {
 
     val hints: Hints = Hints.empty
 
-    final case class EHFallbackClientErrorCase(eHFallbackClientError: EHFallbackClientError) extends ErrorHandlingOperationError { final def _ordinal: Int = 0 }
-    final case class EHServiceUnavailableCase(eHServiceUnavailable: EHServiceUnavailable) extends ErrorHandlingOperationError { final def _ordinal: Int = 1 }
-    final case class EHNotFoundCase(eHNotFound: EHNotFound) extends ErrorHandlingOperationError { final def _ordinal: Int = 2 }
-    final case class EHFallbackServerErrorCase(eHFallbackServerError: EHFallbackServerError) extends ErrorHandlingOperationError { final def _ordinal: Int = 3 }
+    final case class EHFallbackClientErrorCase(eHFallbackClientError: EHFallbackClientError) extends ErrorHandlingOperationError { final def $ordinal: Int = 0 }
+    final case class EHServiceUnavailableCase(eHServiceUnavailable: EHServiceUnavailable) extends ErrorHandlingOperationError { final def $ordinal: Int = 1 }
+    final case class EHNotFoundCase(eHNotFound: EHNotFound) extends ErrorHandlingOperationError { final def $ordinal: Int = 2 }
+    final case class EHFallbackServerErrorCase(eHFallbackServerError: EHFallbackServerError) extends ErrorHandlingOperationError { final def $ordinal: Int = 3 }
 
     object EHFallbackClientErrorCase {
       val hints: Hints = Hints.empty
@@ -150,7 +150,7 @@ object ErrorHandlingServiceOperation {
       EHNotFoundCase.alt,
       EHFallbackServerErrorCase.alt,
     ){
-      _._ordinal
+      _.$ordinal
     }
   }
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/ErrorHandlingService.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/ErrorHandlingService.scala
@@ -108,18 +108,20 @@ object ErrorHandlingServiceOperation {
     def _ordinal: Int
   }
   object ErrorHandlingOperationError extends ShapeTag.Companion[ErrorHandlingOperationError] {
+
+    def eHFallbackClientError(eHFallbackClientError:EHFallbackClientError): ErrorHandlingOperationError = EHFallbackClientErrorCase(eHFallbackClientError)
+    def eHServiceUnavailable(eHServiceUnavailable:EHServiceUnavailable): ErrorHandlingOperationError = EHServiceUnavailableCase(eHServiceUnavailable)
+    def eHNotFound(eHNotFound:EHNotFound): ErrorHandlingOperationError = EHNotFoundCase(eHNotFound)
+    def eHFallbackServerError(eHFallbackServerError:EHFallbackServerError): ErrorHandlingOperationError = EHFallbackServerErrorCase(eHFallbackServerError)
+
     val id: ShapeId = ShapeId("smithy4s.example", "ErrorHandlingOperationError")
 
     val hints: Hints = Hints.empty
 
     final case class EHFallbackClientErrorCase(eHFallbackClientError: EHFallbackClientError) extends ErrorHandlingOperationError { final def _ordinal: Int = 0 }
-    def eHFallbackClientError(eHFallbackClientError:EHFallbackClientError): ErrorHandlingOperationError = EHFallbackClientErrorCase(eHFallbackClientError)
     final case class EHServiceUnavailableCase(eHServiceUnavailable: EHServiceUnavailable) extends ErrorHandlingOperationError { final def _ordinal: Int = 1 }
-    def eHServiceUnavailable(eHServiceUnavailable:EHServiceUnavailable): ErrorHandlingOperationError = EHServiceUnavailableCase(eHServiceUnavailable)
     final case class EHNotFoundCase(eHNotFound: EHNotFound) extends ErrorHandlingOperationError { final def _ordinal: Int = 2 }
-    def eHNotFound(eHNotFound:EHNotFound): ErrorHandlingOperationError = EHNotFoundCase(eHNotFound)
     final case class EHFallbackServerErrorCase(eHFallbackServerError: EHFallbackServerError) extends ErrorHandlingOperationError { final def _ordinal: Int = 3 }
-    def eHFallbackServerError(eHFallbackServerError:EHFallbackServerError): ErrorHandlingOperationError = EHFallbackServerErrorCase(eHFallbackServerError)
 
     object EHFallbackClientErrorCase {
       val hints: Hints = Hints.empty

--- a/modules/bootstrapped/src/generated/smithy4s/example/ErrorHandlingServiceExtraErrors.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/ErrorHandlingServiceExtraErrors.scala
@@ -106,7 +106,7 @@ object ErrorHandlingServiceExtraErrorsOperation {
   }
   sealed trait ExtraErrorOperationError extends scala.Product with scala.Serializable {
     @inline final def widen: ExtraErrorOperationError = this
-    def _ordinal: Int
+    def $ordinal: Int
   }
   object ExtraErrorOperationError extends ShapeTag.Companion[ExtraErrorOperationError] {
 
@@ -119,10 +119,10 @@ object ErrorHandlingServiceExtraErrorsOperation {
 
     val hints: Hints = Hints.empty
 
-    final case class RandomOtherClientErrorCase(randomOtherClientError: RandomOtherClientError) extends ExtraErrorOperationError { final def _ordinal: Int = 0 }
-    final case class RandomOtherServerErrorCase(randomOtherServerError: RandomOtherServerError) extends ExtraErrorOperationError { final def _ordinal: Int = 1 }
-    final case class RandomOtherClientErrorWithCodeCase(randomOtherClientErrorWithCode: RandomOtherClientErrorWithCode) extends ExtraErrorOperationError { final def _ordinal: Int = 2 }
-    final case class RandomOtherServerErrorWithCodeCase(randomOtherServerErrorWithCode: RandomOtherServerErrorWithCode) extends ExtraErrorOperationError { final def _ordinal: Int = 3 }
+    final case class RandomOtherClientErrorCase(randomOtherClientError: RandomOtherClientError) extends ExtraErrorOperationError { final def $ordinal: Int = 0 }
+    final case class RandomOtherServerErrorCase(randomOtherServerError: RandomOtherServerError) extends ExtraErrorOperationError { final def $ordinal: Int = 1 }
+    final case class RandomOtherClientErrorWithCodeCase(randomOtherClientErrorWithCode: RandomOtherClientErrorWithCode) extends ExtraErrorOperationError { final def $ordinal: Int = 2 }
+    final case class RandomOtherServerErrorWithCodeCase(randomOtherServerErrorWithCode: RandomOtherServerErrorWithCode) extends ExtraErrorOperationError { final def $ordinal: Int = 3 }
 
     object RandomOtherClientErrorCase {
       val hints: Hints = Hints.empty
@@ -151,7 +151,7 @@ object ErrorHandlingServiceExtraErrorsOperation {
       RandomOtherClientErrorWithCodeCase.alt,
       RandomOtherServerErrorWithCodeCase.alt,
     ){
-      _._ordinal
+      _.$ordinal
     }
   }
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/ErrorHandlingServiceExtraErrors.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/ErrorHandlingServiceExtraErrors.scala
@@ -109,18 +109,20 @@ object ErrorHandlingServiceExtraErrorsOperation {
     def _ordinal: Int
   }
   object ExtraErrorOperationError extends ShapeTag.Companion[ExtraErrorOperationError] {
+
+    def randomOtherClientError(randomOtherClientError:RandomOtherClientError): ExtraErrorOperationError = RandomOtherClientErrorCase(randomOtherClientError)
+    def randomOtherServerError(randomOtherServerError:RandomOtherServerError): ExtraErrorOperationError = RandomOtherServerErrorCase(randomOtherServerError)
+    def randomOtherClientErrorWithCode(randomOtherClientErrorWithCode:RandomOtherClientErrorWithCode): ExtraErrorOperationError = RandomOtherClientErrorWithCodeCase(randomOtherClientErrorWithCode)
+    def randomOtherServerErrorWithCode(randomOtherServerErrorWithCode:RandomOtherServerErrorWithCode): ExtraErrorOperationError = RandomOtherServerErrorWithCodeCase(randomOtherServerErrorWithCode)
+
     val id: ShapeId = ShapeId("smithy4s.example", "ExtraErrorOperationError")
 
     val hints: Hints = Hints.empty
 
     final case class RandomOtherClientErrorCase(randomOtherClientError: RandomOtherClientError) extends ExtraErrorOperationError { final def _ordinal: Int = 0 }
-    def randomOtherClientError(randomOtherClientError:RandomOtherClientError): ExtraErrorOperationError = RandomOtherClientErrorCase(randomOtherClientError)
     final case class RandomOtherServerErrorCase(randomOtherServerError: RandomOtherServerError) extends ExtraErrorOperationError { final def _ordinal: Int = 1 }
-    def randomOtherServerError(randomOtherServerError:RandomOtherServerError): ExtraErrorOperationError = RandomOtherServerErrorCase(randomOtherServerError)
     final case class RandomOtherClientErrorWithCodeCase(randomOtherClientErrorWithCode: RandomOtherClientErrorWithCode) extends ExtraErrorOperationError { final def _ordinal: Int = 2 }
-    def randomOtherClientErrorWithCode(randomOtherClientErrorWithCode:RandomOtherClientErrorWithCode): ExtraErrorOperationError = RandomOtherClientErrorWithCodeCase(randomOtherClientErrorWithCode)
     final case class RandomOtherServerErrorWithCodeCase(randomOtherServerErrorWithCode: RandomOtherServerErrorWithCode) extends ExtraErrorOperationError { final def _ordinal: Int = 3 }
-    def randomOtherServerErrorWithCode(randomOtherServerErrorWithCode:RandomOtherServerErrorWithCode): ExtraErrorOperationError = RandomOtherServerErrorWithCodeCase(randomOtherServerErrorWithCode)
 
     object RandomOtherClientErrorCase {
       val hints: Hints = Hints.empty

--- a/modules/bootstrapped/src/generated/smithy4s/example/Foo.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/Foo.scala
@@ -19,6 +19,15 @@ sealed trait Foo extends scala.Product with scala.Serializable {
   def _ordinal: Int
 }
 object Foo extends ShapeTag.Companion[Foo] {
+
+  def int(int:Int): Foo = IntCase(int)
+  /** this is a comment saying you should be careful for this case
+    * you never know what lies ahead with Strings like this
+    */
+  def str(str:String): Foo = StrCase(str)
+  def bInt(bInt:BigInt): Foo = BIntCase(bInt)
+  def bDec(bDec:BigDecimal): Foo = BDecCase(bDec)
+
   val id: ShapeId = ShapeId("smithy4s.example", "Foo")
 
   val hints: Hints = Hints(
@@ -26,16 +35,12 @@ object Foo extends ShapeTag.Companion[Foo] {
   )
 
   final case class IntCase(int: Int) extends Foo { final def _ordinal: Int = 0 }
-  def int(int:Int): Foo = IntCase(int)
   /** this is a comment saying you should be careful for this case
     * you never know what lies ahead with Strings like this
     */
   final case class StrCase(str: String) extends Foo { final def _ordinal: Int = 1 }
-  def str(str:String): Foo = StrCase(str)
   final case class BIntCase(bInt: BigInt) extends Foo { final def _ordinal: Int = 2 }
-  def bInt(bInt:BigInt): Foo = BIntCase(bInt)
   final case class BDecCase(bDec: BigDecimal) extends Foo { final def _ordinal: Int = 3 }
-  def bDec(bDec:BigDecimal): Foo = BDecCase(bDec)
 
   object IntCase {
     val hints: Hints = Hints.empty

--- a/modules/bootstrapped/src/generated/smithy4s/example/Foo.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/Foo.scala
@@ -16,7 +16,7 @@ import smithy4s.schema.Schema.union
   */
 sealed trait Foo extends scala.Product with scala.Serializable {
   @inline final def widen: Foo = this
-  def _ordinal: Int
+  def $ordinal: Int
 }
 object Foo extends ShapeTag.Companion[Foo] {
 
@@ -34,13 +34,13 @@ object Foo extends ShapeTag.Companion[Foo] {
     smithy.api.Documentation("Helpful information for Foo\nint, bigInt and bDec are useful number constructs\nThe string case is there because."),
   )
 
-  final case class IntCase(int: Int) extends Foo { final def _ordinal: Int = 0 }
+  final case class IntCase(int: Int) extends Foo { final def $ordinal: Int = 0 }
   /** this is a comment saying you should be careful for this case
     * you never know what lies ahead with Strings like this
     */
-  final case class StrCase(str: String) extends Foo { final def _ordinal: Int = 1 }
-  final case class BIntCase(bInt: BigInt) extends Foo { final def _ordinal: Int = 2 }
-  final case class BDecCase(bDec: BigDecimal) extends Foo { final def _ordinal: Int = 3 }
+  final case class StrCase(str: String) extends Foo { final def $ordinal: Int = 1 }
+  final case class BIntCase(bInt: BigInt) extends Foo { final def $ordinal: Int = 2 }
+  final case class BDecCase(bDec: BigDecimal) extends Foo { final def $ordinal: Int = 3 }
 
   object IntCase {
     val hints: Hints = Hints.empty
@@ -71,6 +71,6 @@ object Foo extends ShapeTag.Companion[Foo] {
     BIntCase.alt,
     BDecCase.alt,
   ){
-    _._ordinal
+    _.$ordinal
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/Food.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/Food.scala
@@ -12,14 +12,16 @@ sealed trait Food extends scala.Product with scala.Serializable {
   def _ordinal: Int
 }
 object Food extends ShapeTag.Companion[Food] {
+
+  def pizza(pizza:Pizza): Food = PizzaCase(pizza)
+  def salad(salad:Salad): Food = SaladCase(salad)
+
   val id: ShapeId = ShapeId("smithy4s.example", "Food")
 
   val hints: Hints = Hints.empty
 
   final case class PizzaCase(pizza: Pizza) extends Food { final def _ordinal: Int = 0 }
-  def pizza(pizza:Pizza): Food = PizzaCase(pizza)
   final case class SaladCase(salad: Salad) extends Food { final def _ordinal: Int = 1 }
-  def salad(salad:Salad): Food = SaladCase(salad)
 
   object PizzaCase {
     val hints: Hints = Hints.empty

--- a/modules/bootstrapped/src/generated/smithy4s/example/Food.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/Food.scala
@@ -9,7 +9,7 @@ import smithy4s.schema.Schema.union
 
 sealed trait Food extends scala.Product with scala.Serializable {
   @inline final def widen: Food = this
-  def _ordinal: Int
+  def $ordinal: Int
 }
 object Food extends ShapeTag.Companion[Food] {
 
@@ -20,8 +20,8 @@ object Food extends ShapeTag.Companion[Food] {
 
   val hints: Hints = Hints.empty
 
-  final case class PizzaCase(pizza: Pizza) extends Food { final def _ordinal: Int = 0 }
-  final case class SaladCase(salad: Salad) extends Food { final def _ordinal: Int = 1 }
+  final case class PizzaCase(pizza: Pizza) extends Food { final def $ordinal: Int = 0 }
+  final case class SaladCase(salad: Salad) extends Food { final def $ordinal: Int = 1 }
 
   object PizzaCase {
     val hints: Hints = Hints.empty
@@ -38,6 +38,6 @@ object Food extends ShapeTag.Companion[Food] {
     PizzaCase.alt,
     SaladCase.alt,
   ){
-    _._ordinal
+    _.$ordinal
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/ForecastResult.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/ForecastResult.scala
@@ -13,6 +13,10 @@ sealed trait ForecastResult extends scala.Product with scala.Serializable {
   def _ordinal: Int
 }
 object ForecastResult extends ShapeTag.Companion[ForecastResult] {
+
+  def rain(rain:ChanceOfRain): ForecastResult = RainCase(rain)
+  def sun(sun:UVIndex): ForecastResult = SunCase(sun)
+
   val id: ShapeId = ShapeId("smithy4s.example", "ForecastResult")
 
   val hints: Hints = Hints.empty
@@ -23,9 +27,7 @@ object ForecastResult extends ShapeTag.Companion[ForecastResult] {
   }
 
   final case class RainCase(rain: ChanceOfRain) extends ForecastResult { final def _ordinal: Int = 0 }
-  def rain(rain:ChanceOfRain): ForecastResult = RainCase(rain)
   final case class SunCase(sun: UVIndex) extends ForecastResult { final def _ordinal: Int = 1 }
-  def sun(sun:UVIndex): ForecastResult = SunCase(sun)
 
   object RainCase {
     val hints: Hints = Hints.empty

--- a/modules/bootstrapped/src/generated/smithy4s/example/ForecastResult.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/ForecastResult.scala
@@ -10,7 +10,7 @@ import smithy4s.schema.Schema.union
 
 sealed trait ForecastResult extends scala.Product with scala.Serializable {
   @inline final def widen: ForecastResult = this
-  def _ordinal: Int
+  def $ordinal: Int
 }
 object ForecastResult extends ShapeTag.Companion[ForecastResult] {
 
@@ -26,8 +26,8 @@ object ForecastResult extends ShapeTag.Companion[ForecastResult] {
     val sun: Prism[ForecastResult, UVIndex] = Prism.partial[ForecastResult, UVIndex]{ case SunCase(t) => t }(SunCase.apply)
   }
 
-  final case class RainCase(rain: ChanceOfRain) extends ForecastResult { final def _ordinal: Int = 0 }
-  final case class SunCase(sun: UVIndex) extends ForecastResult { final def _ordinal: Int = 1 }
+  final case class RainCase(rain: ChanceOfRain) extends ForecastResult { final def $ordinal: Int = 0 }
+  final case class SunCase(sun: UVIndex) extends ForecastResult { final def $ordinal: Int = 1 }
 
   object RainCase {
     val hints: Hints = Hints.empty
@@ -44,6 +44,6 @@ object ForecastResult extends ShapeTag.Companion[ForecastResult] {
     RainCase.alt,
     SunCase.alt,
   ){
-    _._ordinal
+    _.$ordinal
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/KVStore.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/KVStore.scala
@@ -117,14 +117,16 @@ object KVStoreOperation {
     def _ordinal: Int
   }
   object GetError extends ShapeTag.Companion[GetError] {
+
+    def unauthorizedError(unauthorizedError:UnauthorizedError): GetError = UnauthorizedErrorCase(unauthorizedError)
+    def keyNotFoundError(keyNotFoundError:KeyNotFoundError): GetError = KeyNotFoundErrorCase(keyNotFoundError)
+
     val id: ShapeId = ShapeId("smithy4s.example", "GetError")
 
     val hints: Hints = Hints.empty
 
     final case class UnauthorizedErrorCase(unauthorizedError: UnauthorizedError) extends GetError { final def _ordinal: Int = 0 }
-    def unauthorizedError(unauthorizedError:UnauthorizedError): GetError = UnauthorizedErrorCase(unauthorizedError)
     final case class KeyNotFoundErrorCase(keyNotFoundError: KeyNotFoundError) extends GetError { final def _ordinal: Int = 1 }
-    def keyNotFoundError(keyNotFoundError:KeyNotFoundError): GetError = KeyNotFoundErrorCase(keyNotFoundError)
 
     object UnauthorizedErrorCase {
       val hints: Hints = Hints.empty
@@ -172,12 +174,14 @@ object KVStoreOperation {
     def _ordinal: Int
   }
   object PutError extends ShapeTag.Companion[PutError] {
+
+    def unauthorizedError(unauthorizedError:UnauthorizedError): PutError = UnauthorizedErrorCase(unauthorizedError)
+
     val id: ShapeId = ShapeId("smithy4s.example", "PutError")
 
     val hints: Hints = Hints.empty
 
     final case class UnauthorizedErrorCase(unauthorizedError: UnauthorizedError) extends PutError { final def _ordinal: Int = 0 }
-    def unauthorizedError(unauthorizedError:UnauthorizedError): PutError = UnauthorizedErrorCase(unauthorizedError)
 
     object UnauthorizedErrorCase {
       val hints: Hints = Hints.empty
@@ -221,14 +225,16 @@ object KVStoreOperation {
     def _ordinal: Int
   }
   object DeleteError extends ShapeTag.Companion[DeleteError] {
+
+    def unauthorizedError(unauthorizedError:UnauthorizedError): DeleteError = UnauthorizedErrorCase(unauthorizedError)
+    def keyNotFoundError(keyNotFoundError:KeyNotFoundError): DeleteError = KeyNotFoundErrorCase(keyNotFoundError)
+
     val id: ShapeId = ShapeId("smithy4s.example", "DeleteError")
 
     val hints: Hints = Hints.empty
 
     final case class UnauthorizedErrorCase(unauthorizedError: UnauthorizedError) extends DeleteError { final def _ordinal: Int = 0 }
-    def unauthorizedError(unauthorizedError:UnauthorizedError): DeleteError = UnauthorizedErrorCase(unauthorizedError)
     final case class KeyNotFoundErrorCase(keyNotFoundError: KeyNotFoundError) extends DeleteError { final def _ordinal: Int = 1 }
-    def keyNotFoundError(keyNotFoundError:KeyNotFoundError): DeleteError = KeyNotFoundErrorCase(keyNotFoundError)
 
     object UnauthorizedErrorCase {
       val hints: Hints = Hints.empty

--- a/modules/bootstrapped/src/generated/smithy4s/example/KVStore.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/KVStore.scala
@@ -114,7 +114,7 @@ object KVStoreOperation {
   }
   sealed trait GetError extends scala.Product with scala.Serializable {
     @inline final def widen: GetError = this
-    def _ordinal: Int
+    def $ordinal: Int
   }
   object GetError extends ShapeTag.Companion[GetError] {
 
@@ -125,8 +125,8 @@ object KVStoreOperation {
 
     val hints: Hints = Hints.empty
 
-    final case class UnauthorizedErrorCase(unauthorizedError: UnauthorizedError) extends GetError { final def _ordinal: Int = 0 }
-    final case class KeyNotFoundErrorCase(keyNotFoundError: KeyNotFoundError) extends GetError { final def _ordinal: Int = 1 }
+    final case class UnauthorizedErrorCase(unauthorizedError: UnauthorizedError) extends GetError { final def $ordinal: Int = 0 }
+    final case class KeyNotFoundErrorCase(keyNotFoundError: KeyNotFoundError) extends GetError { final def $ordinal: Int = 1 }
 
     object UnauthorizedErrorCase {
       val hints: Hints = Hints.empty
@@ -143,7 +143,7 @@ object KVStoreOperation {
       UnauthorizedErrorCase.alt,
       KeyNotFoundErrorCase.alt,
     ){
-      _._ordinal
+      _.$ordinal
     }
   }
   final case class Put(input: KeyValue) extends KVStoreOperation[KeyValue, KVStoreOperation.PutError, Unit, Nothing, Nothing] {
@@ -171,7 +171,7 @@ object KVStoreOperation {
   }
   sealed trait PutError extends scala.Product with scala.Serializable {
     @inline final def widen: PutError = this
-    def _ordinal: Int
+    def $ordinal: Int
   }
   object PutError extends ShapeTag.Companion[PutError] {
 
@@ -181,7 +181,7 @@ object KVStoreOperation {
 
     val hints: Hints = Hints.empty
 
-    final case class UnauthorizedErrorCase(unauthorizedError: UnauthorizedError) extends PutError { final def _ordinal: Int = 0 }
+    final case class UnauthorizedErrorCase(unauthorizedError: UnauthorizedError) extends PutError { final def $ordinal: Int = 0 }
 
     object UnauthorizedErrorCase {
       val hints: Hints = Hints.empty
@@ -192,7 +192,7 @@ object KVStoreOperation {
     implicit val schema: UnionSchema[PutError] = union(
       UnauthorizedErrorCase.alt,
     ){
-      _._ordinal
+      _.$ordinal
     }
   }
   final case class Delete(input: Key) extends KVStoreOperation[Key, KVStoreOperation.DeleteError, Unit, Nothing, Nothing] {
@@ -222,7 +222,7 @@ object KVStoreOperation {
   }
   sealed trait DeleteError extends scala.Product with scala.Serializable {
     @inline final def widen: DeleteError = this
-    def _ordinal: Int
+    def $ordinal: Int
   }
   object DeleteError extends ShapeTag.Companion[DeleteError] {
 
@@ -233,8 +233,8 @@ object KVStoreOperation {
 
     val hints: Hints = Hints.empty
 
-    final case class UnauthorizedErrorCase(unauthorizedError: UnauthorizedError) extends DeleteError { final def _ordinal: Int = 0 }
-    final case class KeyNotFoundErrorCase(keyNotFoundError: KeyNotFoundError) extends DeleteError { final def _ordinal: Int = 1 }
+    final case class UnauthorizedErrorCase(unauthorizedError: UnauthorizedError) extends DeleteError { final def $ordinal: Int = 0 }
+    final case class KeyNotFoundErrorCase(keyNotFoundError: KeyNotFoundError) extends DeleteError { final def $ordinal: Int = 1 }
 
     object UnauthorizedErrorCase {
       val hints: Hints = Hints.empty
@@ -251,7 +251,7 @@ object KVStoreOperation {
       UnauthorizedErrorCase.alt,
       KeyNotFoundErrorCase.alt,
     ){
-      _._ordinal
+      _.$ordinal
     }
   }
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/NameCollision.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/NameCollision.scala
@@ -104,7 +104,7 @@ object NameCollisionOperation {
   }
   sealed trait MyOpError extends scala.Product with scala.Serializable {
     @inline final def widen: MyOpError = this
-    def _ordinal: Int
+    def $ordinal: Int
   }
   object MyOpError extends ShapeTag.Companion[MyOpError] {
 
@@ -114,7 +114,7 @@ object NameCollisionOperation {
 
     val hints: Hints = Hints.empty
 
-    final case class MyOpErrorCase(myOpError: smithy4s.example.MyOpError) extends MyOpError { final def _ordinal: Int = 0 }
+    final case class MyOpErrorCase(myOpError: smithy4s.example.MyOpError) extends MyOpError { final def $ordinal: Int = 0 }
 
     object MyOpErrorCase {
       val hints: Hints = Hints.empty
@@ -125,7 +125,7 @@ object NameCollisionOperation {
     implicit val schema: UnionSchema[MyOpError] = union(
       MyOpErrorCase.alt,
     ){
-      _._ordinal
+      _.$ordinal
     }
   }
   final case class Endpoint() extends NameCollisionOperation[Unit, Nothing, Unit, Nothing, Nothing] {

--- a/modules/bootstrapped/src/generated/smithy4s/example/NameCollision.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/NameCollision.scala
@@ -107,12 +107,14 @@ object NameCollisionOperation {
     def _ordinal: Int
   }
   object MyOpError extends ShapeTag.Companion[MyOpError] {
+
+    def myOpError(myOpError:smithy4s.example.MyOpError): MyOpError = MyOpErrorCase(myOpError)
+
     val id: ShapeId = ShapeId("smithy4s.example", "MyOpError")
 
     val hints: Hints = Hints.empty
 
     final case class MyOpErrorCase(myOpError: smithy4s.example.MyOpError) extends MyOpError { final def _ordinal: Int = 0 }
-    def myOpError(myOpError:smithy4s.example.MyOpError): MyOpError = MyOpErrorCase(myOpError)
 
     object MyOpErrorCase {
       val hints: Hints = Hints.empty

--- a/modules/bootstrapped/src/generated/smithy4s/example/ObjectService.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/ObjectService.scala
@@ -123,14 +123,16 @@ object ObjectServiceOperation {
     def _ordinal: Int
   }
   object PutObjectError extends ShapeTag.Companion[PutObjectError] {
+
+    def serverError(serverError:ServerError): PutObjectError = ServerErrorCase(serverError)
+    def noMoreSpace(noMoreSpace:NoMoreSpace): PutObjectError = NoMoreSpaceCase(noMoreSpace)
+
     val id: ShapeId = ShapeId("smithy4s.example", "PutObjectError")
 
     val hints: Hints = Hints.empty
 
     final case class ServerErrorCase(serverError: ServerError) extends PutObjectError { final def _ordinal: Int = 0 }
-    def serverError(serverError:ServerError): PutObjectError = ServerErrorCase(serverError)
     final case class NoMoreSpaceCase(noMoreSpace: NoMoreSpace) extends PutObjectError { final def _ordinal: Int = 1 }
-    def noMoreSpace(noMoreSpace:NoMoreSpace): PutObjectError = NoMoreSpaceCase(noMoreSpace)
 
     object ServerErrorCase {
       val hints: Hints = Hints.empty
@@ -181,12 +183,14 @@ object ObjectServiceOperation {
     def _ordinal: Int
   }
   object GetObjectError extends ShapeTag.Companion[GetObjectError] {
+
+    def serverError(serverError:ServerError): GetObjectError = ServerErrorCase(serverError)
+
     val id: ShapeId = ShapeId("smithy4s.example", "GetObjectError")
 
     val hints: Hints = Hints.empty
 
     final case class ServerErrorCase(serverError: ServerError) extends GetObjectError { final def _ordinal: Int = 0 }
-    def serverError(serverError:ServerError): GetObjectError = ServerErrorCase(serverError)
 
     object ServerErrorCase {
       val hints: Hints = Hints.empty

--- a/modules/bootstrapped/src/generated/smithy4s/example/ObjectService.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/ObjectService.scala
@@ -120,7 +120,7 @@ object ObjectServiceOperation {
   }
   sealed trait PutObjectError extends scala.Product with scala.Serializable {
     @inline final def widen: PutObjectError = this
-    def _ordinal: Int
+    def $ordinal: Int
   }
   object PutObjectError extends ShapeTag.Companion[PutObjectError] {
 
@@ -131,8 +131,8 @@ object ObjectServiceOperation {
 
     val hints: Hints = Hints.empty
 
-    final case class ServerErrorCase(serverError: ServerError) extends PutObjectError { final def _ordinal: Int = 0 }
-    final case class NoMoreSpaceCase(noMoreSpace: NoMoreSpace) extends PutObjectError { final def _ordinal: Int = 1 }
+    final case class ServerErrorCase(serverError: ServerError) extends PutObjectError { final def $ordinal: Int = 0 }
+    final case class NoMoreSpaceCase(noMoreSpace: NoMoreSpace) extends PutObjectError { final def $ordinal: Int = 1 }
 
     object ServerErrorCase {
       val hints: Hints = Hints.empty
@@ -149,7 +149,7 @@ object ObjectServiceOperation {
       ServerErrorCase.alt,
       NoMoreSpaceCase.alt,
     ){
-      _._ordinal
+      _.$ordinal
     }
   }
   final case class GetObject(input: GetObjectInput) extends ObjectServiceOperation[GetObjectInput, ObjectServiceOperation.GetObjectError, GetObjectOutput, Nothing, Nothing] {
@@ -180,7 +180,7 @@ object ObjectServiceOperation {
   }
   sealed trait GetObjectError extends scala.Product with scala.Serializable {
     @inline final def widen: GetObjectError = this
-    def _ordinal: Int
+    def $ordinal: Int
   }
   object GetObjectError extends ShapeTag.Companion[GetObjectError] {
 
@@ -190,7 +190,7 @@ object ObjectServiceOperation {
 
     val hints: Hints = Hints.empty
 
-    final case class ServerErrorCase(serverError: ServerError) extends GetObjectError { final def _ordinal: Int = 0 }
+    final case class ServerErrorCase(serverError: ServerError) extends GetObjectError { final def $ordinal: Int = 0 }
 
     object ServerErrorCase {
       val hints: Hints = Hints.empty
@@ -201,7 +201,7 @@ object ObjectServiceOperation {
     implicit val schema: UnionSchema[GetObjectError] = union(
       ServerErrorCase.alt,
     ){
-      _._ordinal
+      _.$ordinal
     }
   }
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/OpticsUnion.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/OpticsUnion.scala
@@ -10,7 +10,7 @@ import smithy4s.schema.Schema.union
 
 sealed trait OpticsUnion extends scala.Product with scala.Serializable {
   @inline final def widen: OpticsUnion = this
-  def _ordinal: Int
+  def $ordinal: Int
 }
 object OpticsUnion extends ShapeTag.Companion[OpticsUnion] {
 
@@ -24,7 +24,7 @@ object OpticsUnion extends ShapeTag.Companion[OpticsUnion] {
     val one: Prism[OpticsUnion, OpticsStructure] = Prism.partial[OpticsUnion, OpticsStructure]{ case OneCase(t) => t }(OneCase.apply)
   }
 
-  final case class OneCase(one: OpticsStructure) extends OpticsUnion { final def _ordinal: Int = 0 }
+  final case class OneCase(one: OpticsStructure) extends OpticsUnion { final def $ordinal: Int = 0 }
 
   object OneCase {
     val hints: Hints = Hints.empty
@@ -35,6 +35,6 @@ object OpticsUnion extends ShapeTag.Companion[OpticsUnion] {
   implicit val schema: Schema[OpticsUnion] = union(
     OneCase.alt,
   ){
-    _._ordinal
+    _.$ordinal
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/OpticsUnion.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/OpticsUnion.scala
@@ -13,6 +13,9 @@ sealed trait OpticsUnion extends scala.Product with scala.Serializable {
   def _ordinal: Int
 }
 object OpticsUnion extends ShapeTag.Companion[OpticsUnion] {
+
+  def one(one:OpticsStructure): OpticsUnion = OneCase(one)
+
   val id: ShapeId = ShapeId("smithy4s.example", "OpticsUnion")
 
   val hints: Hints = Hints.empty
@@ -22,7 +25,6 @@ object OpticsUnion extends ShapeTag.Companion[OpticsUnion] {
   }
 
   final case class OneCase(one: OpticsStructure) extends OpticsUnion { final def _ordinal: Int = 0 }
-  def one(one:OpticsStructure): OpticsUnion = OneCase(one)
 
   object OneCase {
     val hints: Hints = Hints.empty

--- a/modules/bootstrapped/src/generated/smithy4s/example/OrderType.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/OrderType.scala
@@ -14,7 +14,7 @@ import smithy4s.schema.Schema.union
   */
 sealed trait OrderType extends scala.Product with scala.Serializable {
   @inline final def widen: OrderType = this
-  def _ordinal: Int
+  def $ordinal: Int
 }
 object OrderType extends ShapeTag.Companion[OrderType] {
 
@@ -29,10 +29,10 @@ object OrderType extends ShapeTag.Companion[OrderType] {
     smithy.api.Documentation("Our order types have different ways to identify a product\nExcept for preview orders, these don\'t have an ID "),
   )
 
-  final case class OnlineCase(online: OrderNumber) extends OrderType { final def _ordinal: Int = 0 }
+  final case class OnlineCase(online: OrderNumber) extends OrderType { final def $ordinal: Int = 0 }
   /** For an InStoreOrder a location ID isn't needed */
   final case class InStoreOrder(id: OrderNumber, locationId: Option[String] = None) extends OrderType {
-    def _ordinal: Int = 1
+    def $ordinal: Int = 1
   }
   object InStoreOrder extends ShapeTag.Companion[InStoreOrder] {
     val id: ShapeId = ShapeId("smithy4s.example", "InStoreOrder")
@@ -50,7 +50,7 @@ object OrderType extends ShapeTag.Companion[OrderType] {
 
     val alt = schema.oneOf[OrderType]("inStore")
   }
-  case object PreviewCase extends OrderType { final def _ordinal: Int = 2 }
+  case object PreviewCase extends OrderType { final def $ordinal: Int = 2 }
   private val PreviewCaseAlt = Schema.constant(PreviewCase).oneOf[OrderType]("preview").addHints(hints)
 
   object OnlineCase {
@@ -64,6 +64,6 @@ object OrderType extends ShapeTag.Companion[OrderType] {
     InStoreOrder.alt,
     PreviewCaseAlt,
   ){
-    _._ordinal
+    _.$ordinal
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/OrderType.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/OrderType.scala
@@ -17,6 +17,12 @@ sealed trait OrderType extends scala.Product with scala.Serializable {
   def _ordinal: Int
 }
 object OrderType extends ShapeTag.Companion[OrderType] {
+
+  def online(online:OrderNumber): OrderType = OnlineCase(online)
+  /** For an InStoreOrder a location ID isn't needed */
+  def inStoreOrder(id: OrderNumber, locationId: Option[String] = None):InStoreOrder = InStoreOrder(id, locationId)
+  def preview(): OrderType = PreviewCase
+
   val id: ShapeId = ShapeId("smithy4s.example", "OrderType")
 
   val hints: Hints = Hints(
@@ -24,7 +30,6 @@ object OrderType extends ShapeTag.Companion[OrderType] {
   )
 
   final case class OnlineCase(online: OrderNumber) extends OrderType { final def _ordinal: Int = 0 }
-  def online(online:OrderNumber): OrderType = OnlineCase(online)
   /** For an InStoreOrder a location ID isn't needed */
   final case class InStoreOrder(id: OrderNumber, locationId: Option[String] = None) extends OrderType {
     def _ordinal: Int = 1
@@ -46,7 +51,6 @@ object OrderType extends ShapeTag.Companion[OrderType] {
     val alt = schema.oneOf[OrderType]("inStore")
   }
   case object PreviewCase extends OrderType { final def _ordinal: Int = 2 }
-  def preview(): OrderType = PreviewCase
   private val PreviewCaseAlt = Schema.constant(PreviewCase).oneOf[OrderType]("preview").addHints(hints)
 
   object OnlineCase {

--- a/modules/bootstrapped/src/generated/smithy4s/example/PersonContactInfo.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/PersonContactInfo.scala
@@ -11,7 +11,7 @@ import smithy4s.schema.Schema.union
 
 sealed trait PersonContactInfo extends scala.Product with scala.Serializable {
   @inline final def widen: PersonContactInfo = this
-  def _ordinal: Int
+  def $ordinal: Int
 }
 object PersonContactInfo extends ShapeTag.Companion[PersonContactInfo] {
 
@@ -29,8 +29,8 @@ object PersonContactInfo extends ShapeTag.Companion[PersonContactInfo] {
     val phone: Prism[PersonContactInfo, PersonPhoneNumber] = Prism.partial[PersonContactInfo, PersonPhoneNumber]{ case PhoneCase(t) => t }(PhoneCase.apply)
   }
 
-  final case class EmailCase(email: PersonEmail) extends PersonContactInfo { final def _ordinal: Int = 0 }
-  final case class PhoneCase(phone: PersonPhoneNumber) extends PersonContactInfo { final def _ordinal: Int = 1 }
+  final case class EmailCase(email: PersonEmail) extends PersonContactInfo { final def $ordinal: Int = 0 }
+  final case class PhoneCase(phone: PersonPhoneNumber) extends PersonContactInfo { final def $ordinal: Int = 1 }
 
   object EmailCase {
     val hints: Hints = Hints.empty
@@ -47,7 +47,7 @@ object PersonContactInfo extends ShapeTag.Companion[PersonContactInfo] {
     EmailCase.alt,
     PhoneCase.alt,
   ){
-    _._ordinal
+    _.$ordinal
   }.withId(id).addHints(hints)
 
   implicit val personContactInfoHash: cats.Hash[PersonContactInfo] = SchemaVisitorHash.fromSchema(schema)

--- a/modules/bootstrapped/src/generated/smithy4s/example/PersonContactInfo.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/PersonContactInfo.scala
@@ -14,6 +14,10 @@ sealed trait PersonContactInfo extends scala.Product with scala.Serializable {
   def _ordinal: Int
 }
 object PersonContactInfo extends ShapeTag.Companion[PersonContactInfo] {
+
+  def email(email:PersonEmail): PersonContactInfo = EmailCase(email)
+  def phone(phone:PersonPhoneNumber): PersonContactInfo = PhoneCase(phone)
+
   val id: ShapeId = ShapeId("smithy4s.example", "PersonContactInfo")
 
   val hints: Hints = Hints(
@@ -26,9 +30,7 @@ object PersonContactInfo extends ShapeTag.Companion[PersonContactInfo] {
   }
 
   final case class EmailCase(email: PersonEmail) extends PersonContactInfo { final def _ordinal: Int = 0 }
-  def email(email:PersonEmail): PersonContactInfo = EmailCase(email)
   final case class PhoneCase(phone: PersonPhoneNumber) extends PersonContactInfo { final def _ordinal: Int = 1 }
-  def phone(phone:PersonPhoneNumber): PersonContactInfo = PhoneCase(phone)
 
   object EmailCase {
     val hints: Hints = Hints.empty

--- a/modules/bootstrapped/src/generated/smithy4s/example/PizzaAdminService.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/PizzaAdminService.scala
@@ -165,16 +165,18 @@ object PizzaAdminServiceOperation {
     def _ordinal: Int
   }
   object AddMenuItemError extends ShapeTag.Companion[AddMenuItemError] {
+
+    def priceError(priceError:PriceError): AddMenuItemError = PriceErrorCase(priceError)
+    def genericServerError(genericServerError:GenericServerError): AddMenuItemError = GenericServerErrorCase(genericServerError)
+    def genericClientError(genericClientError:GenericClientError): AddMenuItemError = GenericClientErrorCase(genericClientError)
+
     val id: ShapeId = ShapeId("smithy4s.example", "AddMenuItemError")
 
     val hints: Hints = Hints.empty
 
     final case class PriceErrorCase(priceError: PriceError) extends AddMenuItemError { final def _ordinal: Int = 0 }
-    def priceError(priceError:PriceError): AddMenuItemError = PriceErrorCase(priceError)
     final case class GenericServerErrorCase(genericServerError: GenericServerError) extends AddMenuItemError { final def _ordinal: Int = 1 }
-    def genericServerError(genericServerError:GenericServerError): AddMenuItemError = GenericServerErrorCase(genericServerError)
     final case class GenericClientErrorCase(genericClientError: GenericClientError) extends AddMenuItemError { final def _ordinal: Int = 2 }
-    def genericClientError(genericClientError:GenericClientError): AddMenuItemError = GenericClientErrorCase(genericClientError)
 
     object PriceErrorCase {
       val hints: Hints = Hints.empty
@@ -237,18 +239,20 @@ object PizzaAdminServiceOperation {
     def _ordinal: Int
   }
   object GetMenuError extends ShapeTag.Companion[GetMenuError] {
+
+    def genericClientError(genericClientError:GenericClientError): GetMenuError = GenericClientErrorCase(genericClientError)
+    def fallbackError2(fallbackError2:FallbackError2): GetMenuError = FallbackError2Case(fallbackError2)
+    def fallbackError(fallbackError:FallbackError): GetMenuError = FallbackErrorCase(fallbackError)
+    def notFoundError(notFoundError:NotFoundError): GetMenuError = NotFoundErrorCase(notFoundError)
+
     val id: ShapeId = ShapeId("smithy4s.example", "GetMenuError")
 
     val hints: Hints = Hints.empty
 
     final case class GenericClientErrorCase(genericClientError: GenericClientError) extends GetMenuError { final def _ordinal: Int = 0 }
-    def genericClientError(genericClientError:GenericClientError): GetMenuError = GenericClientErrorCase(genericClientError)
     final case class FallbackError2Case(fallbackError2: FallbackError2) extends GetMenuError { final def _ordinal: Int = 1 }
-    def fallbackError2(fallbackError2:FallbackError2): GetMenuError = FallbackError2Case(fallbackError2)
     final case class FallbackErrorCase(fallbackError: FallbackError) extends GetMenuError { final def _ordinal: Int = 2 }
-    def fallbackError(fallbackError:FallbackError): GetMenuError = FallbackErrorCase(fallbackError)
     final case class NotFoundErrorCase(notFoundError: NotFoundError) extends GetMenuError { final def _ordinal: Int = 3 }
-    def notFoundError(notFoundError:NotFoundError): GetMenuError = NotFoundErrorCase(notFoundError)
 
     object GenericClientErrorCase {
       val hints: Hints = Hints.empty
@@ -330,12 +334,14 @@ object PizzaAdminServiceOperation {
     def _ordinal: Int
   }
   object HealthError extends ShapeTag.Companion[HealthError] {
+
+    def unknownServerError(unknownServerError:UnknownServerError): HealthError = UnknownServerErrorCase(unknownServerError)
+
     val id: ShapeId = ShapeId("smithy4s.example", "HealthError")
 
     val hints: Hints = Hints.empty
 
     final case class UnknownServerErrorCase(unknownServerError: UnknownServerError) extends HealthError { final def _ordinal: Int = 0 }
-    def unknownServerError(unknownServerError:UnknownServerError): HealthError = UnknownServerErrorCase(unknownServerError)
 
     object UnknownServerErrorCase {
       val hints: Hints = Hints.empty
@@ -414,12 +420,14 @@ object PizzaAdminServiceOperation {
     def _ordinal: Int
   }
   object GetEnumError extends ShapeTag.Companion[GetEnumError] {
+
+    def unknownServerError(unknownServerError:UnknownServerError): GetEnumError = UnknownServerErrorCase(unknownServerError)
+
     val id: ShapeId = ShapeId("smithy4s.example", "GetEnumError")
 
     val hints: Hints = Hints.empty
 
     final case class UnknownServerErrorCase(unknownServerError: UnknownServerError) extends GetEnumError { final def _ordinal: Int = 0 }
-    def unknownServerError(unknownServerError:UnknownServerError): GetEnumError = UnknownServerErrorCase(unknownServerError)
 
     object UnknownServerErrorCase {
       val hints: Hints = Hints.empty
@@ -464,12 +472,14 @@ object PizzaAdminServiceOperation {
     def _ordinal: Int
   }
   object GetIntEnumError extends ShapeTag.Companion[GetIntEnumError] {
+
+    def unknownServerError(unknownServerError:UnknownServerError): GetIntEnumError = UnknownServerErrorCase(unknownServerError)
+
     val id: ShapeId = ShapeId("smithy4s.example", "GetIntEnumError")
 
     val hints: Hints = Hints.empty
 
     final case class UnknownServerErrorCase(unknownServerError: UnknownServerError) extends GetIntEnumError { final def _ordinal: Int = 0 }
-    def unknownServerError(unknownServerError:UnknownServerError): GetIntEnumError = UnknownServerErrorCase(unknownServerError)
 
     object UnknownServerErrorCase {
       val hints: Hints = Hints.empty
@@ -514,12 +524,14 @@ object PizzaAdminServiceOperation {
     def _ordinal: Int
   }
   object CustomCodeError extends ShapeTag.Companion[CustomCodeError] {
+
+    def unknownServerError(unknownServerError:UnknownServerError): CustomCodeError = UnknownServerErrorCase(unknownServerError)
+
     val id: ShapeId = ShapeId("smithy4s.example", "CustomCodeError")
 
     val hints: Hints = Hints.empty
 
     final case class UnknownServerErrorCase(unknownServerError: UnknownServerError) extends CustomCodeError { final def _ordinal: Int = 0 }
-    def unknownServerError(unknownServerError:UnknownServerError): CustomCodeError = UnknownServerErrorCase(unknownServerError)
 
     object UnknownServerErrorCase {
       val hints: Hints = Hints.empty

--- a/modules/bootstrapped/src/generated/smithy4s/example/PizzaAdminService.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/PizzaAdminService.scala
@@ -162,7 +162,7 @@ object PizzaAdminServiceOperation {
   }
   sealed trait AddMenuItemError extends scala.Product with scala.Serializable {
     @inline final def widen: AddMenuItemError = this
-    def _ordinal: Int
+    def $ordinal: Int
   }
   object AddMenuItemError extends ShapeTag.Companion[AddMenuItemError] {
 
@@ -174,9 +174,9 @@ object PizzaAdminServiceOperation {
 
     val hints: Hints = Hints.empty
 
-    final case class PriceErrorCase(priceError: PriceError) extends AddMenuItemError { final def _ordinal: Int = 0 }
-    final case class GenericServerErrorCase(genericServerError: GenericServerError) extends AddMenuItemError { final def _ordinal: Int = 1 }
-    final case class GenericClientErrorCase(genericClientError: GenericClientError) extends AddMenuItemError { final def _ordinal: Int = 2 }
+    final case class PriceErrorCase(priceError: PriceError) extends AddMenuItemError { final def $ordinal: Int = 0 }
+    final case class GenericServerErrorCase(genericServerError: GenericServerError) extends AddMenuItemError { final def $ordinal: Int = 1 }
+    final case class GenericClientErrorCase(genericClientError: GenericClientError) extends AddMenuItemError { final def $ordinal: Int = 2 }
 
     object PriceErrorCase {
       val hints: Hints = Hints.empty
@@ -199,7 +199,7 @@ object PizzaAdminServiceOperation {
       GenericServerErrorCase.alt,
       GenericClientErrorCase.alt,
     ){
-      _._ordinal
+      _.$ordinal
     }
   }
   final case class GetMenu(input: GetMenuRequest) extends PizzaAdminServiceOperation[GetMenuRequest, PizzaAdminServiceOperation.GetMenuError, GetMenuResult, Nothing, Nothing] {
@@ -236,7 +236,7 @@ object PizzaAdminServiceOperation {
   }
   sealed trait GetMenuError extends scala.Product with scala.Serializable {
     @inline final def widen: GetMenuError = this
-    def _ordinal: Int
+    def $ordinal: Int
   }
   object GetMenuError extends ShapeTag.Companion[GetMenuError] {
 
@@ -249,10 +249,10 @@ object PizzaAdminServiceOperation {
 
     val hints: Hints = Hints.empty
 
-    final case class GenericClientErrorCase(genericClientError: GenericClientError) extends GetMenuError { final def _ordinal: Int = 0 }
-    final case class FallbackError2Case(fallbackError2: FallbackError2) extends GetMenuError { final def _ordinal: Int = 1 }
-    final case class FallbackErrorCase(fallbackError: FallbackError) extends GetMenuError { final def _ordinal: Int = 2 }
-    final case class NotFoundErrorCase(notFoundError: NotFoundError) extends GetMenuError { final def _ordinal: Int = 3 }
+    final case class GenericClientErrorCase(genericClientError: GenericClientError) extends GetMenuError { final def $ordinal: Int = 0 }
+    final case class FallbackError2Case(fallbackError2: FallbackError2) extends GetMenuError { final def $ordinal: Int = 1 }
+    final case class FallbackErrorCase(fallbackError: FallbackError) extends GetMenuError { final def $ordinal: Int = 2 }
+    final case class NotFoundErrorCase(notFoundError: NotFoundError) extends GetMenuError { final def $ordinal: Int = 3 }
 
     object GenericClientErrorCase {
       val hints: Hints = Hints.empty
@@ -281,7 +281,7 @@ object PizzaAdminServiceOperation {
       FallbackErrorCase.alt,
       NotFoundErrorCase.alt,
     ){
-      _._ordinal
+      _.$ordinal
     }
   }
   final case class Version() extends PizzaAdminServiceOperation[Unit, Nothing, VersionOutput, Nothing, Nothing] {
@@ -331,7 +331,7 @@ object PizzaAdminServiceOperation {
   }
   sealed trait HealthError extends scala.Product with scala.Serializable {
     @inline final def widen: HealthError = this
-    def _ordinal: Int
+    def $ordinal: Int
   }
   object HealthError extends ShapeTag.Companion[HealthError] {
 
@@ -341,7 +341,7 @@ object PizzaAdminServiceOperation {
 
     val hints: Hints = Hints.empty
 
-    final case class UnknownServerErrorCase(unknownServerError: UnknownServerError) extends HealthError { final def _ordinal: Int = 0 }
+    final case class UnknownServerErrorCase(unknownServerError: UnknownServerError) extends HealthError { final def $ordinal: Int = 0 }
 
     object UnknownServerErrorCase {
       val hints: Hints = Hints.empty
@@ -352,7 +352,7 @@ object PizzaAdminServiceOperation {
     implicit val schema: UnionSchema[HealthError] = union(
       UnknownServerErrorCase.alt,
     ){
-      _._ordinal
+      _.$ordinal
     }
   }
   final case class HeaderEndpoint(input: HeaderEndpointData) extends PizzaAdminServiceOperation[HeaderEndpointData, Nothing, HeaderEndpointData, Nothing, Nothing] {
@@ -417,7 +417,7 @@ object PizzaAdminServiceOperation {
   }
   sealed trait GetEnumError extends scala.Product with scala.Serializable {
     @inline final def widen: GetEnumError = this
-    def _ordinal: Int
+    def $ordinal: Int
   }
   object GetEnumError extends ShapeTag.Companion[GetEnumError] {
 
@@ -427,7 +427,7 @@ object PizzaAdminServiceOperation {
 
     val hints: Hints = Hints.empty
 
-    final case class UnknownServerErrorCase(unknownServerError: UnknownServerError) extends GetEnumError { final def _ordinal: Int = 0 }
+    final case class UnknownServerErrorCase(unknownServerError: UnknownServerError) extends GetEnumError { final def $ordinal: Int = 0 }
 
     object UnknownServerErrorCase {
       val hints: Hints = Hints.empty
@@ -438,7 +438,7 @@ object PizzaAdminServiceOperation {
     implicit val schema: UnionSchema[GetEnumError] = union(
       UnknownServerErrorCase.alt,
     ){
-      _._ordinal
+      _.$ordinal
     }
   }
   final case class GetIntEnum(input: GetIntEnumInput) extends PizzaAdminServiceOperation[GetIntEnumInput, PizzaAdminServiceOperation.GetIntEnumError, GetIntEnumOutput, Nothing, Nothing] {
@@ -469,7 +469,7 @@ object PizzaAdminServiceOperation {
   }
   sealed trait GetIntEnumError extends scala.Product with scala.Serializable {
     @inline final def widen: GetIntEnumError = this
-    def _ordinal: Int
+    def $ordinal: Int
   }
   object GetIntEnumError extends ShapeTag.Companion[GetIntEnumError] {
 
@@ -479,7 +479,7 @@ object PizzaAdminServiceOperation {
 
     val hints: Hints = Hints.empty
 
-    final case class UnknownServerErrorCase(unknownServerError: UnknownServerError) extends GetIntEnumError { final def _ordinal: Int = 0 }
+    final case class UnknownServerErrorCase(unknownServerError: UnknownServerError) extends GetIntEnumError { final def $ordinal: Int = 0 }
 
     object UnknownServerErrorCase {
       val hints: Hints = Hints.empty
@@ -490,7 +490,7 @@ object PizzaAdminServiceOperation {
     implicit val schema: UnionSchema[GetIntEnumError] = union(
       UnknownServerErrorCase.alt,
     ){
-      _._ordinal
+      _.$ordinal
     }
   }
   final case class CustomCode(input: CustomCodeInput) extends PizzaAdminServiceOperation[CustomCodeInput, PizzaAdminServiceOperation.CustomCodeError, CustomCodeOutput, Nothing, Nothing] {
@@ -521,7 +521,7 @@ object PizzaAdminServiceOperation {
   }
   sealed trait CustomCodeError extends scala.Product with scala.Serializable {
     @inline final def widen: CustomCodeError = this
-    def _ordinal: Int
+    def $ordinal: Int
   }
   object CustomCodeError extends ShapeTag.Companion[CustomCodeError] {
 
@@ -531,7 +531,7 @@ object PizzaAdminServiceOperation {
 
     val hints: Hints = Hints.empty
 
-    final case class UnknownServerErrorCase(unknownServerError: UnknownServerError) extends CustomCodeError { final def _ordinal: Int = 0 }
+    final case class UnknownServerErrorCase(unknownServerError: UnknownServerError) extends CustomCodeError { final def $ordinal: Int = 0 }
 
     object UnknownServerErrorCase {
       val hints: Hints = Hints.empty
@@ -542,7 +542,7 @@ object PizzaAdminServiceOperation {
     implicit val schema: UnionSchema[CustomCodeError] = union(
       UnknownServerErrorCase.alt,
     ){
-      _._ordinal
+      _.$ordinal
     }
   }
   final case class Reservation(input: ReservationInput) extends PizzaAdminServiceOperation[ReservationInput, Nothing, ReservationOutput, Nothing, Nothing] {

--- a/modules/bootstrapped/src/generated/smithy4s/example/Podcast.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/Podcast.scala
@@ -16,6 +16,10 @@ sealed trait Podcast extends PodcastCommon with scala.Product with scala.Seriali
   def _ordinal: Int
 }
 object Podcast extends ShapeTag.Companion[Podcast] {
+
+  def video(title: Option[String] = None, url: Option[String] = None, durationMillis: Option[Long] = None):Video = Video(title, url, durationMillis)
+  def audio(title: Option[String] = None, url: Option[String] = None, durationMillis: Option[Long] = None):Audio = Audio(title, url, durationMillis)
+
   val id: ShapeId = ShapeId("smithy4s.example", "Podcast")
 
   val hints: Hints = Hints.empty

--- a/modules/bootstrapped/src/generated/smithy4s/example/Podcast.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/Podcast.scala
@@ -13,7 +13,7 @@ import smithy4s.schema.Schema.union
 
 sealed trait Podcast extends PodcastCommon with scala.Product with scala.Serializable {
   @inline final def widen: Podcast = this
-  def _ordinal: Int
+  def $ordinal: Int
 }
 object Podcast extends ShapeTag.Companion[Podcast] {
 
@@ -30,7 +30,7 @@ object Podcast extends ShapeTag.Companion[Podcast] {
   }
 
   final case class Video(title: Option[String] = None, url: Option[String] = None, durationMillis: Option[Long] = None) extends Podcast {
-    def _ordinal: Int = 0
+    def $ordinal: Int = 0
   }
   object Video extends ShapeTag.Companion[Video] {
     val id: ShapeId = ShapeId("smithy4s.example", "Video")
@@ -54,7 +54,7 @@ object Podcast extends ShapeTag.Companion[Podcast] {
     val alt = schema.oneOf[Podcast]("video")
   }
   final case class Audio(title: Option[String] = None, url: Option[String] = None, durationMillis: Option[Long] = None) extends Podcast {
-    def _ordinal: Int = 1
+    def $ordinal: Int = 1
   }
   object Audio extends ShapeTag.Companion[Audio] {
     val id: ShapeId = ShapeId("smithy4s.example", "Audio")
@@ -83,6 +83,6 @@ object Podcast extends ShapeTag.Companion[Podcast] {
     Video.alt,
     Audio.alt,
   ){
-    _._ordinal
+    _.$ordinal
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/TestAdt.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/TestAdt.scala
@@ -18,6 +18,10 @@ sealed trait TestAdt extends AdtMixinOne with AdtMixinTwo with scala.Product wit
   def _ordinal: Int
 }
 object TestAdt extends ShapeTag.Companion[TestAdt] {
+
+  def adtOne(lng: Option[Long] = None, sht: Option[Short] = None, blb: Option[Blob] = None, str: Option[String] = None):AdtOne = AdtOne(lng, sht, blb, str)
+  def adtTwo(lng: Option[Long] = None, sht: Option[Short] = None, int: Option[Int] = None):AdtTwo = AdtTwo(lng, sht, int)
+
   val id: ShapeId = ShapeId("smithy4s.example", "TestAdt")
 
   val hints: Hints = Hints.empty

--- a/modules/bootstrapped/src/generated/smithy4s/example/TestAdt.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/TestAdt.scala
@@ -15,7 +15,7 @@ import smithy4s.schema.Schema.union
 
 sealed trait TestAdt extends AdtMixinOne with AdtMixinTwo with scala.Product with scala.Serializable {
   @inline final def widen: TestAdt = this
-  def _ordinal: Int
+  def $ordinal: Int
 }
 object TestAdt extends ShapeTag.Companion[TestAdt] {
 
@@ -27,7 +27,7 @@ object TestAdt extends ShapeTag.Companion[TestAdt] {
   val hints: Hints = Hints.empty
 
   final case class AdtOne(lng: Option[Long] = None, sht: Option[Short] = None, blb: Option[Blob] = None, str: Option[String] = None) extends TestAdt with AdtMixinThree {
-    def _ordinal: Int = 0
+    def $ordinal: Int = 0
   }
   object AdtOne extends ShapeTag.Companion[AdtOne] {
     val id: ShapeId = ShapeId("smithy4s.example", "AdtOne")
@@ -46,7 +46,7 @@ object TestAdt extends ShapeTag.Companion[TestAdt] {
     val alt = schema.oneOf[TestAdt]("one")
   }
   final case class AdtTwo(lng: Option[Long] = None, sht: Option[Short] = None, int: Option[Int] = None) extends TestAdt {
-    def _ordinal: Int = 1
+    def $ordinal: Int = 1
   }
   object AdtTwo extends ShapeTag.Companion[AdtTwo] {
     val id: ShapeId = ShapeId("smithy4s.example", "AdtTwo")
@@ -69,6 +69,6 @@ object TestAdt extends ShapeTag.Companion[TestAdt] {
     AdtOne.alt,
     AdtTwo.alt,
   ){
-    _._ordinal
+    _.$ordinal
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/TestBiggerUnion.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/TestBiggerUnion.scala
@@ -9,7 +9,7 @@ import smithy4s.schema.Schema.union
 
 sealed trait TestBiggerUnion extends scala.Product with scala.Serializable {
   @inline final def widen: TestBiggerUnion = this
-  def _ordinal: Int
+  def $ordinal: Int
 }
 object TestBiggerUnion extends ShapeTag.Companion[TestBiggerUnion] {
 
@@ -22,8 +22,8 @@ object TestBiggerUnion extends ShapeTag.Companion[TestBiggerUnion] {
     alloy.Discriminated("tpe"),
   )
 
-  final case class OneCase(one: One) extends TestBiggerUnion { final def _ordinal: Int = 0 }
-  final case class TwoCase(two: Two) extends TestBiggerUnion { final def _ordinal: Int = 1 }
+  final case class OneCase(one: One) extends TestBiggerUnion { final def $ordinal: Int = 0 }
+  final case class TwoCase(two: Two) extends TestBiggerUnion { final def $ordinal: Int = 1 }
 
   object OneCase {
     val hints: Hints = Hints.empty
@@ -40,6 +40,6 @@ object TestBiggerUnion extends ShapeTag.Companion[TestBiggerUnion] {
     OneCase.alt,
     TwoCase.alt,
   ){
-    _._ordinal
+    _.$ordinal
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/TestBiggerUnion.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/TestBiggerUnion.scala
@@ -12,6 +12,10 @@ sealed trait TestBiggerUnion extends scala.Product with scala.Serializable {
   def _ordinal: Int
 }
 object TestBiggerUnion extends ShapeTag.Companion[TestBiggerUnion] {
+
+  def one(one:One): TestBiggerUnion = OneCase(one)
+  def two(two:Two): TestBiggerUnion = TwoCase(two)
+
   val id: ShapeId = ShapeId("smithy4s.example", "TestBiggerUnion")
 
   val hints: Hints = Hints(
@@ -19,9 +23,7 @@ object TestBiggerUnion extends ShapeTag.Companion[TestBiggerUnion] {
   )
 
   final case class OneCase(one: One) extends TestBiggerUnion { final def _ordinal: Int = 0 }
-  def one(one:One): TestBiggerUnion = OneCase(one)
   final case class TwoCase(two: Two) extends TestBiggerUnion { final def _ordinal: Int = 1 }
-  def two(two:Two): TestBiggerUnion = TwoCase(two)
 
   object OneCase {
     val hints: Hints = Hints.empty

--- a/modules/bootstrapped/src/generated/smithy4s/example/TestMixinAdt.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/TestMixinAdt.scala
@@ -11,7 +11,7 @@ import smithy4s.schema.Schema.union
 
 sealed trait TestMixinAdt extends scala.Product with scala.Serializable {
   @inline final def widen: TestMixinAdt = this
-  def _ordinal: Int
+  def $ordinal: Int
 }
 object TestMixinAdt extends ShapeTag.Companion[TestMixinAdt] {
 
@@ -22,7 +22,7 @@ object TestMixinAdt extends ShapeTag.Companion[TestMixinAdt] {
   val hints: Hints = Hints.empty
 
   final case class TestAdtMemberWithMixin(a: Option[String] = None, b: Option[Int] = None) extends TestMixinAdt with CommonFieldsOne {
-    def _ordinal: Int = 0
+    def $ordinal: Int = 0
   }
   object TestAdtMemberWithMixin extends ShapeTag.Companion[TestAdtMemberWithMixin] {
     val id: ShapeId = ShapeId("smithy4s.example", "TestAdtMemberWithMixin")
@@ -43,6 +43,6 @@ object TestMixinAdt extends ShapeTag.Companion[TestMixinAdt] {
   implicit val schema: Schema[TestMixinAdt] = union(
     TestAdtMemberWithMixin.alt,
   ){
-    _._ordinal
+    _.$ordinal
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/TestMixinAdt.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/TestMixinAdt.scala
@@ -14,6 +14,9 @@ sealed trait TestMixinAdt extends scala.Product with scala.Serializable {
   def _ordinal: Int
 }
 object TestMixinAdt extends ShapeTag.Companion[TestMixinAdt] {
+
+  def testAdtMemberWithMixin(a: Option[String] = None, b: Option[Int] = None):TestAdtMemberWithMixin = TestAdtMemberWithMixin(a, b)
+
   val id: ShapeId = ShapeId("smithy4s.example", "TestMixinAdt")
 
   val hints: Hints = Hints.empty

--- a/modules/bootstrapped/src/generated/smithy4s/example/UnionWithRefinedTypes.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/UnionWithRefinedTypes.scala
@@ -12,14 +12,16 @@ sealed trait UnionWithRefinedTypes extends scala.Product with scala.Serializable
   def _ordinal: Int
 }
 object UnionWithRefinedTypes extends ShapeTag.Companion[UnionWithRefinedTypes] {
+
+  def age(age:Age): UnionWithRefinedTypes = AgeCase(age)
+  def dogName(dogName:smithy4s.refined.Name): UnionWithRefinedTypes = DogNameCase(dogName)
+
   val id: ShapeId = ShapeId("smithy4s.example", "UnionWithRefinedTypes")
 
   val hints: Hints = Hints.empty
 
   final case class AgeCase(age: Age) extends UnionWithRefinedTypes { final def _ordinal: Int = 0 }
-  def age(age:Age): UnionWithRefinedTypes = AgeCase(age)
   final case class DogNameCase(dogName: smithy4s.refined.Name) extends UnionWithRefinedTypes { final def _ordinal: Int = 1 }
-  def dogName(dogName:smithy4s.refined.Name): UnionWithRefinedTypes = DogNameCase(dogName)
 
   object AgeCase {
     val hints: Hints = Hints.empty

--- a/modules/bootstrapped/src/generated/smithy4s/example/UnionWithRefinedTypes.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/UnionWithRefinedTypes.scala
@@ -9,7 +9,7 @@ import smithy4s.schema.Schema.union
 
 sealed trait UnionWithRefinedTypes extends scala.Product with scala.Serializable {
   @inline final def widen: UnionWithRefinedTypes = this
-  def _ordinal: Int
+  def $ordinal: Int
 }
 object UnionWithRefinedTypes extends ShapeTag.Companion[UnionWithRefinedTypes] {
 
@@ -20,8 +20,8 @@ object UnionWithRefinedTypes extends ShapeTag.Companion[UnionWithRefinedTypes] {
 
   val hints: Hints = Hints.empty
 
-  final case class AgeCase(age: Age) extends UnionWithRefinedTypes { final def _ordinal: Int = 0 }
-  final case class DogNameCase(dogName: smithy4s.refined.Name) extends UnionWithRefinedTypes { final def _ordinal: Int = 1 }
+  final case class AgeCase(age: Age) extends UnionWithRefinedTypes { final def $ordinal: Int = 0 }
+  final case class DogNameCase(dogName: smithy4s.refined.Name) extends UnionWithRefinedTypes { final def $ordinal: Int = 1 }
 
   object AgeCase {
     val hints: Hints = Hints.empty
@@ -38,6 +38,6 @@ object UnionWithRefinedTypes extends ShapeTag.Companion[UnionWithRefinedTypes] {
     AgeCase.alt,
     DogNameCase.alt,
   ){
-    _._ordinal
+    _.$ordinal
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/UntaggedUnion.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/UntaggedUnion.scala
@@ -9,7 +9,7 @@ import smithy4s.schema.Schema.union
 
 sealed trait UntaggedUnion extends scala.Product with scala.Serializable {
   @inline final def widen: UntaggedUnion = this
-  def _ordinal: Int
+  def $ordinal: Int
 }
 object UntaggedUnion extends ShapeTag.Companion[UntaggedUnion] {
 
@@ -22,8 +22,8 @@ object UntaggedUnion extends ShapeTag.Companion[UntaggedUnion] {
     alloy.Untagged(),
   )
 
-  final case class ThreeCase(three: Three) extends UntaggedUnion { final def _ordinal: Int = 0 }
-  final case class FourCase(four: Four) extends UntaggedUnion { final def _ordinal: Int = 1 }
+  final case class ThreeCase(three: Three) extends UntaggedUnion { final def $ordinal: Int = 0 }
+  final case class FourCase(four: Four) extends UntaggedUnion { final def $ordinal: Int = 1 }
 
   object ThreeCase {
     val hints: Hints = Hints.empty
@@ -40,6 +40,6 @@ object UntaggedUnion extends ShapeTag.Companion[UntaggedUnion] {
     ThreeCase.alt,
     FourCase.alt,
   ){
-    _._ordinal
+    _.$ordinal
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/UntaggedUnion.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/UntaggedUnion.scala
@@ -12,6 +12,10 @@ sealed trait UntaggedUnion extends scala.Product with scala.Serializable {
   def _ordinal: Int
 }
 object UntaggedUnion extends ShapeTag.Companion[UntaggedUnion] {
+
+  def three(three:Three): UntaggedUnion = ThreeCase(three)
+  def four(four:Four): UntaggedUnion = FourCase(four)
+
   val id: ShapeId = ShapeId("smithy4s.example", "UntaggedUnion")
 
   val hints: Hints = Hints(
@@ -19,9 +23,7 @@ object UntaggedUnion extends ShapeTag.Companion[UntaggedUnion] {
   )
 
   final case class ThreeCase(three: Three) extends UntaggedUnion { final def _ordinal: Int = 0 }
-  def three(three:Three): UntaggedUnion = ThreeCase(three)
   final case class FourCase(four: Four) extends UntaggedUnion { final def _ordinal: Int = 1 }
-  def four(four:Four): UntaggedUnion = FourCase(four)
 
   object ThreeCase {
     val hints: Hints = Hints.empty

--- a/modules/bootstrapped/src/generated/smithy4s/example/Weather.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/Weather.scala
@@ -139,12 +139,14 @@ object WeatherOperation {
     def _ordinal: Int
   }
   object GetCityError extends ShapeTag.Companion[GetCityError] {
+
+    def noSuchResource(noSuchResource:NoSuchResource): GetCityError = NoSuchResourceCase(noSuchResource)
+
     val id: ShapeId = ShapeId("smithy4s.example", "GetCityError")
 
     val hints: Hints = Hints.empty
 
     final case class NoSuchResourceCase(noSuchResource: NoSuchResource) extends GetCityError { final def _ordinal: Int = 0 }
-    def noSuchResource(noSuchResource:NoSuchResource): GetCityError = NoSuchResourceCase(noSuchResource)
 
     object NoSuchResourceCase {
       val hints: Hints = Hints.empty

--- a/modules/bootstrapped/src/generated/smithy4s/example/Weather.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/Weather.scala
@@ -136,7 +136,7 @@ object WeatherOperation {
   }
   sealed trait GetCityError extends scala.Product with scala.Serializable {
     @inline final def widen: GetCityError = this
-    def _ordinal: Int
+    def $ordinal: Int
   }
   object GetCityError extends ShapeTag.Companion[GetCityError] {
 
@@ -146,7 +146,7 @@ object WeatherOperation {
 
     val hints: Hints = Hints.empty
 
-    final case class NoSuchResourceCase(noSuchResource: NoSuchResource) extends GetCityError { final def _ordinal: Int = 0 }
+    final case class NoSuchResourceCase(noSuchResource: NoSuchResource) extends GetCityError { final def $ordinal: Int = 0 }
 
     object NoSuchResourceCase {
       val hints: Hints = Hints.empty
@@ -157,7 +157,7 @@ object WeatherOperation {
     implicit val schema: UnionSchema[GetCityError] = union(
       NoSuchResourceCase.alt,
     ){
-      _._ordinal
+      _.$ordinal
     }
   }
   final case class GetForecast(input: GetForecastInput) extends WeatherOperation[GetForecastInput, Nothing, GetForecastOutput, Nothing, Nothing] {

--- a/modules/bootstrapped/src/generated/smithy4s/example/guides/auth/HelloWorldAuthService.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/guides/auth/HelloWorldAuthService.scala
@@ -116,12 +116,14 @@ object HelloWorldAuthServiceOperation {
     def _ordinal: Int
   }
   object SayWorldError extends ShapeTag.Companion[SayWorldError] {
+
+    def notAuthorizedError(notAuthorizedError:NotAuthorizedError): SayWorldError = NotAuthorizedErrorCase(notAuthorizedError)
+
     val id: ShapeId = ShapeId("smithy4s.example.guides.auth", "SayWorldError")
 
     val hints: Hints = Hints.empty
 
     final case class NotAuthorizedErrorCase(notAuthorizedError: NotAuthorizedError) extends SayWorldError { final def _ordinal: Int = 0 }
-    def notAuthorizedError(notAuthorizedError:NotAuthorizedError): SayWorldError = NotAuthorizedErrorCase(notAuthorizedError)
 
     object NotAuthorizedErrorCase {
       val hints: Hints = Hints.empty
@@ -168,12 +170,14 @@ object HelloWorldAuthServiceOperation {
     def _ordinal: Int
   }
   object HealthCheckError extends ShapeTag.Companion[HealthCheckError] {
+
+    def notAuthorizedError(notAuthorizedError:NotAuthorizedError): HealthCheckError = NotAuthorizedErrorCase(notAuthorizedError)
+
     val id: ShapeId = ShapeId("smithy4s.example.guides.auth", "HealthCheckError")
 
     val hints: Hints = Hints.empty
 
     final case class NotAuthorizedErrorCase(notAuthorizedError: NotAuthorizedError) extends HealthCheckError { final def _ordinal: Int = 0 }
-    def notAuthorizedError(notAuthorizedError:NotAuthorizedError): HealthCheckError = NotAuthorizedErrorCase(notAuthorizedError)
 
     object NotAuthorizedErrorCase {
       val hints: Hints = Hints.empty

--- a/modules/bootstrapped/src/generated/smithy4s/example/guides/auth/HelloWorldAuthService.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/guides/auth/HelloWorldAuthService.scala
@@ -113,7 +113,7 @@ object HelloWorldAuthServiceOperation {
   }
   sealed trait SayWorldError extends scala.Product with scala.Serializable {
     @inline final def widen: SayWorldError = this
-    def _ordinal: Int
+    def $ordinal: Int
   }
   object SayWorldError extends ShapeTag.Companion[SayWorldError] {
 
@@ -123,7 +123,7 @@ object HelloWorldAuthServiceOperation {
 
     val hints: Hints = Hints.empty
 
-    final case class NotAuthorizedErrorCase(notAuthorizedError: NotAuthorizedError) extends SayWorldError { final def _ordinal: Int = 0 }
+    final case class NotAuthorizedErrorCase(notAuthorizedError: NotAuthorizedError) extends SayWorldError { final def $ordinal: Int = 0 }
 
     object NotAuthorizedErrorCase {
       val hints: Hints = Hints.empty
@@ -134,7 +134,7 @@ object HelloWorldAuthServiceOperation {
     implicit val schema: UnionSchema[SayWorldError] = union(
       NotAuthorizedErrorCase.alt,
     ){
-      _._ordinal
+      _.$ordinal
     }
   }
   final case class HealthCheck() extends HelloWorldAuthServiceOperation[Unit, HelloWorldAuthServiceOperation.HealthCheckError, HealthCheckOutput, Nothing, Nothing] {
@@ -167,7 +167,7 @@ object HelloWorldAuthServiceOperation {
   }
   sealed trait HealthCheckError extends scala.Product with scala.Serializable {
     @inline final def widen: HealthCheckError = this
-    def _ordinal: Int
+    def $ordinal: Int
   }
   object HealthCheckError extends ShapeTag.Companion[HealthCheckError] {
 
@@ -177,7 +177,7 @@ object HelloWorldAuthServiceOperation {
 
     val hints: Hints = Hints.empty
 
-    final case class NotAuthorizedErrorCase(notAuthorizedError: NotAuthorizedError) extends HealthCheckError { final def _ordinal: Int = 0 }
+    final case class NotAuthorizedErrorCase(notAuthorizedError: NotAuthorizedError) extends HealthCheckError { final def $ordinal: Int = 0 }
 
     object NotAuthorizedErrorCase {
       val hints: Hints = Hints.empty
@@ -188,7 +188,7 @@ object HelloWorldAuthServiceOperation {
     implicit val schema: UnionSchema[HealthCheckError] = union(
       NotAuthorizedErrorCase.alt,
     ){
-      _._ordinal
+      _.$ordinal
     }
   }
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/hello/HelloWorldService.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/hello/HelloWorldService.scala
@@ -110,14 +110,16 @@ object HelloWorldServiceOperation {
     def _ordinal: Int
   }
   object HelloError extends ShapeTag.Companion[HelloError] {
+
+    def genericServerError(genericServerError:GenericServerError): HelloError = GenericServerErrorCase(genericServerError)
+    def specificServerError(specificServerError:SpecificServerError): HelloError = SpecificServerErrorCase(specificServerError)
+
     val id: ShapeId = ShapeId("smithy4s.example.hello", "HelloError")
 
     val hints: Hints = Hints.empty
 
     final case class GenericServerErrorCase(genericServerError: GenericServerError) extends HelloError { final def _ordinal: Int = 0 }
-    def genericServerError(genericServerError:GenericServerError): HelloError = GenericServerErrorCase(genericServerError)
     final case class SpecificServerErrorCase(specificServerError: SpecificServerError) extends HelloError { final def _ordinal: Int = 1 }
-    def specificServerError(specificServerError:SpecificServerError): HelloError = SpecificServerErrorCase(specificServerError)
 
     object GenericServerErrorCase {
       val hints: Hints = Hints.empty

--- a/modules/bootstrapped/src/generated/smithy4s/example/hello/HelloWorldService.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/hello/HelloWorldService.scala
@@ -107,7 +107,7 @@ object HelloWorldServiceOperation {
   }
   sealed trait HelloError extends scala.Product with scala.Serializable {
     @inline final def widen: HelloError = this
-    def _ordinal: Int
+    def $ordinal: Int
   }
   object HelloError extends ShapeTag.Companion[HelloError] {
 
@@ -118,8 +118,8 @@ object HelloWorldServiceOperation {
 
     val hints: Hints = Hints.empty
 
-    final case class GenericServerErrorCase(genericServerError: GenericServerError) extends HelloError { final def _ordinal: Int = 0 }
-    final case class SpecificServerErrorCase(specificServerError: SpecificServerError) extends HelloError { final def _ordinal: Int = 1 }
+    final case class GenericServerErrorCase(genericServerError: GenericServerError) extends HelloError { final def $ordinal: Int = 0 }
+    final case class SpecificServerErrorCase(specificServerError: SpecificServerError) extends HelloError { final def $ordinal: Int = 1 }
 
     object GenericServerErrorCase {
       val hints: Hints = Hints.empty
@@ -136,7 +136,7 @@ object HelloWorldServiceOperation {
       GenericServerErrorCase.alt,
       SpecificServerErrorCase.alt,
     ){
-      _._ordinal
+      _.$ordinal
     }
   }
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/imp/ImportService.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/imp/ImportService.scala
@@ -107,7 +107,7 @@ object ImportServiceOperation {
   }
   sealed trait ImportOperationError extends scala.Product with scala.Serializable {
     @inline final def widen: ImportOperationError = this
-    def _ordinal: Int
+    def $ordinal: Int
   }
   object ImportOperationError extends ShapeTag.Companion[ImportOperationError] {
 
@@ -117,7 +117,7 @@ object ImportServiceOperation {
 
     val hints: Hints = Hints.empty
 
-    final case class NotFoundErrorCase(notFoundError: NotFoundError) extends ImportOperationError { final def _ordinal: Int = 0 }
+    final case class NotFoundErrorCase(notFoundError: NotFoundError) extends ImportOperationError { final def $ordinal: Int = 0 }
 
     object NotFoundErrorCase {
       val hints: Hints = Hints.empty
@@ -128,7 +128,7 @@ object ImportServiceOperation {
     implicit val schema: UnionSchema[ImportOperationError] = union(
       NotFoundErrorCase.alt,
     ){
-      _._ordinal
+      _.$ordinal
     }
   }
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/imp/ImportService.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/imp/ImportService.scala
@@ -110,12 +110,14 @@ object ImportServiceOperation {
     def _ordinal: Int
   }
   object ImportOperationError extends ShapeTag.Companion[ImportOperationError] {
+
+    def notFoundError(notFoundError:NotFoundError): ImportOperationError = NotFoundErrorCase(notFoundError)
+
     val id: ShapeId = ShapeId("smithy4s.example.imp", "ImportOperationError")
 
     val hints: Hints = Hints.empty
 
     final case class NotFoundErrorCase(notFoundError: NotFoundError) extends ImportOperationError { final def _ordinal: Int = 0 }
-    def notFoundError(notFoundError:NotFoundError): ImportOperationError = NotFoundErrorCase(notFoundError)
 
     object NotFoundErrorCase {
       val hints: Hints = Hints.empty

--- a/modules/bootstrapped/src/generated/smithy4s/example/test/HelloService.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/test/HelloService.scala
@@ -119,14 +119,16 @@ object HelloServiceOperation {
     def _ordinal: Int
   }
   object SayHelloError extends ShapeTag.Companion[SayHelloError] {
+
+    def simpleError(simpleError:SimpleError): SayHelloError = SimpleErrorCase(simpleError)
+    def complexError(complexError:ComplexError): SayHelloError = ComplexErrorCase(complexError)
+
     val id: ShapeId = ShapeId("smithy4s.example.test", "SayHelloError")
 
     val hints: Hints = Hints.empty
 
     final case class SimpleErrorCase(simpleError: SimpleError) extends SayHelloError { final def _ordinal: Int = 0 }
-    def simpleError(simpleError:SimpleError): SayHelloError = SimpleErrorCase(simpleError)
     final case class ComplexErrorCase(complexError: ComplexError) extends SayHelloError { final def _ordinal: Int = 1 }
-    def complexError(complexError:ComplexError): SayHelloError = ComplexErrorCase(complexError)
 
     object SimpleErrorCase {
       val hints: Hints = Hints.empty

--- a/modules/bootstrapped/src/generated/smithy4s/example/test/HelloService.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/test/HelloService.scala
@@ -116,7 +116,7 @@ object HelloServiceOperation {
   }
   sealed trait SayHelloError extends scala.Product with scala.Serializable {
     @inline final def widen: SayHelloError = this
-    def _ordinal: Int
+    def $ordinal: Int
   }
   object SayHelloError extends ShapeTag.Companion[SayHelloError] {
 
@@ -127,8 +127,8 @@ object HelloServiceOperation {
 
     val hints: Hints = Hints.empty
 
-    final case class SimpleErrorCase(simpleError: SimpleError) extends SayHelloError { final def _ordinal: Int = 0 }
-    final case class ComplexErrorCase(complexError: ComplexError) extends SayHelloError { final def _ordinal: Int = 1 }
+    final case class SimpleErrorCase(simpleError: SimpleError) extends SayHelloError { final def $ordinal: Int = 0 }
+    final case class ComplexErrorCase(complexError: ComplexError) extends SayHelloError { final def $ordinal: Int = 1 }
 
     object SimpleErrorCase {
       val hints: Hints = Hints.empty
@@ -145,7 +145,7 @@ object HelloServiceOperation {
       SimpleErrorCase.alt,
       ComplexErrorCase.alt,
     ){
-      _._ordinal
+      _.$ordinal
     }
   }
   final case class Listen() extends HelloServiceOperation[Unit, Nothing, Unit, Nothing, Nothing] {

--- a/modules/codegen/src/smithy4s/codegen/internals/Renderer.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/Renderer.scala
@@ -983,7 +983,7 @@ private[internals] class Renderer(compilationUnit: CompilationUnit) { self =>
         line"sealed trait ${NameDef(name.name)} extends ${mixinExtendsStatement}scala.Product with scala.Serializable"
       )(
         line"@inline final def widen: $name = this",
-        line"def _ordinal: Int"
+        line"def $$ordinal: Int"
       ),
       obj(name, line"${shapeTag(name)}")(
         newline,
@@ -1001,7 +1001,7 @@ private[internals] class Renderer(compilationUnit: CompilationUnit) { self =>
             lines(
               documentationAnnotation(altHints),
               deprecationAnnotation(altHints),
-              line"case object $cn extends $name { final def _ordinal: Int = $index }",
+              line"case object $cn extends $name { final def $$ordinal: Int = $index }",
               line"""private val ${cn}Alt = $Schema_.constant($cn)${renderConstraintValidation(altHints)}.oneOf[$name]("$realName").addHints(hints)""",
             )
             // format: on
@@ -1013,7 +1013,7 @@ private[internals] class Renderer(compilationUnit: CompilationUnit) { self =>
             lines(
               documentationAnnotation(altHints),
               deprecationAnnotation(altHints),
-              line"final case class $cn(${uncapitalise(altName)}: $tpe) extends $name { final def _ordinal: Int = $index }"
+              line"final case class $cn(${uncapitalise(altName)}: $tpe) extends $name { final def $$ordinal: Int = $index }"
             )
           case (
                 Alt(_, realName, UnionMember.ProductCase(struct), altHints),
@@ -1031,7 +1031,7 @@ private[internals] class Renderer(compilationUnit: CompilationUnit) { self =>
               struct.copy(hints = altHints ++ struct.hints),
               adtParent = Some(name),
               additionalLines,
-              classBody = Lines(line"def _ordinal: Int = $index")
+              classBody = Lines(line"def $$ordinal: Int = $index")
             )
         },
         newline,
@@ -1067,7 +1067,7 @@ private[internals] class Renderer(compilationUnit: CompilationUnit) { self =>
               }
             }
             .block {
-              line"_._ordinal"
+              line"_.$$ordinal"
             }
             .appendToLast(
               if (error) "" else ".withId(id).addHints(hints)"

--- a/modules/codegen/test/src/smithy4s/codegen/internals/RendererConfigSpec.scala
+++ b/modules/codegen/test/src/smithy4s/codegen/internals/RendererConfigSpec.scala
@@ -245,18 +245,18 @@ final class RendererConfigSpec extends munit.FunSuite {
     assertContainsSection(serviceCode, "sealed trait OperationError")(
       """|sealed trait OperationError extends scala.Product with scala.Serializable {
          |  @inline final def widen: OperationError = this
-         |  def _ordinal: Int
+         |  def $ordinal: Int
          |}""".stripMargin
     )
 
     assertContainsSection(serviceCode, "object OperationError")(
       """|object OperationError extends ShapeTag.Companion[OperationError] {
+         |  def badRequest(badRequest:BadRequest): OperationError = BadRequestCase(badRequest)
+         |  def internalServerError(internalServerError:InternalServerError): OperationError = InternalServerErrorCase(internalServerError)
          |  val id: ShapeId = ShapeId("smithy4s.errors", "OperationError")
          |  val hints: Hints = Hints.empty
-         |  final case class BadRequestCase(badRequest: BadRequest) extends OperationError { final def _ordinal: Int = 0 }
-         |  def badRequest(badRequest:BadRequest): OperationError = BadRequestCase(badRequest)
-         |  final case class InternalServerErrorCase(internalServerError: InternalServerError) extends OperationError { final def _ordinal: Int = 1 }
-         |  def internalServerError(internalServerError:InternalServerError): OperationError = InternalServerErrorCase(internalServerError)
+         |  final case class BadRequestCase(badRequest: BadRequest) extends OperationError { final def $ordinal: Int = 0 }
+         |  final case class InternalServerErrorCase(internalServerError: InternalServerError) extends OperationError { final def $ordinal: Int = 1 }
          |  object BadRequestCase {
          |    val hints: Hints = Hints.empty
          |    val schema: Schema[BadRequestCase] = bijection(BadRequest.schema.addHints(hints), BadRequestCase(_), _.badRequest)
@@ -271,7 +271,7 @@ final class RendererConfigSpec extends munit.FunSuite {
          |    BadRequestCase.alt,
          |    InternalServerErrorCase.alt,
          |  ){
-         |    _._ordinal
+         |    _.$ordinal
          |  }
          |}""".stripMargin
     )


### PR DESCRIPTION
* Move smart constructors to the top of the companion object, for improved visibility 
* Rename `_ordinal` (which is allowed in smithy) to `$ordinal` (which is not)