### PR TITLE
Only transform AWS shapes named after standard shapes

### DIFF
--- a/modules/codegen/src/smithy4s/codegen/transformers/AwsStandardTypesTransformer.scala
+++ b/modules/codegen/src/smithy4s/codegen/transformers/AwsStandardTypesTransformer.scala
@@ -84,7 +84,8 @@ class AwsStandardTypesTransformer extends ProjectionTransformer {
   private def canReplace(shape: Shape): Boolean = {
     shape.isInstanceOf[SimpleShape] &&
     isAwsShape(shape) &&
-    onlySupportedTraits(shape.getAllTraits)
+    onlySupportedTraits(shape.getAllTraits) &&
+    hasStandardName(shape)
   }
 
   @annotation.nowarn
@@ -96,11 +97,32 @@ class AwsStandardTypesTransformer extends ProjectionTransformer {
         t.isInstanceOf[DefaultTrait] || t.isInstanceOf[BoxTrait]
       })
 
+  private def hasStandardName(shape: Shape): Boolean =
+    AwsStandardTypesTransformer.standardSimpleShapes.contains(
+      shape.getId().getName()
+    )
+
 }
 
 object AwsStandardTypesTransformer {
 
   val name: String = "AwsStandardTypesTransformer"
+
+  val standardSimpleShapes = Set(
+    "Integer",
+    "Short",
+    "Long",
+    "Float",
+    "Double",
+    "BigInteger",
+    "BigDecimal",
+    "Byte",
+    "Blob",
+    "Boolean",
+    "String",
+    "Document",
+    "Timestamp"
+  )
 
   private[transformers] final implicit class MemberShapeBuilderOps(
       val builder: MemberShape.Builder

--- a/modules/codegen/test/src/smithy4s/codegen/transformers/AwsStandardTypesTransformerSpec.scala
+++ b/modules/codegen/test/src/smithy4s/codegen/transformers/AwsStandardTypesTransformerSpec.scala
@@ -25,12 +25,20 @@ final class AwsStandardTypesTransformerSpec extends munit.FunSuite {
 
   import smithy4s.codegen.internals.TestUtils._
 
-  test("Flattens member shapes targeting AWS new-types") {
+  test(
+    "Flattens member shapes targeting AWS new-types named after standard shapes"
+  ) {
     val kinesisNamespace =
-      """|namespace com.amazonaws.kinesis
+      """|$version: "2"
+         |namespace com.amazonaws.kinesis
          |
+         |// We expect this one to be removed in favour of smithy.api#Integer
          |integer Integer
+         |// This one should be kept because it has a different name
          |timestamp Date
+         |// This one should be kept because it has a trait
+         |@range(min: 1)
+         |long Long
          |""".stripMargin
 
     val testNamespace =
@@ -38,8 +46,10 @@ final class AwsStandardTypesTransformerSpec extends munit.FunSuite {
         |namespace test
         |
         |structure TestStructure {
+        | @required
         | i: com.amazonaws.kinesis#Integer
         | d: com.amazonaws.kinesis#Date
+        | l: com.amazonaws.kinesis#Long,
         |}
         |""".stripMargin
 
@@ -61,24 +71,25 @@ final class AwsStandardTypesTransformerSpec extends munit.FunSuite {
       structureCode,
       """package test
         |
+        |import com.amazonaws.kinesis.Date
+        |import com.amazonaws.kinesis.Long
         |import smithy4s.Hints
         |import smithy4s.Schema
         |import smithy4s.ShapeId
         |import smithy4s.ShapeTag
-        |import smithy4s.Timestamp
         |import smithy4s.schema.Schema.int
         |import smithy4s.schema.Schema.struct
-        |import smithy4s.schema.Schema.timestamp
         |
-        |case class TestStructure(i: Int = 0, d: Option[Timestamp] = None)
+        |case class TestStructure(i: Int, d: Option[Date] = None, l: Option[Long] = None)
         |object TestStructure extends ShapeTag.Companion[TestStructure] {
         |  val id: ShapeId = ShapeId("test", "TestStructure")
         |
         |  val hints: Hints = Hints.empty
         |
         |  implicit val schema: Schema[TestStructure] = struct(
-        |    int.required[TestStructure]("i", _.i).addHints(smithy.api.Default(smithy4s.Document.fromDouble(0.0d))),
-        |    timestamp.optional[TestStructure]("d", _.d),
+        |    int.required[TestStructure]("i", _.i).addHints(smithy.api.Required()),
+        |    Date.schema.optional[TestStructure]("d", _.d),
+        |    Long.schema.optional[TestStructure]("l", _.l),
         |  ){
         |    TestStructure.apply
         |  }.withId(id).addHints(hints)
@@ -234,6 +245,7 @@ final class AwsStandardTypesTransformerSpec extends munit.FunSuite {
       """|namespace com.amazonaws.kinesis
          |
          |timestamp Date
+         |timestamp Timestamp
          |""".stripMargin
 
     val transformer = new AwsStandardTypesTransformer()
@@ -246,8 +258,14 @@ final class AwsStandardTypesTransformerSpec extends munit.FunSuite {
     val transformedModel = transformer.transform(transformerContext)
 
     assert(
-      !transformedModel
+      transformedModel
         .getShape(ShapeId.from("com.amazonaws.kinesis#Date"))
+        .isPresent
+    )
+
+    assert(
+      !transformedModel
+        .getShape(ShapeId.from("com.amazonaws.kinesis#Timestamp"))
         .isPresent
     )
   }


### PR DESCRIPTION
I messed up when reviewing https://github.com/disneystreaming/smithy4s/pull/1110 : the requirements were to only transform shapes that are named after standard simple shapes, such as [this one](https://github.com/aws/aws-sdk-js-v3/blob/main/codegen/sdk-codegen/aws-models/dynamodb.json#L7433-L7438). 

This PR fixes that