### PR TITLE
HEAD response fix (again)

### DIFF
--- a/modules/http4s/src/smithy4s/http4s/internals/SmithyHttp4sServerEndpoint.scala
+++ b/modules/http4s/src/smithy4s/http4s/internals/SmithyHttp4sServerEndpoint.scala
@@ -33,7 +33,6 @@ import smithy4s.schema.Alt
 import smithy4s.kinds._
 import org.http4s.HttpApp
 import org.typelevel.vault.Key
-import org.typelevel.ci.CIString
 
 /**
   * A construct that encapsulates a smithy4s endpoint, and exposes
@@ -107,14 +106,7 @@ private[http4s] class SmithyHttp4sServerEndpointImpl[F[_], Op[_, _, _, _, _], I,
 
   private val headRemoveBody: Response[F] => Response[F] =
     if (endpoint.hints.get[smithy.api.Http].exists(_.method.value === "HEAD"))
-      r =>
-        r.withHeaders(
-          r.headers.headers.filterNot(h =>
-            h.name === CIString("Content-Type") || h.name === CIString(
-              "Content-Length"
-            )
-          )
-        ).withBodyStream(fs2.Stream.empty)
+      r => r.withBodyStream(fs2.Stream.empty)
     else identity
 
   override val httpApp: HttpApp[F] = {

--- a/modules/tests/src/smithy4s/tests/PizzaAdminServiceImpl.scala
+++ b/modules/tests/src/smithy4s/tests/PizzaAdminServiceImpl.scala
@@ -118,6 +118,7 @@ class PizzaAdminServiceImpl(ref: Compat.Ref[IO, State])
       queryParam: Option[String]
   ): IO[Unit] = IO.unit
 
-  def headRequest(): cats.effect.IO[HeadRequestOutput] =
-    IO.pure(HeadRequestOutput("test"))
+  def headRequest(test: Option[String]): cats.effect.IO[HeadRequestOutput] =
+    IO.pure(HeadRequestOutput("test", test))
+
 }

--- a/modules/tests/src/smithy4s/tests/PizzaSpec.scala
+++ b/modules/tests/src/smithy4s/tests/PizzaSpec.scala
@@ -355,7 +355,7 @@ abstract class PizzaSpec
           "Content-Type" -> List("application/json")
         )
         val containsProperHeaders =
-          expectedHeaders.forall(h => headers.get(h._1).isDefined)
+          expectedHeaders.forall(h => headers.get(h._1).contains(h._2))
         expect.same(code, 200) &&
         expect.same(body, "") &&
         expect(

--- a/modules/tests/src/smithy4s/tests/PizzaSpec.scala
+++ b/modules/tests/src/smithy4s/tests/PizzaSpec.scala
@@ -329,7 +329,7 @@ abstract class PizzaSpec
         "Content-Type" -> List("application/json")
       )
       val containsProperHeaders =
-        expectedHeaders.forall(h => headers.get(h._1).isDefined)
+        expectedHeaders.forall(h => headers.get(h._1).contains(h._2))
       expect.same(code, 200) &&
       expect.same(body, "") &&
       expect(

--- a/sampleSpecs/pizza.smithy
+++ b/sampleSpecs/pizza.smithy
@@ -340,11 +340,14 @@ structure EchoBody {
 @http(method: "HEAD", uri: "/head-request")
 @readonly
 operation HeadRequest {
-    output: HeadRequestOutput
-}
-
-structure HeadRequestOutput {
-    @httpHeader("Test")
-    @required
-    test: String
+    input := {
+        @httpQuery("test")
+        test: String
+    }
+    output := {
+        @httpHeader("Test")
+        @required
+        test: String
+        bodyField: String
+    }
 }


### PR DESCRIPTION
I realized that my excluding of the Content-Type and Content-Length headers from HEAD requests was incorrect. From the HTTP Spec, it is supposed to be the case that the headers on a HEAD request are exactly as they would be on the same request with a GET method, the only difference is the body is not actually returned. I also updated the test to be more permissive of having extra headers in place as some HTTP libraries add other headers by default which is fine.

(I will update #1148 to match this behavior) 