### PR TITLE
[0.18] Fix ClassCastException in document encoding

### DIFF
--- a/modules/json/src/smithy4s/json/internals/SchemaVisitorJCodec.scala
+++ b/modules/json/src/smithy4s/json/internals/SchemaVisitorJCodec.scala
@@ -399,13 +399,15 @@ private[smithy4s] class SchemaVisitorJCodec(
             // short-circuiting on empty arrays to avoid the downcast to array of documents
             // which has proven to be dangerous in Scala 3:
             // https://github.com/disneystreaming/smithy4s/issues/1158
-            case x: ArraySeq[_] if x.isEmpty =>
             case x: ArraySeq[_] =>
-              val xs = x.unsafeArray.asInstanceOf[Array[Document]]
-              var i = 0
-              while (i < xs.length) {
-                encodeValue(xs(i), out)
-                i += 1
+              if (x.isEmpty) ()
+              else {
+                val xs = x.unsafeArray.asInstanceOf[Array[Document]]
+                var i = 0
+                while (i < xs.length) {
+                  encodeValue(xs(i), out)
+                  i += 1
+                }
               }
             case xs =>
               xs.foreach(encodeValue(_, out))

--- a/modules/json/src/smithy4s/json/internals/SchemaVisitorJCodec.scala
+++ b/modules/json/src/smithy4s/json/internals/SchemaVisitorJCodec.scala
@@ -396,11 +396,11 @@ private[smithy4s] class SchemaVisitorJCodec(
         case a: DArray =>
           out.writeArrayStart()
           a.value match {
-            case x: ArraySeq[Document] =>
-              val xs = x.unsafeArray.asInstanceOf[Array[Document]]
+            case x: ArraySeq[_] =>
+              val xs = x.unsafeArray
               var i = 0
               while (i < xs.length) {
-                encodeValue(xs(i), out)
+                encodeValue(xs(i).asInstanceOf[Document], out)
                 i += 1
               }
             case xs =>

--- a/modules/json/test/src/smithy4s/json/SchemaVisitorJCodecTests.scala
+++ b/modules/json/test/src/smithy4s/json/SchemaVisitorJCodecTests.scala
@@ -399,6 +399,18 @@ class SchemaVisitorJCodecTests() extends FunSuite {
     expect.same(decoded, doc)
   }
 
+  test("empty document arrays can be encoded (#1158)") {
+    val doc: Document = Document.array()
+    val documentJson = writeToString(doc)
+    val expected =
+      """[]"""
+
+    val decoded = readFromString[Document](documentJson)
+
+    expect.same(documentJson, expected)
+    expect.same(decoded, doc)
+  }
+
   test("Range checks are performed correctly") {
     val json = """{"qty":0}"""
     val result = util.Try(readFromString[RangeCheck](json))


### PR DESCRIPTION
Closes #1158.

As far as I understand, `case x: ArraySeq[Document]` isn't actually doing a class check because of type erasure.

The unsafe array inside turns out to actually be an `Array[Object]`, so casting it to `Array[Document]` throws because arrays aren't erased (unlike `ArraySeq` which is a normal generic class).

I'm sure this solution is a bit inefficient, another one I had in mind would confirm the identity of the wrapped array:

```scala
a.value match {
  case x: ArraySeq[_]
      if x.unsafeArray.getClass == classOf[Array[Document]] =>
    val xs = x.unsafeArray.asInstanceOf[Array[Document]]
    var i = 0
    while (i < xs.length) {
      encodeValue(xs(i), out)
      i += 1
    }
  case xs =>
    xs.foreach(encodeValue(_, out))
}
```

but I'm not sure it's better as I didn't run any benchmarks. @plokhotnyuk any thoughts on this PR?

Note: the fix for the issue should be backported to 0.17.

EDIT: updated the implementation to be closer to the original, just checking for empty arrays instead. Perhaps it's worth a property-based test of roundtripping arbitrary documents just in case.