### PR TITLE
[0.17] Fix ClassCastException in document encoding

### DIFF
--- a/modules/json/src/smithy4s/http/json/SchemaVisitorJCodec.scala
+++ b/modules/json/src/smithy4s/http/json/SchemaVisitorJCodec.scala
@@ -324,12 +324,18 @@ private[smithy4s] class SchemaVisitorJCodec(
         case a: DArray =>
           out.writeArrayStart()
           a.value match {
-            case x: ArraySeq[Document] =>
-              val xs = x.unsafeArray.asInstanceOf[Array[Document]]
-              var i = 0
-              while (i < xs.length) {
-                encodeValue(xs(i), out)
-                i += 1
+            // short-circuiting on empty arrays to avoid the downcast to array of documents
+            // which has proven to be dangerous in Scala 3:
+            // https://github.com/disneystreaming/smithy4s/issues/1158
+            case x: ArraySeq[_] =>
+              if (x.isEmpty) ()
+              else {
+                val xs = x.unsafeArray.asInstanceOf[Array[Document]]
+                var i = 0
+                while (i < xs.length) {
+                  encodeValue(xs(i), out)
+                  i += 1
+                }
               }
             case xs =>
               xs.foreach(encodeValue(_, out))

--- a/modules/json/test/src/smithy4s/http/json/SchemaVisitorJCodecTests.scala
+++ b/modules/json/test/src/smithy4s/http/json/SchemaVisitorJCodecTests.scala
@@ -379,6 +379,18 @@ class SchemaVisitorJCodecTests() extends FunSuite {
     expect.same(decoded, doc)
   }
 
+  test("empty document arrays can be encoded (#1158)") {
+    val doc: Document = Document.array()
+    val documentJson = writeToString(doc)
+    val expected =
+      """[]"""
+
+    val decoded = readFromString[Document](documentJson)
+
+    expect.same(documentJson, expected)
+    expect.same(decoded, doc)
+  }
+
   test("Range checks are performed correctly") {
     val json = """{"qty":0}"""
     val result = util.Try(readFromString[RangeCheck](json))


### PR DESCRIPTION
Backports #1159 to the 0.17 series.
