### PR TITLE
Include fs2 in root aggregation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -57,6 +57,7 @@ lazy val allModules = Seq(
   bootstrapped,
   tests,
   http4s,
+  fs2,
   cats,
   `http4s-kernel`,
   `http4s-swagger`,

--- a/modules/fs2/src/smithy4s/interopfs2/package.scala
+++ b/modules/fs2/src/smithy4s/interopfs2/package.scala
@@ -1,3 +1,19 @@
+/*
+ *  Copyright 2021-2022 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 package smithy4s
 
 import _root_.fs2.Stream

--- a/modules/http4s/test/src/smithy4s/http4s/ServiceBuilderHttp4sSpec.scala
+++ b/modules/http4s/test/src/smithy4s/http4s/ServiceBuilderHttp4sSpec.scala
@@ -1,3 +1,19 @@
+/*
+ *  Copyright 2021-2022 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 package smithy4s.http4s
 
 import cats.effect.IO


### PR DESCRIPTION
Currently, it's not being published with the snapshots which I believe is oversight.