### PR TITLE
Fix for Json Cursor

### DIFF
--- a/modules/json/src/smithy4s/json/internals/Cursor.scala
+++ b/modules/json/src/smithy4s/json/internals/Cursor.scala
@@ -22,7 +22,7 @@ import com.github.plokhotnyuk.jsoniter_scala.core.JsonReader
 import com.github.plokhotnyuk.jsoniter_scala.core.JsonReaderException
 import smithy4s.codecs._
 
-private[internals] class Cursor private () {
+private[internals] class Cursor private[internals] () {
   private[this] var indexStack: Array[Int] = new Array[Int](8)
   private[this] var labelStack: Array[String] = new Array[String](8)
   private[this] var top: Int = _
@@ -65,7 +65,12 @@ private[internals] class Cursor private () {
     top += 1
   }
 
-  def pop(): Unit = top -= 1
+  def pop(): Unit = {
+    if (top > 0) {
+      top -= 1
+    }
+    labelStack(top) = null
+  }
 
   def payloadError[A](codec: JCodec[A], message: String): Nothing =
     throw new PayloadError(getPath(Nil), codec.expecting, message)
@@ -78,7 +83,9 @@ private[internals] class Cursor private () {
     throw new PayloadError(path, expecting, "Missing required field")
   }
 
-  private def getPath(segments: List[PayloadPath.Segment]): PayloadPath = {
+  private[internals] def getPath(
+      segments: List[PayloadPath.Segment]
+  ): PayloadPath = {
     var top = this.top
     var list = segments
     while (top > 0) {

--- a/modules/json/test/src/smithy4s/json/internals/CursorSpec.scala
+++ b/modules/json/test/src/smithy4s/json/internals/CursorSpec.scala
@@ -1,7 +1,6 @@
 package smithy4s.json.internals
 
 import munit._
-import smithy4s.json.internals.Cursor
 import smithy4s.codecs.PayloadPath
 
 final class CursorSpec extends FunSuite {

--- a/modules/json/test/src/smithy4s/json/internals/CursorSpec.scala
+++ b/modules/json/test/src/smithy4s/json/internals/CursorSpec.scala
@@ -6,7 +6,7 @@ import smithy4s.codecs.PayloadPath
 
 final class CursorSpec extends FunSuite {
 
-  test("check") {
+  test("check push / pop accuracy") {
     val c = new Cursor()
     c.push("test")
     c.pop()

--- a/modules/json/test/src/smithy4s/json/internals/CursorSpec.scala
+++ b/modules/json/test/src/smithy4s/json/internals/CursorSpec.scala
@@ -1,0 +1,20 @@
+package smithy4s.json.internals
+
+import munit._
+import smithy4s.json.internals.Cursor
+import smithy4s.codecs.PayloadPath
+
+final class CursorSpec extends FunSuite {
+
+  test("check") {
+    val c = new Cursor()
+    c.push("test")
+    c.pop()
+    c.push(1)
+    assertEquals(
+      c.getPath(List.empty),
+      PayloadPath(List(PayloadPath.Segment(1)))
+    )
+  }
+
+}


### PR DESCRIPTION
Fixes an issue where the cursor would reflect the wrong item being popped off when converting to a PayloadPath. This happened since we the labelStack could have an item still in place at the current `top` index since we were never actually clearing it. I also added a check to make sure we never decrement the top index under zero. This will guard against any possible index out of bounds issues from uneven push/pop calls.