### PR TITLE
Split Writer and Encoder into two different constructs

### DIFF
--- a/modules/aws-http4s/src/smithy4s/aws/internals/AwsEc2QueryCodecs.scala
+++ b/modules/aws-http4s/src/smithy4s/aws/internals/AwsEc2QueryCodecs.scala
@@ -23,7 +23,6 @@ import alloy.UrlFormFlattened
 import smithy.api.XmlName
 import smithy4s._
 import smithy4s.capability.MonadThrowLike
-import smithy4s.codecs.Writer
 import smithy4s.http._
 import smithy4s.kinds.PolyFunction5
 import smithy4s.xml.Xml
@@ -90,7 +89,7 @@ private[aws] object AwsEcsQueryCodecs {
   private[aws] val inputEncoders = {
     UrlForm
       .Encoder(capitalizeStructAndUnionMemberNames = true)
-      .mapK { UrlForm.Encoder.toWriterK.andThen(Writer.addingTo[Any].andThenK(form => Blob(form.render))) }
+      .mapK { smithy4s.codecs.Encoder.andThenK((form: UrlForm) => Blob(form.render)) }
   }
 
   def make[F[_]: MonadThrowLike](

--- a/modules/aws-http4s/src/smithy4s/aws/internals/AwsQueryCodecs.scala
+++ b/modules/aws-http4s/src/smithy4s/aws/internals/AwsQueryCodecs.scala
@@ -24,7 +24,6 @@ import smithy.api.XmlFlattened
 import smithy.api.XmlName
 import smithy4s._
 import smithy4s.capability.MonadThrowLike
-import smithy4s.codecs.Writer
 import smithy4s.http._
 import smithy4s.http.internals.StaticUrlFormElements
 import smithy4s.kinds.PolyFunction5
@@ -39,7 +38,7 @@ private[aws] object AwsQueryCodecs {
   private[aws] val inputEncoders = {
     UrlForm
       .Encoder(capitalizeStructAndUnionMemberNames = false)
-      .mapK { UrlForm.Encoder.toWriterK.andThen(Writer.addingTo[Any].andThenK(form => Blob(form.render))) }
+      .mapK { smithy4s.codecs.Encoder.andThenK((form: UrlForm) => Blob(form.render)) }
   }
 
   // Takes the `@awsQueryError` trait into consideration to decide how to

--- a/modules/aws-http4s/src/smithy4s/aws/internals/AwsRestJsonCodecs.scala
+++ b/modules/aws-http4s/src/smithy4s/aws/internals/AwsRestJsonCodecs.scala
@@ -19,7 +19,6 @@ package internals
 
 import smithy4s.Blob
 import smithy4s.capability.MonadThrowLike
-import smithy4s.codecs.Writer
 import smithy4s.http._
 import smithy4s.json.Json
 
@@ -43,7 +42,7 @@ private[aws] object AwsRestJsonCodecs {
     def nullToEmptyObject(blob: Blob): Blob =
       if (blob.sameBytesAs(Json.NullBlob)) Json.EmptyObjectBlob else blob
 
-    val jsonWriters = jsonPayloadCodecs.writers.mapK { Writer.addingTo[Any].andThenK(nullToEmptyObject) }
+    val jsonWriters = jsonPayloadCodecs.writers.mapK { smithy4s.codecs.Encoder.andThenK(nullToEmptyObject) }
     val jsonDecoders = jsonPayloadCodecs.decoders
 
     HttpUnaryClientCodecs.builder

--- a/modules/bootstrapped/test/src/smithy4s/codecs/StringAndBlobSpec.scala
+++ b/modules/bootstrapped/test/src/smithy4s/codecs/StringAndBlobSpec.scala
@@ -27,12 +27,12 @@ class StringAndBlobSpec() extends munit.FunSuite {
   object DummyDecoderCompiler
       extends CachedSchemaCompiler.Impl[PayloadDecoder] {
     def fromSchema[A](schema: Schema[A], cache: Cache): PayloadDecoder[A] =
-      Decoder.decodeStatic(Left(error): Either[PayloadError, A])
+      Decoder.static(Left(error): Either[PayloadError, A])
   }
 
-  object DummyWriterCompiler extends CachedSchemaCompiler.Impl[PayloadWriter] {
-    def fromSchema[A](schema: Schema[A], cache: Cache): PayloadWriter[A] =
-      Writer.encodeStatic(Blob.empty): Encoder[Blob, A]
+  object DummyWriterCompiler extends CachedSchemaCompiler.Impl[PayloadEncoder] {
+    def fromSchema[A](schema: Schema[A], cache: Cache): PayloadEncoder[A] =
+      Encoder.static(Blob.empty): Encoder[Blob, A]
 
   }
 
@@ -40,8 +40,8 @@ class StringAndBlobSpec() extends munit.FunSuite {
     StringAndBlobCodecs.decoders,
     DummyDecoderCompiler
   )
-  val stringsAndBlobsWriters = CachedSchemaCompiler.getOrElse(
-    StringAndBlobCodecs.writers,
+  val stringsAndBlobsEncoders = CachedSchemaCompiler.getOrElse(
+    StringAndBlobCodecs.encoders,
     DummyWriterCompiler
   )
 
@@ -50,7 +50,7 @@ class StringAndBlobSpec() extends munit.FunSuite {
       data: A,
       expectedEncoded: Blob
   ): Unit = {
-    val writer = stringsAndBlobsWriters.fromSchema(schema)
+    val writer = stringsAndBlobsEncoders.fromSchema(schema)
     val decoder = stringsAndBlobsDecoders.fromSchema(schema)
     val result = writer.encode(data)
     val roundTripped = decoder.decode(result)
@@ -99,7 +99,7 @@ class StringAndBlobSpec() extends munit.FunSuite {
   }
 
   test("Delegates to some other codec when neither strings not bytes") {
-    val writer = stringsAndBlobsWriters.fromSchema(Schema.int)
+    val writer = stringsAndBlobsEncoders.fromSchema(Schema.int)
     val decoder = stringsAndBlobsDecoders.fromSchema(Schema.int)
     val result = writer.encode(1)
     val roundTripped = decoder.decode(result)

--- a/modules/core/src/smithy4s/codecs/Encoder.scala
+++ b/modules/core/src/smithy4s/codecs/Encoder.scala
@@ -1,0 +1,110 @@
+/*
+ *  Copyright 2021-2022 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package smithy4s.codecs
+
+import smithy4s.schema.CachedSchemaCompiler
+import smithy4s.kinds.PolyFunction
+import smithy4s.capability.EncoderK
+
+/**
+  * An abstraction that codifies the notion of transforming a piece of data into some output.
+  */
+trait Encoder[+Out, -A] { self =>
+
+  /**
+    * Symbolises the action of writing some content `A` into an output `Out`.
+    */
+  def encode(a: A): Out
+
+  /**
+    * Contramap the data which this writer works. The writer is a contravariant-functor on `A`.
+    */
+  final def contramap[B](f: B => A): Encoder[Out, B] =
+    new Encoder[Out, B] {
+      def encode(b: B): Out =
+        self.encode(f(b))
+    }
+
+  /**
+    * Transforms the Output type
+    */
+  final def andThen[Out0](
+      f: Out => Out0
+  ): Encoder[Out0, A] =
+    new Encoder[Out0, A] {
+      def encode(a: A): Out0 = f(self.encode(a))
+    }
+
+  /**
+    * Connects this writer's output channel to the data channel of another writer. This is useful
+    * for connecting an encoder into a larger writer.
+    */
+  def pipeToWriter[Message](
+      writer: Writer[Message, Out]
+  ): Writer[Message, A] =
+    new Writer[Message, A] {
+      def write(message: Message, a: A): Message =
+        writer.write(message, self.encode(a))
+    }
+
+}
+
+object Encoder {
+
+  type CachedCompiler[Message] = CachedSchemaCompiler[Encoder[Message, *]]
+
+  /**
+    * Lifts an Output transformation as a higher-kinded function that
+    * operates on encoders.
+    */
+  def andThenK[Out, Out0](
+      f: Out => Out0
+  ): PolyFunction[Encoder[Out, *], Encoder[Out0, *]] =
+    new PolyFunction[Encoder[Out, *], Encoder[Out0, *]] {
+      def apply[A](fa: Encoder[Out, A]): Encoder[Out0, A] =
+        fa.andThen(f)
+    }
+
+  /**
+    * Lifts an piping transformation that connects the result of an encoder
+    * to the message channel of a writer.
+    */
+  def pipeToWriterK[Message, Out](
+      other: Writer[Message, Out]
+  ): PolyFunction[Encoder[Out, *], Writer[Message, *]] =
+    new PolyFunction[Encoder[Out, *], Writer[Message, *]] {
+      def apply[A](writer: Encoder[Out, A]): Writer[Message, A] =
+        writer.pipeToWriter(other)
+    }
+
+  /**
+    * Creates an encoder from a function.
+    */
+  def lift[A, Out](f: A => Out): Encoder[Out, A] = f(_)
+
+  /**
+    * Creates an encoder from a static output.
+    */
+  def static[Out](out: Out): Encoder[Out, Any] = _ => out
+
+  implicit def encoderEncoderK[In, Out]: EncoderK[Encoder[Out, *], Out] =
+    new EncoderK[Encoder[Out, *], Out] {
+      def apply[A](fa: Encoder[Out, A], a: A): Out = fa.encode(a)
+      def absorb[A](f: A => Out): Encoder[Out, A] = f(_)
+    }
+
+}

--- a/modules/core/src/smithy4s/codecs/Writer.scala
+++ b/modules/core/src/smithy4s/codecs/Writer.scala
@@ -17,247 +17,99 @@
 package smithy4s.codecs
 
 import smithy4s.schema._
-import smithy4s.kinds.PolyFunction
 import smithy4s.capability.EncoderK
 
 /**
-  * An abstraction that codifies the notion of writing a piece of data into an output,
-  * provided some contextual information.
+  * An abstraction that codifies the notion of modifying a message with some additional information.
   *
   * This has two input channels:
-  *   * one for contextual information (In)
+  *   * one for the message that is being modified (Message)
   *   * one for the actual data (A)
   *
   * This is particularly useful for http requests/responses, where different subsets of data
   * have a different impact on different locations of the http message : some fields may
   * impact headers, some fields may impact the http body, other things that are driven from
-  * static information (smithy traits) may lead to a transformation of the message. In this situation,
-  * the Input and Output channels are of the same type.
+  * static information (smithy traits) may lead to a transformation of the message.
   *
   * Having the ability to decompose the notion of encoding a piece of data into different
   * writers that can be composed together is powerful and helps centralising some complexity
   * in third-party agnostic code.
   *
-  * @tparam In : some input channel used as context to write data. When set to Any, the implication
-  *   is that the data produces some output on its own
-  * @tparam Out: the output channel in which the data is written.
+  * @tparam Message: some data being modified with the added information contained by A.
   * @tparam A: the type of data that is being written into the output channel
   */
 // scalafmt: {maxColumn = 120}
-trait Writer[-In, +Out, -A] { self =>
+trait Writer[Message, -A] { self =>
 
   /**
     * Symbolises the action of writing some content `A` into an output `Out`, provided some context `In`
     */
-  def write(input: In, a: A): Out
+  def write(message: Message, a: A): Message
 
-  /**
-    * When the data `A` is sufficient to produce the output, anything can be used as a context input.
-    * Therefore, traditional encoders (like Json/Xml) can be modelled as Writers with type `In == Any`
-    *
-    * This method is a short-hand for encoding the data without the caller forced to pass a dummy input.
-    */
-  def encode[In0 <: In](a: A)(implicit ev: Any =:= In0): Out =
-    write(ev.apply(()), a)
+  def combine[A0 <: A](other: Writer[Message, A0]): Writer[Message, A0] = new Writer[Message, A0] {
+    def write(message: Message, a: A0): Message = other.write(self.write(message, a), a)
+  }
+
+  def compose(f: Message => Message): Writer[Message, A] = (m, a) => self.write(f(m), a)
+
+  def andThen(f: Message => Message): Writer[Message, A] = (m, a) => f(self.write(m, a))
 
   /**
     * Contramap the data which this writer works. The writer is a contravariant-functor on `A`.
     */
-  final def contramap[B](f: B => A): Writer[In, Out, B] =
-    new Writer[In, Out, B] {
-      def write(message: In, b: B): Out =
-        self.write(message: In, f(b))
-    }
-
-  /**
-    * Transforms the Output type
-    */
-  final def andThen[Out0](
-      f: Out => Out0
-  ): Writer[In, Out0, A] =
-    new Writer[In, Out0, A] {
-      def write(message: In, a: A): Out0 = f(self.write(message, a))
-    }
-
-  /**
-    * Transforms the context Input type
-    */
-  final def compose[In0](
-      f: In0 => In
-  ): Writer[In0, Out, A] =
-    new Writer[In0, Out, A] {
-      def write(message: In0, a: A): Out = self.write(f(message), a)
+  final def contramap[B](f: B => A): Writer[Message, B] =
+    new Writer[Message, B] {
+      def write(message: Message, b: B): Message =
+        self.write(message, f(b))
     }
 
   /**
    * Transforms a writer into an Encoder by supplying an initial value.
    */
-  final def toEncoder(in: In): Writer[Any, Out, A] = compose(_ => in)
-
-  /**
-    * Connects this writer's output channel to the contextual input channel of another writer.
-    */
-  def pipe[Out0, A0 <: A](other: Writer[Out, Out0, A0]): Writer[In, Out0, A0] =
-    new Writer[In, Out0, A0] {
-      def write(message: In, a: A0): Out0 =
-        other.write(self.write(message, a), a)
-    }
-
-  /**
-    * Connects this writer's output channel to the data channel of another writer. This is useful
-    * for connecting an encoder into a larger writer.
-    */
-  def pipeData[Message <: In, Out0 >: Out](other: Writer[Message, Message, Out]): Writer[Message, Message, A] =
-    new Writer[Message, Message, A] {
-      def write(message: Message, a: A): Message = other.write(message, self.write(message, a))
-    }
+  final def toEncoder(initial: Message): Encoder[Message, A] = new Encoder[Message, A] {
+    def encode(a: A): Message = self.write(initial, a)
+  }
 
 }
 
 object Writer {
 
   def combineCompilers[Message](
-      left: CachedSchemaCompiler[Writer[Message, Message, *]],
-      right: CachedSchemaCompiler[Writer[Message, Message, *]]
-  ): CachedSchemaCompiler[Writer[Message, Message, *]] = new CachedSchemaCompiler[Writer[Message, Message, *]] {
+      left: CachedSchemaCompiler[Writer[Message, *]],
+      right: CachedSchemaCompiler[Writer[Message, *]]
+  ): CachedSchemaCompiler[Writer[Message, *]] = new CachedSchemaCompiler[Writer[Message, *]] {
 
     type Cache = (left.Cache, right.Cache)
     def createCache(): Cache = (left.createCache(), right.createCache())
-    def fromSchema[A](schema: Schema[A]): Writer[Message, Message, A] =
+    def fromSchema[A](schema: Schema[A]): Writer[Message, A] =
       fromSchema(schema, createCache())
-    def fromSchema[A](schema: Schema[A], cache: Cache): Writer[Message, Message, A] = {
-      val first: Writer[Message, Message, A] = left.fromSchema(schema, cache._1)
-      val second: Writer[Message, Message, A] = right.fromSchema(schema, cache._2)
-      first.pipe(second)
+    def fromSchema[A](schema: Schema[A], cache: Cache): Writer[Message, A] = {
+      val first: Writer[Message, A] = left.fromSchema(schema, cache._1)
+      val second: Writer[Message, A] = right.fromSchema(schema, cache._2)
+      first.combine(second)
     }
 
   }
 
-  type CachedCompiler[In, Out] = CachedSchemaCompiler[Writer[In, Out, *]]
-
-  def addingTo[In]: PartiallyAppliedWriterBuilder[In] = new PartiallyAppliedWriterBuilder()
-
-  class PartiallyAppliedWriterBuilder[In](val dummy: Boolean = true) extends AnyVal {
-
-    /**
-    * Lifts an Output transformation as a higher-kinded function that
-    * operates on writers.
-    */
-    def andThenK[Out, Out0](
-        f: Out => Out0
-    ): PolyFunction[Writer[In, Out, *], Writer[In, Out0, *]] =
-      new PolyFunction[Writer[In, Out, *], Writer[In, Out0, *]] {
-        def apply[A](fa: Writer[In, Out, A]): Writer[In, Out0, A] =
-          fa.andThen(f)
-      }
-
-    /**
-    * Lifts an Output transformation as a higher-kinded function that
-    * operates on writers.
-    */
-    def andThenK_(f: In => In): PolyFunction[Writer[In, In, *], Writer[In, In, *]] =
-      andThenK(f)
-
-    /**
-    * Lifts an piping transformation that connects the output channel of a writer
-    * to the data channel of another writer.
-    */
-    def pipeDataK[Out](
-        other: Writer[In, In, Out]
-    ): PolyFunction[Writer[In, Out, *], Writer[In, In, *]] =
-      new PolyFunction[Writer[In, Out, *], Writer[In, In, *]] {
-        def apply[A](writer: Writer[In, Out, A]): Writer[In, In, A] =
-          writer.pipeData(other)
-      }
-  }
+  type CachedCompiler[Message] = CachedSchemaCompiler[Writer[Message, *]]
 
   /**
     * Creates an writer from a function.
     */
-  def lift[In, Message, A](f: (In, A) => Message): Writer[In, Message, A] = { (in, a) => f(in, a) }
-
-  /**
-    * Creates an encoder (a writer that takes any input) from a function.
-    */
-  def encodeBy[A, Message](f: A => Message): Encoder[Message, A] = { (_, a) => f(a) }
-
-  /**
-    * Creates an encoder (a writer that takes any input) from a static output.
-    */
-  def encodeStatic[Message](message: Message): Encoder[Message, Any] =
-    new Encoder[Message, Any] {
-      def write(in: Any, a: Any): Message = message
-    }
+  def lift[Message, A](f: (Message, A) => Message): Writer[Message, A] = f(_, _)
 
   /**
     * Creates a writer that returns its input as its output, without taking
     * the data into consideration
     */
-  def noop[Message]: Writer[Message, Message, Any] =
-    new Writer[Message, Message, Any] {
-      def write(message: Message, a: Any): Message = message
-    }
-
-  /**
-    * Lifts an Output transformation as a higher-kinded function that
-    * operates on writers.
-    */
-  def andThenK[In, Out, Out0](
-      f: Out => Out0
-  ): PolyFunction[Writer[In, Out, *], Writer[In, Out0, *]] =
-    new PolyFunction[Writer[In, Out, *], Writer[In, Out0, *]] {
-      def apply[A](fa: Writer[In, Out, A]): Writer[In, Out0, A] =
-        fa.andThen(f)
-    }
-
-  /**
-    * Lifts an Output transformation as a higher-kinded function that
-    * operates on writers.
-    */
-  def andThenK_[Message](
-      f: Message => Message
-  ): PolyFunction[Writer[Message, Message, *], Writer[Message, Message, *]] =
-    andThenK(f)
-
-  /**
-    * Lifts an Input transformation as a higher-kinded function that
-    * operates on writers.
-    */
-  def composeK[In0, In, Out](
-      f: In0 => In
-  ): PolyFunction[Writer[In, Out, *], Writer[In0, Out, *]] =
-    new PolyFunction[Writer[In, Out, *], Writer[In0, Out, *]] {
-      def apply[A](fa: Writer[In, Out, A]): Writer[In0, Out, A] =
-        fa.compose(f)
-    }
-
-  /**
-    * Lifts an Input transformation as a higher-kinded function that
-    * operates on writers, when the Input and Output are of the same type.
-    */
-  def composeK_[Message](
-      f: Message => Message
-  ): PolyFunction[Writer[Message, Message, *], Writer[Message, Message, *]] =
-    composeK(f)
-
-  /**
-    * Lifts an piping transformation that connects the output channel of a writer
-    * to the data channel of another writer.
-    */
-  def pipeDataK[Message, Out](
-      other: Writer[Message, Message, Out]
-  ): PolyFunction[Writer[Message, Out, *], Writer[Message, Message, *]] =
-    new PolyFunction[Writer[Message, Out, *], Writer[Message, Message, *]] {
-      def apply[A](writer: Writer[Message, Out, A]): Writer[Message, Message, A] =
-        writer.pipeData(other)
-    }
+  def noop[Message]: Writer[Message, Any] = (message, _) => message
 
   // format: off
-  implicit def writerEncoderK[In, Out]: EncoderK[Writer[In, Out, *], In => Out] =
-    new EncoderK[Writer[In, Out, *], In => Out] {
-      def apply[A](fa: Writer[In, Out, A], a: A): In => Out = fa.write(_, a)
-      def absorb[A](f: A => (In => Out)): Writer[In, Out, A] = new Writer[In, Out, A] {
-        def write(message: In, a: A): Out = f(a)(message)
+  implicit def writerEncoderK[Message]: EncoderK[Writer[Message, *], Message => Message] =
+    new EncoderK[Writer[Message, *], Message => Message] {
+      def apply[A](fa: Writer[Message, A], a: A): Message => Message = fa.write(_, a)
+      def absorb[A](f: A => (Message => Message)): Writer[Message, A] = new Writer[Message, A]{
+        def write(message: Message, a: A): Message = f(a)(message)
       }
     }
   // format: on

--- a/modules/core/src/smithy4s/codecs/package.scala
+++ b/modules/core/src/smithy4s/codecs/package.scala
@@ -20,13 +20,11 @@ import smithy4s.schema.CachedSchemaCompiler
 
 package object codecs {
 
-  type Encoder[Out, A] = Writer[Any, Out, A]
-
   type BlobEncoder[A] = Encoder[Blob, A]
   object BlobEncoder {
     type Compiler = CachedSchemaCompiler[BlobEncoder]
     val noop: Compiler = new CachedSchemaCompiler.Uncached[BlobEncoder] {
-      def fromSchema[A](schema: Schema[A]) = Writer.encodeBy(_ => Blob.empty)
+      def fromSchema[A](schema: Schema[A]) = Encoder.static(Blob.empty)
     }
   }
 
@@ -45,9 +43,9 @@ package object codecs {
     type CachedCompiler = CachedSchemaCompiler[PayloadDecoder]
   }
 
-  type PayloadWriter[A] = Writer[Any, Blob, A]
-  object PayloadWriter {
-    type CachedCompiler = CachedSchemaCompiler[PayloadWriter]
+  type PayloadEncoder[A] = Encoder[Blob, A]
+  object PayloadEncoder {
+    type CachedCompiler = CachedSchemaCompiler[PayloadEncoder]
   }
 
 }

--- a/modules/core/src/smithy4s/http/HttpUnaryClientCodecs.scala
+++ b/modules/core/src/smithy4s/http/HttpUnaryClientCodecs.scala
@@ -19,7 +19,8 @@ package http
 
 import smithy4s.client.UnaryClientCodecs
 import smithy4s.codecs.{BlobEncoder, BlobDecoder}
-import smithy4s.codecs.{Decoder, Writer}
+import smithy4s.codecs.{Decoder}
+import smithy4s.codecs.Writer
 import smithy4s.codecs.PayloadError
 import smithy4s.schema.CachedSchemaCompiler
 import smithy4s.schema.OperationSchema
@@ -108,21 +109,20 @@ object HttpUnaryClientCodecs {
       copy(responseTransformation = f.andThen(F.flatMap(_)(responseTransformation)))
 
     def build(): UnaryClientCodecs.Make[F, Request, Response] = {
-      val setBody: HttpRequest.Encoder[Blob, Blob] = Writer.lift((req, blob) => req.copy(body = blob))
-      val setBodyK = Writer
-        .pipeDataK[HttpRequest[Blob], Blob](setBody)
+      val setBody: HttpRequest.Writer[Blob, Blob] = Writer.lift((req, blob) => req.copy(body = blob))
+      val setBodyK = smithy4s.codecs.Encoder.pipeToWriterK[HttpRequest[Blob], Blob](setBody)
 
-      val mediaTypeWriters = new CachedSchemaCompiler.Uncached[HttpRequest.Encoder[Blob, *]] {
-        def fromSchema[A](schema: Schema[A]): HttpRequest.Encoder[Blob, A] = {
+      val mediaTypeWriters = new CachedSchemaCompiler.Uncached[HttpRequest.Writer[Blob, *]] {
+        def fromSchema[A](schema: Schema[A]): HttpRequest.Writer[Blob, A] = {
           val maybeRawMediaType = HttpMediaType.fromSchema(schema).map(_.value)
           maybeRawMediaType match {
             case Some(mt) =>
-              new HttpRequest.Encoder[Blob, A] {
+              new HttpRequest.Writer[Blob, A] {
                 def write(request: HttpRequest[Blob], value: A): HttpRequest[Blob] =
                   request.withContentType(mt)
               }
             case None =>
-              new HttpRequest.Encoder[Blob, A] {
+              new HttpRequest.Writer[Blob, A] {
                 def write(request: HttpRequest[Blob], value: A): HttpRequest[Blob] =
                   if (request.body.isEmpty) request
                   else request.withContentType(requestMediaType)
@@ -131,13 +131,13 @@ object HttpUnaryClientCodecs {
         }
       }
 
-      val httpBodyWriters: CachedSchemaCompiler[HttpRequest.Encoder[Blob, *]] = if (rawStringsAndBlobPayloads) {
+      val httpBodyWriters: CachedSchemaCompiler[HttpRequest.Writer[Blob, *]] = if (rawStringsAndBlobPayloads) {
         val finalBodyEncoders = CachedSchemaCompiler
-          .getOrElse(smithy4s.codecs.StringAndBlobCodecs.writers, requestBodyEncoders)
+          .getOrElse(smithy4s.codecs.StringAndBlobCodecs.encoders, requestBodyEncoders)
         finalBodyEncoders.mapK(setBodyK)
       } else requestBodyEncoders.mapK(setBodyK)
 
-      val httpMediaWriter: CachedSchemaCompiler[HttpRequest.Encoder[Blob, *]] =
+      val httpMediaWriter: CachedSchemaCompiler[HttpRequest.Writer[Blob, *]] =
         Writer.combineCompilers(httpBodyWriters, mediaTypeWriters)
 
       def responseDecoders(blobDecoders: BlobDecoder.Compiler) = {
@@ -164,7 +164,7 @@ object HttpUnaryClientCodecs {
 
       val inputEncoders = metadataEncoders match {
         case Some(mEncoders) =>
-          HttpRequest.Encoder.restSchemaCompiler(mEncoders, httpMediaWriter, writeEmptyStructs)
+          HttpRequest.Writer.restSchemaCompiler(mEncoders, httpMediaWriter, writeEmptyStructs)
         case None => httpMediaWriter
       }
       val outputDecoders = responseDecoders(successResponseBodyDecoders)
@@ -180,14 +180,14 @@ object HttpUnaryClientCodecs {
         ): UnaryClientCodecs[F, Request, Response, I, E, O] = {
           val endpoint = operationPreprocessor(originalEndpoint)
 
-          val inputWriter: HttpRequest.Encoder[Blob, I] =
+          val inputWriter: HttpRequest.Writer[Blob, I] =
             HttpEndpoint.cast(endpoint).toOption match {
               case Some(httpEndpoint) => {
                 val httpInputEncoder =
-                  HttpRequest.Encoder.fromHttpEndpoint[Blob, I](httpEndpoint)
+                  HttpRequest.Writer.fromHttpEndpoint[Blob, I](httpEndpoint)
                 val requestEncoder =
                   inputEncoders.fromSchema(endpoint.input, inputEncoderCache)
-                httpInputEncoder.pipe(requestEncoder)
+                httpInputEncoder.combine(requestEncoder)
               }
               case None => inputEncoders.fromSchema(endpoint.input, inputEncoderCache)
             }

--- a/modules/core/src/smithy4s/http/UrlForm.scala
+++ b/modules/core/src/smithy4s/http/UrlForm.scala
@@ -26,7 +26,6 @@ import smithy4s.http.internals.UrlFormDataEncoder
 import smithy4s.http.internals.UrlFormDataEncoderSchemaVisitor
 import smithy4s.schema.CachedSchemaCompiler
 import smithy4s.schema.Schema
-import smithy4s.codecs._
 
 import java.io.UnsupportedEncodingException
 import java.net.URLDecoder
@@ -35,7 +34,6 @@ import java.nio.CharBuffer
 import java.nio.charset.StandardCharsets
 import scala.collection.immutable.BitSet
 import scala.collection.mutable
-import smithy4s.kinds.PolyFunction
 
 private[smithy4s] final case class UrlForm(values: List[UrlForm.FormData]) {
 
@@ -187,9 +185,7 @@ private[smithy4s] object UrlForm {
       }
   }
 
-  trait Encoder[A] {
-    def encode(a: A): UrlForm
-  }
+  type Encoder[A] = smithy4s.codecs.Encoder[UrlForm, A]
 
   object Encoder {
     def apply(
@@ -222,10 +218,5 @@ private[smithy4s] object UrlForm {
         }
       }
 
-    val toWriterK: PolyFunction[Encoder, Writer[Any, UrlForm, *]] =
-      new PolyFunction[Encoder, Writer[Any, UrlForm, *]] {
-        def apply[A](fa: Encoder[A]): Writer[Any, UrlForm, A] =
-          Writer.encodeBy(fa.encode(_))
-      }
   }
 }

--- a/modules/decline/src/core/Printer.scala
+++ b/modules/decline/src/core/Printer.scala
@@ -20,7 +20,7 @@ import cats.Applicative
 import cats.effect.std.Console
 import cats.implicits._
 import smithy4s.Endpoint
-import smithy4s.codecs.PayloadWriter
+import smithy4s.codecs.PayloadEncoder
 
 trait Printer[F[_], -I, -O] {
   def printInput(input: I): F[Unit]
@@ -32,7 +32,7 @@ object Printer {
 
   def fromCodecs[F[_]: Console: Applicative, Op[_, _, _, _, _], I, O](
       endpoint: Endpoint[Op, I, _, O, _, _],
-      writers: PayloadWriter.CachedCompiler
+      writers: PayloadEncoder.CachedCompiler
   ): Printer[F, I, O] =
     new Printer[F, I, O] {
       private val outCodec = writers.fromSchema(endpoint.output)

--- a/modules/decline/src/util/PrinterApi.scala
+++ b/modules/decline/src/util/PrinterApi.scala
@@ -62,7 +62,7 @@ object PrinterApi {
   )
 
   def useCodec[F[_]: Console: Applicative](
-      codec: PayloadWriter.CachedCompiler
+      codec: PayloadEncoder.CachedCompiler
   ): PrinterApi[F] =
     new PrinterApi[F] {
 

--- a/modules/fs2/src/smithy4s/interopfs2/package.scala
+++ b/modules/fs2/src/smithy4s/interopfs2/package.scala
@@ -22,7 +22,7 @@ import fs2.Stream
 package object interopfs2 {
 
   type ByteStreamEncoder[F[_], A] =
-    smithy4s.codecs.Writer[Any, Stream[F, Byte], A]
+    smithy4s.codecs.Encoder[Stream[F, Byte], A]
   type ByteStreamDecoder[F[_], A] =
     smithy4s.codecs.Decoder[F, Stream[F, Byte], A]
 

--- a/modules/json/src/smithy4s/json/Json.scala
+++ b/modules/json/src/smithy4s/json/Json.scala
@@ -22,7 +22,7 @@ import smithy4s.codecs.PayloadError
 import smithy4s.schema.Schema
 import com.github.plokhotnyuk.jsoniter_scala.core._
 import smithy4s.schema.CachedSchemaCompiler
-import smithy4s.codecs.PayloadWriter
+import smithy4s.codecs.PayloadEncoder
 import smithy4s.codecs.PayloadDecoder
 
 object Json {
@@ -51,8 +51,8 @@ object Json {
     * When writing interpreters, please prefer using the [[payloadCodecs]] object.
     */
   def writeBlob[A: Schema](a: A): Blob = {
-    payloadWriters
-      .fromSchema(Schema[A], payloadWritersGlobalCache)
+    payloadEncoders
+      .fromSchema(Schema[A], payloadEncodersGlobalCache)
       .encode(a)
   }
 
@@ -128,22 +128,22 @@ object Json {
   val payloadCodecs: JsonPayloadCodecCompiler =
     internals.JsonPayloadCodecCompilerImpl.defaultJsonPayloadCodecCompiler
 
-  private[smithy4s] val payloadWriters: CachedSchemaCompiler[PayloadWriter] =
+  private[smithy4s] val payloadEncoders: CachedSchemaCompiler[PayloadEncoder] =
     payloadCodecs.writers
 
   private[smithy4s] val payloadDecoders: CachedSchemaCompiler[PayloadDecoder] =
     payloadCodecs.decoders
 
-  private val payloadWritersGlobalCache = payloadWriters.createCache()
+  private val payloadEncodersGlobalCache = payloadEncoders.createCache()
   private val payloadDecodersGlobalCache = payloadDecoders.createCache()
 
-  private val documentWriter: PayloadWriter[Document] =
-    payloadWriters.fromSchema(Schema.document)
+  private val documentWriter: PayloadEncoder[Document] =
+    payloadEncoders.fromSchema(Schema.document)
 
   private val documentDecoder: PayloadDecoder[Document] =
     payloadDecoders.fromSchema(Schema.document)
 
-  private val prettyDocumentWriters: PayloadWriter[Document] = {
+  private val prettyDocumentWriters: PayloadEncoder[Document] = {
     import com.github.plokhotnyuk.jsoniter_scala.core.WriterConfig
     payloadCodecs
       .withJsoniterWriterConfig(WriterConfig.withIndentionStep(2))

--- a/modules/json/src/smithy4s/json/JsonPayloadCodecCompiler.scala
+++ b/modules/json/src/smithy4s/json/JsonPayloadCodecCompiler.scala
@@ -22,7 +22,7 @@ import smithy4s.schema.CachedSchemaCompiler
 import com.github.plokhotnyuk.jsoniter_scala.core.{ReaderConfig => JsoniterReaderConfig}
 import com.github.plokhotnyuk.jsoniter_scala.core.{WriterConfig => JsoniterWriterConfig}
 import smithy4s.codecs.PayloadDecoder
-import smithy4s.codecs.PayloadWriter
+import smithy4s.codecs.PayloadEncoder
 
 trait JsonPayloadCodecCompiler {
 
@@ -46,6 +46,6 @@ trait JsonPayloadCodecCompiler {
   def withJsoniterWriterConfig(jsoniterWriterConfig: JsoniterWriterConfig): JsonPayloadCodecCompiler
 
   def decoders: CachedSchemaCompiler[PayloadDecoder]
-  def writers: CachedSchemaCompiler[PayloadWriter]
+  def writers: CachedSchemaCompiler[PayloadEncoder]
 
 }

--- a/modules/json/src/smithy4s/json/internals/JsonPayloadCodecCompilerImpl.scala
+++ b/modules/json/src/smithy4s/json/internals/JsonPayloadCodecCompilerImpl.scala
@@ -48,20 +48,19 @@ private[json] case class JsonPayloadCodecCompilerImpl(
   ): JsonPayloadCodecCompiler =
     copy(jsoniterWriterConfig = jsoniterWriterConfig)
 
-  def writers: CachedSchemaCompiler[PayloadWriter] =
-    new CachedSchemaCompiler[PayloadWriter] {
+  def writers: CachedSchemaCompiler[PayloadEncoder] =
+    new CachedSchemaCompiler[PayloadEncoder] {
       type Cache = jsoniterCodecCompiler.Cache
       def createCache(): Cache = jsoniterCodecCompiler.createCache()
 
-      def fromSchema[A](schema: Schema[A], cache: Cache): PayloadWriter[A] = {
+      def fromSchema[A](schema: Schema[A], cache: Cache): PayloadEncoder[A] = {
         val jcodec = jsoniterCodecCompiler.fromSchema(schema, cache)
-        Writer.encodeBy { (value: A) =>
+        (value: A) =>
           Blob(
             writeToArray(value, jsoniterWriterConfig)(jcodec)
           )
-        }
       }
-      def fromSchema[A](schema: Schema[A]): PayloadWriter[A] =
+      def fromSchema[A](schema: Schema[A]): PayloadEncoder[A] =
         fromSchema(schema, createCache())
     }
 

--- a/modules/xml/src/smithy4s/xml/Xml.scala
+++ b/modules/xml/src/smithy4s/xml/Xml.scala
@@ -83,8 +83,8 @@ object Xml {
     def createCache(): Cache = XmlDocument.Encoder.createCache()
     def fromSchema[A](schema: Schema[A], cache: Cache): BlobEncoder[A] = {
       val xmlDocumentEncoder = XmlDocument.Encoder.fromSchema(schema, cache)
-      new BlobEncoder[A] {
-        def write(input: Any, a: A): smithy4s.Blob = Blob {
+      (a: A) =>
+        Blob {
           XmlDocument.documentEventifier
             .eventify(xmlDocumentEncoder.encode(a))
             .through(render(collapseEmpty = false))
@@ -92,7 +92,6 @@ object Xml {
             .compile
             .to(Collector.supportsArray(Array))
         }
-      }
     }
     def fromSchema[A](schema: Schema[A]): BlobEncoder[A] =
       fromSchema(schema, createCache())


### PR DESCRIPTION
The benefits are :
* more concrete, easier to digest constructs
* less higher-kinded transformations
* more consistent names across the codebase