### PR TITLE
Facilitate the loading of AWS specifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,10 +34,12 @@ As a result, the **smithy4s-json** module has been rewritten. In particular, the
 
 ### AWS SDK support.
 
-Smithy4s' coverage of the AWS protocols has increased drastically. Now, the vast majority of services and operations are supported. This does mean that Smithy4s can effectively be used as a cross-platform AWS SDK, delegating to `http4s` for transport.
+Smithy4s' coverage of the AWS protocols has increased drastically. Now, the vast majority of services and operations are supported. This does mean that Smithy4s can effectively be used as a cross-platform AWS SDK (with caveats), delegating to `http4s` for transport.
 
+The Smithy4s build plugins now also come with utilities to facilitate the code-generation from AWS service specifications.
 
-This however comes with a caveat, please refer yourself to the relevant [documentation page](https://disneystreaming.github.io/smithy4s/docs/protocols/aws/aws).
+Please refer yourself to the relevant [documentation page](https://disneystreaming.github.io/smithy4s/docs/protocols/aws/aws).
+
 
 ### Mill
 

--- a/build.sbt
+++ b/build.sbt
@@ -379,7 +379,12 @@ lazy val codegen = projectMatrix
     libraryDependencies ++= munitDeps.value,
     scalacOptions := scalacOptions.value
       .filterNot(Seq("-Ywarn-value-discard", "-Wvalue-discard").contains),
-    bloopEnabled := true
+    bloopEnabled := true,
+    Compile / sourceGenerators += {
+      sourceManaged
+        .map(AwsBoilerplate.generate(_))
+        .taskValue,
+    }
   )
 
 /**

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/aws-specs/build.sbt
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/aws-specs/build.sbt
@@ -1,0 +1,6 @@
+lazy val root = (project in file("."))
+  .enablePlugins(Smithy4sCodegenPlugin)
+  .settings(
+    scalaVersion := "2.13.10",
+    smithy4sAwsSpecs ++= Seq(AWS.dynamodb)
+  )

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/aws-specs/project/build.properties
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/aws-specs/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.8.3

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/aws-specs/project/plugins.sbt
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/aws-specs/project/plugins.sbt
@@ -1,0 +1,9 @@
+sys.props.get("plugin.version") match {
+  case Some(x) =>
+    addSbtPlugin("com.disneystreaming.smithy4s" % "smithy4s-sbt-codegen" % x)
+  case _ =>
+    sys.error(
+      """|The system property 'plugin.version' is not defined.
+         |Specify this property using the scriptedLaunchOpts -D.""".stripMargin
+    )
+}

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/aws-specs/test
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/aws-specs/test
@@ -1,0 +1,3 @@
+# check if smithy4sCodegen works
+> smithy4sCodegen
+$ exists target/scala-2.13/src_managed/main/scala/com/amazonaws/dynamodb/AttributeValue.scala

--- a/modules/codegen-plugin/src/smithy4s/codegen/JsonConverters.scala
+++ b/modules/codegen-plugin/src/smithy4s/codegen/JsonConverters.scala
@@ -20,7 +20,6 @@ import sjsonnew._
 import BasicJsonProtocol._
 import sbt.FileInfo
 import sbt.HashFileInfo
-import sjsonnew._
 import cats.data.Validated.Invalid
 import cats.data.Validated.Valid
 import sbt.io.Hash

--- a/modules/docs/markdown/03-protocols/03-aws/01-aws.md
+++ b/modules/docs/markdown/03-protocols/03-aws/01-aws.md
@@ -43,6 +43,23 @@ libraryDependencies ++= Seq(
 )
 ```
 
+### Mill
+
+In `build.sc`
+
+```scala
+import $ivy.`com.disneystreaming.smithy4s::smithy4s-mill-codegen-plugin::@VERSION@`
+import smithy4s.codegen.mill._
+
+object foo extends Smithy4sModule {
+  override def scalaVersion = "2.13.10"
+  override def ivyDeps = Agg(
+    ivy"com.disneystreaming.smithy4s::smithy4s-aws-http4s:${smithy4sVersion()}",
+  )
+  override def smithy4sAwsSpecs: T[Seq[String]] = T(Seq(AWS.dynamodb))
+}
+```
+
 
 ## Example usage
 

--- a/modules/docs/markdown/03-protocols/03-aws/01-aws.md
+++ b/modules/docs/markdown/03-protocols/03-aws/01-aws.md
@@ -15,18 +15,6 @@ Our implementation of the AWS protocols is tested against the official [complian
 * [service-specific customisations](https://smithy.io/2.0/aws/customizations/index.html)  are currently unsupported.
 * **users should not use smithy4s to talk to AWS S3**
 
-### Where to find the specs ?
-
-* SBT : `"com.disneystreaming.smithy" % s"aws-${service_name}-spec" % "@AWS_SPEC_VERSION@"`
-* Mill : `ivy"com.disneystreaming.smithy:aws-${service_name}-spec:@AWS_SPEC_VERSION@"`
-
-The version corresponds to the latest release in this repo: [aws-sdk-smithy-specs](https://github.com/disneystreaming/aws-sdk-smithy-specs).
-
-AWS does not publishes the specs to their services to Maven. However, The specs in question (that are written in json syntax) can be found in some of the [official SDKs](https://github.com/aws/aws-sdk-js-v3/tree/main/codegen/sdk-codegen/aws-models) published by AWS. These `.json files` can be understood by smithy4s, just like `.smithy`, and can be used to generate code.
-
-The **aws-sdk-smithy-specs** project periodically gathers the specs from the Javascript SDK repo and publishes them
-to maven central to lower the barrier of entry.
-
 ### Note on pre-built artifacts
 
 We (the Smithy4s maintainers) **do not** intend to publish pre-generated artifacts containing the AWS clients, there's a lot of nuance there and maintainance burden that we do not have the capacity to assume. In particular, backward binary compatibility of the generated code is impossible to guarantee at this time.
@@ -38,14 +26,23 @@ We (the Smithy4s maintainers) **do not** intend to publish pre-generated artifac
 In `build.sbt`
 
 ```scala
-import smithy4s.codegen.BuildInfo._
+libraryDependencies ++= Seq(
+  "com.disneystreaming.smithy4s" %% "smithy4s-aws-http4s" % smithy4sVersion.value
+)
+// The `AWS` object contains a list of references to artifacts that contain specifications to AWS services.
+smithy4sAwsSpecs ++= Seq(AWS.dynamodb)
+```
 
+Alternatively, the following is also valid :
+
+```scala
 libraryDependencies ++= Seq(
   // version sourced from the plugin
   "com.disneystreaming.smithy4s" %% "smithy4s-aws-http4s" % smithy4sVersion.value
   "com.disneystreaming.smithy" % "aws-dynamodb-spec" % "@AWS_SPEC_VERSION@" % Smithy4s
 )
 ```
+
 
 ## Example usage
 
@@ -76,6 +73,18 @@ object Main extends IOApp.Simple {
 }
 
 ```
+
+## Note on where to find the AWS specifications
+
+* SBT : `"com.disneystreaming.smithy" % s"aws-${service_name}-spec" % "@AWS_SPEC_VERSION@"`
+* Mill : `ivy"com.disneystreaming.smithy:aws-${service_name}-spec:@AWS_SPEC_VERSION@"`
+
+The version corresponds to the latest release in this repo: [aws-sdk-smithy-specs](https://github.com/disneystreaming/aws-sdk-smithy-specs).
+
+AWS does not publishes the specs to their services to Maven. However, The specs in question (that are written in json syntax) can be found in some of the [official SDKs](https://github.com/aws/aws-sdk-js-v3/tree/main/codegen/sdk-codegen/aws-models) published by AWS. These `.json files` can be understood by smithy4s, just like `.smithy`, and can be used to generate code.
+
+The **aws-sdk-smithy-specs** project periodically gathers the specs from the Javascript SDK repo and publishes them
+to maven central to lower the barrier of entry.
 
 ## Service summary
 

--- a/modules/json/test/src/smithy4s/json/internals/CursorSpec.scala
+++ b/modules/json/test/src/smithy4s/json/internals/CursorSpec.scala
@@ -1,3 +1,19 @@
+/*
+ *  Copyright 2021-2022 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 package smithy4s.json.internals
 
 import munit._

--- a/modules/mill-codegen-plugin/src/smithy4s/codegen/mill/Smithy4sModule.scala
+++ b/modules/mill-codegen-plugin/src/smithy4s/codegen/mill/Smithy4sModule.scala
@@ -37,6 +37,8 @@ import mill.scalalib.CrossVersion.Full
 
 trait Smithy4sModule extends ScalaModule {
 
+  val AWS = smithy4s.codegen.AwsSpecs
+
   /** Input directory for .smithy files */
   protected def smithy4sInputDirs: Target[Seq[PathRef]] = T.sources {
     Seq(PathRef(millSourcePath / "smithy"))
@@ -122,11 +124,26 @@ trait Smithy4sModule extends ScalaModule {
     }
   }
 
+  def smithy4sAwsSpecs: T[Seq[String]] = T {
+    Seq.empty[String]
+  }
+
+  def smithy4sAwsSpecsVersion: T[String] = T {
+    AWS.knownVersion
+  }
+
+  def smithy4sAwsSpecDependencies: T[Agg[Dep]] = T {
+    val org = AWS.org
+    val version = smithy4sAwsSpecsVersion()
+    smithy4sAwsSpecs().map { artifactName => ivy"$org:$artifactName:$version" }
+  }
+
   def smithy4sAllExternalDependencies: T[Agg[BoundDep]] = T {
     val bind = bindDependency()
     transitiveIvyDeps() ++
       smithy4sTransitiveIvyDeps().map(bind) ++
-      smithy4sExternallyTrackedIvyDeps().map(bind)
+      smithy4sExternallyTrackedIvyDeps().map(bind) ++
+      smithy4sAwsSpecDependencies().map(bind)
   }
 
   def smithy4sResolvedAllExternalDependencies: T[Agg[PathRef]] = T {

--- a/modules/mill-codegen-plugin/test/src/smithy4s/codegen/mill/Smithy4sModuleSpec.scala
+++ b/modules/mill-codegen-plugin/test/src/smithy4s/codegen/mill/Smithy4sModuleSpec.scala
@@ -348,6 +348,24 @@ class Smithy4sModuleSpec extends munit.FunSuite {
 
   }
 
+  test("codegen with aws specs") {
+    object foo extends testKit.BaseModule with Smithy4sModule {
+      override def scalaVersion = "2.13.10"
+      override def ivyDeps = Agg(coreDep)
+      override def smithy4sAwsSpecs: T[Seq[String]] = T(
+        Seq(AWS.dynamodb)
+      )
+    }
+    val ev =
+      testKit.staticTestEvaluator(foo)(FullName("codegen-with-aws-specs"))
+
+    taskWorks(foo.smithy4sCodegen, ev)
+    checkFileExist(
+      ev.outPath / "smithy4sOutputDir.dest" / "scala" / "com" / "amazonaws" / "dynamodb" / "AttributeValue.scala",
+      shouldExist = true
+    )
+  }
+
   private def compileWorks(
       sm: ScalaModule,
       testEvaluator: testKit.TestEvaluator

--- a/project/AwsBoilerplate.scala
+++ b/project/AwsBoilerplate.scala
@@ -1,0 +1,103 @@
+import sbt._
+import scala.annotation.tailrec
+import java.net.URLClassLoader
+import scala.jdk.CollectionConverters._
+import sjsonnew._
+import sjsonnew.:*:
+import sjsonnew.BasicJsonProtocol._
+import scala.io.Source
+import sjsonnew.shaded.scalajson.ast.JValue
+import com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec
+import com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker
+import scala.collection.immutable
+
+object AwsBoilerplate {
+
+  def generate(directory: java.io.File): Seq[File] = {
+    val summary = loadSummary()
+    val serviceValues = summary.artifacts.map {
+      case Module(service, artifactName) =>
+        s"""  val ${toCamelCase(service)} = "$artifactName""""
+    }
+    val thisYear = java.time.OffsetDateTime.now().getYear()
+    val copyright =
+      s"""/*
+         | *  Copyright 2021-$thisYear Disney Streaming
+         | *
+         | *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+         | *  you may not use this file except in compliance with the License.
+         | *  You may obtain a copy of the License at
+         | *
+         | *     https://disneystreaming.github.io/TOST-1.0.txt
+         | *
+         | *  Unless required by applicable law or agreed to in writing, software
+         | *  distributed under the License is distributed on an "AS IS" BASIS,
+         | *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+         | *  See the License for the specific language governing permissions and
+         | *  limitations under the License.
+         | */
+         |""".stripMargin
+
+    val content =
+      s"""|$copyright
+          |package smithy4s.codegen
+          |
+          |object AwsSpecs {
+          |  val org = "${Dependencies.AwsSpecSummary.org}"
+          |  val knownVersion = "${Dependencies.AwsSpecSummary.awsSpecSummaryVersion}"
+          |
+          |${serviceValues.mkString(System.lineSeparator())}
+          |}
+      """.stripMargin
+
+    val target = directory / "smithy4s" / "codegen" / "AwsSpecs.scala"
+    sbt.IO.write(target, content)
+    Seq(target)
+  }
+
+  private def loadSummary(): Summary = {
+    import Dependencies.AwsSpecSummary._
+    val urls = coursierapi.Fetch
+      .create()
+      .addDependencies(
+        coursierapi.Dependency.of(org, name, awsSpecSummaryVersion)
+      )
+      .fetch()
+      .asScala
+      .map(_.toURI().toURL())
+      .toArray
+    val cl = new URLClassLoader(urls)
+    val jsonString = Source
+      .fromResource("summary.json", cl)
+      .getLines()
+      .mkString(System.lineSeparator())
+
+    com.github.plokhotnyuk.jsoniter_scala.core
+      .readFromString[Summary](jsonString)
+  }
+
+  private case class Module(service: String, name: String)
+  private type GenModule = String :*: String :*: LNil
+  private object Module {
+    implicit val jsonFormat: IsoLList.Aux[Module, GenModule] =
+      LList.iso[Module, GenModule](
+        { (m: Module) => ("service", m.service) :*: ("name", m.name) :*: LNil },
+        { case (_, service) :*: (_, name) :*: LNil => Module(service, name) }
+      )
+  }
+
+  private case class Summary(artifacts: Vector[Module])
+
+  private object Summary {
+    implicit val jsoncodec: JsonValueCodec[Summary] = JsonCodecMaker.make
+
+  }
+
+  private def toCamelCase(str: String): String = {
+    str.split('-').toList match {
+      case head :: tl => (head :: tl.map(_.capitalize)).mkString
+      case Nil        => ""
+    }
+  }
+
+}

--- a/project/AwsBoilerplate.scala
+++ b/project/AwsBoilerplate.scala
@@ -2,11 +2,7 @@ import sbt._
 import scala.annotation.tailrec
 import java.net.URLClassLoader
 import scala.jdk.CollectionConverters._
-import sjsonnew._
-import sjsonnew.:*:
-import sjsonnew.BasicJsonProtocol._
 import scala.io.Source
-import sjsonnew.shaded.scalajson.ast.JValue
 import com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec
 import com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker
 import scala.collection.immutable
@@ -77,14 +73,6 @@ object AwsBoilerplate {
   }
 
   private case class Module(service: String, name: String)
-  private type GenModule = String :*: String :*: LNil
-  private object Module {
-    implicit val jsonFormat: IsoLList.Aux[Module, GenModule] =
-      LList.iso[Module, GenModule](
-        { (m: Module) => ("service", m.service) :*: ("name", m.name) :*: LNil },
-        { case (_, service) :*: (_, name) :*: LNil => Module(service, name) }
-      )
-  }
 
   private case class Summary(artifacts: Vector[Module])
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -154,9 +154,10 @@ object Dependencies {
   }
 
   object AwsSpecSummary {
+    val org = "com.disneystreaming.smithy"
+    val name = "aws-spec-summary"
     val awsSpecSummaryVersion = "2023.09.22"
-    val value =
-      "com.disneystreaming.smithy" % "aws-spec-summary" % awsSpecSummaryVersion
+    val value = org % name % awsSpecSummaryVersion
   }
 
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -16,6 +16,9 @@ addSbtPlugin("com.github.sbt"       % "sbt-git"                       % "2.0.1")
 addSbtPlugin("com.typesafe"         % "sbt-mima-plugin"               % "1.1.3")
 addSbtPlugin("ch.epfl.scala"        % "sbt-bloop"                     % "1.5.11")
 
-libraryDependencies ++= Seq("com.lihaoyi" %% "os-lib" % "0.8.1")
+libraryDependencies ++= Seq(
+  "com.lihaoyi" %% "os-lib" % "0.8.1",
+  "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-macros" % "2.23.4"
+)
 
 addDependencyTreePlugin


### PR DESCRIPTION
* Adds logic to code-generate a list of artifacts containing AWS specifications in a Scala object 
* Add build tasks (for SBT and Mill) to lower the barrier of entry for referencing those artifacts in their build. Since the artifacts are listed as Scala values, the users get auto-completion to help set-up the code generation of AWS services. 
* Added corresponding tests for both SBT and Mill, avoiding the compilation of the generated code to save on CI time. 