### PR TITLE
Attempt to compute the original url, otherwise keep behaviour

### DIFF
--- a/modules/http4s-swagger/src-jvm/smithy4s/http4s/swagger/Docs.scala
+++ b/modules/http4s-swagger/src-jvm/smithy4s/http4s/swagger/Docs.scala
@@ -49,7 +49,7 @@ private[smithy4s] abstract class Docs[F[_]](
   private val validSpecs = ids.map(toSwaggerUrl).map(_._1).toList
   private val specsUrls = ids.map(toSwaggerUrl).map(_._2)
 
-  val actualPath: Path = Uri.Path.unsafeFromString("/" + path)
+  private val actualPath: Path = Uri.Path.unsafeFromString("/" + path)
 
   object DocPath {
     def unapply(p: Path): Boolean = {


### PR DESCRIPTION
An attempt at fixing https://github.com/disneystreaming/smithy4s/issues/439

If we have the info available, we use it to generate the redirect path. For example, a request that goes like:

```
browser -> nginx (http://proxy.com/admin/docs) -> backend (http://localhost:8080/docs) => "http://localhost:8080/docs/index.html"
```

The proxy can then rewrite it appropriately and send the right response to the client.

```
browser -> backend (http://localhost:8080/docs) => "http://localhost:8080/docs/index.html"
```


If we force no host header:

```
curl -H 'Host:' ... -> backend (http://localhost:8080/docs) => "/docs/index.html"
```

IMO, this is a low hanging fruit type of fix that will help working from behind a proxy w/o affecting other uses cases.

Fixes #439 