### PR TITLE
Change the DynamicSchemaIndex API

### DIFF
--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/defaults/src/main/scala/Main.scala
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/defaults/src/main/scala/Main.scala
@@ -32,5 +32,5 @@ object Main extends App {
   def buildSchemaIndex() = Model.assembler().assemble().unwrap()
 
   val model = buildSchemaIndex()
-  DynamicSchemaIndex.loadModel(model).toTry.get
+  DynamicSchemaIndex.loadModel(model)
 }

--- a/modules/docs/markdown/06-guides/dynamic.md
+++ b/modules/docs/markdown/06-guides/dynamic.md
@@ -106,7 +106,7 @@ The entrypoint to loading models is `DynamicSchemaIndex`.
 
 ```scala mdoc
 import smithy4s.dynamic.DynamicSchemaIndex
-val dsi = DynamicSchemaIndex.loadModel(model).toTry.get
+val dsi = DynamicSchemaIndex.loadModel(model)
 ```
 
 For alternative ways to load a DSI, see `DynamicSchemaIndex.load`.

--- a/modules/dynamic/src-jvm/DynamicSchemaIndexPlatform.scala
+++ b/modules/dynamic/src-jvm/DynamicSchemaIndexPlatform.scala
@@ -16,7 +16,6 @@
 
 package smithy4s.dynamic
 
-import smithy4s.codecs.PayloadError
 import software.amazon.smithy.model.shapes.ModelSerializer
 import software.amazon.smithy.model.transform.ModelTransformer
 
@@ -28,14 +27,17 @@ private[dynamic] trait DynamicSchemaIndexPlatform {
     */
   def loadModel(
       model: software.amazon.smithy.model.Model
-  ): Either[PayloadError, DynamicSchemaIndex] = {
+  ): DynamicSchemaIndex = {
     val flattenedModel =
       ModelTransformer.create().flattenAndRemoveMixins(model);
     val node = ModelSerializer.builder().build.serialize(flattenedModel)
     val document = NodeToDocument(node)
     smithy4s.Document
       .decode[smithy4s.dynamic.model.Model](document)
-      .map(load(_))
+      .map(load(_)) match {
+      case Left(error)  => throw error
+      case Right(value) => value
+    }
   }
 
 }

--- a/modules/dynamic/src/smithy4s/dynamic/DynamicSchemaIndex.scala
+++ b/modules/dynamic/src/smithy4s/dynamic/DynamicSchemaIndex.scala
@@ -23,11 +23,11 @@ package dynamic
   * without requiring code generation.
   */
 trait DynamicSchemaIndex {
-  def allServices: List[DynamicSchemaIndex.ServiceWrapper]
+  def allServices: Iterable[DynamicSchemaIndex.ServiceWrapper]
   def getService(shapeId: ShapeId): Option[DynamicSchemaIndex.ServiceWrapper] =
     allServices.find(_.service.id == shapeId)
 
-  def allSchemas: Vector[Schema[_]]
+  def allSchemas: Iterable[Schema[_]]
   def getSchema(shapeId: ShapeId): Option[Schema[_]]
 
   def metadata: Map[String, Document]

--- a/modules/dynamic/src/smithy4s/dynamic/internals/DynamicSchemaIndexImpl.scala
+++ b/modules/dynamic/src/smithy4s/dynamic/internals/DynamicSchemaIndexImpl.scala
@@ -24,10 +24,10 @@ private[internals] class DynamicSchemaIndexImpl(
     schemaMap: Map[ShapeId, Schema[DynData]]
 ) extends DynamicSchemaIndex {
 
-  def allServices: List[DynamicSchemaIndex.ServiceWrapper] =
-    serviceMap.values.toList
-  def allSchemas: Vector[Schema[_]] =
-    schemaMap.values.toVector
+  def allServices: Iterable[DynamicSchemaIndex.ServiceWrapper] =
+    serviceMap.values
+  def allSchemas: Iterable[Schema[_]] =
+    schemaMap.values
 
   def getSchema(
       shapeId: ShapeId

--- a/modules/dynamic/test/src-jvm/smithy4s/dynamic/DynamicMemberHintsSpec.scala
+++ b/modules/dynamic/test/src-jvm/smithy4s/dynamic/DynamicMemberHintsSpec.scala
@@ -32,7 +32,6 @@ class DynamicMemberHintsSpec() extends DummyIO.Suite {
 
     val dsi = DynamicSchemaIndex
       .loadModel(model)
-      .getOrElse(sys.error("Couldn't load model"))
 
     dsi
       .getSchema(shapeId)

--- a/modules/dynamic/test/src-jvm/smithy4s/dynamic/DynamicStabilitySpec.scala
+++ b/modules/dynamic/test/src-jvm/smithy4s/dynamic/DynamicStabilitySpec.scala
@@ -108,7 +108,6 @@ class DynamicStabilitySpec extends FunSuite {
 
     def parseAndLoad() = DynamicSchemaIndex
       .loadModel(model)
-      .getOrElse(sys.error("Couldn't load model"))
 
     // We are testing that loading a schema several times and running
     // it through a cached visitor does actually hit the cache.

--- a/modules/dynamic/test/src-jvm/smithy4s/dynamic/FieldOrderingSpec.scala
+++ b/modules/dynamic/test/src-jvm/smithy4s/dynamic/FieldOrderingSpec.scala
@@ -40,10 +40,7 @@ class FieldOrderingSpec extends munit.ScalaCheckSuite {
       val struct = structBuilder.build()
       val union = unionBuilder.build()
       val model = Model.builder().addShapes(struct, union).build()
-      val schemaIndex = DynamicSchemaIndex
-        .loadModel(model)
-        .toOption
-        .get
+      val schemaIndex = DynamicSchemaIndex.loadModel(model)
 
       for {
         id <- List("Foo", "Bar")

--- a/modules/dynamic/test/src-jvm/smithy4s/dynamic/PlatformUtils.scala
+++ b/modules/dynamic/test/src-jvm/smithy4s/dynamic/PlatformUtils.scala
@@ -18,18 +18,16 @@ package smithy4s.dynamic
 
 import software.amazon.smithy.model.{Model => SModel}
 import software.amazon.smithy.model.loader.ModelAssembler
-import cats.syntax.all._
 import DummyIO._
 
 private[dynamic] trait PlatformUtils { self: Utils.type =>
 
   def compile(string: String): IO[DynamicSchemaIndex] =
-    parse(string).map(DynamicSchemaIndex.loadModel).flatMap(_.liftTo[IO])
+    parse(string).map(DynamicSchemaIndex.loadModel)
 
   def compileSampleSpec(string: String): IO[DynamicSchemaIndex] =
     parseSampleSpec(string)
       .map(DynamicSchemaIndex.loadModel)
-      .flatMap(_.liftTo[IO])
 
   private def parse(string: String): IO[SModel] =
     IO(

--- a/modules/http4s/test/src-jvm/smithy4s/http4s/Http4sDynamicPizzaClientSpec.scala
+++ b/modules/http4s/test/src-jvm/smithy4s/http4s/Http4sDynamicPizzaClientSpec.scala
@@ -33,11 +33,7 @@ class DynamicHttpProxy(client: Client[IO]) {
 
   val dynamicServiceIO =
     parseSampleSpec("pizza.smithy")
-      .flatMap { model =>
-        DynamicSchemaIndex
-          .loadModel(model)
-          .liftTo[IO]
-      }
+      .map(DynamicSchemaIndex.loadModel)
       .map { index =>
         index
           .getService(ShapeId("smithy4s.example", "PizzaAdminService"))


### PR DESCRIPTION
* Return `Iterable` instead of `List`/`Vector`
* Have `loadModel` not return an Either. This is mostly to future-proof it as we should be able to change the implementation to circumvent the Node and Document jumps, thus turning it into a bonafide total function.