### PR TITLE
Tweak codegen api

### DIFF
--- a/modules/codegen-cli/src/smithy4s/codegen/cli/Main.scala
+++ b/modules/codegen-cli/src/smithy4s/codegen/cli/Main.scala
@@ -43,7 +43,7 @@ object Main {
         .parse(args.toList)
         .map {
           case Smithy4sCommand.Generate(args) =>
-            val res = Codegen.processSpecs(args)
+            val res = Codegen.generateToDisk(args)
             if (res.isEmpty) {
               // Printing to stderr because we print generated files path to stdout
               Console.err.println(

--- a/modules/codegen-plugin/src/smithy4s/codegen/Smithy4sCodegenPlugin.scala
+++ b/modules/codegen-plugin/src/smithy4s/codegen/Smithy4sCodegenPlugin.scala
@@ -415,7 +415,7 @@ object Smithy4sCodegenPlugin extends AutoPlugin {
           ) { case ((inputChanged, args), outputs) =>
             if (inputChanged || outputs.isEmpty) {
               val resPaths = smithy4s.codegen.Codegen
-                .processSpecs(args)
+                .generateToDisk(args)
                 .toList
               resPaths.map(path => new File(path.toString))
             } else {

--- a/modules/codegen/src/smithy4s/codegen/CodegenResult.scala
+++ b/modules/codegen/src/smithy4s/codegen/CodegenResult.scala
@@ -16,16 +16,19 @@
 
 package smithy4s.codegen
 
-object Codegen {
-
-  def generate(args: CodegenArgs): CodegenResult =
-    internals.CodegenImpl.generate(args)
-
-  def generateToDisk(args: CodegenArgs): Set[os.Path] = {
-    internals.CodegenImpl.write(generate(args))
+sealed trait CodegenEntry {
+  def toPath: os.Path = this match {
+    case CodegenEntry.FromMemory(path, _) => path
+    case CodegenEntry.FromDisk(path, _)   => path
   }
-
-  def dumpModel(args: DumpModelArgs): String =
-    internals.CodegenImpl.dumpModel(args)
-
 }
+
+object CodegenEntry {
+  case class FromMemory(path: os.Path, content: String) extends CodegenEntry
+  case class FromDisk(path: os.Path, sourceFile: os.Path) extends CodegenEntry
+}
+
+final case class CodegenResult(
+    sources: Seq[CodegenEntry],
+    resources: Seq[CodegenEntry]
+)

--- a/modules/codegen/src/smithy4s/codegen/CodegenResult.scala
+++ b/modules/codegen/src/smithy4s/codegen/CodegenResult.scala
@@ -24,8 +24,10 @@ sealed trait CodegenEntry {
 }
 
 object CodegenEntry {
-  case class FromMemory(path: os.Path, content: String) extends CodegenEntry
-  case class FromDisk(path: os.Path, sourceFile: os.Path) extends CodegenEntry
+  case class FromMemory(targetPath: os.Path, content: String)
+      extends CodegenEntry
+  case class FromDisk(targetPath: os.Path, sourcePath: os.Path)
+      extends CodegenEntry
 }
 
 final case class CodegenResult(

--- a/modules/codegen/src/smithy4s/codegen/internals/CodegenImpl.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/CodegenImpl.scala
@@ -18,19 +18,18 @@ package smithy4s.codegen
 package internals
 
 import alloy.openapi._
+import smithy4s.codegen.CodegenEntry.FromDisk
+import smithy4s.codegen.CodegenEntry.FromMemory
 import smithy4s.codegen.transformers._
 import software.amazon.smithy.model.Model
-
-import scala.jdk.CollectionConverters._
 import software.amazon.smithy.model.node.Node
 import software.amazon.smithy.model.shapes.ModelSerializer
 
+import scala.jdk.CollectionConverters._
+
 private[codegen] object CodegenImpl { self =>
 
-  def processSpecs(
-      args: CodegenArgs
-  ): Set[os.Path] = {
-
+  def generate(args: CodegenArgs): CodegenResult = {
     val (classloader, model): (ClassLoader, Model) = internals.ModelLoader.load(
       args.specs.map(_.toIO).toSet,
       args.dependencies,
@@ -46,8 +45,7 @@ private[codegen] object CodegenImpl { self =>
       val scalaFiles = codegenResult.map { case (relPath, result) =>
         val fileName = result.name + ".scala"
         val scalaFile = (args.output / relPath / fileName)
-        os.write.over(scalaFile, result.content, createFolders = true)
-        scalaFile
+        CodegenEntry.FromMemory(scalaFile, result.content)
       }
       val generatedNamespaces = codegenResult.map(_._2.namespace).distinct
       // when args.specs and generatedNamespaces are empty
@@ -60,7 +58,7 @@ private[codegen] object CodegenImpl { self =>
           args.specs,
           generatedNamespaces
         )
-      } else List.empty
+      } else List.empty[CodegenEntry]
       (scalaFiles, resources)
     } else (List.empty, List.empty)
 
@@ -69,12 +67,40 @@ private[codegen] object CodegenImpl { self =>
         case OpenApiConversionResult(_, serviceId, outputString) =>
           val name = serviceId.getNamespace() + "." + serviceId.getName()
           val openapiFile = (args.resourceOutput / (name + ".json"))
-          os.write.over(openapiFile, outputString, createFolders = true)
-          openapiFile
+          CodegenEntry.FromMemory(openapiFile, outputString)
       }
     } else List.empty
 
-    (scalaFiles ++ openApiFiles ++ smithyResources).toSet
+    CodegenResult(
+      sources = scalaFiles,
+      resources = openApiFiles ++ smithyResources
+    )
+  }
+
+  def write(result: CodegenResult): Set[os.Path] = {
+    def entryToDisk(entry: CodegenEntry): Unit = entry match {
+      case FromMemory(path, content) =>
+        os.write.over(path, content, createFolders = true)
+        ()
+      case FromDisk(path, sourceFile) =>
+        os.copy.over(
+          from = sourceFile,
+          to = path,
+          replaceExisting = true,
+          createFolders = true
+        )
+    }
+
+    val sourcesPaths = result.sources.map { e =>
+      entryToDisk(e)
+      e.toPath
+    }
+    val resourcesPaths = result.resources.map { e =>
+      entryToDisk(e)
+      e.toPath
+    }
+
+    (sourcesPaths ++ resourcesPaths).toSet
   }
 
   private[internals] def generate(

--- a/modules/codegen/src/smithy4s/codegen/internals/SmithyResources.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/SmithyResources.scala
@@ -14,9 +14,11 @@
  *  limitations under the License.
  */
 
-package smithy4s.codegen
+package smithy4s.codegen.internals
 
 import os.RelPath
+import smithy4s.codegen.BuildInfo
+import smithy4s.codegen.CodegenEntry
 
 /**
   * This construct aims at adding metadata information to the classpath to let Smithy4s
@@ -31,7 +33,7 @@ private[smithy4s] object SmithyResources {
       resourceOutputFolder: os.Path,
       specs: List[os.Path],
       namespaces: List[String]
-  ): List[os.Path] = {
+  ): List[CodegenEntry] = {
 
     val localSmithyFiles = specs.flatMap { spec =>
       if (os.isDir(spec))
@@ -42,44 +44,34 @@ private[smithy4s] object SmithyResources {
 
     val smithyFolder = resourceOutputFolder / "META-INF" / "smithy"
     val trackingFile = smithyFolder / s"smithy4s.tracking.smithy"
+
     val smithy4sVersion = BuildInfo.version
     val nsString = namespaces.map(ns => s""""$ns"""").mkString(", ")
     val content = s"""|$$version: "2.0"
                       |
                       |metadata smithy4sGenerated = [{smithy4sVersion: "$smithy4sVersion", namespaces: [$nsString]}]
                       |""".stripMargin
+    val trackingFileEntry = CodegenEntry.FromMemory(trackingFile, content)
 
     val metadataFile = smithyFolder / "manifest"
-
-    val metadataFileContent =
+    val metadataFileRelPaths =
       (trackingFile :: localSmithyFiles).flatMap {
         case f if os.isDir(f) =>
           os.walk(f).filter(os.isFile(_)).map(_.relativeTo(f))
         case f => RelPath(f.last) :: Nil
       }.distinct
 
-    os.write.over(
+    val metadataFileEntry = CodegenEntry.FromMemory(
       metadataFile,
-      metadataFileContent.mkString(System.lineSeparator()),
-      createFolders = true
+      metadataFileRelPaths.mkString(System.lineSeparator())
     )
 
-    os.write.over(trackingFile, content, createFolders = true)
-
-    localSmithyFiles
-      .foreach { path =>
-        os.copy.over(
-          from = path,
-          to = smithyFolder / path.last,
-          replaceExisting = true,
-          createFolders = true
-        )
+    val localSmithyFilesEntries = localSmithyFiles
+      .map { path =>
+        CodegenEntry.FromDisk(smithyFolder / path.last, path)
       }
 
-    val allProducedFiles =
-      metadataFile :: metadataFileContent.map(_.resolveFrom(smithyFolder))
-
-    allProducedFiles
+    localSmithyFilesEntries :+ metadataFileEntry :+ trackingFileEntry
   }
 
 }

--- a/modules/codegen/test/src/smithy4s/codegen/internals/SmithyResourcesSpec.scala
+++ b/modules/codegen/test/src/smithy4s/codegen/internals/SmithyResourcesSpec.scala
@@ -1,0 +1,43 @@
+/*
+ *  Copyright 2021-2022 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package smithy4s.codegen.internals
+
+import munit._
+
+final class SmithyResourcesSpec extends FunSuite {
+  test("produce smithy4s metadata files") {
+    val resDir = os.temp.dir()
+
+    val paths = SmithyResources.produce(
+      resDir,
+      List(
+        os.Path(
+          "/Users/David.Francoeur/workspace/dev/smithy4s/sampleSpecs/greet.smithy"
+        )
+      ),
+      List("smithy4s.example.greet")
+    )
+    assertEquals(
+      paths.map(_.toPath.relativeTo(resDir)),
+      List(
+        os.RelPath("META-INF/smithy/greet.smithy"),
+        os.RelPath("META-INF/smithy/manifest"),
+        os.RelPath("META-INF/smithy/smithy4s.tracking.smithy")
+      )
+    )
+  }
+}

--- a/modules/mill-codegen-plugin/src/smithy4s/codegen/mill/Smithy4sModule.scala
+++ b/modules/mill-codegen-plugin/src/smithy4s/codegen/mill/Smithy4sModule.scala
@@ -212,7 +212,7 @@ trait Smithy4sModule extends ScalaModule {
       localJars = allLocalJars
     )
 
-    Smithy4s.processSpecs(args)
+    Smithy4s.generateToDisk(args)
     (PathRef(scalaOutput), PathRef(resourcesOutput))
   }
 


### PR DESCRIPTION
This changes comes after a discussion regarding a way to run codegen, from the outside of this project without writing to the file system. This PR changes the api in a breaking way:

From `processSpecs(args: CodegenArgs): Set[os.Path]` to the dual:

- `def generate(args: CodegenArgs): CodegenResult`
- `def generateToDisk(args: CodegenArgs): Set[os.Path]`

I could have kept `processSpecs` or slap a deprecate on it but I don't think it will be particularly useful