### PR TITLE
Extra dollar sign to avoid env var substitution in docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,6 @@ version
 .bsp
 
 .direnv
+
+#smithy cli metadata
+build/smithy/classpath.json

--- a/modules/bootstrapped/src/generated/smithy4s/example/EnvVarString.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/EnvVarString.scala
@@ -1,0 +1,28 @@
+package smithy4s.example
+
+import smithy4s.Hints
+import smithy4s.Schema
+import smithy4s.ShapeId
+import smithy4s.ShapeTag
+import smithy4s.schema.Schema.string
+import smithy4s.schema.Schema.struct
+
+/** This is meant to be used with $${ENV_VAR}
+  * @param member
+  *   This is meant to be used with $$ENV_VAR
+  */
+final case class EnvVarString(member: Option[String] = None)
+
+object EnvVarString extends ShapeTag.Companion[EnvVarString] {
+  val id: ShapeId = ShapeId("smithy4s.example", "EnvVarString")
+
+  val hints: Hints = Hints(
+    smithy.api.Documentation(s"This is meant to be used with $${ENV_VAR}"),
+  )
+
+  implicit val schema: Schema[EnvVarString] = struct(
+    string.optional[EnvVarString]("member", _.member).addHints(smithy.api.Documentation(s"This is meant to be used with $$ENV_VAR")),
+  ){
+    EnvVarString.apply
+  }.withId(id).addHints(hints)
+}

--- a/modules/codegen/src/smithy4s/codegen/internals/Renderer.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/Renderer.scala
@@ -229,17 +229,22 @@ private[internals] class Renderer(compilationUnit: CompilationUnit) { self =>
       hints: List[Hint],
       skipMemberDocs: Boolean = false
   ): Lines = {
+    def atLiteral(s: String) = s.replace("@", "{@literal @}")
+    def dollarLiteral(s: String) = s.replace("$", "$$")
     hints
       .collectFirst { case h: Hint.Documentation => h }
       .foldMap { doc =>
         val shapeDocs: List[String] =
-          doc.docLines.map(_.replace("@", "{@literal @}"))
+          doc.docLines
+            .map(atLiteral)
+            .map(dollarLiteral)
         val memberDocs: List[String] =
           if (skipMemberDocs) List.empty
           else
             doc.memberDocLines.flatMap { case (memberName, text) =>
               s"@param $memberName" :: text
-                .map(_.replace("@", "{@literal @}"))
+                .map(atLiteral)
+                .map(dollarLiteral)
                 .map("  " + _)
             }.toList
 

--- a/sampleSpecs/quoted_string.smithy
+++ b/sampleSpecs/quoted_string.smithy
@@ -11,6 +11,11 @@ string AString
 string AnotherString
 
 structure AStructure {
-
     astring: AString = "\"Hello World\" with \"quotes\""
+}
+
+@documentation("This is meant to be used with ${ENV_VAR}")
+structure EnvVarString {
+    @documentation("This is meant to be used with $ENV_VAR")
+    member: String
 }


### PR DESCRIPTION
Previous implementation left the dollar sign as is, this triggered a warning:

```
[warn] [bootstrapped] /Users/David.Francoeur/workspace/dev/smithy4s/modules/bootstrapped/src/generated/smithy4s/example/EnvVarString.scala:12:38: Variable ENV undefined in comment for class EnvVarString in class EnvVarString
[warn] [bootstrapped]   *   This is meant to be used with $ENV_VAR
[warn] [bootstrapped]                                      ^
[warn] [bootstrapped] one warning found
```

Current implementation uses a double `$` sign to avoid this. I tried using `{@literal $}` but they must be using some sort of basic regex that fails, because when I try, it fails with an `Illegal group reference` similar to [this SO question](https://stackoverflow.com/questions/11913709/why-does-replaceall-fail-with-illegal-group-reference)