### PR TITLE
Expose UrlForm.parse and UrlFormDecodeError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ In 0.18.0, support was added for [open enums](https://disneystreaming.github.io/
 This model-preprocessor aims at removing constraints from output types in AWS specs (as AWS doesn't seem to respect said constraints)
 https://github.com/disneystreaming/smithy4s/pull/1251
 
+## Expose UrlForm.parse and UrlFormDecodeError
+
+In 0.18.0, support was added for `application/x-www-form-urlencoded` data. But, many of its related constructs were private, they are now public for users to access them directly.
+https://github.com/disneystreaming/smithy4s/pull/1254
+
 # 0.18.0
 
 ## Behavioural changes

--- a/modules/core/src/smithy4s/http/UrlForm.scala
+++ b/modules/core/src/smithy4s/http/UrlForm.scala
@@ -165,6 +165,7 @@ object UrlForm {
     smithy4s.codecs.Decoder[Either[UrlFormDecodeError, *], UrlForm, A]
 
   object Decoder {
+
     /** Constructs a [[Decoder]] that decodes [[UrlForm]]s into custom data. Can be configured using `@alloyurlformname`. */
     def apply(
         ignoreUrlFormFlattened: Boolean,
@@ -193,6 +194,7 @@ object UrlForm {
   type Encoder[A] = smithy4s.codecs.Encoder[UrlForm, A]
 
   object Encoder {
+
     /** Constructs an [[Encoder]] that encodes data as [[UrlForm]]s. Can be configured using `@alloyurlformname`. */
     def apply(
         capitalizeStructAndUnionMemberNames: Boolean

--- a/modules/core/src/smithy4s/http/UrlForm.scala
+++ b/modules/core/src/smithy4s/http/UrlForm.scala
@@ -35,6 +35,7 @@ import java.nio.charset.StandardCharsets
 import scala.collection.immutable.BitSet
 import scala.collection.mutable
 
+/** Represents data that was encoded using the `application/x-www-form-urlencoded` format. */
 final case class UrlForm(values: List[UrlForm.FormData]) {
 
   def render: String = {
@@ -80,10 +81,11 @@ object UrlForm {
     }
   }
 
-  // This is based on http4s' own equivalent, but simplified for our use case.
+  /** Parses a `application/x-www-form-urlencoded` formatted String into a [[UrlForm]]. */
   def parse(
       urlFormString: String
   ): Either[UrlFormDecodeError, UrlForm] = {
+    // This is based on http4s' own equivalent, but simplified for our use case.
     val inputBuffer = CharBuffer.wrap(urlFormString)
     val encodedTermBuilder = new StringBuilder(capacity = 32)
     val outputBuilder = List.newBuilder[UrlForm.FormData]
@@ -163,6 +165,7 @@ object UrlForm {
     smithy4s.codecs.Decoder[Either[UrlFormDecodeError, *], UrlForm, A]
 
   object Decoder {
+    /** Constructs a [[Decoder]] that decodes [[UrlForm]]s into custom data. Can be configured using `@alloyurlformname`. */
     def apply(
         ignoreUrlFormFlattened: Boolean,
         capitalizeStructAndUnionMemberNames: Boolean
@@ -190,6 +193,7 @@ object UrlForm {
   type Encoder[A] = smithy4s.codecs.Encoder[UrlForm, A]
 
   object Encoder {
+    /** Constructs an [[Encoder]] that encodes data as [[UrlForm]]s. Can be configured using `@alloyurlformname`. */
     def apply(
         capitalizeStructAndUnionMemberNames: Boolean
     ): CachedSchemaCompiler[Encoder] =
@@ -219,6 +223,5 @@ object UrlForm {
 
         }
       }
-
   }
 }

--- a/modules/core/src/smithy4s/http/UrlForm.scala
+++ b/modules/core/src/smithy4s/http/UrlForm.scala
@@ -81,7 +81,7 @@ object UrlForm {
   }
 
   // This is based on http4s' own equivalent, but simplified for our use case.
-  private[smithy4s] def parse(
+  def parse(
       urlFormString: String
   ): Either[UrlFormDecodeError, UrlForm] = {
     val inputBuffer = CharBuffer.wrap(urlFormString)

--- a/modules/core/src/smithy4s/http/UrlFormDecodeError.scala
+++ b/modules/core/src/smithy4s/http/UrlFormDecodeError.scala
@@ -20,7 +20,7 @@ package http
 import smithy4s.codecs.PayloadPath
 import smithy4s.http.internals.UrlFormCursor
 
-private[http] final case class UrlFormDecodeError(
+final case class UrlFormDecodeError(
     path: PayloadPath,
     message: String
 ) extends Throwable {


### PR DESCRIPTION
At work, we built our own `SimpleUrlFormProtocol` and the implementation mostly reuses what **smithy4s** already has.
However, we had to use runtime reflection to access these bits. Which, IMHO, could _(should?)_ be public.

Let me know what you think and if I should do something else.

-----

## PR Checklist

- [x] Added unit-tests _(already there)_
- [x] Added documentation
- [x] Updated changelog
