### PR TITLE
Throwable toString override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.18.2
+
+## Override `toString` on error shapes
+
+Default `toString` implementation on `Throwable` prints the class name, instead, we decided to rely on the case class `toString` implementation.
+
 # 0.18.1
 
 ## Open enum support in Dynamic module

--- a/modules/bootstrapped/resources/smithy4s.example.ObjectService.json
+++ b/modules/bootstrapped/resources/smithy4s.example.ObjectService.json
@@ -50,6 +50,16 @@
                             }
                         }
                     },
+                    "400": {
+                        "description": "ClientError 400 response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ClientErrorResponseContent"
+                                }
+                            }
+                        }
+                    },
                     "500": {
                         "description": "ServerError 500 response",
                         "content": {
@@ -110,6 +120,16 @@
                     "200": {
                         "description": "PutObject 200 response"
                     },
+                    "400": {
+                        "description": "ClientError 400 response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ClientErrorResponseContent"
+                                }
+                            }
+                        }
+                    },
                     "500": {
                         "description": "ServerError 500 response",
                         "content": {
@@ -136,6 +156,22 @@
     },
     "components": {
         "schemas": {
+            "ClientErrorResponseContent": {
+                "type": "object",
+                "properties": {
+                    "code": {
+                        "type": "integer",
+                        "format": "int32"
+                    },
+                    "details": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "code",
+                    "details"
+                ]
+            },
             "Foo": {
                 "description": "Helpful information for Foo\nint, bigInt and bDec are useful number constructs\nThe string case is there because.",
                 "oneOf": [

--- a/modules/bootstrapped/src/generated/com/amazonaws/dynamodb/InternalServerError.scala
+++ b/modules/bootstrapped/src/generated/com/amazonaws/dynamodb/InternalServerError.scala
@@ -4,13 +4,14 @@ import smithy4s.Hints
 import smithy4s.Schema
 import smithy4s.ShapeId
 import smithy4s.ShapeTag
+import smithy4s.Smithy4sThrowable
 import smithy4s.schema.Schema.struct
 
 /** <p>An error occurred on the server side.</p>
   * @param message
   *   <p>The server encountered an internal error trying to fulfill the request.</p>
   */
-final case class InternalServerError(message: Option[ErrorMessage] = None) extends Throwable {
+final case class InternalServerError(message: Option[ErrorMessage] = None) extends Smithy4sThrowable {
   override def getMessage(): String = message.map(_.value).orNull
 }
 

--- a/modules/bootstrapped/src/generated/com/amazonaws/dynamodb/InvalidEndpointException.scala
+++ b/modules/bootstrapped/src/generated/com/amazonaws/dynamodb/InvalidEndpointException.scala
@@ -4,10 +4,11 @@ import smithy4s.Hints
 import smithy4s.Schema
 import smithy4s.ShapeId
 import smithy4s.ShapeTag
+import smithy4s.Smithy4sThrowable
 import smithy4s.schema.Schema.string
 import smithy4s.schema.Schema.struct
 
-final case class InvalidEndpointException(message: Option[String] = None) extends Throwable {
+final case class InvalidEndpointException(message: Option[String] = None) extends Smithy4sThrowable {
   override def getMessage(): String = message.orNull
 }
 

--- a/modules/bootstrapped/src/generated/smithy4s/example/ClientError.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/ClientError.scala
@@ -1,0 +1,28 @@
+package smithy4s.example
+
+import smithy4s.Hints
+import smithy4s.Schema
+import smithy4s.ShapeId
+import smithy4s.ShapeTag
+import smithy4s.Smithy4sThrowable
+import smithy4s.schema.Schema.int
+import smithy4s.schema.Schema.string
+import smithy4s.schema.Schema.struct
+
+final case class ClientError(code: Int, details: String) extends Smithy4sThrowable {
+}
+
+object ClientError extends ShapeTag.Companion[ClientError] {
+  val id: ShapeId = ShapeId("smithy4s.example", "ClientError")
+
+  val hints: Hints = Hints(
+    smithy.api.Error.CLIENT.widen,
+  )
+
+  implicit val schema: Schema[ClientError] = struct(
+    int.required[ClientError]("code", _.code),
+    string.required[ClientError]("details", _.details),
+  ){
+    ClientError.apply
+  }.withId(id).addHints(hints)
+}

--- a/modules/bootstrapped/src/generated/smithy4s/example/EHFallbackServerError.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/EHFallbackServerError.scala
@@ -4,10 +4,11 @@ import smithy4s.Hints
 import smithy4s.Schema
 import smithy4s.ShapeId
 import smithy4s.ShapeTag
+import smithy4s.Smithy4sThrowable
 import smithy4s.schema.Schema.string
 import smithy4s.schema.Schema.struct
 
-final case class EHFallbackServerError(message: Option[String] = None) extends Throwable {
+final case class EHFallbackServerError(message: Option[String] = None) extends Smithy4sThrowable {
   override def getMessage(): String = message.orNull
 }
 

--- a/modules/bootstrapped/src/generated/smithy4s/example/FallbackError.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/FallbackError.scala
@@ -1,15 +1,14 @@
 package smithy4s.example
 
-import scala.runtime.ScalaRunTime
 import smithy4s.Hints
 import smithy4s.Schema
 import smithy4s.ShapeId
 import smithy4s.ShapeTag
+import smithy4s.Smithy4sThrowable
 import smithy4s.schema.Schema.string
 import smithy4s.schema.Schema.struct
 
-final case class FallbackError(error: String) extends Throwable {
-  override def toString(): String = ScalaRunTime._toString(this)
+final case class FallbackError(error: String) extends Smithy4sThrowable {
 }
 
 object FallbackError extends ShapeTag.Companion[FallbackError] {

--- a/modules/bootstrapped/src/generated/smithy4s/example/FallbackError.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/FallbackError.scala
@@ -1,5 +1,6 @@
 package smithy4s.example
 
+import scala.runtime.ScalaRunTime
 import smithy4s.Hints
 import smithy4s.Schema
 import smithy4s.ShapeId
@@ -8,6 +9,7 @@ import smithy4s.schema.Schema.string
 import smithy4s.schema.Schema.struct
 
 final case class FallbackError(error: String) extends Throwable {
+  override def toString(): String = ScalaRunTime._toString(this)
 }
 
 object FallbackError extends ShapeTag.Companion[FallbackError] {

--- a/modules/bootstrapped/src/generated/smithy4s/example/FallbackError2.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/FallbackError2.scala
@@ -1,5 +1,6 @@
 package smithy4s.example
 
+import scala.runtime.ScalaRunTime
 import smithy4s.Hints
 import smithy4s.Schema
 import smithy4s.ShapeId
@@ -8,6 +9,7 @@ import smithy4s.schema.Schema.string
 import smithy4s.schema.Schema.struct
 
 final case class FallbackError2(error: String) extends Throwable {
+  override def toString(): String = ScalaRunTime._toString(this)
 }
 
 object FallbackError2 extends ShapeTag.Companion[FallbackError2] {

--- a/modules/bootstrapped/src/generated/smithy4s/example/FallbackError2.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/FallbackError2.scala
@@ -1,15 +1,14 @@
 package smithy4s.example
 
-import scala.runtime.ScalaRunTime
 import smithy4s.Hints
 import smithy4s.Schema
 import smithy4s.ShapeId
 import smithy4s.ShapeTag
+import smithy4s.Smithy4sThrowable
 import smithy4s.schema.Schema.string
 import smithy4s.schema.Schema.struct
 
-final case class FallbackError2(error: String) extends Throwable {
-  override def toString(): String = ScalaRunTime._toString(this)
+final case class FallbackError2(error: String) extends Smithy4sThrowable {
 }
 
 object FallbackError2 extends ShapeTag.Companion[FallbackError2] {

--- a/modules/bootstrapped/src/generated/smithy4s/example/GenericClientError.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/GenericClientError.scala
@@ -4,10 +4,11 @@ import smithy4s.Hints
 import smithy4s.Schema
 import smithy4s.ShapeId
 import smithy4s.ShapeTag
+import smithy4s.Smithy4sThrowable
 import smithy4s.schema.Schema.string
 import smithy4s.schema.Schema.struct
 
-final case class GenericClientError(message: String) extends Throwable {
+final case class GenericClientError(message: String) extends Smithy4sThrowable {
   override def getMessage(): String = message
 }
 

--- a/modules/bootstrapped/src/generated/smithy4s/example/GenericServerError.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/GenericServerError.scala
@@ -4,10 +4,11 @@ import smithy4s.Hints
 import smithy4s.Schema
 import smithy4s.ShapeId
 import smithy4s.ShapeTag
+import smithy4s.Smithy4sThrowable
 import smithy4s.schema.Schema.string
 import smithy4s.schema.Schema.struct
 
-final case class GenericServerError(message: String) extends Throwable {
+final case class GenericServerError(message: String) extends Smithy4sThrowable {
   override def getMessage(): String = message
 }
 

--- a/modules/bootstrapped/src/generated/smithy4s/example/KeyNotFoundError.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/KeyNotFoundError.scala
@@ -4,10 +4,11 @@ import smithy4s.Hints
 import smithy4s.Schema
 import smithy4s.ShapeId
 import smithy4s.ShapeTag
+import smithy4s.Smithy4sThrowable
 import smithy4s.schema.Schema.string
 import smithy4s.schema.Schema.struct
 
-final case class KeyNotFoundError(message: String) extends Throwable {
+final case class KeyNotFoundError(message: String) extends Smithy4sThrowable {
   override def getMessage(): String = message
 }
 

--- a/modules/bootstrapped/src/generated/smithy4s/example/MixinErrorExample.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/MixinErrorExample.scala
@@ -1,5 +1,6 @@
 package smithy4s.example
 
+import scala.runtime.ScalaRunTime
 import smithy4s.Hints
 import smithy4s.Schema
 import smithy4s.ShapeId
@@ -11,6 +12,7 @@ import smithy4s.schema.Schema.string
 import smithy4s.schema.Schema.struct
 
 final case class MixinErrorExample(a: Option[String] = None, b: Option[Int] = None, c: Option[Long] = None, d: Option[Boolean] = None) extends Throwable with CommonFieldsOne with CommonFieldsTwo {
+  override def toString(): String = ScalaRunTime._toString(this)
 }
 
 object MixinErrorExample extends ShapeTag.Companion[MixinErrorExample] {

--- a/modules/bootstrapped/src/generated/smithy4s/example/MixinErrorExample.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/MixinErrorExample.scala
@@ -1,18 +1,17 @@
 package smithy4s.example
 
-import scala.runtime.ScalaRunTime
 import smithy4s.Hints
 import smithy4s.Schema
 import smithy4s.ShapeId
 import smithy4s.ShapeTag
+import smithy4s.Smithy4sThrowable
 import smithy4s.schema.Schema.boolean
 import smithy4s.schema.Schema.int
 import smithy4s.schema.Schema.long
 import smithy4s.schema.Schema.string
 import smithy4s.schema.Schema.struct
 
-final case class MixinErrorExample(a: Option[String] = None, b: Option[Int] = None, c: Option[Long] = None, d: Option[Boolean] = None) extends Throwable with CommonFieldsOne with CommonFieldsTwo {
-  override def toString(): String = ScalaRunTime._toString(this)
+final case class MixinErrorExample(a: Option[String] = None, b: Option[Int] = None, c: Option[Long] = None, d: Option[Boolean] = None) extends Smithy4sThrowable with CommonFieldsOne with CommonFieldsTwo {
 }
 
 object MixinErrorExample extends ShapeTag.Companion[MixinErrorExample] {

--- a/modules/bootstrapped/src/generated/smithy4s/example/MyOpError.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/MyOpError.scala
@@ -1,14 +1,13 @@
 package smithy4s.example
 
-import scala.runtime.ScalaRunTime
 import smithy4s.Hints
 import smithy4s.Schema
 import smithy4s.ShapeId
 import smithy4s.ShapeTag
+import smithy4s.Smithy4sThrowable
 import smithy4s.schema.Schema.constant
 
-final case class MyOpError() extends Throwable {
-  override def toString(): String = ScalaRunTime._toString(this)
+final case class MyOpError() extends Smithy4sThrowable {
 }
 
 object MyOpError extends ShapeTag.Companion[MyOpError] {

--- a/modules/bootstrapped/src/generated/smithy4s/example/MyOpError.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/MyOpError.scala
@@ -1,5 +1,6 @@
 package smithy4s.example
 
+import scala.runtime.ScalaRunTime
 import smithy4s.Hints
 import smithy4s.Schema
 import smithy4s.ShapeId
@@ -7,6 +8,7 @@ import smithy4s.ShapeTag
 import smithy4s.schema.Schema.constant
 
 final case class MyOpError() extends Throwable {
+  override def toString(): String = ScalaRunTime._toString(this)
 }
 
 object MyOpError extends ShapeTag.Companion[MyOpError] {

--- a/modules/bootstrapped/src/generated/smithy4s/example/NoMoreSpace.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/NoMoreSpace.scala
@@ -4,6 +4,7 @@ import smithy4s.Hints
 import smithy4s.Schema
 import smithy4s.ShapeId
 import smithy4s.ShapeTag
+import smithy4s.Smithy4sThrowable
 import smithy4s.schema.Schema.string
 import smithy4s.schema.Schema.struct
 
@@ -12,7 +13,7 @@ import smithy4s.schema.Schema.struct
   *   int, bigInt and bDec are useful number constructs
   *   The string case is there because.
   */
-final case class NoMoreSpace(message: String, foo: Option[Foo] = None) extends Throwable {
+final case class NoMoreSpace(message: String, foo: Option[Foo] = None) extends Smithy4sThrowable {
   override def getMessage(): String = message
 }
 

--- a/modules/bootstrapped/src/generated/smithy4s/example/NoSuchResource.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/NoSuchResource.scala
@@ -1,15 +1,14 @@
 package smithy4s.example
 
-import scala.runtime.ScalaRunTime
 import smithy4s.Hints
 import smithy4s.Schema
 import smithy4s.ShapeId
 import smithy4s.ShapeTag
+import smithy4s.Smithy4sThrowable
 import smithy4s.schema.Schema.string
 import smithy4s.schema.Schema.struct
 
-final case class NoSuchResource(resourceType: String) extends Throwable {
-  override def toString(): String = ScalaRunTime._toString(this)
+final case class NoSuchResource(resourceType: String) extends Smithy4sThrowable {
 }
 
 object NoSuchResource extends ShapeTag.Companion[NoSuchResource] {

--- a/modules/bootstrapped/src/generated/smithy4s/example/NoSuchResource.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/NoSuchResource.scala
@@ -1,5 +1,6 @@
 package smithy4s.example
 
+import scala.runtime.ScalaRunTime
 import smithy4s.Hints
 import smithy4s.Schema
 import smithy4s.ShapeId
@@ -8,6 +9,7 @@ import smithy4s.schema.Schema.string
 import smithy4s.schema.Schema.struct
 
 final case class NoSuchResource(resourceType: String) extends Throwable {
+  override def toString(): String = ScalaRunTime._toString(this)
 }
 
 object NoSuchResource extends ShapeTag.Companion[NoSuchResource] {

--- a/modules/bootstrapped/src/generated/smithy4s/example/NotFoundError.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/NotFoundError.scala
@@ -1,5 +1,6 @@
 package smithy4s.example
 
+import scala.runtime.ScalaRunTime
 import smithy4s.Hints
 import smithy4s.Schema
 import smithy4s.ShapeId
@@ -8,6 +9,7 @@ import smithy4s.schema.Schema.string
 import smithy4s.schema.Schema.struct
 
 final case class NotFoundError(name: String) extends Throwable {
+  override def toString(): String = ScalaRunTime._toString(this)
 }
 
 object NotFoundError extends ShapeTag.Companion[NotFoundError] {

--- a/modules/bootstrapped/src/generated/smithy4s/example/NotFoundError.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/NotFoundError.scala
@@ -1,15 +1,14 @@
 package smithy4s.example
 
-import scala.runtime.ScalaRunTime
 import smithy4s.Hints
 import smithy4s.Schema
 import smithy4s.ShapeId
 import smithy4s.ShapeTag
+import smithy4s.Smithy4sThrowable
 import smithy4s.schema.Schema.string
 import smithy4s.schema.Schema.struct
 
-final case class NotFoundError(name: String) extends Throwable {
-  override def toString(): String = ScalaRunTime._toString(this)
+final case class NotFoundError(name: String) extends Smithy4sThrowable {
 }
 
 object NotFoundError extends ShapeTag.Companion[NotFoundError] {

--- a/modules/bootstrapped/src/generated/smithy4s/example/ObjectService.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/ObjectService.scala
@@ -107,17 +107,20 @@ object ObjectServiceOperation {
 
     object project {
       def serverError: Option[ServerError] = PutObjectError.ServerErrorCase.alt.project.lift(self).map(_.serverError)
+      def clientError: Option[ClientError] = PutObjectError.ClientErrorCase.alt.project.lift(self).map(_.clientError)
       def noMoreSpace: Option[NoMoreSpace] = PutObjectError.NoMoreSpaceCase.alt.project.lift(self).map(_.noMoreSpace)
     }
 
     def accept[A](visitor: PutObjectError.Visitor[A]): A = this match {
       case value: PutObjectError.ServerErrorCase => visitor.serverError(value.serverError)
+      case value: PutObjectError.ClientErrorCase => visitor.clientError(value.clientError)
       case value: PutObjectError.NoMoreSpaceCase => visitor.noMoreSpace(value.noMoreSpace)
     }
   }
   object PutObjectError extends ErrorSchema.Companion[PutObjectError] {
 
     def serverError(serverError: ServerError): PutObjectError = ServerErrorCase(serverError)
+    def clientError(clientError: ClientError): PutObjectError = ClientErrorCase(clientError)
     def noMoreSpace(noMoreSpace: NoMoreSpace): PutObjectError = NoMoreSpaceCase(noMoreSpace)
 
     val id: ShapeId = ShapeId("smithy4s.example", "PutObjectError")
@@ -125,12 +128,18 @@ object ObjectServiceOperation {
     val hints: Hints = Hints.empty
 
     final case class ServerErrorCase(serverError: ServerError) extends PutObjectError { final def $ordinal: Int = 0 }
-    final case class NoMoreSpaceCase(noMoreSpace: NoMoreSpace) extends PutObjectError { final def $ordinal: Int = 1 }
+    final case class ClientErrorCase(clientError: ClientError) extends PutObjectError { final def $ordinal: Int = 1 }
+    final case class NoMoreSpaceCase(noMoreSpace: NoMoreSpace) extends PutObjectError { final def $ordinal: Int = 2 }
 
     object ServerErrorCase {
       val hints: Hints = Hints.empty
       val schema: Schema[PutObjectError.ServerErrorCase] = bijection(ServerError.schema.addHints(hints), PutObjectError.ServerErrorCase(_), _.serverError)
       val alt = schema.oneOf[PutObjectError]("ServerError")
+    }
+    object ClientErrorCase {
+      val hints: Hints = Hints.empty
+      val schema: Schema[PutObjectError.ClientErrorCase] = bijection(ClientError.schema.addHints(hints), PutObjectError.ClientErrorCase(_), _.clientError)
+      val alt = schema.oneOf[PutObjectError]("ClientError")
     }
     object NoMoreSpaceCase {
       val hints: Hints = Hints.empty
@@ -140,6 +149,7 @@ object ObjectServiceOperation {
 
     trait Visitor[A] {
       def serverError(value: ServerError): A
+      def clientError(value: ClientError): A
       def noMoreSpace(value: NoMoreSpace): A
     }
 
@@ -147,23 +157,27 @@ object ObjectServiceOperation {
       trait Default[A] extends Visitor[A] {
         def default: A
         def serverError(value: ServerError): A = default
+        def clientError(value: ClientError): A = default
         def noMoreSpace(value: NoMoreSpace): A = default
       }
     }
 
     implicit val schema: Schema[PutObjectError] = union(
       PutObjectError.ServerErrorCase.alt,
+      PutObjectError.ClientErrorCase.alt,
       PutObjectError.NoMoreSpaceCase.alt,
     ){
       _.$ordinal
     }
     def liftError(throwable: Throwable): Option[PutObjectError] = throwable match {
       case e: ServerError => Some(PutObjectError.ServerErrorCase(e))
+      case e: ClientError => Some(PutObjectError.ClientErrorCase(e))
       case e: NoMoreSpace => Some(PutObjectError.NoMoreSpaceCase(e))
       case _ => None
     }
     def unliftError(e: PutObjectError): Throwable = e match {
       case PutObjectError.ServerErrorCase(e) => e
+      case PutObjectError.ClientErrorCase(e) => e
       case PutObjectError.NoMoreSpaceCase(e) => e
     }
   }
@@ -186,50 +200,64 @@ object ObjectServiceOperation {
 
     object project {
       def serverError: Option[ServerError] = GetObjectError.ServerErrorCase.alt.project.lift(self).map(_.serverError)
+      def clientError: Option[ClientError] = GetObjectError.ClientErrorCase.alt.project.lift(self).map(_.clientError)
     }
 
     def accept[A](visitor: GetObjectError.Visitor[A]): A = this match {
       case value: GetObjectError.ServerErrorCase => visitor.serverError(value.serverError)
+      case value: GetObjectError.ClientErrorCase => visitor.clientError(value.clientError)
     }
   }
   object GetObjectError extends ErrorSchema.Companion[GetObjectError] {
 
     def serverError(serverError: ServerError): GetObjectError = ServerErrorCase(serverError)
+    def clientError(clientError: ClientError): GetObjectError = ClientErrorCase(clientError)
 
     val id: ShapeId = ShapeId("smithy4s.example", "GetObjectError")
 
     val hints: Hints = Hints.empty
 
     final case class ServerErrorCase(serverError: ServerError) extends GetObjectError { final def $ordinal: Int = 0 }
+    final case class ClientErrorCase(clientError: ClientError) extends GetObjectError { final def $ordinal: Int = 1 }
 
     object ServerErrorCase {
       val hints: Hints = Hints.empty
       val schema: Schema[GetObjectError.ServerErrorCase] = bijection(ServerError.schema.addHints(hints), GetObjectError.ServerErrorCase(_), _.serverError)
       val alt = schema.oneOf[GetObjectError]("ServerError")
     }
+    object ClientErrorCase {
+      val hints: Hints = Hints.empty
+      val schema: Schema[GetObjectError.ClientErrorCase] = bijection(ClientError.schema.addHints(hints), GetObjectError.ClientErrorCase(_), _.clientError)
+      val alt = schema.oneOf[GetObjectError]("ClientError")
+    }
 
     trait Visitor[A] {
       def serverError(value: ServerError): A
+      def clientError(value: ClientError): A
     }
 
     object Visitor {
       trait Default[A] extends Visitor[A] {
         def default: A
         def serverError(value: ServerError): A = default
+        def clientError(value: ClientError): A = default
       }
     }
 
     implicit val schema: Schema[GetObjectError] = union(
       GetObjectError.ServerErrorCase.alt,
+      GetObjectError.ClientErrorCase.alt,
     ){
       _.$ordinal
     }
     def liftError(throwable: Throwable): Option[GetObjectError] = throwable match {
       case e: ServerError => Some(GetObjectError.ServerErrorCase(e))
+      case e: ClientError => Some(GetObjectError.ClientErrorCase(e))
       case _ => None
     }
     def unliftError(e: GetObjectError): Throwable = e match {
       case GetObjectError.ServerErrorCase(e) => e
+      case GetObjectError.ClientErrorCase(e) => e
     }
   }
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/PriceError.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/PriceError.scala
@@ -4,11 +4,12 @@ import smithy4s.Hints
 import smithy4s.Schema
 import smithy4s.ShapeId
 import smithy4s.ShapeTag
+import smithy4s.Smithy4sThrowable
 import smithy4s.schema.Schema.int
 import smithy4s.schema.Schema.string
 import smithy4s.schema.Schema.struct
 
-final case class PriceError(message: String, code: Int) extends Throwable {
+final case class PriceError(message: String, code: Int) extends Smithy4sThrowable {
   override def getMessage(): String = message
 }
 

--- a/modules/bootstrapped/src/generated/smithy4s/example/RandomOtherClientError.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/RandomOtherClientError.scala
@@ -4,10 +4,11 @@ import smithy4s.Hints
 import smithy4s.Schema
 import smithy4s.ShapeId
 import smithy4s.ShapeTag
+import smithy4s.Smithy4sThrowable
 import smithy4s.schema.Schema.string
 import smithy4s.schema.Schema.struct
 
-final case class RandomOtherClientError(message: Option[String] = None) extends Throwable {
+final case class RandomOtherClientError(message: Option[String] = None) extends Smithy4sThrowable {
   override def getMessage(): String = message.orNull
 }
 

--- a/modules/bootstrapped/src/generated/smithy4s/example/RandomOtherClientErrorWithCode.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/RandomOtherClientErrorWithCode.scala
@@ -4,10 +4,11 @@ import smithy4s.Hints
 import smithy4s.Schema
 import smithy4s.ShapeId
 import smithy4s.ShapeTag
+import smithy4s.Smithy4sThrowable
 import smithy4s.schema.Schema.string
 import smithy4s.schema.Schema.struct
 
-final case class RandomOtherClientErrorWithCode(message: Option[String] = None) extends Throwable {
+final case class RandomOtherClientErrorWithCode(message: Option[String] = None) extends Smithy4sThrowable {
   override def getMessage(): String = message.orNull
 }
 

--- a/modules/bootstrapped/src/generated/smithy4s/example/RandomOtherServerError.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/RandomOtherServerError.scala
@@ -4,10 +4,11 @@ import smithy4s.Hints
 import smithy4s.Schema
 import smithy4s.ShapeId
 import smithy4s.ShapeTag
+import smithy4s.Smithy4sThrowable
 import smithy4s.schema.Schema.string
 import smithy4s.schema.Schema.struct
 
-final case class RandomOtherServerError(message: Option[String] = None) extends Throwable {
+final case class RandomOtherServerError(message: Option[String] = None) extends Smithy4sThrowable {
   override def getMessage(): String = message.orNull
 }
 

--- a/modules/bootstrapped/src/generated/smithy4s/example/RandomOtherServerErrorWithCode.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/RandomOtherServerErrorWithCode.scala
@@ -4,10 +4,11 @@ import smithy4s.Hints
 import smithy4s.Schema
 import smithy4s.ShapeId
 import smithy4s.ShapeTag
+import smithy4s.Smithy4sThrowable
 import smithy4s.schema.Schema.string
 import smithy4s.schema.Schema.struct
 
-final case class RandomOtherServerErrorWithCode(message: Option[String] = None) extends Throwable {
+final case class RandomOtherServerErrorWithCode(message: Option[String] = None) extends Smithy4sThrowable {
   override def getMessage(): String = message.orNull
 }
 

--- a/modules/bootstrapped/src/generated/smithy4s/example/ServerError.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/ServerError.scala
@@ -4,10 +4,11 @@ import smithy4s.Hints
 import smithy4s.Schema
 import smithy4s.ShapeId
 import smithy4s.ShapeTag
+import smithy4s.Smithy4sThrowable
 import smithy4s.schema.Schema.string
 import smithy4s.schema.Schema.struct
 
-final case class ServerError(message: Option[String] = None) extends Throwable {
+final case class ServerError(message: Option[String] = None) extends Smithy4sThrowable {
   override def getMessage(): String = message.orNull
 }
 

--- a/modules/bootstrapped/src/generated/smithy4s/example/ServerErrorCustomMessage.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/ServerErrorCustomMessage.scala
@@ -4,10 +4,11 @@ import smithy4s.Hints
 import smithy4s.Schema
 import smithy4s.ShapeId
 import smithy4s.ShapeTag
+import smithy4s.Smithy4sThrowable
 import smithy4s.schema.Schema.string
 import smithy4s.schema.Schema.struct
 
-final case class ServerErrorCustomMessage(messageField: Option[String] = None) extends Throwable {
+final case class ServerErrorCustomMessage(messageField: Option[String] = None) extends Smithy4sThrowable {
   override def getMessage(): String = messageField.orNull
 }
 

--- a/modules/bootstrapped/src/generated/smithy4s/example/UnauthorizedError.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/UnauthorizedError.scala
@@ -1,5 +1,6 @@
 package smithy4s.example
 
+import scala.runtime.ScalaRunTime
 import smithy4s.Hints
 import smithy4s.Schema
 import smithy4s.ShapeId
@@ -8,6 +9,7 @@ import smithy4s.schema.Schema.string
 import smithy4s.schema.Schema.struct
 
 final case class UnauthorizedError(reason: String) extends Throwable {
+  override def toString(): String = ScalaRunTime._toString(this)
 }
 
 object UnauthorizedError extends ShapeTag.Companion[UnauthorizedError] {

--- a/modules/bootstrapped/src/generated/smithy4s/example/UnauthorizedError.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/UnauthorizedError.scala
@@ -1,15 +1,14 @@
 package smithy4s.example
 
-import scala.runtime.ScalaRunTime
 import smithy4s.Hints
 import smithy4s.Schema
 import smithy4s.ShapeId
 import smithy4s.ShapeTag
+import smithy4s.Smithy4sThrowable
 import smithy4s.schema.Schema.string
 import smithy4s.schema.Schema.struct
 
-final case class UnauthorizedError(reason: String) extends Throwable {
-  override def toString(): String = ScalaRunTime._toString(this)
+final case class UnauthorizedError(reason: String) extends Smithy4sThrowable {
 }
 
 object UnauthorizedError extends ShapeTag.Companion[UnauthorizedError] {

--- a/modules/bootstrapped/src/generated/smithy4s/example/UnknownServerError.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/UnknownServerError.scala
@@ -1,15 +1,14 @@
 package smithy4s.example
 
-import scala.runtime.ScalaRunTime
 import smithy4s.Hints
 import smithy4s.Schema
 import smithy4s.ShapeId
 import smithy4s.ShapeTag
+import smithy4s.Smithy4sThrowable
 import smithy4s.schema.Schema.string
 import smithy4s.schema.Schema.struct
 
-final case class UnknownServerError(errorCode: UnknownServerErrorCode, description: Option[String] = None, stateHash: Option[String] = None) extends Throwable {
-  override def toString(): String = ScalaRunTime._toString(this)
+final case class UnknownServerError(errorCode: UnknownServerErrorCode, description: Option[String] = None, stateHash: Option[String] = None) extends Smithy4sThrowable {
 }
 
 object UnknownServerError extends ShapeTag.Companion[UnknownServerError] {

--- a/modules/bootstrapped/src/generated/smithy4s/example/UnknownServerError.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/UnknownServerError.scala
@@ -1,5 +1,6 @@
 package smithy4s.example
 
+import scala.runtime.ScalaRunTime
 import smithy4s.Hints
 import smithy4s.Schema
 import smithy4s.ShapeId
@@ -8,6 +9,7 @@ import smithy4s.schema.Schema.string
 import smithy4s.schema.Schema.struct
 
 final case class UnknownServerError(errorCode: UnknownServerErrorCode, description: Option[String] = None, stateHash: Option[String] = None) extends Throwable {
+  override def toString(): String = ScalaRunTime._toString(this)
 }
 
 object UnknownServerError extends ShapeTag.Companion[UnknownServerError] {

--- a/modules/bootstrapped/src/generated/smithy4s/example/error/NotFoundError.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/error/NotFoundError.scala
@@ -1,5 +1,6 @@
 package smithy4s.example.error
 
+import scala.runtime.ScalaRunTime
 import smithy4s.Hints
 import smithy4s.Schema
 import smithy4s.ShapeId
@@ -8,6 +9,7 @@ import smithy4s.schema.Schema.string
 import smithy4s.schema.Schema.struct
 
 final case class NotFoundError(error: Option[String] = None) extends Throwable {
+  override def toString(): String = ScalaRunTime._toString(this)
 }
 
 object NotFoundError extends ShapeTag.Companion[NotFoundError] {

--- a/modules/bootstrapped/src/generated/smithy4s/example/error/NotFoundError.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/error/NotFoundError.scala
@@ -1,15 +1,14 @@
 package smithy4s.example.error
 
-import scala.runtime.ScalaRunTime
 import smithy4s.Hints
 import smithy4s.Schema
 import smithy4s.ShapeId
 import smithy4s.ShapeTag
+import smithy4s.Smithy4sThrowable
 import smithy4s.schema.Schema.string
 import smithy4s.schema.Schema.struct
 
-final case class NotFoundError(error: Option[String] = None) extends Throwable {
-  override def toString(): String = ScalaRunTime._toString(this)
+final case class NotFoundError(error: Option[String] = None) extends Smithy4sThrowable {
 }
 
 object NotFoundError extends ShapeTag.Companion[NotFoundError] {

--- a/modules/bootstrapped/src/generated/smithy4s/example/guides/auth/NotAuthorizedError.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/guides/auth/NotAuthorizedError.scala
@@ -4,10 +4,11 @@ import smithy4s.Hints
 import smithy4s.Schema
 import smithy4s.ShapeId
 import smithy4s.ShapeTag
+import smithy4s.Smithy4sThrowable
 import smithy4s.schema.Schema.string
 import smithy4s.schema.Schema.struct
 
-final case class NotAuthorizedError(message: String) extends Throwable {
+final case class NotAuthorizedError(message: String) extends Smithy4sThrowable {
   override def getMessage(): String = message
 }
 

--- a/modules/bootstrapped/src/generated/smithy4s/example/hello/GenericServerError.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/hello/GenericServerError.scala
@@ -4,10 +4,11 @@ import smithy4s.Hints
 import smithy4s.Schema
 import smithy4s.ShapeId
 import smithy4s.ShapeTag
+import smithy4s.Smithy4sThrowable
 import smithy4s.schema.Schema.string
 import smithy4s.schema.Schema.struct
 
-final case class GenericServerError(message: Option[String] = None) extends Throwable {
+final case class GenericServerError(message: Option[String] = None) extends Smithy4sThrowable {
   override def getMessage(): String = message.orNull
 }
 

--- a/modules/bootstrapped/src/generated/smithy4s/example/hello/SpecificServerError.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/hello/SpecificServerError.scala
@@ -4,10 +4,11 @@ import smithy4s.Hints
 import smithy4s.Schema
 import smithy4s.ShapeId
 import smithy4s.ShapeTag
+import smithy4s.Smithy4sThrowable
 import smithy4s.schema.Schema.string
 import smithy4s.schema.Schema.struct
 
-final case class SpecificServerError(message: Option[String] = None) extends Throwable {
+final case class SpecificServerError(message: Option[String] = None) extends Smithy4sThrowable {
   override def getMessage(): String = message.orNull
 }
 

--- a/modules/bootstrapped/src/generated/smithy4s/example/test/ComplexError.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/test/ComplexError.scala
@@ -4,11 +4,12 @@ import smithy4s.Hints
 import smithy4s.Schema
 import smithy4s.ShapeId
 import smithy4s.ShapeTag
+import smithy4s.Smithy4sThrowable
 import smithy4s.schema.Schema.int
 import smithy4s.schema.Schema.string
 import smithy4s.schema.Schema.struct
 
-final case class ComplexError(value: Int, message: String, details: Option[ErrorDetails] = None) extends Throwable {
+final case class ComplexError(value: Int, message: String, details: Option[ErrorDetails] = None) extends Smithy4sThrowable {
   override def getMessage(): String = message
 }
 

--- a/modules/bootstrapped/src/generated/smithy4s/example/test/SimpleError.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/test/SimpleError.scala
@@ -1,15 +1,14 @@
 package smithy4s.example.test
 
-import scala.runtime.ScalaRunTime
 import smithy4s.Hints
 import smithy4s.Schema
 import smithy4s.ShapeId
 import smithy4s.ShapeTag
+import smithy4s.Smithy4sThrowable
 import smithy4s.schema.Schema.int
 import smithy4s.schema.Schema.struct
 
-final case class SimpleError(expected: Int) extends Throwable {
-  override def toString(): String = ScalaRunTime._toString(this)
+final case class SimpleError(expected: Int) extends Smithy4sThrowable {
 }
 
 object SimpleError extends ShapeTag.Companion[SimpleError] {

--- a/modules/bootstrapped/src/generated/smithy4s/example/test/SimpleError.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/test/SimpleError.scala
@@ -1,5 +1,6 @@
 package smithy4s.example.test
 
+import scala.runtime.ScalaRunTime
 import smithy4s.Hints
 import smithy4s.Schema
 import smithy4s.ShapeId
@@ -8,6 +9,7 @@ import smithy4s.schema.Schema.int
 import smithy4s.schema.Schema.struct
 
 final case class SimpleError(expected: Int) extends Throwable {
+  override def toString(): String = ScalaRunTime._toString(this)
 }
 
 object SimpleError extends ShapeTag.Companion[SimpleError] {

--- a/modules/bootstrapped/test/src/smithy4s/ErrorMessageTraitSpec.scala
+++ b/modules/bootstrapped/test/src/smithy4s/ErrorMessageTraitSpec.scala
@@ -15,7 +15,9 @@
  */
 
 package smithy4s
+
 import munit._
+import smithy4s.example.ClientError
 import smithy4s.example.ServerErrorCustomMessage
 
 class ErrorMessageTraitSpec extends FunSuite {
@@ -26,6 +28,18 @@ class ErrorMessageTraitSpec extends FunSuite {
     val e = ServerErrorCustomMessage(Some("error message"))
 
     expect.eql(e.getMessage, "error message")
+    expect.eql(
+      e.toString,
+      "smithy4s.example.ServerErrorCustomMessage: error message"
+    )
+  }
+
+  test("Generated getMessage") {
+    val e = ClientError(400, "oopsy")
+
+    val expected = "smithy4s.example.ClientError(400, oopsy)"
+    expect.eql(e.getMessage, null)
+    expect.eql(e.toString, expected)
   }
 
 }

--- a/modules/codegen/src/smithy4s/codegen/internals/CollisionAvoidance.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/CollisionAvoidance.scala
@@ -341,7 +341,6 @@ private[internals] object CollisionAvoidance {
     val some = NameRef("scala", "Some")
     val noStackTrace = NameRef("scala.util.control", "NoStackTrace")
     val throwable = NameRef("java.lang", "Throwable")
-    val scalaRuntime = NameRef("scala.runtime", "ScalaRunTime")
 
   }
 

--- a/modules/codegen/src/smithy4s/codegen/internals/CollisionAvoidance.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/CollisionAvoidance.scala
@@ -313,6 +313,7 @@ private[internals] object CollisionAvoidance {
     val Constant_ = NameDef("Constant")
     val Default_ = NameDef("Default")
     val const5_ = NameRef("smithy4s.kinds.toPolyFunction5", "const5")
+    val smithy4sThrowable = NameRef("smithy4s", "Smithy4sThrowable")
 
     // We reserve these keywords as they collide with types that the
     // users are bound to manipulate when using Smithy4s .

--- a/modules/codegen/src/smithy4s/codegen/internals/CollisionAvoidance.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/CollisionAvoidance.scala
@@ -341,6 +341,7 @@ private[internals] object CollisionAvoidance {
     val some = NameRef("scala", "Some")
     val noStackTrace = NameRef("scala.util.control", "NoStackTrace")
     val throwable = NameRef("java.lang", "Throwable")
+    val scalaRuntime = NameRef("scala.runtime", "ScalaRunTime")
 
   }
 

--- a/modules/codegen/src/smithy4s/codegen/internals/Renderer.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/Renderer.scala
@@ -663,17 +663,16 @@ private[internals] class Renderer(compilationUnit: CompilationUnit) { self =>
           val ext = mixins.map(m => line"$m").intercalate(line" with ")
           line" with $ext"
         } else Line.empty
-        val messageField = fields
-          .find { f =>
-            f.hints.contains_(Hint.ErrorMessage) ||
-            f.name === "message"
-          }
-          .filter {
-            _.tpe.dealiased == Type.PrimitiveType(Primitive.String)
-          }
-
         block(line"$decl extends $exception$mixinExtensions") {
-          messageField.fold(defaultThrowableGetMessage)(renderGetMessage)
+          fields
+            .find { f =>
+              f.hints.contains_(Hint.ErrorMessage) ||
+              f.name === "message"
+            }
+            .filter {
+              _.tpe.dealiased == Type.PrimitiveType(Primitive.String)
+            }
+            .foldMap(renderGetMessage)
         }
       } else {
         val extendAdt = adtParent.map(t => line"$t").toList
@@ -801,10 +800,6 @@ private[internals] class Renderer(compilationUnit: CompilationUnit) { self =>
       base
     )
   }
-
-  // Default toString on Throwable prints the classname, instead we use the case class toString.
-  private def defaultThrowableGetMessage =
-    line"override def toString(): $string_ = $scalaRuntime._toString(this)"
 
   private def renderGetMessage(field: Field) = field match {
     case field if field.tpe.isResolved && field.required =>

--- a/modules/codegen/src/smithy4s/codegen/internals/Renderer.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/Renderer.scala
@@ -663,16 +663,17 @@ private[internals] class Renderer(compilationUnit: CompilationUnit) { self =>
           val ext = mixins.map(m => line"$m").intercalate(line" with ")
           line" with $ext"
         } else Line.empty
+        val messageField = fields
+          .find { f =>
+            f.hints.contains_(Hint.ErrorMessage) ||
+            f.name === "message"
+          }
+          .filter {
+            _.tpe.dealiased == Type.PrimitiveType(Primitive.String)
+          }
+
         block(line"$decl extends $exception$mixinExtensions") {
-          fields
-            .find { f =>
-              f.hints.contains_(Hint.ErrorMessage) ||
-              f.name === "message"
-            }
-            .filter {
-              _.tpe.dealiased == Type.PrimitiveType(Primitive.String)
-            }
-            .foldMap(renderGetMessage)
+          messageField.fold(defaultThrowableGetMessage)(renderGetMessage)
         }
       } else {
         val extendAdt = adtParent.map(t => line"$t").toList
@@ -800,6 +801,10 @@ private[internals] class Renderer(compilationUnit: CompilationUnit) { self =>
       base
     )
   }
+
+  // Default toString on Throwable prints the classname, instead we use the case class toString.
+  private def defaultThrowableGetMessage =
+    line"override def toString(): $string_ = $scalaRuntime._toString(this)"
 
   private def renderGetMessage(field: Field) = field match {
     case field if field.tpe.isResolved && field.required =>

--- a/modules/codegen/src/smithy4s/codegen/internals/Renderer.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/Renderer.scala
@@ -659,7 +659,7 @@ private[internals] class Renderer(compilationUnit: CompilationUnit) { self =>
         val exception =
           if (hints.contains(Hint.NoStackTrace))
             noStackTrace
-          else throwable
+          else smithy4sThrowable
         val mixinExtensions = if (mixins.nonEmpty) {
           val ext = mixins.map(m => line"$m").intercalate(line" with ")
           line" with $ext"

--- a/modules/core/src/smithy4s/Smithy4sThrowable.scala
+++ b/modules/core/src/smithy4s/Smithy4sThrowable.scala
@@ -1,0 +1,44 @@
+/*
+ *  Copyright 2021-2023 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package smithy4s
+
+trait Smithy4sThrowable extends Throwable { self: Product =>
+
+  /**
+    * implementing toString, because implementing getMessage
+    * lead to `smithy4s.example.ClientError: smithy4s.example.ClientError(400, "oops")`
+    * which felt weird
+    */
+  override def toString(): String = {
+    val name = getClass().getName()
+    val message = getLocalizedMessage()
+    if (message == null) {
+      val sb = new StringBuilder()
+      sb.append(name)
+      sb.append("(")
+      val iter = this.productIterator
+      while (iter.hasNext) {
+        sb.append(iter.next())
+        if (iter.hasNext) { sb.append(", ") }
+      }
+      sb.append(")")
+      sb.toString()
+    } else {
+      s"$name: $message"
+    }
+  }
+}

--- a/sampleSpecs/example.smithy
+++ b/sampleSpecs/example.smithy
@@ -12,7 +12,7 @@ use smithy4s.meta#errorMessage
 @simpleRestJson
 service ObjectService {
   version: "1.0.0",
-  errors: [ServerError],
+  errors: [ServerError, ClientError],
   operations: [PutObject, GetObject]
 }
 
@@ -133,6 +133,14 @@ integer ObjectSize
 @error("server")
 structure ServerError {
   message: String
+}
+
+@error("client")
+structure ClientError {
+  @required
+  code: Integer
+  @required
+  details: String
 }
 
 @trait


### PR DESCRIPTION
Default `toString` on `Throwable` prints the classname. This is suboptimal when we could have the case class `toString` implementation available.

## PR Checklist (not all items are relevant to all PRs)

- [ ] Added unit-tests (for runtime code)
- [x] Update bootstrapped code + smoke tests (when the rendering logic is modified)
- [ ] Added build-plugins integration tests (when reflection loading is required at codegen-time)
- [ ] Added alloy compliance tests (when simpleRestJson protocol behaviour is expanded/updated)
- [ ] Updated dynamic module to match generated-code behaviour
- [ ] Added documentation
- [x] Updated changelog
