### PR TITLE
Demonstrating lack of alloy.Untagged support in the DocumentDecoder

### DIFF
--- a/modules/bootstrapped/test/src/smithy4s/DocumentSpec.scala
+++ b/modules/bootstrapped/test/src/smithy4s/DocumentSpec.scala
@@ -137,6 +137,20 @@ class DocumentSpec() extends FunSuite {
     expect.same(roundTripped, Right(fooOrBar))
   }
 
+  test("untagged unions encoding".only) {
+    import smithy4s.example.CheckedOrUnchecked2
+    import Document._
+
+    val checked = CheckedOrUnchecked2.checked("value")
+    val document = Document.encode(checked)
+    val expectedDocument = fromString("value")
+
+    val roundTripped = Document.decode[CheckedOrUnchecked2](document)
+
+    expect.same(document, expectedDocument)
+    expect.same(roundTripped, checked)
+  }
+
   test("discriminated unions encoding - empty structure alternative") {
     val fooOrBaz: Either[Foo, Baz] = Right(Baz())
 


### PR DESCRIPTION
This PR is the test case that needs to pass to resolve https://github.com/disneystreaming/smithy4s/issues/1273

## PR Checklist (not all items are relevant to all PRs)

- [x] Added unit-tests (for runtime code)
- [] Added bootstrapped code + smoke tests (when the rendering logic is modified)
- [] Added build-plugins integration tests (when reflection loading is required at codegen-time)
- [] Added alloy compliance tests (when simpleRestJson protocol behaviour is expanded/updated)
- [] Updated dynamic module to match generated-code behaviour
- [] Added documentation
- [] Updated changelog
