### PR TITLE
Avoid duplicate repos/deps/imports in the smithy-build.json

### DIFF
--- a/modules/codegen-plugin/src/smithy4s/codegen/GenerateSmithyBuild.scala
+++ b/modules/codegen-plugin/src/smithy4s/codegen/GenerateSmithyBuild.scala
@@ -92,6 +92,7 @@ private[codegen] object GenerateSmithyBuild {
       .flatten
       .filter(_.configurations.exists(_.contains(Smithy4s.name)))
       .flatMap(Smithy4sCodegenPlugin.moduleIdEncode(_, scalaBin))
+      .distinct
   }
 
   private def extractRepos(
@@ -103,6 +104,7 @@ private[codegen] object GenerateSmithyBuild {
       .toList
       .flatten
       .collect(prepareResolvers)
+      .distinct
 
   private def extractImports(
       pr: ProjectRef,
@@ -114,6 +116,7 @@ private[codegen] object GenerateSmithyBuild {
       .toList
       .flatten
       .collect(prepareInputDirs(rootDir))
+      .distinct
 
   private val prepareResolvers: PartialFunction[Resolver, String] = {
     case mr: MavenRepository if !mr.root.contains("repo1.maven.org") => mr.root


### PR DESCRIPTION
Already happening in mill https://github.com/disneystreaming/smithy4s/blob/series/0.18/modules/mill-codegen-plugin/src/smithy4s/codegen/LSP.scala#L47

## PR Checklist (not all items are relevant to all PRs)

- [ ] Added unit-tests (for runtime code)
- [ ] Added bootstrapped code + smoke tests (when the rendering logic is modified)
- [ ] Added build-plugins integration tests (when reflection loading is required at codegen-time)
- [ ] Added alloy compliance tests (when simpleRestJson protocol behaviour is expanded/updated)
- [ ] Updated dynamic module to match generated-code behaviour
- [ ] Added documentation
- [ ] Updated changelog
