### PR TITLE
Escape astrisks following slashes in documentation

### DIFF
--- a/modules/bootstrapped/src/generated/smithy4s/example/DocumentationComment.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/DocumentationComment.scala
@@ -1,0 +1,28 @@
+package smithy4s.example
+
+import smithy4s.Hints
+import smithy4s.Schema
+import smithy4s.ShapeId
+import smithy4s.ShapeTag
+import smithy4s.schema.Schema.string
+import smithy4s.schema.Schema.struct
+
+/** We should be able to use comments in documentation /&ast; \*\/
+  * @param member
+  *   /&ast;
+  */
+final case class DocumentationComment(member: Option[String] = None)
+
+object DocumentationComment extends ShapeTag.Companion[DocumentationComment] {
+  val id: ShapeId = ShapeId("smithy4s.example", "DocumentationComment")
+
+  val hints: Hints = Hints(
+    smithy.api.Documentation("We should be able to use comments in documentation /* */"),
+  )
+
+  implicit val schema: Schema[DocumentationComment] = struct(
+    string.optional[DocumentationComment]("member", _.member).addHints(smithy.api.Documentation("/*")),
+  ){
+    DocumentationComment.apply
+  }.withId(id).addHints(hints)
+}

--- a/modules/codegen/test/src/smithy4s/codegen/internals/RendererSpec.scala
+++ b/modules/codegen/test/src/smithy4s/codegen/internals/RendererSpec.scala
@@ -428,4 +428,22 @@ final class RendererSpec extends munit.FunSuite {
       contents.exists(_.contains("smithy.api.Documentation(s\"foo $$bar\")"))
     )
   }
+
+  test(
+    "string literal containing /* is rendered as a string with * escaped as &ast;"
+  ) {
+    val smithy = """
+                   |$version: "2.0"
+                   |
+                   |namespace smithy4s
+                   |
+                   |@documentation("/*")
+                   |string MyString
+                   |""".stripMargin
+
+    val contents = generateScalaCode(smithy).values
+
+    assert(contents.exists(_.contains("/** /&ast; */")))
+    assert(contents.exists(_.contains("""smithy.api.Documentation("/*")""")))
+  }
 }

--- a/sampleSpecs/quoted_string.smithy
+++ b/sampleSpecs/quoted_string.smithy
@@ -19,3 +19,9 @@ structure EnvVarString {
     @documentation("This is meant to be used with $ENV_VAR")
     member: String
 }
+
+@documentation("We should be able to use comments in documentation /* */")
+structure DocumentationComment {
+    @documentation("/*")
+    member: String
+}


### PR DESCRIPTION
When `/*` is present in Smithy documentation, it causes Unclosed Comment errors in the generated Scala code. Replacing the `*` with `&ast;` avoids the issue.

Fixes #1300.

## PR Checklist (not all items are relevant to all PRs)

- [x] Added unit-tests (for runtime code)
- [x] Added bootstrapped code + smoke tests (when the rendering logic is modified)
- [ ] Added build-plugins integration tests (when reflection loading is required at codegen-time)
- [ ] Added alloy compliance tests (when simpleRestJson protocol behaviour is expanded/updated)
- [ ] Updated dynamic module to match generated-code behaviour
- [ ] Added documentation
- [ ] Updated changelog
