### PR TITLE
Use field.getUnlessDefault instead of field.get in UrlFormDataEncoder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.18.5
+
+* When encoding to `application/x-www-form-urlencoded`, omit optional fields set to the field's default value.
+
 # 0.18.4
 
 * Changes the behaviour of `Field#getUnlessDefault` and `Field#foreachUnlessDefault` to always take the value into consideration when the `smithy.api#required` trait

--- a/modules/bootstrapped/test/src/smithy4s/http/internals/UrlFormDataEncoderDecoderSchemaVisitorSpec.scala
+++ b/modules/bootstrapped/test/src/smithy4s/http/internals/UrlFormDataEncoderDecoderSchemaVisitorSpec.scala
@@ -175,6 +175,89 @@ object UrlFormDataEncoderDecoderSchemaVisitorSpec extends SimpleIOSuite {
     )
   }
 
+  pureTest(
+    "struct: default (but not required) values are omitted from encoded output"
+  ) {
+    val defaultValue = "default"
+    case class Foo(x: Int, y: String)
+    object Foo {
+      implicit val schema: Schema[Foo] = {
+        val x = int.required[Foo]("x", _.x)
+        val y = smithy4s.schema
+          .Field[Foo, String]("x", string, _.y)
+          .addHints(
+            smithy.api.Default(smithy4s.Document.fromString(defaultValue))
+          )
+        struct(x, y)(Foo.apply)
+      }
+    }
+
+    expect.same(
+      UrlForm
+        .Encoder(
+          capitalizeStructAndUnionMemberNames = false
+        )
+        .fromSchema(Foo.schema)
+        .encode(Foo(42, defaultValue))
+        .render,
+      "x=42"
+    )
+  }
+
+  pureTest("struct: required default values are included in encoded output") {
+    val defaultValue = "default"
+    case class Foo(x: Int, y: String)
+    object Foo {
+      implicit val schema: Schema[Foo] = {
+        val x = int.required[Foo]("x", _.x)
+        val y = string
+          .required[Foo]("y", _.y)
+          .addHints(
+            smithy.api.Default(smithy4s.Document.fromString(defaultValue))
+          )
+        struct(x, y)(Foo.apply)
+      }
+    }
+
+    expect.same(
+      UrlForm
+        .Encoder(
+          capitalizeStructAndUnionMemberNames = false
+        )
+        .fromSchema(Foo.schema)
+        .encode(Foo(42, defaultValue))
+        .render,
+      "x=42&y=default"
+    )
+  }
+
+  pureTest("struct: optional default values are omitted from encoded output") {
+    val defaultValue = "default"
+    case class Foo(x: Int, y: Option[String])
+    object Foo {
+      implicit val schema: Schema[Foo] = {
+        val x = int.required[Foo]("x", _.x)
+        val y = string
+          .optional[Foo]("y", _.y)
+          .addHints(
+            smithy.api.Default(smithy4s.Document.fromString(defaultValue))
+          )
+        struct(x, y)(Foo.apply)
+      }
+    }
+
+    expect.same(
+      UrlForm
+        .Encoder(
+          capitalizeStructAndUnionMemberNames = false
+        )
+        .fromSchema(Foo.schema)
+        .encode(Foo(42, Some(defaultValue)))
+        .render,
+      "x=42"
+    )
+  }
+
   pureTest("list") {
     case class Foo(foos: List[Int])
     object Foo {


### PR DESCRIPTION
Fixes #1321.

## PR Checklist (not all items are relevant to all PRs)

- [x] Added unit-tests (for runtime code)
- [ ] Added bootstrapped code + smoke tests (when the rendering logic is modified)
- [ ] Added build-plugins integration tests (when reflection loading is required at codegen-time)
- [ ] Added alloy compliance tests (when simpleRestJson protocol behaviour is expanded/updated)
- [ ] Updated dynamic module to match generated-code behaviour
- [ ] Added documentation
- [x] Updated changelog
