### PR TITLE
Add support for Unit primitives when unfolding typed nodes

### DIFF
--- a/modules/codegen/src/smithy4s/codegen/internals/SmithyToIR.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/SmithyToIR.scala
@@ -1407,6 +1407,11 @@ private[codegen] class SmithyToIR(model: Model, namespace: String) {
         Primitive.Timestamp,
         java.time.Instant.ofEpochSecond(0)
       )
+    case (_, Primitive.Unit) =>
+      TypedNode.PrimitiveTN(
+        Primitive.Unit,
+        ()
+      )
     case other =>
       throw new NotImplementedError(s"Unsupported case: $other")
   }

--- a/modules/codegen/test/src/smithy4s/codegen/internals/RendererSpec.scala
+++ b/modules/codegen/test/src/smithy4s/codegen/internals/RendererSpec.scala
@@ -446,4 +446,33 @@ final class RendererSpec extends munit.FunSuite {
     assert(contents.exists(_.contains("/** /&ast; */")))
     assert(contents.exists(_.contains("""smithy.api.Documentation("/*")""")))
   }
+
+  test("trait with subcomponent targeting smithy.api#Unit") {
+    val smithy =
+      """
+        |$version: "2"
+        |
+        |namespace input
+        |
+        |@trait
+        |union myTrait {
+        |    u: Unit
+        |}
+        |
+        |@myTrait(u: {
+        |
+        |})
+        |string Example
+        |""".stripMargin
+
+    val contents = generateScalaCode(smithy).values
+
+    assert(
+      contents.exists(
+        _.contains(
+          "sealed trait MyTrait extends scala.Product with scala.Serializable"
+        )
+      )
+    )
+  }
 }


### PR DESCRIPTION
Fixes: #1297

## PR Checklist (not all items are relevant to all PRs)

- [x] Added unit-tests (for runtime code)
