### PR TITLE
Rework EnumerationSchema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.19.0
+
+* Reworked enumerations / the EnumerationSchema to eliminate a OOM pitfall and improve ergonomics of SchemaVisitor
+
 # 0.18.5
 
 * When encoding to `application/x-www-form-urlencoded`, omit optional fields set to the field's default value.

--- a/modules/bootstrapped/src/generated/smithy4s/example/AudioEnum.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/AudioEnum.scala
@@ -5,13 +5,12 @@ import smithy4s.Hints
 import smithy4s.Schema
 import smithy4s.ShapeId
 import smithy4s.ShapeTag
-import smithy4s.schema.EnumTag
-import smithy4s.schema.Schema.enumeration
+import smithy4s.schema.Schema.stringEnumeration
 
-sealed abstract class AudioEnum(_value: String, _name: String, _intValue: Int, _hints: Hints) extends Enumeration.Value {
+sealed abstract class AudioEnum(_name: String, _stringValue: String, _intValue: Int, _hints: Hints) extends Enumeration.Value {
   override type EnumType = AudioEnum
-  override val value: String = _value
   override val name: String = _name
+  override val stringValue: String = _stringValue
   override val intValue: Int = _intValue
   override val hints: Hints = _hints
   override def enumeration: Enumeration[EnumType] = AudioEnum
@@ -24,13 +23,12 @@ object AudioEnum extends Enumeration[AudioEnum] with ShapeTag.Companion[AudioEnu
     smithy.api.MediaType("audio/mpeg3"),
   )
 
-  case object GUITAR extends AudioEnum("guitar", "GUITAR", 0, Hints())
-  case object BASS extends AudioEnum("bass", "BASS", 1, Hints())
+  case object GUITAR extends AudioEnum("GUITAR", "guitar", 0, Hints())
+  case object BASS extends AudioEnum("BASS", "bass", 1, Hints())
 
   val values: List[AudioEnum] = List(
     GUITAR,
     BASS,
   )
-  val tag: EnumTag[AudioEnum] = EnumTag.ClosedStringEnum
-  implicit val schema: Schema[AudioEnum] = enumeration(tag, values).withId(id).addHints(hints)
+  implicit val schema: Schema[AudioEnum] = stringEnumeration(values).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/EnumResult.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/EnumResult.scala
@@ -5,13 +5,12 @@ import smithy4s.Hints
 import smithy4s.Schema
 import smithy4s.ShapeId
 import smithy4s.ShapeTag
-import smithy4s.schema.EnumTag
-import smithy4s.schema.Schema.enumeration
+import smithy4s.schema.Schema.intEnumeration
 
-sealed abstract class EnumResult(_value: String, _name: String, _intValue: Int, _hints: Hints) extends Enumeration.Value {
+sealed abstract class EnumResult(_name: String, _stringValue: String, _intValue: Int, _hints: Hints) extends Enumeration.Value {
   override type EnumType = EnumResult
-  override val value: String = _value
   override val name: String = _name
+  override val stringValue: String = _stringValue
   override val intValue: Int = _intValue
   override val hints: Hints = _hints
   override def enumeration: Enumeration[EnumType] = EnumResult
@@ -29,6 +28,5 @@ object EnumResult extends Enumeration[EnumResult] with ShapeTag.Companion[EnumRe
     FIRST,
     SECOND,
   )
-  val tag: EnumTag[EnumResult] = EnumTag.ClosedIntEnum
-  implicit val schema: Schema[EnumResult] = enumeration(tag, values).withId(id).addHints(hints)
+  implicit val schema: Schema[EnumResult] = intEnumeration(values).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/EnumWithDeprecations.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/EnumWithDeprecations.scala
@@ -5,15 +5,14 @@ import smithy4s.Hints
 import smithy4s.Schema
 import smithy4s.ShapeId
 import smithy4s.ShapeTag
-import smithy4s.schema.EnumTag
-import smithy4s.schema.Schema.enumeration
+import smithy4s.schema.Schema.stringEnumeration
 
 /** some docs here */
 @deprecated(message = "N/A", since = "N/A")
-sealed abstract class EnumWithDeprecations(_value: String, _name: String, _intValue: Int, _hints: Hints) extends Enumeration.Value {
+sealed abstract class EnumWithDeprecations(_name: String, _stringValue: String, _intValue: Int, _hints: Hints) extends Enumeration.Value {
   override type EnumType = EnumWithDeprecations
-  override val value: String = _value
   override val name: String = _name
+  override val stringValue: String = _stringValue
   override val intValue: Int = _intValue
   override val hints: Hints = _hints
   override def enumeration: Enumeration[EnumType] = EnumWithDeprecations
@@ -35,6 +34,5 @@ object EnumWithDeprecations extends Enumeration[EnumWithDeprecations] with Shape
     OLD,
     NEW,
   )
-  val tag: EnumTag[EnumWithDeprecations] = EnumTag.ClosedStringEnum
-  implicit val schema: Schema[EnumWithDeprecations] = enumeration(tag, values).withId(id).addHints(hints)
+  implicit val schema: Schema[EnumWithDeprecations] = stringEnumeration(values).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/EnumWithSymbols.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/EnumWithSymbols.scala
@@ -5,13 +5,12 @@ import smithy4s.Hints
 import smithy4s.Schema
 import smithy4s.ShapeId
 import smithy4s.ShapeTag
-import smithy4s.schema.EnumTag
-import smithy4s.schema.Schema.enumeration
+import smithy4s.schema.Schema.stringEnumeration
 
-sealed abstract class EnumWithSymbols(_value: String, _name: String, _intValue: Int, _hints: Hints) extends Enumeration.Value {
+sealed abstract class EnumWithSymbols(_name: String, _stringValue: String, _intValue: Int, _hints: Hints) extends Enumeration.Value {
   override type EnumType = EnumWithSymbols
-  override val value: String = _value
   override val name: String = _name
+  override val stringValue: String = _stringValue
   override val intValue: Int = _intValue
   override val hints: Hints = _hints
   override def enumeration: Enumeration[EnumType] = EnumWithSymbols
@@ -22,15 +21,14 @@ object EnumWithSymbols extends Enumeration[EnumWithSymbols] with ShapeTag.Compan
 
   val hints: Hints = Hints.empty
 
-  case object FooFooFoo extends EnumWithSymbols("foo:foo:foo", "FooFooFoo", 0, Hints())
-  case object BarBarBar extends EnumWithSymbols("bar:bar:bar", "BarBarBar", 1, Hints())
-  case object Value2 extends EnumWithSymbols("_", "Value2", 2, Hints())
+  case object FooFooFoo extends EnumWithSymbols("FooFooFoo", "foo:foo:foo", 0, Hints())
+  case object BarBarBar extends EnumWithSymbols("BarBarBar", "bar:bar:bar", 1, Hints())
+  case object Value2 extends EnumWithSymbols("Value2", "_", 2, Hints())
 
   val values: List[EnumWithSymbols] = List(
     FooFooFoo,
     BarBarBar,
     Value2,
   )
-  val tag: EnumTag[EnumWithSymbols] = EnumTag.ClosedStringEnum
-  implicit val schema: Schema[EnumWithSymbols] = enumeration(tag, values).withId(id).addHints(hints)
+  implicit val schema: Schema[EnumWithSymbols] = stringEnumeration(values).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/FaceCard.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/FaceCard.scala
@@ -5,14 +5,13 @@ import smithy4s.Hints
 import smithy4s.Schema
 import smithy4s.ShapeId
 import smithy4s.ShapeTag
-import smithy4s.schema.EnumTag
-import smithy4s.schema.Schema.enumeration
+import smithy4s.schema.Schema.intEnumeration
 
 /** FaceCard types */
-sealed abstract class FaceCard(_value: String, _name: String, _intValue: Int, _hints: Hints) extends Enumeration.Value {
+sealed abstract class FaceCard(_name: String, _stringValue: String, _intValue: Int, _hints: Hints) extends Enumeration.Value {
   override type EnumType = FaceCard
-  override val value: String = _value
   override val name: String = _name
+  override val stringValue: String = _stringValue
   override val intValue: Int = _intValue
   override val hints: Hints = _hints
   override def enumeration: Enumeration[EnumType] = FaceCard
@@ -38,6 +37,5 @@ object FaceCard extends Enumeration[FaceCard] with ShapeTag.Companion[FaceCard] 
     ACE,
     JOKER,
   )
-  val tag: EnumTag[FaceCard] = EnumTag.ClosedIntEnum
-  implicit val schema: Schema[FaceCard] = enumeration(tag, values).withId(id).addHints(hints)
+  implicit val schema: Schema[FaceCard] = intEnumeration(values).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/FooEnum.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/FooEnum.scala
@@ -5,13 +5,12 @@ import smithy4s.Hints
 import smithy4s.Schema
 import smithy4s.ShapeId
 import smithy4s.ShapeTag
-import smithy4s.schema.EnumTag
-import smithy4s.schema.Schema.enumeration
+import smithy4s.schema.Schema.stringEnumeration
 
-sealed abstract class FooEnum(_value: String, _name: String, _intValue: Int, _hints: Hints) extends Enumeration.Value {
+sealed abstract class FooEnum(_name: String, _stringValue: String, _intValue: Int, _hints: Hints) extends Enumeration.Value {
   override type EnumType = FooEnum
-  override val value: String = _value
   override val name: String = _name
+  override val stringValue: String = _stringValue
   override val intValue: Int = _intValue
   override val hints: Hints = _hints
   override def enumeration: Enumeration[EnumType] = FooEnum
@@ -22,11 +21,10 @@ object FooEnum extends Enumeration[FooEnum] with ShapeTag.Companion[FooEnum] {
 
   val hints: Hints = Hints.empty
 
-  case object FOO extends FooEnum("Foo", "FOO", 0, Hints())
+  case object FOO extends FooEnum("FOO", "Foo", 0, Hints())
 
   val values: List[FooEnum] = List(
     FOO,
   )
-  val tag: EnumTag[FooEnum] = EnumTag.ClosedStringEnum
-  implicit val schema: Schema[FooEnum] = enumeration(tag, values).withId(id).addHints(hints)
+  implicit val schema: Schema[FooEnum] = stringEnumeration(values).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/HostLabelEnum.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/HostLabelEnum.scala
@@ -5,13 +5,12 @@ import smithy4s.Hints
 import smithy4s.Schema
 import smithy4s.ShapeId
 import smithy4s.ShapeTag
-import smithy4s.schema.EnumTag
-import smithy4s.schema.Schema.enumeration
+import smithy4s.schema.Schema.stringEnumeration
 
-sealed abstract class HostLabelEnum(_value: String, _name: String, _intValue: Int, _hints: Hints) extends Enumeration.Value {
+sealed abstract class HostLabelEnum(_name: String, _stringValue: String, _intValue: Int, _hints: Hints) extends Enumeration.Value {
   override type EnumType = HostLabelEnum
-  override val value: String = _value
   override val name: String = _name
+  override val stringValue: String = _stringValue
   override val intValue: Int = _intValue
   override val hints: Hints = _hints
   override def enumeration: Enumeration[EnumType] = HostLabelEnum
@@ -29,6 +28,5 @@ object HostLabelEnum extends Enumeration[HostLabelEnum] with ShapeTag.Companion[
     THING1,
     THING2,
   )
-  val tag: EnumTag[HostLabelEnum] = EnumTag.ClosedStringEnum
-  implicit val schema: Schema[HostLabelEnum] = enumeration(tag, values).withId(id).addHints(hints)
+  implicit val schema: Schema[HostLabelEnum] = stringEnumeration(values).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/Ingredient.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/Ingredient.scala
@@ -5,13 +5,12 @@ import smithy4s.Hints
 import smithy4s.Schema
 import smithy4s.ShapeId
 import smithy4s.ShapeTag
-import smithy4s.schema.EnumTag
-import smithy4s.schema.Schema.enumeration
+import smithy4s.schema.Schema.stringEnumeration
 
-sealed abstract class Ingredient(_value: String, _name: String, _intValue: Int, _hints: Hints) extends Enumeration.Value {
+sealed abstract class Ingredient(_name: String, _stringValue: String, _intValue: Int, _hints: Hints) extends Enumeration.Value {
   override type EnumType = Ingredient
-  override val value: String = _value
   override val name: String = _name
+  override val stringValue: String = _stringValue
   override val intValue: Int = _intValue
   override val hints: Hints = _hints
   override def enumeration: Enumeration[EnumType] = Ingredient
@@ -22,10 +21,10 @@ object Ingredient extends Enumeration[Ingredient] with ShapeTag.Companion[Ingred
 
   val hints: Hints = Hints.empty
 
-  case object MUSHROOM extends Ingredient("Mushroom", "MUSHROOM", 0, Hints())
-  case object CHEESE extends Ingredient("Cheese", "CHEESE", 1, Hints())
-  case object SALAD extends Ingredient("Salad", "SALAD", 2, Hints())
-  case object TOMATO extends Ingredient("Tomato", "TOMATO", 3, Hints())
+  case object MUSHROOM extends Ingredient("MUSHROOM", "Mushroom", 0, Hints())
+  case object CHEESE extends Ingredient("CHEESE", "Cheese", 1, Hints())
+  case object SALAD extends Ingredient("SALAD", "Salad", 2, Hints())
+  case object TOMATO extends Ingredient("TOMATO", "Tomato", 3, Hints())
 
   val values: List[Ingredient] = List(
     MUSHROOM,
@@ -33,6 +32,5 @@ object Ingredient extends Enumeration[Ingredient] with ShapeTag.Companion[Ingred
     SALAD,
     TOMATO,
   )
-  val tag: EnumTag[Ingredient] = EnumTag.ClosedStringEnum
-  implicit val schema: Schema[Ingredient] = enumeration(tag, values).withId(id).addHints(hints)
+  implicit val schema: Schema[Ingredient] = stringEnumeration(values).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/LeftRight.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/LeftRight.scala
@@ -5,13 +5,12 @@ import smithy4s.Hints
 import smithy4s.Schema
 import smithy4s.ShapeId
 import smithy4s.ShapeTag
-import smithy4s.schema.EnumTag
-import smithy4s.schema.Schema.enumeration
+import smithy4s.schema.Schema.stringEnumeration
 
-sealed abstract class LeftRight(_value: String, _name: String, _intValue: Int, _hints: Hints) extends Enumeration.Value {
+sealed abstract class LeftRight(_name: String, _stringValue: String, _intValue: Int, _hints: Hints) extends Enumeration.Value {
   override type EnumType = LeftRight
-  override val value: String = _value
   override val name: String = _name
+  override val stringValue: String = _stringValue
   override val intValue: Int = _intValue
   override val hints: Hints = _hints
   override def enumeration: Enumeration[EnumType] = LeftRight
@@ -22,13 +21,12 @@ object LeftRight extends Enumeration[LeftRight] with ShapeTag.Companion[LeftRigh
 
   val hints: Hints = Hints.empty
 
-  case object LEFT extends LeftRight("left", "LEFT", 0, Hints())
-  case object RIGHT extends LeftRight("right", "RIGHT", 1, Hints())
+  case object LEFT extends LeftRight("LEFT", "left", 0, Hints())
+  case object RIGHT extends LeftRight("RIGHT", "right", 1, Hints())
 
   val values: List[LeftRight] = List(
     LEFT,
     RIGHT,
   )
-  val tag: EnumTag[LeftRight] = EnumTag.ClosedStringEnum
-  implicit val schema: Schema[LeftRight] = enumeration(tag, values).withId(id).addHints(hints)
+  implicit val schema: Schema[LeftRight] = stringEnumeration(values).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/Letters.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/Letters.scala
@@ -5,13 +5,12 @@ import smithy4s.Hints
 import smithy4s.Schema
 import smithy4s.ShapeId
 import smithy4s.ShapeTag
-import smithy4s.schema.EnumTag
-import smithy4s.schema.Schema.enumeration
+import smithy4s.schema.Schema.stringEnumeration
 
-sealed abstract class Letters(_value: String, _name: String, _intValue: Int, _hints: Hints) extends Enumeration.Value {
+sealed abstract class Letters(_name: String, _stringValue: String, _intValue: Int, _hints: Hints) extends Enumeration.Value {
   override type EnumType = Letters
-  override val value: String = _value
   override val name: String = _name
+  override val stringValue: String = _stringValue
   override val intValue: Int = _intValue
   override val hints: Hints = _hints
   override def enumeration: Enumeration[EnumType] = Letters
@@ -22,15 +21,14 @@ object Letters extends Enumeration[Letters] with ShapeTag.Companion[Letters] {
 
   val hints: Hints = Hints.empty
 
-  case object A extends Letters("a", "A", 0, Hints())
-  case object B extends Letters("b", "B", 1, Hints())
-  case object C extends Letters("c", "C", 2, Hints())
+  case object A extends Letters("A", "a", 0, Hints())
+  case object B extends Letters("B", "b", 1, Hints())
+  case object C extends Letters("C", "c", 2, Hints())
 
   val values: List[Letters] = List(
     A,
     B,
     C,
   )
-  val tag: EnumTag[Letters] = EnumTag.ClosedStringEnum
-  implicit val schema: Schema[Letters] = enumeration(tag, values).withId(id).addHints(hints)
+  implicit val schema: Schema[Letters] = stringEnumeration(values).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/LowHigh.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/LowHigh.scala
@@ -5,18 +5,17 @@ import smithy4s.Hints
 import smithy4s.Schema
 import smithy4s.ShapeId
 import smithy4s.ShapeTag
-import smithy4s.schema.EnumTag
-import smithy4s.schema.Schema.enumeration
+import smithy4s.schema.Schema.stringEnumeration
 
 /** @param LOW
   *   low
   * @param HIGH
   *   high
   */
-sealed abstract class LowHigh(_value: String, _name: String, _intValue: Int, _hints: Hints) extends Enumeration.Value {
+sealed abstract class LowHigh(_name: String, _stringValue: String, _intValue: Int, _hints: Hints) extends Enumeration.Value {
   override type EnumType = LowHigh
-  override val value: String = _value
   override val name: String = _name
+  override val stringValue: String = _stringValue
   override val intValue: Int = _intValue
   override val hints: Hints = _hints
   override def enumeration: Enumeration[EnumType] = LowHigh
@@ -28,14 +27,13 @@ object LowHigh extends Enumeration[LowHigh] with ShapeTag.Companion[LowHigh] {
   val hints: Hints = Hints.empty
 
   /** low */
-  case object LOW extends LowHigh("Low", "LOW", 0, Hints(smithy.api.Documentation("low")))
+  case object LOW extends LowHigh("LOW", "Low", 0, Hints(smithy.api.Documentation("low")))
   /** high */
-  case object HIGH extends LowHigh("High", "HIGH", 1, Hints(smithy.api.Documentation("high")))
+  case object HIGH extends LowHigh("HIGH", "High", 1, Hints(smithy.api.Documentation("high")))
 
   val values: List[LowHigh] = List(
     LOW,
     HIGH,
   )
-  val tag: EnumTag[LowHigh] = EnumTag.ClosedStringEnum
-  implicit val schema: Schema[LowHigh] = enumeration(tag, values).withId(id).addHints(hints)
+  implicit val schema: Schema[LowHigh] = stringEnumeration(values).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/NetworkConnectionType.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/NetworkConnectionType.scala
@@ -6,13 +6,12 @@ import smithy4s.Schema
 import smithy4s.ShapeId
 import smithy4s.ShapeTag
 import smithy4s.interopcats.SchemaVisitorHash
-import smithy4s.schema.EnumTag
-import smithy4s.schema.Schema.enumeration
+import smithy4s.schema.Schema.stringEnumeration
 
-sealed abstract class NetworkConnectionType(_value: String, _name: String, _intValue: Int, _hints: Hints) extends Enumeration.Value {
+sealed abstract class NetworkConnectionType(_name: String, _stringValue: String, _intValue: Int, _hints: Hints) extends Enumeration.Value {
   override type EnumType = NetworkConnectionType
-  override val value: String = _value
   override val name: String = _name
+  override val stringValue: String = _stringValue
   override val intValue: Int = _intValue
   override val hints: Hints = _hints
   override def enumeration: Enumeration[EnumType] = NetworkConnectionType
@@ -32,8 +31,7 @@ object NetworkConnectionType extends Enumeration[NetworkConnectionType] with Sha
     ETHERNET,
     WIFI,
   )
-  val tag: EnumTag[NetworkConnectionType] = EnumTag.ClosedStringEnum
-  implicit val schema: Schema[NetworkConnectionType] = enumeration(tag, values).withId(id).addHints(hints)
+  implicit val schema: Schema[NetworkConnectionType] = stringEnumeration(values).withId(id).addHints(hints)
 
   implicit val networkConnectionTypeHash: cats.Hash[NetworkConnectionType] = SchemaVisitorHash.fromSchema(schema)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/Numbers.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/Numbers.scala
@@ -5,13 +5,12 @@ import smithy4s.Hints
 import smithy4s.Schema
 import smithy4s.ShapeId
 import smithy4s.ShapeTag
-import smithy4s.schema.EnumTag
-import smithy4s.schema.Schema.enumeration
+import smithy4s.schema.Schema.intEnumeration
 
-sealed abstract class Numbers(_value: String, _name: String, _intValue: Int, _hints: Hints) extends Enumeration.Value {
+sealed abstract class Numbers(_name: String, _stringValue: String, _intValue: Int, _hints: Hints) extends Enumeration.Value {
   override type EnumType = Numbers
-  override val value: String = _value
   override val name: String = _name
+  override val stringValue: String = _stringValue
   override val intValue: Int = _intValue
   override val hints: Hints = _hints
   override def enumeration: Enumeration[EnumType] = Numbers
@@ -29,6 +28,5 @@ object Numbers extends Enumeration[Numbers] with ShapeTag.Companion[Numbers] {
     ONE,
     TWO,
   )
-  val tag: EnumTag[Numbers] = EnumTag.ClosedIntEnum
-  implicit val schema: Schema[Numbers] = enumeration(tag, values).withId(id).addHints(hints)
+  implicit val schema: Schema[Numbers] = intEnumeration(values).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/OldStyleLeftRight.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/OldStyleLeftRight.scala
@@ -5,13 +5,12 @@ import smithy4s.Hints
 import smithy4s.Schema
 import smithy4s.ShapeId
 import smithy4s.ShapeTag
-import smithy4s.schema.EnumTag
-import smithy4s.schema.Schema.enumeration
+import smithy4s.schema.Schema.stringEnumeration
 
-sealed abstract class OldStyleLeftRight(_value: String, _name: String, _intValue: Int, _hints: Hints) extends Enumeration.Value {
+sealed abstract class OldStyleLeftRight(_name: String, _stringValue: String, _intValue: Int, _hints: Hints) extends Enumeration.Value {
   override type EnumType = OldStyleLeftRight
-  override val value: String = _value
   override val name: String = _name
+  override val stringValue: String = _stringValue
   override val intValue: Int = _intValue
   override val hints: Hints = _hints
   override def enumeration: Enumeration[EnumType] = OldStyleLeftRight
@@ -22,13 +21,12 @@ object OldStyleLeftRight extends Enumeration[OldStyleLeftRight] with ShapeTag.Co
 
   val hints: Hints = Hints.empty
 
-  case object LEFT extends OldStyleLeftRight("left", "LEFT", 0, Hints())
-  case object RIGHT extends OldStyleLeftRight("right", "RIGHT", 1, Hints())
+  case object LEFT extends OldStyleLeftRight("LEFT", "left", 0, Hints())
+  case object RIGHT extends OldStyleLeftRight("RIGHT", "right", 1, Hints())
 
   val values: List[OldStyleLeftRight] = List(
     LEFT,
     RIGHT,
   )
-  val tag: EnumTag[OldStyleLeftRight] = EnumTag.ClosedStringEnum
-  implicit val schema: Schema[OldStyleLeftRight] = enumeration(tag, values).withId(id).addHints(hints)
+  implicit val schema: Schema[OldStyleLeftRight] = stringEnumeration(values).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/OneTwo.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/OneTwo.scala
@@ -5,13 +5,12 @@ import smithy4s.Hints
 import smithy4s.Schema
 import smithy4s.ShapeId
 import smithy4s.ShapeTag
-import smithy4s.schema.EnumTag
-import smithy4s.schema.Schema.enumeration
+import smithy4s.schema.Schema.intEnumeration
 
-sealed abstract class OneTwo(_value: String, _name: String, _intValue: Int, _hints: Hints) extends Enumeration.Value {
+sealed abstract class OneTwo(_name: String, _stringValue: String, _intValue: Int, _hints: Hints) extends Enumeration.Value {
   override type EnumType = OneTwo
-  override val value: String = _value
   override val name: String = _name
+  override val stringValue: String = _stringValue
   override val intValue: Int = _intValue
   override val hints: Hints = _hints
   override def enumeration: Enumeration[EnumType] = OneTwo
@@ -29,6 +28,5 @@ object OneTwo extends Enumeration[OneTwo] with ShapeTag.Companion[OneTwo] {
     ONE,
     TWO,
   )
-  val tag: EnumTag[OneTwo] = EnumTag.ClosedIntEnum
-  implicit val schema: Schema[OneTwo] = enumeration(tag, values).withId(id).addHints(hints)
+  implicit val schema: Schema[OneTwo] = intEnumeration(values).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/OpenEnumCollisionTest.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/OpenEnumCollisionTest.scala
@@ -34,7 +34,7 @@ object OpenEnumCollisionTest extends Enumeration[OpenEnumCollisionTest] with Sha
   case object ONE extends OpenEnumCollisionTest("ONE", "ONE", 0, Hints())
   case object TWO extends OpenEnumCollisionTest("TWO", "TWO", 1, Hints())
   case object Unknown extends OpenEnumCollisionTest("Unknown", "Unknown", 2, Hints())
-  final case class $Unknown(str: String) extends OpenEnumCollisionTest(str, "$Unknown", -1, Hints.empty)
+  final case class $Unknown(str: String) extends OpenEnumCollisionTest("$Unknown", str, -1, Hints.empty)
 
   val $unknown: String => OpenEnumCollisionTest = $Unknown(_)
 

--- a/modules/bootstrapped/src/generated/smithy4s/example/OpenEnumCollisionTest.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/OpenEnumCollisionTest.scala
@@ -6,13 +6,12 @@ import smithy4s.Schema
 import smithy4s.ShapeId
 import smithy4s.ShapeTag
 import smithy4s.optics.Prism
-import smithy4s.schema.EnumTag
-import smithy4s.schema.Schema.enumeration
+import smithy4s.schema.Schema.openStringEnumeration
 
-sealed abstract class OpenEnumCollisionTest(_value: String, _name: String, _intValue: Int, _hints: Hints) extends Enumeration.Value {
+sealed abstract class OpenEnumCollisionTest(_name: String, _stringValue: String, _intValue: Int, _hints: Hints) extends Enumeration.Value {
   override type EnumType = OpenEnumCollisionTest
-  override val value: String = _value
   override val name: String = _name
+  override val stringValue: String = _stringValue
   override val intValue: Int = _intValue
   override val hints: Hints = _hints
   override def enumeration: Enumeration[EnumType] = OpenEnumCollisionTest
@@ -44,6 +43,5 @@ object OpenEnumCollisionTest extends Enumeration[OpenEnumCollisionTest] with Sha
     TWO,
     Unknown,
   )
-  val tag: EnumTag[OpenEnumCollisionTest] = EnumTag.OpenStringEnum($unknown)
-  implicit val schema: Schema[OpenEnumCollisionTest] = enumeration(tag, values).withId(id).addHints(hints)
+  implicit val schema: Schema[OpenEnumCollisionTest] = openStringEnumeration(values, $unknown).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/OpenEnumCollisionTest2.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/OpenEnumCollisionTest2.scala
@@ -34,7 +34,7 @@ object OpenEnumCollisionTest2 extends Enumeration[OpenEnumCollisionTest2] with S
   case object ONE extends OpenEnumCollisionTest2("ONE", "ONE", 0, Hints())
   case object TWO extends OpenEnumCollisionTest2("TWO", "TWO", 1, Hints())
   case object THREE extends OpenEnumCollisionTest2("THREE", "unknown", 2, Hints())
-  final case class $Unknown(str: String) extends OpenEnumCollisionTest2(str, "$Unknown", -1, Hints.empty)
+  final case class $Unknown(str: String) extends OpenEnumCollisionTest2("$Unknown", str, -1, Hints.empty)
 
   val $unknown: String => OpenEnumCollisionTest2 = $Unknown(_)
 

--- a/modules/bootstrapped/src/generated/smithy4s/example/OpenEnumCollisionTest2.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/OpenEnumCollisionTest2.scala
@@ -6,13 +6,12 @@ import smithy4s.Schema
 import smithy4s.ShapeId
 import smithy4s.ShapeTag
 import smithy4s.optics.Prism
-import smithy4s.schema.EnumTag
-import smithy4s.schema.Schema.enumeration
+import smithy4s.schema.Schema.openStringEnumeration
 
-sealed abstract class OpenEnumCollisionTest2(_value: String, _name: String, _intValue: Int, _hints: Hints) extends Enumeration.Value {
+sealed abstract class OpenEnumCollisionTest2(_name: String, _stringValue: String, _intValue: Int, _hints: Hints) extends Enumeration.Value {
   override type EnumType = OpenEnumCollisionTest2
-  override val value: String = _value
   override val name: String = _name
+  override val stringValue: String = _stringValue
   override val intValue: Int = _intValue
   override val hints: Hints = _hints
   override def enumeration: Enumeration[EnumType] = OpenEnumCollisionTest2
@@ -34,7 +33,7 @@ object OpenEnumCollisionTest2 extends Enumeration[OpenEnumCollisionTest2] with S
 
   case object ONE extends OpenEnumCollisionTest2("ONE", "ONE", 0, Hints())
   case object TWO extends OpenEnumCollisionTest2("TWO", "TWO", 1, Hints())
-  case object THREE extends OpenEnumCollisionTest2("unknown", "THREE", 2, Hints())
+  case object THREE extends OpenEnumCollisionTest2("THREE", "unknown", 2, Hints())
   final case class $Unknown(str: String) extends OpenEnumCollisionTest2(str, "$Unknown", -1, Hints.empty)
 
   val $unknown: String => OpenEnumCollisionTest2 = $Unknown(_)
@@ -44,6 +43,5 @@ object OpenEnumCollisionTest2 extends Enumeration[OpenEnumCollisionTest2] with S
     TWO,
     THREE,
   )
-  val tag: EnumTag[OpenEnumCollisionTest2] = EnumTag.OpenStringEnum($unknown)
-  implicit val schema: Schema[OpenEnumCollisionTest2] = enumeration(tag, values).withId(id).addHints(hints)
+  implicit val schema: Schema[OpenEnumCollisionTest2] = openStringEnumeration(values, $unknown).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/OpenEnumCollisionTest3.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/OpenEnumCollisionTest3.scala
@@ -6,13 +6,12 @@ import smithy4s.Schema
 import smithy4s.ShapeId
 import smithy4s.ShapeTag
 import smithy4s.optics.Prism
-import smithy4s.schema.EnumTag
-import smithy4s.schema.Schema.enumeration
+import smithy4s.schema.Schema.openStringEnumeration
 
-sealed abstract class OpenEnumCollisionTest3(_value: String, _name: String, _intValue: Int, _hints: Hints) extends Enumeration.Value {
+sealed abstract class OpenEnumCollisionTest3(_name: String, _stringValue: String, _intValue: Int, _hints: Hints) extends Enumeration.Value {
   override type EnumType = OpenEnumCollisionTest3
-  override val value: String = _value
   override val name: String = _name
+  override val stringValue: String = _stringValue
   override val intValue: Int = _intValue
   override val hints: Hints = _hints
   override def enumeration: Enumeration[EnumType] = OpenEnumCollisionTest3
@@ -44,6 +43,5 @@ object OpenEnumCollisionTest3 extends Enumeration[OpenEnumCollisionTest3] with S
     TWO,
     unknown,
   )
-  val tag: EnumTag[OpenEnumCollisionTest3] = EnumTag.OpenStringEnum($unknown)
-  implicit val schema: Schema[OpenEnumCollisionTest3] = enumeration(tag, values).withId(id).addHints(hints)
+  implicit val schema: Schema[OpenEnumCollisionTest3] = openStringEnumeration(values, $unknown).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/OpenEnumCollisionTest3.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/OpenEnumCollisionTest3.scala
@@ -34,7 +34,7 @@ object OpenEnumCollisionTest3 extends Enumeration[OpenEnumCollisionTest3] with S
   case object ONE extends OpenEnumCollisionTest3("ONE", "ONE", 0, Hints())
   case object TWO extends OpenEnumCollisionTest3("TWO", "TWO", 1, Hints())
   case object unknown extends OpenEnumCollisionTest3("unknown", "unknown", 2, Hints())
-  final case class $Unknown(str: String) extends OpenEnumCollisionTest3(str, "$Unknown", -1, Hints.empty)
+  final case class $Unknown(str: String) extends OpenEnumCollisionTest3("$Unknown", str, -1, Hints.empty)
 
   val $unknown: String => OpenEnumCollisionTest3 = $Unknown(_)
 

--- a/modules/bootstrapped/src/generated/smithy4s/example/OpenEnumTest.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/OpenEnumTest.scala
@@ -6,13 +6,12 @@ import smithy4s.Schema
 import smithy4s.ShapeId
 import smithy4s.ShapeTag
 import smithy4s.optics.Prism
-import smithy4s.schema.EnumTag
-import smithy4s.schema.Schema.enumeration
+import smithy4s.schema.Schema.openStringEnumeration
 
-sealed abstract class OpenEnumTest(_value: String, _name: String, _intValue: Int, _hints: Hints) extends Enumeration.Value {
+sealed abstract class OpenEnumTest(_name: String, _stringValue: String, _intValue: Int, _hints: Hints) extends Enumeration.Value {
   override type EnumType = OpenEnumTest
-  override val value: String = _value
   override val name: String = _name
+  override val stringValue: String = _stringValue
   override val intValue: Int = _intValue
   override val hints: Hints = _hints
   override def enumeration: Enumeration[EnumType] = OpenEnumTest
@@ -38,6 +37,5 @@ object OpenEnumTest extends Enumeration[OpenEnumTest] with ShapeTag.Companion[Op
   val values: List[OpenEnumTest] = List(
     ONE,
   )
-  val tag: EnumTag[OpenEnumTest] = EnumTag.OpenStringEnum($unknown)
-  implicit val schema: Schema[OpenEnumTest] = enumeration(tag, values).withId(id).addHints(hints)
+  implicit val schema: Schema[OpenEnumTest] = openStringEnumeration(values, $unknown).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/OpenEnumTest.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/OpenEnumTest.scala
@@ -30,7 +30,7 @@ object OpenEnumTest extends Enumeration[OpenEnumTest] with ShapeTag.Companion[Op
   }
 
   case object ONE extends OpenEnumTest("ONE", "ONE", 0, Hints())
-  final case class $Unknown(str: String) extends OpenEnumTest(str, "$Unknown", -1, Hints.empty)
+  final case class $Unknown(str: String) extends OpenEnumTest("$Unknown", str, -1, Hints.empty)
 
   val $unknown: String => OpenEnumTest = $Unknown(_)
 

--- a/modules/bootstrapped/src/generated/smithy4s/example/OpenIntEnumCollisionTest.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/OpenIntEnumCollisionTest.scala
@@ -6,13 +6,12 @@ import smithy4s.Schema
 import smithy4s.ShapeId
 import smithy4s.ShapeTag
 import smithy4s.optics.Prism
-import smithy4s.schema.EnumTag
-import smithy4s.schema.Schema.enumeration
+import smithy4s.schema.Schema.openIntEnumeration
 
-sealed abstract class OpenIntEnumCollisionTest(_value: String, _name: String, _intValue: Int, _hints: Hints) extends Enumeration.Value {
+sealed abstract class OpenIntEnumCollisionTest(_name: String, _stringValue: String, _intValue: Int, _hints: Hints) extends Enumeration.Value {
   override type EnumType = OpenIntEnumCollisionTest
-  override val value: String = _value
   override val name: String = _name
+  override val stringValue: String = _stringValue
   override val intValue: Int = _intValue
   override val hints: Hints = _hints
   override def enumeration: Enumeration[EnumType] = OpenIntEnumCollisionTest
@@ -44,6 +43,5 @@ object OpenIntEnumCollisionTest extends Enumeration[OpenIntEnumCollisionTest] wi
     TWO,
     Unknown,
   )
-  val tag: EnumTag[OpenIntEnumCollisionTest] = EnumTag.OpenIntEnum($unknown)
-  implicit val schema: Schema[OpenIntEnumCollisionTest] = enumeration(tag, values).withId(id).addHints(hints)
+  implicit val schema: Schema[OpenIntEnumCollisionTest] = openIntEnumeration(values, $unknown).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/OpenIntEnumCollisionTest2.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/OpenIntEnumCollisionTest2.scala
@@ -6,13 +6,12 @@ import smithy4s.Schema
 import smithy4s.ShapeId
 import smithy4s.ShapeTag
 import smithy4s.optics.Prism
-import smithy4s.schema.EnumTag
-import smithy4s.schema.Schema.enumeration
+import smithy4s.schema.Schema.openIntEnumeration
 
-sealed abstract class OpenIntEnumCollisionTest2(_value: String, _name: String, _intValue: Int, _hints: Hints) extends Enumeration.Value {
+sealed abstract class OpenIntEnumCollisionTest2(_name: String, _stringValue: String, _intValue: Int, _hints: Hints) extends Enumeration.Value {
   override type EnumType = OpenIntEnumCollisionTest2
-  override val value: String = _value
   override val name: String = _name
+  override val stringValue: String = _stringValue
   override val intValue: Int = _intValue
   override val hints: Hints = _hints
   override def enumeration: Enumeration[EnumType] = OpenIntEnumCollisionTest2
@@ -44,6 +43,5 @@ object OpenIntEnumCollisionTest2 extends Enumeration[OpenIntEnumCollisionTest2] 
     TWO,
     unknown,
   )
-  val tag: EnumTag[OpenIntEnumCollisionTest2] = EnumTag.OpenIntEnum($unknown)
-  implicit val schema: Schema[OpenIntEnumCollisionTest2] = enumeration(tag, values).withId(id).addHints(hints)
+  implicit val schema: Schema[OpenIntEnumCollisionTest2] = openIntEnumeration(values, $unknown).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/OpenIntEnumTest.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/OpenIntEnumTest.scala
@@ -6,13 +6,12 @@ import smithy4s.Schema
 import smithy4s.ShapeId
 import smithy4s.ShapeTag
 import smithy4s.optics.Prism
-import smithy4s.schema.EnumTag
-import smithy4s.schema.Schema.enumeration
+import smithy4s.schema.Schema.openIntEnumeration
 
-sealed abstract class OpenIntEnumTest(_value: String, _name: String, _intValue: Int, _hints: Hints) extends Enumeration.Value {
+sealed abstract class OpenIntEnumTest(_name: String, _stringValue: String, _intValue: Int, _hints: Hints) extends Enumeration.Value {
   override type EnumType = OpenIntEnumTest
-  override val value: String = _value
   override val name: String = _name
+  override val stringValue: String = _stringValue
   override val intValue: Int = _intValue
   override val hints: Hints = _hints
   override def enumeration: Enumeration[EnumType] = OpenIntEnumTest
@@ -38,6 +37,5 @@ object OpenIntEnumTest extends Enumeration[OpenIntEnumTest] with ShapeTag.Compan
   val values: List[OpenIntEnumTest] = List(
     ONE,
   )
-  val tag: EnumTag[OpenIntEnumTest] = EnumTag.OpenIntEnum($unknown)
-  implicit val schema: Schema[OpenIntEnumTest] = enumeration(tag, values).withId(id).addHints(hints)
+  implicit val schema: Schema[OpenIntEnumTest] = openIntEnumeration(values, $unknown).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/OpenNums.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/OpenNums.scala
@@ -5,13 +5,12 @@ import smithy4s.Hints
 import smithy4s.Schema
 import smithy4s.ShapeId
 import smithy4s.ShapeTag
-import smithy4s.schema.EnumTag
-import smithy4s.schema.Schema.enumeration
+import smithy4s.schema.Schema.openIntEnumeration
 
-sealed abstract class OpenNums(_value: String, _name: String, _intValue: Int, _hints: Hints) extends Enumeration.Value {
+sealed abstract class OpenNums(_name: String, _stringValue: String, _intValue: Int, _hints: Hints) extends Enumeration.Value {
   override type EnumType = OpenNums
-  override val value: String = _value
   override val name: String = _name
+  override val stringValue: String = _stringValue
   override val intValue: Int = _intValue
   override val hints: Hints = _hints
   override def enumeration: Enumeration[EnumType] = OpenNums
@@ -34,6 +33,5 @@ object OpenNums extends Enumeration[OpenNums] with ShapeTag.Companion[OpenNums] 
     ONE,
     TWO,
   )
-  val tag: EnumTag[OpenNums] = EnumTag.OpenIntEnum($unknown)
-  implicit val schema: Schema[OpenNums] = enumeration(tag, values).withId(id).addHints(hints)
+  implicit val schema: Schema[OpenNums] = openIntEnumeration(values, $unknown).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/OpenNumsStr.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/OpenNumsStr.scala
@@ -5,13 +5,12 @@ import smithy4s.Hints
 import smithy4s.Schema
 import smithy4s.ShapeId
 import smithy4s.ShapeTag
-import smithy4s.schema.EnumTag
-import smithy4s.schema.Schema.enumeration
+import smithy4s.schema.Schema.openStringEnumeration
 
-sealed abstract class OpenNumsStr(_value: String, _name: String, _intValue: Int, _hints: Hints) extends Enumeration.Value {
+sealed abstract class OpenNumsStr(_name: String, _stringValue: String, _intValue: Int, _hints: Hints) extends Enumeration.Value {
   override type EnumType = OpenNumsStr
-  override val value: String = _value
   override val name: String = _name
+  override val stringValue: String = _stringValue
   override val intValue: Int = _intValue
   override val hints: Hints = _hints
   override def enumeration: Enumeration[EnumType] = OpenNumsStr
@@ -34,6 +33,5 @@ object OpenNumsStr extends Enumeration[OpenNumsStr] with ShapeTag.Companion[Open
     ONE,
     TWO,
   )
-  val tag: EnumTag[OpenNumsStr] = EnumTag.OpenStringEnum($unknown)
-  implicit val schema: Schema[OpenNumsStr] = enumeration(tag, values).withId(id).addHints(hints)
+  implicit val schema: Schema[OpenNumsStr] = openStringEnumeration(values, $unknown).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/OpenNumsStr.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/OpenNumsStr.scala
@@ -25,7 +25,7 @@ object OpenNumsStr extends Enumeration[OpenNumsStr] with ShapeTag.Companion[Open
 
   case object ONE extends OpenNumsStr("ONE", "ONE", 0, Hints())
   case object TWO extends OpenNumsStr("TWO", "TWO", 1, Hints())
-  final case class $Unknown(str: String) extends OpenNumsStr(str, "$Unknown", -1, Hints.empty)
+  final case class $Unknown(str: String) extends OpenNumsStr("$Unknown", str, -1, Hints.empty)
 
   val $unknown: String => OpenNumsStr = $Unknown(_)
 

--- a/modules/bootstrapped/src/generated/smithy4s/example/OpenOldEnumCollisionTest.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/OpenOldEnumCollisionTest.scala
@@ -24,7 +24,7 @@ object OpenOldEnumCollisionTest extends Enumeration[OpenOldEnumCollisionTest] wi
   )
 
   case object Unknown extends OpenOldEnumCollisionTest("Unknown", "unknown", 0, Hints())
-  final case class $Unknown(str: String) extends OpenOldEnumCollisionTest(str, "$Unknown", -1, Hints.empty)
+  final case class $Unknown(str: String) extends OpenOldEnumCollisionTest("$Unknown", str, -1, Hints.empty)
 
   val $unknown: String => OpenOldEnumCollisionTest = $Unknown(_)
 

--- a/modules/bootstrapped/src/generated/smithy4s/example/OpenOldEnumCollisionTest.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/OpenOldEnumCollisionTest.scala
@@ -5,13 +5,12 @@ import smithy4s.Hints
 import smithy4s.Schema
 import smithy4s.ShapeId
 import smithy4s.ShapeTag
-import smithy4s.schema.EnumTag
-import smithy4s.schema.Schema.enumeration
+import smithy4s.schema.Schema.openStringEnumeration
 
-sealed abstract class OpenOldEnumCollisionTest(_value: String, _name: String, _intValue: Int, _hints: Hints) extends Enumeration.Value {
+sealed abstract class OpenOldEnumCollisionTest(_name: String, _stringValue: String, _intValue: Int, _hints: Hints) extends Enumeration.Value {
   override type EnumType = OpenOldEnumCollisionTest
-  override val value: String = _value
   override val name: String = _name
+  override val stringValue: String = _stringValue
   override val intValue: Int = _intValue
   override val hints: Hints = _hints
   override def enumeration: Enumeration[EnumType] = OpenOldEnumCollisionTest
@@ -24,7 +23,7 @@ object OpenOldEnumCollisionTest extends Enumeration[OpenOldEnumCollisionTest] wi
     alloy.OpenEnum(),
   )
 
-  case object Unknown extends OpenOldEnumCollisionTest("unknown", "Unknown", 0, Hints())
+  case object Unknown extends OpenOldEnumCollisionTest("Unknown", "unknown", 0, Hints())
   final case class $Unknown(str: String) extends OpenOldEnumCollisionTest(str, "$Unknown", -1, Hints.empty)
 
   val $unknown: String => OpenOldEnumCollisionTest = $Unknown(_)
@@ -32,6 +31,5 @@ object OpenOldEnumCollisionTest extends Enumeration[OpenOldEnumCollisionTest] wi
   val values: List[OpenOldEnumCollisionTest] = List(
     Unknown,
   )
-  val tag: EnumTag[OpenOldEnumCollisionTest] = EnumTag.OpenStringEnum($unknown)
-  implicit val schema: Schema[OpenOldEnumCollisionTest] = enumeration(tag, values).withId(id).addHints(hints)
+  implicit val schema: Schema[OpenOldEnumCollisionTest] = openStringEnumeration(values, $unknown).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/OpenOldEnumTest.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/OpenOldEnumTest.scala
@@ -5,13 +5,12 @@ import smithy4s.Hints
 import smithy4s.Schema
 import smithy4s.ShapeId
 import smithy4s.ShapeTag
-import smithy4s.schema.EnumTag
-import smithy4s.schema.Schema.enumeration
+import smithy4s.schema.Schema.openStringEnumeration
 
-sealed abstract class OpenOldEnumTest(_value: String, _name: String, _intValue: Int, _hints: Hints) extends Enumeration.Value {
+sealed abstract class OpenOldEnumTest(_name: String, _stringValue: String, _intValue: Int, _hints: Hints) extends Enumeration.Value {
   override type EnumType = OpenOldEnumTest
-  override val value: String = _value
   override val name: String = _name
+  override val stringValue: String = _stringValue
   override val intValue: Int = _intValue
   override val hints: Hints = _hints
   override def enumeration: Enumeration[EnumType] = OpenOldEnumTest
@@ -32,6 +31,5 @@ object OpenOldEnumTest extends Enumeration[OpenOldEnumTest] with ShapeTag.Compan
   val values: List[OpenOldEnumTest] = List(
     ONE,
   )
-  val tag: EnumTag[OpenOldEnumTest] = EnumTag.OpenStringEnum($unknown)
-  implicit val schema: Schema[OpenOldEnumTest] = enumeration(tag, values).withId(id).addHints(hints)
+  implicit val schema: Schema[OpenOldEnumTest] = openStringEnumeration(values, $unknown).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/OpenOldEnumTest.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/OpenOldEnumTest.scala
@@ -24,7 +24,7 @@ object OpenOldEnumTest extends Enumeration[OpenOldEnumTest] with ShapeTag.Compan
   )
 
   case object ONE extends OpenOldEnumTest("ONE", "ONE", 0, Hints())
-  final case class $Unknown(str: String) extends OpenOldEnumTest(str, "$Unknown", -1, Hints.empty)
+  final case class $Unknown(str: String) extends OpenOldEnumTest("$Unknown", str, -1, Hints.empty)
 
   val $unknown: String => OpenOldEnumTest = $Unknown(_)
 

--- a/modules/bootstrapped/src/generated/smithy4s/example/OpticsEnum.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/OpticsEnum.scala
@@ -6,13 +6,12 @@ import smithy4s.Schema
 import smithy4s.ShapeId
 import smithy4s.ShapeTag
 import smithy4s.optics.Prism
-import smithy4s.schema.EnumTag
-import smithy4s.schema.Schema.enumeration
+import smithy4s.schema.Schema.stringEnumeration
 
-sealed abstract class OpticsEnum(_value: String, _name: String, _intValue: Int, _hints: Hints) extends Enumeration.Value {
+sealed abstract class OpticsEnum(_name: String, _stringValue: String, _intValue: Int, _hints: Hints) extends Enumeration.Value {
   override type EnumType = OpticsEnum
-  override val value: String = _value
   override val name: String = _name
+  override val stringValue: String = _stringValue
   override val intValue: Int = _intValue
   override val hints: Hints = _hints
   override def enumeration: Enumeration[EnumType] = OpticsEnum
@@ -35,6 +34,5 @@ object OpticsEnum extends Enumeration[OpticsEnum] with ShapeTag.Companion[Optics
     A,
     B,
   )
-  val tag: EnumTag[OpticsEnum] = EnumTag.ClosedStringEnum
-  implicit val schema: Schema[OpticsEnum] = enumeration(tag, values).withId(id).addHints(hints)
+  implicit val schema: Schema[OpticsEnum] = stringEnumeration(values).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/PizzaBase.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/PizzaBase.scala
@@ -5,13 +5,12 @@ import smithy4s.Hints
 import smithy4s.Schema
 import smithy4s.ShapeId
 import smithy4s.ShapeTag
-import smithy4s.schema.EnumTag
-import smithy4s.schema.Schema.enumeration
+import smithy4s.schema.Schema.stringEnumeration
 
-sealed abstract class PizzaBase(_value: String, _name: String, _intValue: Int, _hints: Hints) extends Enumeration.Value {
+sealed abstract class PizzaBase(_name: String, _stringValue: String, _intValue: Int, _hints: Hints) extends Enumeration.Value {
   override type EnumType = PizzaBase
-  override val value: String = _value
   override val name: String = _name
+  override val stringValue: String = _stringValue
   override val intValue: Int = _intValue
   override val hints: Hints = _hints
   override def enumeration: Enumeration[EnumType] = PizzaBase
@@ -22,13 +21,12 @@ object PizzaBase extends Enumeration[PizzaBase] with ShapeTag.Companion[PizzaBas
 
   val hints: Hints = Hints.empty
 
-  case object CREAM extends PizzaBase("C", "CREAM", 0, Hints())
-  case object TOMATO extends PizzaBase("T", "TOMATO", 1, Hints())
+  case object CREAM extends PizzaBase("CREAM", "C", 0, Hints())
+  case object TOMATO extends PizzaBase("TOMATO", "T", 1, Hints())
 
   val values: List[PizzaBase] = List(
     CREAM,
     TOMATO,
   )
-  val tag: EnumTag[PizzaBase] = EnumTag.ClosedStringEnum
-  implicit val schema: Schema[PizzaBase] = enumeration(tag, values).withId(id).addHints(hints)
+  implicit val schema: Schema[PizzaBase] = stringEnumeration(values).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/StringEnum.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/StringEnum.scala
@@ -5,13 +5,12 @@ import smithy4s.Hints
 import smithy4s.Schema
 import smithy4s.ShapeId
 import smithy4s.ShapeTag
-import smithy4s.schema.EnumTag
-import smithy4s.schema.Schema.enumeration
+import smithy4s.schema.Schema.stringEnumeration
 
-sealed abstract class StringEnum(_value: String, _name: String, _intValue: Int, _hints: Hints) extends Enumeration.Value {
+sealed abstract class StringEnum(_name: String, _stringValue: String, _intValue: Int, _hints: Hints) extends Enumeration.Value {
   override type EnumType = StringEnum
-  override val value: String = _value
   override val name: String = _name
+  override val stringValue: String = _stringValue
   override val intValue: Int = _intValue
   override val hints: Hints = _hints
   override def enumeration: Enumeration[EnumType] = StringEnum
@@ -22,13 +21,12 @@ object StringEnum extends Enumeration[StringEnum] with ShapeTag.Companion[String
 
   val hints: Hints = Hints.empty
 
-  case object STRING extends StringEnum("string", "STRING", 0, Hints())
-  case object INTERESTING extends StringEnum("interesting", "INTERESTING", 1, Hints())
+  case object STRING extends StringEnum("STRING", "string", 0, Hints())
+  case object INTERESTING extends StringEnum("INTERESTING", "interesting", 1, Hints())
 
   val values: List[StringEnum] = List(
     STRING,
     INTERESTING,
   )
-  val tag: EnumTag[StringEnum] = EnumTag.ClosedStringEnum
-  implicit val schema: Schema[StringEnum] = enumeration(tag, values).withId(id).addHints(hints)
+  implicit val schema: Schema[StringEnum] = stringEnumeration(values).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/SwitchState.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/SwitchState.scala
@@ -5,13 +5,12 @@ import smithy4s.Hints
 import smithy4s.Schema
 import smithy4s.ShapeId
 import smithy4s.ShapeTag
-import smithy4s.schema.EnumTag
-import smithy4s.schema.Schema.enumeration
+import smithy4s.schema.Schema.stringEnumeration
 
-sealed abstract class SwitchState(_value: String, _name: String, _intValue: Int, _hints: Hints) extends Enumeration.Value {
+sealed abstract class SwitchState(_name: String, _stringValue: String, _intValue: Int, _hints: Hints) extends Enumeration.Value {
   override type EnumType = SwitchState
-  override val value: String = _value
   override val name: String = _name
+  override val stringValue: String = _stringValue
   override val intValue: Int = _intValue
   override val hints: Hints = _hints
   override def enumeration: Enumeration[EnumType] = SwitchState
@@ -29,6 +28,5 @@ object SwitchState extends Enumeration[SwitchState] with ShapeTag.Companion[Swit
     ON,
     OFF,
   )
-  val tag: EnumTag[SwitchState] = EnumTag.ClosedStringEnum
-  implicit val schema: Schema[SwitchState] = enumeration(tag, values).withId(id).addHints(hints)
+  implicit val schema: Schema[SwitchState] = stringEnumeration(values).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/TheEnum.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/TheEnum.scala
@@ -5,13 +5,12 @@ import smithy4s.Hints
 import smithy4s.Schema
 import smithy4s.ShapeId
 import smithy4s.ShapeTag
-import smithy4s.schema.EnumTag
-import smithy4s.schema.Schema.enumeration
+import smithy4s.schema.Schema.stringEnumeration
 
-sealed abstract class TheEnum(_value: String, _name: String, _intValue: Int, _hints: Hints) extends Enumeration.Value {
+sealed abstract class TheEnum(_name: String, _stringValue: String, _intValue: Int, _hints: Hints) extends Enumeration.Value {
   override type EnumType = TheEnum
-  override val value: String = _value
   override val name: String = _name
+  override val stringValue: String = _stringValue
   override val intValue: Int = _intValue
   override val hints: Hints = _hints
   override def enumeration: Enumeration[EnumType] = TheEnum
@@ -22,13 +21,12 @@ object TheEnum extends Enumeration[TheEnum] with ShapeTag.Companion[TheEnum] {
 
   val hints: Hints = Hints.empty
 
-  case object V1 extends TheEnum("v1", "V1", 0, Hints())
-  case object V2 extends TheEnum("v2", "V2", 1, Hints())
+  case object V1 extends TheEnum("V1", "v1", 0, Hints())
+  case object V2 extends TheEnum("V2", "v2", 1, Hints())
 
   val values: List[TheEnum] = List(
     V1,
     V2,
   )
-  val tag: EnumTag[TheEnum] = EnumTag.ClosedStringEnum
-  implicit val schema: Schema[TheEnum] = enumeration(tag, values).withId(id).addHints(hints)
+  implicit val schema: Schema[TheEnum] = stringEnumeration(values).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/UnknownServerErrorCode.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/UnknownServerErrorCode.scala
@@ -5,13 +5,12 @@ import smithy4s.Hints
 import smithy4s.Schema
 import smithy4s.ShapeId
 import smithy4s.ShapeTag
-import smithy4s.schema.EnumTag
-import smithy4s.schema.Schema.enumeration
+import smithy4s.schema.Schema.stringEnumeration
 
-sealed abstract class UnknownServerErrorCode(_value: String, _name: String, _intValue: Int, _hints: Hints) extends Enumeration.Value {
+sealed abstract class UnknownServerErrorCode(_name: String, _stringValue: String, _intValue: Int, _hints: Hints) extends Enumeration.Value {
   override type EnumType = UnknownServerErrorCode
-  override val value: String = _value
   override val name: String = _name
+  override val stringValue: String = _stringValue
   override val intValue: Int = _intValue
   override val hints: Hints = _hints
   override def enumeration: Enumeration[EnumType] = UnknownServerErrorCode
@@ -22,11 +21,10 @@ object UnknownServerErrorCode extends Enumeration[UnknownServerErrorCode] with S
 
   val hints: Hints = Hints.empty
 
-  case object ERROR_CODE extends UnknownServerErrorCode("server.error", "ERROR_CODE", 0, Hints())
+  case object ERROR_CODE extends UnknownServerErrorCode("ERROR_CODE", "server.error", 0, Hints())
 
   val values: List[UnknownServerErrorCode] = List(
     ERROR_CODE,
   )
-  val tag: EnumTag[UnknownServerErrorCode] = EnumTag.ClosedStringEnum
-  implicit val schema: Schema[UnknownServerErrorCode] = enumeration(tag, values).withId(id).addHints(hints)
+  implicit val schema: Schema[UnknownServerErrorCode] = stringEnumeration(values).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/test/src/smithy4s/CachedSchemaVisitorSpec.scala
+++ b/modules/bootstrapped/test/src/smithy4s/CachedSchemaVisitorSpec.scala
@@ -69,8 +69,7 @@ class CachedSchemaVisitorSpec() extends FunSuite {
         shapeId: ShapeId,
         hints: Hints,
         tag: EnumTag[E],
-        values: List[EnumValue[E]],
-        total: E => EnumValue[E]
+        values: List[EnumValue[E]]
     ): Unit = discard {
       counter.incrementAndGet()
     }

--- a/modules/bootstrapped/test/src/smithy4s/DocumentSpec.scala
+++ b/modules/bootstrapped/test/src/smithy4s/DocumentSpec.scala
@@ -218,7 +218,7 @@ class DocumentSpec() extends FunSuite {
     val one: OpenEnumTest = OpenEnumTest.ONE
     val document = Document.encode(one)
     import Document._
-    val expectedDocument = DString(OpenEnumTest.ONE.value)
+    val expectedDocument = DString(OpenEnumTest.ONE.stringValue)
 
     val roundTripped = Document.decode[OpenEnumTest](document)
 

--- a/modules/bootstrapped/test/src/smithy4s/IntEnumSmokeSpec.scala
+++ b/modules/bootstrapped/test/src/smithy4s/IntEnumSmokeSpec.scala
@@ -33,10 +33,12 @@ final class IntEnumSmokeSpec extends FunSuite {
       smithy4s.example.FaceCard.JOKER
     )
     assertEquals(values, expected)
-    assert(
-      smithy4s.example.FaceCard.tag == EnumTag.ClosedIntEnum,
-      "tag should be IntEnum"
-    )
+    smithy4s.example.FaceCard.schema match {
+      case s: smithy4s.schema.Schema.EnumerationSchema[_] =>
+        assert(s.tag.isInstanceOf[EnumTag.IntEnum[_]], "tag should be IntEnum")
+      case _ => fail("schema should be an enumeration schema")
+    }
+
   }
 
 }

--- a/modules/bootstrapped/test/src/smithy4s/http/internals/HttpResponseCodeSchemaVisitorSpec.scala
+++ b/modules/bootstrapped/test/src/smithy4s/http/internals/HttpResponseCodeSchemaVisitorSpec.scala
@@ -58,7 +58,7 @@ class HttpResponseCodeSchemaVisitorSpec() extends FunSuite {
       _hints: Hints
   ) extends Enumeration.Value {
     override type EnumType = StatusCode
-    override val value: String = _value
+    override val stringValue: String = _value
     override val name: String = _name
     override val intValue: Int = _intValue
     override val hints: Hints = _hints

--- a/modules/bootstrapped/test/src/smithy4s/http/internals/UrlFormDataEncoderDecoderSchemaVisitorSpec.scala
+++ b/modules/bootstrapped/test/src/smithy4s/http/internals/UrlFormDataEncoderDecoderSchemaVisitorSpec.scala
@@ -362,9 +362,9 @@ object UrlFormDataEncoderDecoderSchemaVisitorSpec extends SimpleIOSuite {
   }
 
   pureTest("enumeration") {
-    sealed abstract class FooBar(val value: String, val intValue: Int)
+    sealed abstract class FooBar(val stringValue: String, val intValue: Int)
         extends smithy4s.Enumeration.Value {
-      val name = value
+      val name = stringValue
       val hints = Hints.empty
       type EnumType = FooBar
       def enumeration: smithy4s.Enumeration[FooBar] = FooBar

--- a/modules/bootstrapped/test/src/smithy4s/internals/StructurePatternRefinementProviderSpec.scala
+++ b/modules/bootstrapped/test/src/smithy4s/internals/StructurePatternRefinementProviderSpec.scala
@@ -18,7 +18,6 @@ package smithy4s.internals
 
 import munit._
 import smithy4s._
-import smithy4s.schema.EnumTag
 import smithy4s.schema.Schema._
 import java.util.UUID
 import smithy4s.example.OpenEnumTest
@@ -68,7 +67,7 @@ final class StructurePatternRefinementProviderSpec extends FunSuite {
       _hints: Hints
   ) extends Enumeration.Value {
     override type EnumType = SomeEnum
-    override val value: String = _value
+    override val stringValue: String = _value
     override val name: String = _name
     override val intValue: Int = _intValue
     override val hints: Hints = _hints
@@ -89,10 +88,8 @@ final class StructurePatternRefinementProviderSpec extends FunSuite {
 
     val values = List(ONE, TWO)
 
-    val tag = EnumTag.ClosedStringEnum
-
     implicit val schema: Schema[SomeEnum] =
-      enumeration(tag, values).withId(id).addHints(hints)
+      stringEnumeration(values).withId(id).addHints(hints)
   }
 
   case class Primitives(

--- a/modules/bootstrapped/test/src/smithy4s/schema/HintsTransformationSpec.scala
+++ b/modules/bootstrapped/test/src/smithy4s/schema/HintsTransformationSpec.scala
@@ -211,10 +211,11 @@ class HintsTransformationSpec() extends FunSuite {
         shapeId: ShapeId,
         hints: Hints,
         tag: EnumTag[E],
-        values: List[EnumValue[E]],
-        total: E => EnumValue[E]
+        values: List[EnumValue[E]]
     ): Count[E] = { e =>
-      count(hints) + count(total(e).hints)
+      count(hints) + count(
+        values.find(_.value == e).map(_.hints).getOrElse(Hints.empty)
+      )
     }
 
     def struct[S](

--- a/modules/cats/src/smithy4s/interopcats/SchemaVisitorHash.scala
+++ b/modules/cats/src/smithy4s/interopcats/SchemaVisitorHash.scala
@@ -77,18 +77,14 @@ final class SchemaVisitorHash(
       shapeId: ShapeId,
       hints: Hints,
       tag: EnumTag[E],
-      values: List[EnumValue[E]],
-      total: E => EnumValue[E]
+      values: List[EnumValue[E]]
   ): Hash[E] = {
-    implicit val enumValueHash: Hash[EnumValue[E]] =
-      tag match {
-        case EnumTag.IntEnum() =>
-          Hash[Int].contramap(_.intValue)
-        case _ =>
-          Hash[String].contramap(_.stringValue)
-      }
-
-    Hash[EnumValue[E]].contramap(total)
+    tag match {
+      case EnumTag.IntEnum(value, _) =>
+        Hash[Int].contramap(value)
+      case EnumTag.StringEnum(value, _) =>
+        Hash[String].contramap(value)
+    }
   }
 
   override def struct[S](

--- a/modules/cats/src/smithy4s/interopcats/SchemaVisitorShow.scala
+++ b/modules/cats/src/smithy4s/interopcats/SchemaVisitorShow.scala
@@ -117,11 +117,12 @@ final class SchemaVisitorShow(
       shapeId: ShapeId,
       hints: Hints,
       tag: EnumTag[E],
-      values: List[EnumValue[E]],
-      total: E => EnumValue[E]
-  ): Show[E] = Show.show { e =>
-    total(e).stringValue
-  }
+      values: List[EnumValue[E]]
+  ): Show[E] =
+    tag match {
+      case EnumTag.StringEnum(value, _) => Show.show(value)
+      case EnumTag.IntEnum(value, _)    => Show.show(value(_).toString)
+    }
 
   override def struct[S](
       shapeId: ShapeId,

--- a/modules/codegen/src/smithy4s/codegen/internals/CollisionAvoidance.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/CollisionAvoidance.scala
@@ -296,6 +296,13 @@ private[internals] object CollisionAvoidance {
     val union_ = NameRef("smithy4s.schema.Schema", "union")
     val recursive_ = NameRef("smithy4s.schema.Schema", "recursive")
     val enumeration_ = NameRef("smithy4s.schema.Schema", "enumeration")
+    val stringEnumeration_ =
+      NameRef("smithy4s.schema.Schema", "stringEnumeration")
+    val intEnumeration_ = NameRef("smithy4s.schema.Schema", "intEnumeration")
+    val openStringEnumeration_ =
+      NameRef("smithy4s.schema.Schema", "openStringEnumeration")
+    val openIntEnumeration_ =
+      NameRef("smithy4s.schema.Schema", "openIntEnumeration")
     val constant_ = NameRef("smithy4s.schema.Schema", "constant")
     val struct_ = NameRef("smithy4s.schema.Schema", "struct")
     val bijection_ = NameRef("smithy4s.schema.Schema", "bijection")

--- a/modules/codegen/src/smithy4s/codegen/internals/Renderer.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/Renderer.scala
@@ -1269,7 +1269,7 @@ private[internals] class Renderer(compilationUnit: CompilationUnit) { self =>
           val intValue = if (isIntEnum) paramName else "-1"
           val stringValue = if (isIntEnum) "\"$Unknown\"" else paramName
           lines(
-            line"""final case class $$Unknown($paramName: $paramType) extends $name($stringValue, "$$Unknown", $intValue, Hints.empty)""",
+            line"""final case class $$Unknown($paramName: $paramType) extends $name("$$Unknown", $stringValue, $intValue, Hints.empty)""",
             newline,
             line"val $$unknown: $paramType => $name = $$Unknown(_)"
           )

--- a/modules/codegen/src/smithy4s/codegen/internals/Renderer.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/Renderer.scala
@@ -20,8 +20,6 @@ package internals
 import cats.data.NonEmptyList
 import cats.data.Reader
 import cats.syntax.all._
-import smithy4s.codegen.internals.EnumTag.IntEnum
-import smithy4s.codegen.internals.EnumTag.StringEnum
 import smithy4s.codegen.internals.LineSegment._
 import smithy4s.codegen.internals.Primitive.Nothing
 import smithy4s.codegen.internals.Type.Nullable
@@ -1443,16 +1441,6 @@ private[internals] class Renderer(compilationUnit: CompilationUnit) { self =>
     val ns = shapeId.getNamespace()
     val name = shapeId.getName()
     line"""val id: $ShapeId_ = $ShapeId_("$ns", "$name")"""
-  }
-
-  def renderEnumTag(parentType: NameRef, tag: EnumTag): Line = {
-    val tagStr = tag match {
-      case IntEnum                => "ClosedIntEnum"
-      case StringEnum             => "ClosedStringEnum"
-      case EnumTag.OpenIntEnum    => "OpenIntEnum($unknown)"
-      case EnumTag.OpenStringEnum => "OpenStringEnum($unknown)"
-    }
-    line"val tag: $EnumTag_[$parentType] = $EnumTag_.$tagStr"
   }
 
   def renderHintsVal(hints: List[Hint]): Lines = {

--- a/modules/codegen/test/src/smithy4s/codegen/internals/RendererSpec.scala
+++ b/modules/codegen/test/src/smithy4s/codegen/internals/RendererSpec.scala
@@ -208,7 +208,7 @@ final class RendererSpec extends munit.FunSuite {
     )
     assert(
       definition.contains(
-        """case object TAIL extends Coin("t:a$i\l", "TAIL", 1, Hints())"""
+        """case object TAIL extends Coin("TAIL", "t:a$i\l", 1, Hints())"""
       ),
       "enum trait value without name but with non alphanumeric value must be rendered as enum variant"
     )

--- a/modules/codegen/test/src/smithy4s/codegen/internals/RendererSpec.scala
+++ b/modules/codegen/test/src/smithy4s/codegen/internals/RendererSpec.scala
@@ -212,11 +212,7 @@ final class RendererSpec extends munit.FunSuite {
     )
     assert(
       definition.contains(
-        <<<<<<< HEAD
-          """case object TAIL extends Coin("TAIL", "t:a$i\l", 1, Hints())"""
-          =======
-          """case object TAIL extends Coin("t:a$i\l", "TAIL", 1, Hints.empty)"""
-          >>>>>>> origin / series / 0.19
+        """case object TAIL extends Coin("TAIL", "t:a$i\l", 1, Hints.empty)"""
       ),
       "enum trait value without name but with non alphanumeric value must be rendered as enum variant"
     )

--- a/modules/compliance-tests/src/smithy4s/compliancetests/TestConfig.scala
+++ b/modules/compliance-tests/src/smithy4s/compliancetests/TestConfig.scala
@@ -37,11 +37,11 @@ object TestConfig {
   val serverReq = TestConfig(AppliesTo.SERVER, TestType.Request)
   val serverRes = TestConfig(AppliesTo.SERVER, TestType.Response)
   sealed abstract class TestType(
-      val value: String,
+      val stringValue: String,
       val intValue: Int
   ) extends Enumeration.Value {
     type EnumType = TestType
-    def name: String = value
+    def name: String = stringValue
     def hints: Hints = Hints.empty
     def enumeration: Enumeration[EnumType] = TestType
   }

--- a/modules/compliance-tests/src/smithy4s/compliancetests/internals/DefaultSchemaVisitor.scala
+++ b/modules/compliance-tests/src/smithy4s/compliancetests/internals/DefaultSchemaVisitor.scala
@@ -69,8 +69,7 @@ private[compliancetests] object DefaultSchemaVisitor extends SchemaVisitor[Id] {
       shapeId: ShapeId,
       hints: Hints,
       tag: EnumTag[E],
-      values: List[EnumValue[E]],
-      total: E => EnumValue[E]
+      values: List[EnumValue[E]]
   ): Id[E] = values.head.value
 
   override def struct[S](

--- a/modules/compliance-tests/src/smithy4s/compliancetests/internals/eq/EqSchemaVisitor.scala
+++ b/modules/compliance-tests/src/smithy4s/compliancetests/internals/eq/EqSchemaVisitor.scala
@@ -62,12 +62,11 @@ object EqSchemaVisitor extends SchemaVisitor[Eq] { self =>
       shapeId: ShapeId,
       hints: Hints,
       tag: EnumTag[E],
-      values: List[EnumValue[E]],
-      total: E => EnumValue[E]
+      values: List[EnumValue[E]]
   ): Eq[E] =
-    Eq.by { x =>
-      val enumX = total(x)
-      (enumX.intValue, enumX.stringValue)
+    tag match {
+      case EnumTag.StringEnum(value, _) => Eq.by(value)
+      case EnumTag.IntEnum(value, _)    => Eq.by(value)
     }
 
   override def struct[S](

--- a/modules/core/src/smithy4s/Document.scala
+++ b/modules/core/src/smithy4s/Document.scala
@@ -81,6 +81,8 @@ object Document {
   case class DArray(value: IndexedSeq[Document]) extends Document
   case class DObject(value: Map[String, Document]) extends Document
 
+  final val EmptyObject = DObject(Map.empty)
+
   def fromString(str: String): Document = DString(str)
   def fromInt(int: Int): Document = DNumber(BigDecimal(int))
   def fromLong(long: Long): Document = DNumber(BigDecimal(long))
@@ -91,7 +93,8 @@ object Document {
   def array(values: Iterable[Document]): Document = DArray(
     IndexedSeq.newBuilder.++=(values).result()
   )
-  def obj(kv: (String, Document)*): Document = DObject(Map(kv: _*))
+  def obj(kv: (String, Document)*): Document =
+    if (kv.isEmpty) EmptyObject else DObject(Map(kv: _*))
   def nullDoc: Document = DNull
 
   trait Encoder[A] {

--- a/modules/core/src/smithy4s/Enumeration.scala
+++ b/modules/core/src/smithy4s/Enumeration.scala
@@ -22,7 +22,7 @@ trait Enumeration[E <: Enumeration.Value] extends ShapeTag.Companion[E] {
   def id: ShapeId
   def hints: Hints
   def values: List[E]
-  lazy val valueMap = values.map(e => e.value -> e).toMap
+  lazy val valueMap = values.map(e => e.stringValue -> e).toMap
   lazy val intValueMap = values.map(e => e.intValue -> e).toMap
   final def fromString(s: String): Option[E] = valueMap.get(s)
   final def fromOrdinal(s: Int): Option[E] = intValueMap.get(s)
@@ -33,8 +33,8 @@ object Enumeration {
   abstract class Value extends Product with Serializable {
     type EnumType <: Value
 
-    def value: String
     def name: String
+    def stringValue: String
     def intValue: Int
     def hints: Hints
     def enumeration: Enumeration[EnumType]
@@ -42,7 +42,7 @@ object Enumeration {
 
   object Value {
     def toSchema[E <: Value](e: E): EnumValue[E] = {
-      EnumValue(e.value, e.intValue, e, e.name, e.hints)
+      EnumValue(e.stringValue, e.intValue, e, e.name, e.hints)
     }
   }
 

--- a/modules/core/src/smithy4s/RefinementProvider.scala
+++ b/modules/core/src/smithy4s/RefinementProvider.scala
@@ -183,7 +183,7 @@ private[smithy4s] trait LowPriorityImplicits {
 
   implicit def enumLengthConstraint[E <: Enumeration.Value]
       : RefinementProvider[Length, E, E] =
-    new RefinementProvider.LengthConstraint[E](e => e.value.size)
+    new RefinementProvider.LengthConstraint[E](e => e.stringValue.size)
 
   implicit def enumRangeConstraint[E <: Enumeration.Value]
       : RefinementProvider[Range, E, E] =
@@ -191,7 +191,7 @@ private[smithy4s] trait LowPriorityImplicits {
 
   implicit def enumPatternConstraint[E <: Enumeration.Value]
       : RefinementProvider[Pattern, E, E] =
-    new RefinementProvider.PatternConstraint[E](e => e.value)
+    new RefinementProvider.PatternConstraint[E](e => e.stringValue)
 
   implicit def isomorphismConstraint[C, A, A0](implicit
       constraintOnA: RefinementProvider.Simple[C, A],

--- a/modules/core/src/smithy4s/codecs/StringAndBlobCodecs.scala
+++ b/modules/core/src/smithy4s/codecs/StringAndBlobCodecs.scala
@@ -62,11 +62,10 @@ object StringAndBlobCodecs {
         shapeId: ShapeId,
         hints: Hints,
         tag: EnumTag[E],
-        values: List[EnumValue[E]],
-        total: E => EnumValue[E]
+        values: List[EnumValue[E]]
     ): MaybeBlobDecoder[E] = {
       tag match {
-        case EnumTag.ClosedStringEnum =>
+        case EnumTag.StringEnum(_, None) =>
           Some(new BlobDecoder[E] {
             def decode(blob: Blob): Either[PayloadError, E] = {
               val str = blob.toUTF8String
@@ -83,7 +82,7 @@ object StringAndBlobCodecs {
               }
             }
           })
-        case EnumTag.OpenStringEnum(processUnknown) =>
+        case EnumTag.StringEnum(_, Some(processUnknown)) =>
           Some(new BlobDecoder[E] {
             def decode(blob: Blob): Either[PayloadError, E] = {
               val str = blob.toUTF8String
@@ -155,14 +154,11 @@ object StringAndBlobCodecs {
         shapeId: ShapeId,
         hints: Hints,
         tag: EnumTag[E],
-        values: List[EnumValue[E]],
-        total: E => EnumValue[E]
+        values: List[EnumValue[E]]
     ): MaybeBlobEncoder[E] = {
       tag match {
-        case EnumTag.ClosedStringEnum =>
-          Some(stringEncoder.contramap(total(_: E).stringValue))
-        case EnumTag.OpenStringEnum(_) =>
-          Some(stringEncoder.contramap(total(_: E).stringValue))
+        case EnumTag.StringEnum(value, _) =>
+          Some(stringEncoder.contramap(value))
         case _ => None
       }
     }

--- a/modules/core/src/smithy4s/http/HttpMediaType.scala
+++ b/modules/core/src/smithy4s/http/HttpMediaType.scala
@@ -65,8 +65,7 @@ object HttpMediaType extends Newtype[String] {
         shapeId: ShapeId,
         hints: Hints,
         tag: EnumTag[E],
-        values: List[EnumValue[E]],
-        total: E => EnumValue[E]
+        values: List[EnumValue[E]]
     ): Option[String] = Some(stringMediaType(hints))
 
     override def biject[A, B](

--- a/modules/core/src/smithy4s/http/internals/HostPrefixSchemaVisitor.scala
+++ b/modules/core/src/smithy4s/http/internals/HostPrefixSchemaVisitor.scala
@@ -48,13 +48,11 @@ object HostPrefixSchemaVisitor
       shapeId: ShapeId,
       hints: Hints,
       tag: EnumTag[E],
-      values: List[EnumValue[E]],
-      total: E => EnumValue[E]
+      values: List[EnumValue[E]]
   ): MaybeHostPrefixEncoder[E] =
     tag match {
-      case EnumTag.IntEnum() => default
-      case _ =>
-        maybeStr.map(_.contramap(total(_).stringValue))
+      case EnumTag.IntEnum(_, _)        => default
+      case EnumTag.StringEnum(value, _) => maybeStr.map(_.contramap(value))
     }
 
   override def struct[S](

--- a/modules/core/src/smithy4s/http/internals/HttpResponseCodeSchemaVisitor.scala
+++ b/modules/core/src/smithy4s/http/internals/HttpResponseCodeSchemaVisitor.scala
@@ -55,14 +55,14 @@ class HttpResponseCodeSchemaVisitor()
       shapeId: ShapeId,
       hints: Hints,
       tag: EnumTag[E],
-      values: List[EnumValue[E]],
-      total: E => EnumValue[E]
+      values: List[EnumValue[E]]
   ): ResponseCodeExtractor[E] =
     tag match {
-      case EnumTag.IntEnum() if hints.has[smithy.api.HttpResponseCode] =>
+      case EnumTag.IntEnum(value, _)
+          if hints.has[smithy.api.HttpResponseCode] =>
         Contravariant[ResponseCodeExtractor].contramap(
           HttpResponseCodeSchemaVisitor.int
-        )(e => total(e).intValue)
+        )(value)
       case _ =>
         NoResponseCode
     }

--- a/modules/core/src/smithy4s/http/internals/SchemaVisitorHeaderMerge.scala
+++ b/modules/core/src/smithy4s/http/internals/SchemaVisitorHeaderMerge.scala
@@ -64,11 +64,10 @@ object SchemaVisitorHeaderMerge
       shapeId: ShapeId,
       hints: Hints,
       tag: EnumTag[E],
-      values: List[EnumValue[E]],
-      total: E => EnumValue[E]
+      values: List[EnumValue[E]]
   ): AwsMergeableHeader[E] = tag match {
-    case EnumTag.IntEnum() => Some((e: E) => total(e).intValue.toString())
-    case _                 => Some((e: E) => total(e).stringValue)
+    case EnumTag.IntEnum(value, _)    => Some(value(_).toString())
+    case EnumTag.StringEnum(value, _) => Some(value(_))
   }
 
 }

--- a/modules/core/src/smithy4s/http/internals/SchemaVisitorHeaderSplit.scala
+++ b/modules/core/src/smithy4s/http/internals/SchemaVisitorHeaderSplit.scala
@@ -67,8 +67,7 @@ object SchemaVisitorHeaderSplit
       shapeId: ShapeId,
       hints: Hints,
       tag: EnumTag[E],
-      values: List[EnumValue[E]],
-      total: E => EnumValue[E]
+      values: List[EnumValue[E]]
   ): AwsHeaderSplitter[E] = Some(splitHeaderValue(_, isHttpDate = false))
 
   private[internals] def splitHeaderValue(

--- a/modules/core/src/smithy4s/http/internals/SchemaVisitorMetadataReader.scala
+++ b/modules/core/src/smithy4s/http/internals/SchemaVisitorMetadataReader.scala
@@ -112,8 +112,7 @@ private[http] class SchemaVisitorMetadataReader(
       shapeId: ShapeId,
       hints: Hints,
       tag: EnumTag[E],
-      values: List[EnumValue[E]],
-      total: E => EnumValue[E]
+      values: List[EnumValue[E]]
   ): MetaDecode[E] = {
     val intVals = s"Enum[${values.map(_.stringValue).mkString(",")}]"
     val stringVals = s"Enum[${values.map(_.stringValue).mkString(",")}]"
@@ -126,16 +125,16 @@ private[http] class SchemaVisitorMetadataReader(
       values.find(_.stringValue == string).map(_.value)
     }
     tag match {
-      case EnumTag.ClosedIntEnum =>
+      case EnumTag.IntEnum(_, None) =>
         MetaDecode.from(intVals)(str => handleInt(str.toIntOption))
-      case EnumTag.OpenIntEnum(unknown) =>
+      case EnumTag.IntEnum(_, Some(unknown)) =>
         MetaDecode.from(intVals) { string =>
           val maybeInt = string.toIntOption
           handleInt(maybeInt).orElse(maybeInt.map(unknown))
         }
-      case EnumTag.ClosedStringEnum =>
+      case EnumTag.StringEnum(_, None) =>
         MetaDecode.from(stringVals)(handleString)
-      case EnumTag.OpenStringEnum(unknown) =>
+      case EnumTag.StringEnum(_, Some(unknown)) =>
         MetaDecode.from(stringVals)(str =>
           Some(handleString(str).getOrElse(unknown(str)))
         )

--- a/modules/core/src/smithy4s/http/internals/SchemaVisitorMetadataWriter.scala
+++ b/modules/core/src/smithy4s/http/internals/SchemaVisitorMetadataWriter.scala
@@ -143,14 +143,13 @@ class SchemaVisitorMetadataWriter(
       shapeId: ShapeId,
       hints: Hints,
       tag: EnumTag[E],
-      values: List[EnumValue[E]],
-      total: E => EnumValue[E]
+      values: List[EnumValue[E]]
   ): MetaEncode[E] =
     tag match {
-      case EnumTag.IntEnum() =>
-        StringValueMetaEncode(e => total(e).intValue.toString())
-      case _ =>
-        StringValueMetaEncode(e => total(e).stringValue)
+      case EnumTag.IntEnum(value, _) =>
+        StringValueMetaEncode(e => value(e).toString())
+      case EnumTag.StringEnum(value, _) =>
+        StringValueMetaEncode(value)
     }
 
   override def struct[S](

--- a/modules/core/src/smithy4s/http/internals/SchemaVisitorPathEncoder.scala
+++ b/modules/core/src/smithy4s/http/internals/SchemaVisitorPathEncoder.scala
@@ -62,14 +62,13 @@ object SchemaVisitorPathEncoder
       shapeId: ShapeId,
       hints: Hints,
       tag: EnumTag[E],
-      values: List[EnumValue[E]],
-      total: E => EnumValue[E]
+      values: List[EnumValue[E]]
   ): MaybePathEncode[E] =
     tag match {
-      case EnumTag.IntEnum() =>
-        PathEncode.from(e => total(e).intValue.toString)
-      case _ =>
-        PathEncode.from(e => total(e).stringValue)
+      case EnumTag.IntEnum(value, _) =>
+        PathEncode.from(e => value(e).toString)
+      case EnumTag.StringEnum(value, _) =>
+        PathEncode.from(value)
     }
 
   override def struct[S](

--- a/modules/core/src/smithy4s/http/internals/UrlFormDataDecoderSchemaVisitor.scala
+++ b/modules/core/src/smithy4s/http/internals/UrlFormDataDecoderSchemaVisitor.scala
@@ -120,17 +120,16 @@ private[http] class UrlFormDataDecoderSchemaVisitor(
       shapeId: ShapeId,
       hints: Hints,
       tag: EnumTag[E],
-      values: List[EnumValue[E]],
-      total: E => EnumValue[E]
+      values: List[EnumValue[E]]
   ): UrlFormDataDecoder[E] = tag match {
-    case EnumTag.IntEnum() =>
+    case EnumTag.IntEnum(_, _) =>
       val desc = s"enum[${values.map(_.intValue).mkString(", ")}]"
       val valueMap = values.map(ev => ev.intValue -> ev.value).toMap
       UrlFormDataDecoder.fromStringParser(desc)(
         _.toIntOption.flatMap(valueMap.get(_))
       )
 
-    case _ =>
+    case EnumTag.StringEnum(_, _) =>
       val desc = s"enum[${values.map(_.stringValue).mkString(", ")}]"
       val valueMap = values.map(ev => ev.stringValue -> ev.value).toMap
       UrlFormDataDecoder.fromStringParser(desc)(valueMap.get)

--- a/modules/core/src/smithy4s/http/internals/UrlFormDataEncoderSchemaVisitor.scala
+++ b/modules/core/src/smithy4s/http/internals/UrlFormDataEncoderSchemaVisitor.scala
@@ -107,24 +107,23 @@ private[http] class UrlFormDataEncoderSchemaVisitor(
       shapeId: ShapeId,
       hints: Hints,
       tag: EnumTag[E],
-      values: List[EnumValue[E]],
-      total: E => EnumValue[E]
+      values: List[EnumValue[E]]
   ): UrlFormDataEncoder[E] = tag match {
-    case EnumTag.IntEnum() =>
-      value =>
+    case EnumTag.IntEnum(value, _) =>
+      e =>
         List(
           UrlForm.FormData(
             PayloadPath.root,
-            Some(total(value).intValue.toString)
+            Some(value(e).toString)
           )
         )
 
-    case _ =>
-      value =>
+    case EnumTag.StringEnum(value, _) =>
+      e =>
         List(
           UrlForm.FormData(
             PayloadPath.root,
-            Some(total(value).stringValue)
+            Some(value(e))
           )
         )
   }

--- a/modules/core/src/smithy4s/internals/DocumentDecoderSchemaVisitor.scala
+++ b/modules/core/src/smithy4s/internals/DocumentDecoderSchemaVisitor.scala
@@ -277,28 +277,27 @@ class DocumentDecoderSchemaVisitor(
       shapeId: ShapeId,
       hints: Hints,
       tag: EnumTag[E],
-      values: List[EnumValue[E]],
-      total: E => EnumValue[E]
+      values: List[EnumValue[E]]
   ): DocumentDecoder[E] = {
     val fromName = values.map(e => e.stringValue -> e.value).toMap
     val fromOrdinal =
       values.map(e => BigDecimal(e.intValue) -> e.value).toMap
     val label = s"value in [${fromName.keySet.mkString(", ")}]"
     tag match {
-      case EnumTag.ClosedIntEnum =>
+      case EnumTag.IntEnum(_, None) =>
         from(label) {
           case DNumber(value) if fromOrdinal.contains(value) =>
             fromOrdinal(value)
         }
-      case EnumTag.OpenIntEnum(unknown) =>
+      case EnumTag.IntEnum(_, Some(unknown)) =>
         from(label) { case DNumber(value) =>
           fromOrdinal.getOrElse(value, unknown(value.toInt))
         }
-      case EnumTag.ClosedStringEnum =>
+      case EnumTag.StringEnum(_, None) =>
         from(label) {
           case DString(value) if fromName.contains(value) => fromName(value)
         }
-      case EnumTag.OpenStringEnum(unknown) =>
+      case EnumTag.StringEnum(_, Some(unknown)) =>
         from(label) { case DString(value) =>
           fromName.getOrElse(value, unknown(value))
         }

--- a/modules/core/src/smithy4s/internals/DocumentEncoderSchemaVisitor.scala
+++ b/modules/core/src/smithy4s/internals/DocumentEncoderSchemaVisitor.scala
@@ -166,14 +166,13 @@ class DocumentEncoderSchemaVisitor(
       shapeId: ShapeId,
       hints: Hints,
       tag: EnumTag[E],
-      values: List[EnumValue[E]],
-      total: E => EnumValue[E]
+      values: List[EnumValue[E]]
   ): DocumentEncoder[E] =
     tag match {
-      case EnumTag.IntEnum() =>
-        from(e => Document.fromInt(total(e).intValue))
-      case _ =>
-        from(e => DString(total(e).stringValue))
+      case EnumTag.IntEnum(value, _) =>
+        from(e => Document.fromInt(value(e)))
+      case EnumTag.StringEnum(value, _) =>
+        from(e => DString(value(e)))
     }
 
   override def struct[S](

--- a/modules/core/src/smithy4s/internals/DocumentKeyEncoder.scala
+++ b/modules/core/src/smithy4s/internals/DocumentKeyEncoder.scala
@@ -91,13 +91,12 @@ object DocumentKeyEncoder {
           shapeId: ShapeId,
           hints: Hints,
           tag: EnumTag[E],
-          values: List[EnumValue[E]],
-          total: E => EnumValue[E]
+          values: List[EnumValue[E]]
       ): OptDocumentKeyEncoder[E] = tag match {
-        case EnumTag.IntEnum() =>
-          Some { a => total(a).intValue.toString }
-        case _ =>
-          Some { a => total(a).stringValue }
+        case EnumTag.IntEnum(value, _) =>
+          Some { a => value(a).toString }
+        case EnumTag.StringEnum(value, _) =>
+          Some { value(_) }
       }
 
       override def biject[A, B](

--- a/modules/core/src/smithy4s/internals/SchemaDescription.scala
+++ b/modules/core/src/smithy4s/internals/SchemaDescription.scala
@@ -38,7 +38,7 @@ object SchemaDescription extends SchemaVisitor[SchemaDescription] {
   override def map[K, V](shapeId: ShapeId, hints: Hints, key: Schema[K], value: Schema[V]): SchemaDescription[Map[K,V]] =
     SchemaDescription.of("Map")
 
-  override def enumeration[E](shapeId: ShapeId, hints: Hints, tag: EnumTag[E], values: List[EnumValue[E]], total: E => EnumValue[E]): SchemaDescription[E] =
+  override def enumeration[E](shapeId: ShapeId, hints: Hints, tag: EnumTag[E], values: List[EnumValue[E]]): SchemaDescription[E] =
     SchemaDescription.of("Enumeration")
 
   override def struct[S](shapeId: ShapeId, hints: Hints, fields: Vector[Field[S, _]], make: IndexedSeq[Any] => S): SchemaDescription[S] =

--- a/modules/core/src/smithy4s/internals/SchemaDescriptionDetailed.scala
+++ b/modules/core/src/smithy4s/internals/SchemaDescriptionDetailed.scala
@@ -73,8 +73,7 @@ private[internals] object SchemaDescriptionDetailedImpl
       shapeId: ShapeId,
       hints: Hints,
       tag: EnumTag[E],
-      values: List[EnumValue[E]],
-      total: E => EnumValue[E]
+      values: List[EnumValue[E]]
   ): SchemaDescriptionDetailedImpl[E] = {
     val vDesc = values.map(e => s""""${e.stringValue}"""").mkString(", ")
     SchemaDescriptionDetailedImpl.of(shapeId, s"enum($vDesc)")

--- a/modules/core/src/smithy4s/internals/SchemaVisitorPatternDecoder.scala
+++ b/modules/core/src/smithy4s/internals/SchemaVisitorPatternDecoder.scala
@@ -49,23 +49,21 @@ private[internals] final class SchemaVisitorPatternDecoder(
       shapeId: ShapeId,
       hints: Hints,
       tag: EnumTag[E],
-      values: List[EnumValue[E]],
-      total: E => EnumValue[E]
+      values: List[EnumValue[E]]
   ): MaybePatternDecode[E] = {
     val fromName = values.map(e => e.stringValue -> e.value).toMap
-    val fromOrdinal =
+    val fromIntValue =
       values.map(e => BigDecimal(e.intValue) -> e.value).toMap
     tag match {
-      case EnumTag.ClosedIntEnum =>
+      case EnumTag.OpenStringEnum(unknown) =>
         PatternDecode.from(value =>
-          if (fromOrdinal.contains(BigDecimal(value)))
-            fromOrdinal(BigDecimal(value))
-          else throw StructurePatternError(s"Enum case for '$value' not found.")
+          if (fromName.contains(value)) fromName(value)
+          else unknown(value)
         )
       case EnumTag.OpenIntEnum(unknown) =>
         PatternDecode.from(value =>
-          if (fromOrdinal.contains(BigDecimal(value)))
-            fromOrdinal(BigDecimal(value))
+          if (fromIntValue.contains(BigDecimal(value)))
+            fromIntValue(BigDecimal(value))
           else
             // toIntOption not available on 2.12
             util
@@ -78,15 +76,16 @@ private[internals] final class SchemaVisitorPatternDecoder(
                 )
               )
         )
-      case EnumTag.ClosedStringEnum =>
+      case EnumTag.IntEnum(_, _) =>
+        PatternDecode.from(value =>
+          if (fromIntValue.contains(BigDecimal(value)))
+            fromIntValue(BigDecimal(value))
+          else throw StructurePatternError(s"Enum case for '$value' not found.")
+        )
+      case EnumTag.StringEnum(_, _) =>
         PatternDecode.from(value =>
           if (fromName.contains(value)) fromName(value)
           else throw StructurePatternError(s"Enum case for '$value' not found.")
-        )
-      case EnumTag.OpenStringEnum(unknown) =>
-        PatternDecode.from(value =>
-          if (fromName.contains(value)) fromName(value)
-          else unknown(value)
         )
     }
   }

--- a/modules/core/src/smithy4s/internals/SchemaVisitorPatternDecoder.scala
+++ b/modules/core/src/smithy4s/internals/SchemaVisitorPatternDecoder.scala
@@ -55,12 +55,12 @@ private[internals] final class SchemaVisitorPatternDecoder(
     val fromIntValue =
       values.map(e => BigDecimal(e.intValue) -> e.value).toMap
     tag match {
-      case EnumTag.OpenStringEnum(unknown) =>
+      case EnumTag.StringEnum(_, Some(unknown)) =>
         PatternDecode.from(value =>
           if (fromName.contains(value)) fromName(value)
           else unknown(value)
         )
-      case EnumTag.OpenIntEnum(unknown) =>
+      case EnumTag.IntEnum(_, Some(unknown)) =>
         PatternDecode.from(value =>
           if (fromIntValue.contains(BigDecimal(value)))
             fromIntValue(BigDecimal(value))
@@ -76,13 +76,13 @@ private[internals] final class SchemaVisitorPatternDecoder(
                 )
               )
         )
-      case EnumTag.IntEnum(_, _) =>
+      case EnumTag.IntEnum(_, None) =>
         PatternDecode.from(value =>
           if (fromIntValue.contains(BigDecimal(value)))
             fromIntValue(BigDecimal(value))
           else throw StructurePatternError(s"Enum case for '$value' not found.")
         )
-      case EnumTag.StringEnum(_, _) =>
+      case EnumTag.StringEnum(_, None) =>
         PatternDecode.from(value =>
           if (fromName.contains(value)) fromName(value)
           else throw StructurePatternError(s"Enum case for '$value' not found.")

--- a/modules/core/src/smithy4s/internals/SchemaVisitorPatternEncoder.scala
+++ b/modules/core/src/smithy4s/internals/SchemaVisitorPatternEncoder.scala
@@ -45,14 +45,13 @@ private[internals] final class SchemaVisitorPatternEncoder(
       shapeId: ShapeId,
       hints: Hints,
       tag: EnumTag[E],
-      values: List[EnumValue[E]],
-      total: E => EnumValue[E]
+      values: List[EnumValue[E]]
   ): MaybePathEncode[E] =
     tag match {
-      case EnumTag.IntEnum() =>
-        PathEncode.from(e => total(e).intValue.toString)
-      case _ =>
-        PathEncode.from(e => total(e).stringValue)
+      case EnumTag.IntEnum(value, _) =>
+        PathEncode.from(value(_).toString)
+      case EnumTag.StringEnum(value, _) =>
+        PathEncode.from(value(_))
     }
 
   override def struct[S](

--- a/modules/core/src/smithy4s/schema/CollectionTag.scala
+++ b/modules/core/src/smithy4s/schema/CollectionTag.scala
@@ -144,7 +144,7 @@ object CollectionTag {
       case IndexedSeqTag => Some(implicitly[ClassTag[IndexedSeq[A]]])
     }
     def map[K, V](shapeId: ShapeId, hints: Hints, key: Schema[K], value: Schema[V]): MaybeCT[Map[K,V]] = Some(implicitly[ClassTag[Map[K, V]]])
-    def enumeration[E](shapeId: ShapeId, hints: Hints, tag: EnumTag[E], values: List[EnumValue[E]], total: E => EnumValue[E]): MaybeCT[E] = None
+    def enumeration[E](shapeId: ShapeId, hints: Hints, tag: EnumTag[E], values: List[EnumValue[E]]): MaybeCT[E] = None
     def struct[S](shapeId: ShapeId, hints: Hints, fields: Vector[Field[S, _]], make: IndexedSeq[Any] => S): MaybeCT[S] = None
     def union[U](shapeId: ShapeId, hints: Hints, alternatives: Vector[Alt[U, _]], dispatch: Alt.Dispatcher[U]): MaybeCT[U] = None
     def biject[A, B](schema: Schema[A], bijection: Bijection[A, B]): MaybeCT[B] = {

--- a/modules/core/src/smithy4s/schema/DefaultValueSchemaVisitor.scala
+++ b/modules/core/src/smithy4s/schema/DefaultValueSchemaVisitor.scala
@@ -61,8 +61,7 @@ private[schema] object DefaultValueSchemaVisitor extends SchemaVisitor[Option] {
       shapeId: ShapeId,
       hints: Hints,
       tag: EnumTag[E],
-      values: List[EnumValue[E]],
-      total: E => EnumValue[E]
+      values: List[EnumValue[E]]
   ): Option[E] = None
 
   def struct[S](

--- a/modules/core/src/smithy4s/schema/EnumTag.scala
+++ b/modules/core/src/smithy4s/schema/EnumTag.scala
@@ -22,20 +22,4 @@ sealed trait EnumTag[E]
 object EnumTag {
   case class StringEnum[E](value: E => String, unknown: Option[String => E]) extends EnumTag[E]
   case class IntEnum[E](value: E => Int, unknown: Option[Int => E])          extends EnumTag[E]
-
-  object OpenStringEnum {
-    def unapply[E](enumTag: EnumTag[E]): Option[String => E] = enumTag match {
-      case t: StringEnum[E] => t.unknown
-      case _                => None
-    }
-
-  }
-
-  object OpenIntEnum {
-    def unapply[E](enumTag: EnumTag[E]): Option[Int => E] = enumTag match {
-      case t: IntEnum[E] => t.unknown
-      case _             => None
-    }
-  }
-
 }

--- a/modules/core/src/smithy4s/schema/EnumTag.scala
+++ b/modules/core/src/smithy4s/schema/EnumTag.scala
@@ -16,28 +16,26 @@
 
 package smithy4s.schema
 
-sealed trait EnumTag[+E]
+// scalafmt: { maxColumn = 120, align.preset = most}
+sealed trait EnumTag[E]
 
 object EnumTag {
-  case object ClosedStringEnum extends EnumTag[Nothing]
-  case object ClosedIntEnum extends EnumTag[Nothing]
-  case class OpenStringEnum[E](unknown: String => E) extends EnumTag[E]
-  case class OpenIntEnum[E](unknown: Int => E) extends EnumTag[E]
+  case class StringEnum[E](value: E => String, unknown: Option[String => E]) extends EnumTag[E]
+  case class IntEnum[E](value: E => Int, unknown: Option[Int => E])          extends EnumTag[E]
 
-  object StringEnum {
-    def unapply[E](enumTag: EnumTag[E]): Boolean = enumTag match {
-      case ClosedStringEnum  => true
-      case OpenStringEnum(_) => true
-      case _                 => false
+  object OpenStringEnum {
+    def unapply[E](enumTag: EnumTag[E]): Option[String => E] = enumTag match {
+      case t: StringEnum[E] => t.unknown
+      case _                => None
     }
 
   }
 
-  object IntEnum {
-    def unapply[E](enumTag: EnumTag[E]): Boolean = enumTag match {
-      case ClosedIntEnum  => true
-      case OpenIntEnum(_) => true
-      case _              => false
+  object OpenIntEnum {
+    def unapply[E](enumTag: EnumTag[E]): Option[Int => E] = enumTag match {
+      case t: IntEnum[E] => t.unknown
+      case _             => None
     }
   }
+
 }

--- a/modules/core/src/smithy4s/schema/Schema.scala
+++ b/modules/core/src/smithy4s/schema/Schema.scala
@@ -42,7 +42,7 @@ sealed trait Schema[A]{
     case PrimitiveSchema(_, hints, tag) => PrimitiveSchema(newId, hints, tag)
     case s: CollectionSchema[c, a] => CollectionSchema(newId, s.hints, s.tag, s.member).asInstanceOf[Schema[A]]
     case s: MapSchema[k, v] => MapSchema(newId, s.hints, s.key, s.value).asInstanceOf[Schema[A]]
-    case EnumerationSchema(_, hints, values, tag, total) => EnumerationSchema(newId, hints, values, tag, total)
+    case EnumerationSchema(_, hints, values, tag) => EnumerationSchema(newId, hints, values, tag)
     case StructSchema(_, hints, fields, make) => StructSchema(newId, hints, fields, make)
     case UnionSchema(_, hints, alternatives, dispatch) => UnionSchema(newId, hints, alternatives, dispatch)
     case BijectionSchema(schema, bijection) => BijectionSchema(schema.withId(newId), bijection)
@@ -57,7 +57,7 @@ sealed trait Schema[A]{
     case PrimitiveSchema(shapeId, hints, tag) => PrimitiveSchema(shapeId, f(hints), tag)
     case s: CollectionSchema[c, a] => CollectionSchema(s.shapeId, f(s.hints), s.tag, s.member).asInstanceOf[Schema[A]]
     case s: MapSchema[k, v] => MapSchema(s.shapeId, f(s.hints), s.key, s.value).asInstanceOf[Schema[A]]
-    case EnumerationSchema(shapeId, hints, values, tag, total) => EnumerationSchema(shapeId, f(hints), values, tag, total)
+    case EnumerationSchema(shapeId, hints, values, tag) => EnumerationSchema(shapeId, f(hints), values, tag)
     case StructSchema(shapeId, hints, fields, make) => StructSchema(shapeId, f(hints), fields, make)
     case UnionSchema(shapeId, hints, alternatives, dispatch) => UnionSchema(shapeId, f(hints), alternatives, dispatch)
     case BijectionSchema(schema, bijection) => BijectionSchema(schema.transformHintsLocally(f), bijection)
@@ -70,7 +70,7 @@ sealed trait Schema[A]{
     case PrimitiveSchema(shapeId, hints, tag) => PrimitiveSchema(shapeId, f(hints), tag)
     case s: CollectionSchema[c, a] => CollectionSchema[c, a](s.shapeId, f(s.hints), s.tag, s.member.transformHintsTransitively(f)).asInstanceOf[Schema[A]]
     case s: MapSchema[k, v] => MapSchema(s.shapeId, f(s.hints), s.key.transformHintsTransitively(f), s.value.transformHintsTransitively(f)).asInstanceOf[Schema[A]]
-    case EnumerationSchema(shapeId, hints, tag, values, total) => EnumerationSchema(shapeId, f(hints), tag, values.map(_.transformHints(f)), total andThen (_.transformHints(f)))
+    case EnumerationSchema(shapeId, hints, tag, values) => EnumerationSchema(shapeId, f(hints), tag, values.map(_.transformHints(f)))
     case StructSchema(shapeId, hints, fields, make) => StructSchema(shapeId, f(hints), fields.map(_.transformHintsTransitively(f)), make)
     case UnionSchema(shapeId, hints, alternatives, dispatch) => UnionSchema(shapeId, f(hints), alternatives.map(_.transformHintsTransitively(f)), dispatch)
     case BijectionSchema(schema, bijection) => BijectionSchema(schema.transformHintsTransitively(f), bijection)
@@ -158,7 +158,7 @@ object Schema {
   final case class PrimitiveSchema[P](shapeId: ShapeId, hints: Hints, tag: Primitive[P]) extends Schema[P]
   final case class CollectionSchema[C[_], A](shapeId: ShapeId, hints: Hints, tag: CollectionTag[C], member: Schema[A]) extends Schema[C[A]]
   final case class MapSchema[K, V](shapeId: ShapeId, hints: Hints, key: Schema[K], value: Schema[V]) extends Schema[Map[K, V]]
-  final case class EnumerationSchema[E](shapeId: ShapeId, hints: Hints, tag: EnumTag[E], values: List[EnumValue[E]], total: E => EnumValue[E]) extends Schema[E]
+  final case class EnumerationSchema[E](shapeId: ShapeId, hints: Hints, tag: EnumTag[E], values: List[EnumValue[E]]) extends Schema[E]
   final case class StructSchema[S](shapeId: ShapeId, hints: Hints, fields: Vector[Field[S, _]], make: IndexedSeq[Any] => S) extends Schema[S]
   final case class UnionSchema[U](shapeId: ShapeId, hints: Hints, alternatives: Vector[Alt[U, _]], ordinal: U => Int) extends Schema[U]
   final case class OptionSchema[A](underlying: Schema[A]) extends Schema[Option[A]]{
@@ -240,23 +240,20 @@ object Schema {
     }
   }
 
-  def enumeration[E](total: E => EnumValue[E], tag: EnumTag[E], values: List[EnumValue[E]]): Schema[E] =
-    Schema.EnumerationSchema(placeholder, Hints.empty, tag, values, total)
-
-  def stringEnumeration[E](total: E => EnumValue[E], values: List[EnumValue[E]]): Schema[E] =
-    enumeration(total, EnumTag.ClosedStringEnum, values)
-
-  def intEnumeration[E](total: E => EnumValue[E], values: List[EnumValue[E]]): Schema[E] =
-    enumeration(total, EnumTag.ClosedIntEnum, values)
-
-  def enumeration[E <: Enumeration.Value](tag: EnumTag[E], values: List[E]): Schema[E] =
-    Schema.EnumerationSchema(placeholder, Hints.empty, tag, values.map(Enumeration.Value.toSchema(_)), Enumeration.Value.toSchema[E])
+  def enumeration[E](tag: EnumTag[E], values: List[EnumValue[E]]): Schema[E] =
+    Schema.EnumerationSchema(placeholder, Hints.empty, tag, values)
 
   def stringEnumeration[E <: Enumeration.Value](values: List[E]): Schema[E] =
-    enumeration(EnumTag.ClosedStringEnum, values)
+    enumeration(EnumTag.StringEnum[E](_.stringValue, None), values.map(Enumeration.Value.toSchema(_)))
 
   def intEnumeration[E <: Enumeration.Value](values: List[E]): Schema[E] =
-    enumeration(EnumTag.ClosedIntEnum, values)
+    enumeration(EnumTag.IntEnum[E](_.intValue, None), values.map(Enumeration.Value.toSchema(_)))
+
+  def openStringEnumeration[E <: Enumeration.Value](values: List[E], unknown: String => E): Schema[E] =
+    enumeration(EnumTag.StringEnum[E](_.stringValue, Some(unknown)), values.map(Enumeration.Value.toSchema(_)))
+
+  def openIntEnumeration[E <: Enumeration.Value](values: List[E], unknown: Int => E): Schema[E] =
+    enumeration(EnumTag.IntEnum[E](_.intValue, Some(unknown)), values.map(Enumeration.Value.toSchema(_)))
 
   def bijection[A, B](a: Schema[A], bijection: Bijection[A, B]): Schema[B] =
     Schema.BijectionSchema(a, bijection)

--- a/modules/core/src/smithy4s/schema/SchemaVisitor.scala
+++ b/modules/core/src/smithy4s/schema/SchemaVisitor.scala
@@ -25,7 +25,7 @@ trait SchemaVisitor[F[_]] extends (Schema ~> F) { self =>
   def primitive[P](shapeId: ShapeId, hints: Hints, tag: Primitive[P]): F[P]
   def collection[C[_], A](shapeId: ShapeId, hints: Hints, tag: CollectionTag[C], member: Schema[A]): F[C[A]]
   def map[K, V](shapeId: ShapeId, hints: Hints, key: Schema[K], value: Schema[V]): F[Map[K, V]]
-  def enumeration[E](shapeId: ShapeId, hints: Hints, tag: EnumTag[E], values: List[EnumValue[E]], total: E => EnumValue[E]): F[E]
+  def enumeration[E](shapeId: ShapeId, hints: Hints, tag: EnumTag[E], values: List[EnumValue[E]]): F[E]
   def struct[S](shapeId: ShapeId, hints: Hints, fields: Vector[Field[S, _]], make: IndexedSeq[Any] => S): F[S]
   def union[U](shapeId: ShapeId, hints: Hints, alternatives: Vector[Alt[U, _]], dispatch: Alt.Dispatcher[U]): F[U]
   def biject[A, B](schema: Schema[A], bijection: Bijection[A, B]): F[B]
@@ -37,7 +37,7 @@ trait SchemaVisitor[F[_]] extends (Schema ~> F) { self =>
     case PrimitiveSchema(shapeId, hints, tag) => primitive(shapeId, hints, tag)
     case s: CollectionSchema[c, a] => collection[c,a](s.shapeId, s.hints, s.tag, s.member)
     case MapSchema(shapeId, hints, key, value) => map(shapeId, hints, key, value)
-    case EnumerationSchema(shapeId, hints, tag, values, total) => enumeration(shapeId, hints, tag, values, total)
+    case EnumerationSchema(shapeId, hints, tag, values) => enumeration(shapeId, hints, tag, values)
     case StructSchema(shapeId, hints, fields, make) => struct(shapeId, hints, fields, make)
     case u@UnionSchema(shapeId, hints, alts, _) => union(shapeId, hints, alts, Alt.Dispatcher.fromUnion(u))
     case BijectionSchema(schema, bijection) => biject(schema, bijection)
@@ -57,7 +57,7 @@ object SchemaVisitor { outer =>
     override def primitive[P](shapeId: ShapeId, hints: Hints, tag: Primitive[P]): F[P] = default
     override def collection[C[_], A](shapeId: ShapeId, hints: Hints, tag: CollectionTag[C], member: Schema[A]): F[C[A]] = default
     override def map[K, V](shapeId: ShapeId, hints: Hints, key: Schema[K], value: Schema[V]): F[Map[K,V]] = default
-    override def enumeration[E](shapeId: ShapeId, hints: Hints, tag: EnumTag[E], values: List[EnumValue[E]], total: E => EnumValue[E]): F[E] = default
+    override def enumeration[E](shapeId: ShapeId, hints: Hints, tag: EnumTag[E], values: List[EnumValue[E]]): F[E] = default
     override def struct[S](shapeId: ShapeId, hints: Hints, fields: Vector[Field[S, _]], make: IndexedSeq[Any] => S): F[S] = default
     override def union[U](shapeId: ShapeId, hints: Hints, alternatives: Vector[Alt[U, _]], dispatch: Alt.Dispatcher[U]): F[U] = default
     override def biject[A, B](schema: Schema[A], bijection: Bijection[A, B]): F[B] = default

--- a/modules/decline/src/core/OptsVisitor.scala
+++ b/modules/decline/src/core/OptsVisitor.scala
@@ -89,17 +89,17 @@ object OptsVisitor extends SchemaVisitor[Opts] { self =>
       fieldName: CoreHints.FieldName,
       tag: EnumTag[E]
   ): Argument[E] = {
-    val ordinalMap: Map[Int, E] = values.map(v => v.intValue -> v.value).toMap
+    val stringMap: Map[Int, E] = values.map(v => v.intValue -> v.value).toMap
     val nameMap: Map[String, E] =
       values.map(v => v.stringValue -> v.value).toMap
     val extract: String => Option[E] = tag match {
-      case EnumTag.OpenIntEnum(unknown) =>
-        _.toIntOption.map(i => ordinalMap.getOrElse(i, unknown(i)))
-      case EnumTag.ClosedIntEnum =>
-        _.toIntOption.flatMap(ordinalMap.get)
-      case EnumTag.OpenStringEnum(unknown) =>
+      case EnumTag.IntEnum(_, Some(unknown)) =>
+        _.toIntOption.map(i => stringMap.getOrElse(i, unknown(i)))
+      case EnumTag.IntEnum(_, None) =>
+        _.toIntOption.flatMap(stringMap.get)
+      case EnumTag.StringEnum(_, Some(unknown)) =>
         str => Some(nameMap.getOrElse(str, unknown(str)))
-      case EnumTag.ClosedStringEnum =>
+      case EnumTag.StringEnum(_, None) =>
         nameMap.get(_)
     }
     Argument.from("enum") { name =>
@@ -264,8 +264,7 @@ object OptsVisitor extends SchemaVisitor[Opts] { self =>
       shapeId: ShapeId,
       hints: Hints,
       tag: EnumTag[E],
-      values: List[EnumValue[E]],
-      total: E => EnumValue[E]
+      values: List[EnumValue[E]]
   ): Opts[E] = {
     implicit val arg: Argument[E] =
       enumArg(values, FieldName.require(hints), tag)

--- a/modules/decline/test/src/smithy4s/decline/core/OptsVisitorSpec.scala
+++ b/modules/decline/test/src/smithy4s/decline/core/OptsVisitorSpec.scala
@@ -70,12 +70,15 @@ object OptsSchematicSpec extends SimpleIOSuite {
 
       sampleStruct(
         "superpower",
-        stringEnumeration[Superpower](
-          {
-            case Fire  => fire
-            case Ice   => ice
-            case Water => water
-          },
+        enumeration[Superpower](
+          smithy4s.schema.EnumTag.StringEnum(
+            {
+              case Fire  => "FIRE"
+              case Ice   => "ICE"
+              case Water => "WATER"
+            },
+            None
+          ),
           List(
             fire,
             ice,

--- a/modules/docs/markdown/05-design/02-schemas.md
+++ b/modules/docs/markdown/05-design/02-schemas.md
@@ -333,10 +333,10 @@ intEnum Numbers {
 The corresponding generated Scala-code is :
 
 ```scala
-sealed abstract class Numbers(_value: String, _name: String, _intValue: Int, _hints: Hints) extends Enumeration.Value {
+sealed abstract class Numbers(_stringValue: String, _name: String, _intValue: Int, _hints: Hints) extends Enumeration.Value {
   override type EnumType = Numbers
-  override val value: String = _value
   override val name: String = _name
+  override val stringValue: String = _stringValue
   override val intValue: Int = _intValue
   override val hints: Hints = _hints
   override def enumeration: Enumeration[EnumType] = Numbers
@@ -354,8 +354,7 @@ object Numbers extends Enumeration[Numbers] with ShapeTag.Companion[Numbers] {
     ONE,
     TWO,
   )
-  val tag: EnumTag[Numbers] = EnumTag.ClosedIntEnum
-  implicit val schema: Schema[Numbers] = enumeration(tag, values).withId(id).addHints(hints)
+  implicit val schema: Schema[Numbers] = stringEnumeration(values).withId(id).addHints(hints)
 }
 ```
 
@@ -388,10 +387,10 @@ import smithy4s.ShapeTag
 import smithy4s.schema.EnumTag
 import smithy4s.schema.Schema.enumeration
 
-sealed abstract class OpenNums(_value: String, _name: String, _intValue: Int, _hints: Hints) extends Enumeration.Value {
+sealed abstract class OpenNums(_stringValue: String, _name: String, _intValue: Int, _hints: Hints) extends Enumeration.Value {
   override type EnumType = OpenNums
-  override val value: String = _value
   override val name: String = _name
+  override val stringValue: String = _stringValue
   override val intValue: Int = _intValue
   override val hints: Hints = _hints
   override def enumeration: Enumeration[EnumType] = OpenNums
@@ -414,8 +413,7 @@ object OpenNums extends Enumeration[OpenNums] with ShapeTag.Companion[OpenNums] 
     ONE,
     TWO,
   )
-  val tag: EnumTag[OpenNums] = EnumTag.OpenIntEnum($unknown)
-  implicit val schema: Schema[OpenNums] = enumeration(tag, values).withId(id).addHints(hints)
+  implicit val schema: Schema[OpenNums] = openStringEnumeration(values, $unknown).withId(id).addHints(hints)
 }
 ```
 

--- a/modules/dynamic/src/smithy4s/dynamic/internals/DynamicLambdas.scala
+++ b/modules/dynamic/src/smithy4s/dynamic/internals/DynamicLambdas.scala
@@ -57,4 +57,11 @@ private[internals] object DynamicLambdas {
     }
   }
 
+  case object StringIdentity extends (String => String) {
+    def apply(str: String): String = str
+  }
+
+  case object IntIdentity extends (Int => Int) {
+    def apply(int: Int): Int = int
+  }
 }

--- a/modules/dynamic/src/smithy4s/dynamic/internals/DynamicModelCompiler.scala
+++ b/modules/dynamic/src/smithy4s/dynamic/internals/DynamicModelCompiler.scala
@@ -253,9 +253,9 @@ private[dynamic] object Compiler {
     ) = {
       val unknown: Option[String => String] =
         if (traits.contains(IdRef("alloy#openEnum"))) {
-          Some(identity[String])
+          Some(DynamicLambdas.StringIdentity)
         } else None
-      val tag = EnumTag.StringEnum(identity[String], unknown)
+      val tag = EnumTag.StringEnum(DynamicLambdas.StringIdentity, unknown)
       enumeration(tag, values)
     }
 
@@ -289,9 +289,9 @@ private[dynamic] object Compiler {
 
       val unknown: Option[Int => Int] =
         if (shape.traits.contains(IdRef("alloy#openEnum"))) {
-          Some(identity[Int])
+          Some(DynamicLambdas.IntIdentity)
         } else None
-      val tag = EnumTag.IntEnum(identity[Int], unknown)
+      val tag = EnumTag.IntEnum(DynamicLambdas.IntIdentity, unknown)
       val schema = enumeration(tag, valueList)
       update(id, shape.traits, schema)
 

--- a/modules/dynamic/src/smithy4s/dynamic/internals/DynamicModelCompiler.scala
+++ b/modules/dynamic/src/smithy4s/dynamic/internals/DynamicModelCompiler.scala
@@ -315,7 +315,6 @@ private[dynamic] object Compiler {
               EnumValue(
                 stringValue = value,
                 intValue = intValue,
-                // Using the intValue as a runtime value
                 value = value,
                 name = enumDefinition.name
                   .map(_.value)

--- a/modules/dynamic/test/src-jvm/smithy4s/dynamic/DynamicStabilitySpec.scala
+++ b/modules/dynamic/test/src-jvm/smithy4s/dynamic/DynamicStabilitySpec.scala
@@ -178,8 +178,7 @@ class DynamicStabilitySpec extends FunSuite {
         shapeId: ShapeId,
         hints: Hints,
         tag: EnumTag[E],
-        values: List[EnumValue[E]],
-        total: E => EnumValue[E]
+        values: List[EnumValue[E]]
     ): ConstUnit[E] = {
       val _ = counter.incrementAndGet()
     }

--- a/modules/dynamic/test/src-jvm/smithy4s/dynamic/EnumSpec.scala
+++ b/modules/dynamic/test/src-jvm/smithy4s/dynamic/EnumSpec.scala
@@ -83,9 +83,9 @@ class EnumSpec extends DummyIO.Suite {
 
   val compiled = Utils.compile(model)
 
-  def assertEnum(
+  def assertEnum[A](
       shapeId: ShapeId,
-      expectedValues: List[EnumValue[_]]
+      expectedValues: List[EnumValue[A]]
   )(implicit
       loc: Location
   ) = {
@@ -112,14 +112,14 @@ class EnumSpec extends DummyIO.Suite {
         EnumValue(
           stringValue = "Ice",
           intValue = 0,
-          value = 0,
+          value = "Ice",
           name = "ICE",
           hints = Hints.empty
         ),
         EnumValue(
           stringValue = "Fire",
           intValue = 1,
-          value = 1,
+          value = "Fire",
           name = "FIRE",
           hints = Hints.empty
         )
@@ -134,14 +134,14 @@ class EnumSpec extends DummyIO.Suite {
         EnumValue(
           stringValue = "Vanilla",
           intValue = 0,
-          value = 0,
+          value = "Vanilla",
           name = "VANILLA",
           hints = Hints.empty
         ),
         EnumValue(
           stringValue = "Ice",
           intValue = 1,
-          value = 1,
+          value = "Ice",
           name = "ICE",
           hints = Hints.empty
         )
@@ -156,14 +156,14 @@ class EnumSpec extends DummyIO.Suite {
         EnumValue(
           stringValue = "Fire",
           intValue = 0,
-          value = 0,
+          value = "Fire",
           name = "FIRE",
           hints = Hints.empty
         ),
         EnumValue(
           stringValue = "Ice",
           intValue = 1,
-          value = 1,
+          value = "Ice",
           name = "ICE",
           hints = Hints.empty
         )
@@ -200,9 +200,9 @@ class EnumSpec extends DummyIO.Suite {
           index
             .getSchema(ShapeId("example", "Smithy20Enum"))
             .getOrElse(fail("Error: shape missing"))
-            .asInstanceOf[Schema[Int]]
+            .asInstanceOf[Schema[String]]
         )
-        .encode(1)
+        .encode("Ice")
 
       assertEquals(actual, Document.DString("Ice"))
     }
@@ -232,14 +232,14 @@ class EnumSpec extends DummyIO.Suite {
         EnumValue(
           stringValue = "FIRE",
           intValue = 0,
-          value = 0,
+          value = "FIRE",
           name = "FIRE",
           hints = Hints.empty
         ),
         EnumValue(
           stringValue = "ICE",
           intValue = 1,
-          value = 1,
+          value = "ICE",
           name = "ICE",
           hints = Hints(
             ShapeId("smithy.api", "deprecated") -> Document.obj()

--- a/modules/json/src/smithy4s/json/internals/SchemaVisitorJCodec.scala
+++ b/modules/json/src/smithy4s/json/internals/SchemaVisitorJCodec.scala
@@ -1160,24 +1160,18 @@ private[smithy4s] class SchemaVisitorJCodec(
       values: List[EnumValue[E]],
       tag: EnumTag.StringEnum[E]
   ): JCodec[E] = new JCodec[E] {
-    private val nameMap: Map[String, E] =
+    private val stringValueMap: Map[String, E] =
       values.map(v => v.stringValue -> v.value).toMap
-
-    private def fromName(v: String): Option[E] =
-      nameMap.get(v)
-
-    private def fromNameOpen(v: String, unknown: String => E): E =
-      nameMap.getOrElse(v, unknown(v))
 
     val expecting: String =
       s"enumeration: [${values.map(_.stringValue).mkString(", ")}]"
 
-    private val decode: (JsonReader, String) => E = tag match {
-      case EnumTag.OpenStringEnum(unknown) =>
-        (_, str) => fromNameOpen(str, unknown)
-      case _ =>
+    private val decode: (JsonReader, String) => E = tag.unknown match {
+      case Some(unknown) =>
+        (_, str) => stringValueMap.getOrElse(str, unknown(str))
+      case None =>
         (in, str) =>
-          fromName(str) match {
+          stringValueMap.get(str) match {
             case Some(value) => value
             case None        => in.enumValueError(str)
           }
@@ -1209,21 +1203,15 @@ private[smithy4s] class SchemaVisitorJCodec(
     private val intValueMap: Map[Int, E] =
       values.map(v => v.intValue -> v.value).toMap
 
-    private def fromOrdinal(v: Int): Option[E] =
-      intValueMap.get(v)
-
-    private def fromOrdinalOpen(v: Int, unknown: Int => E): E =
-      intValueMap.getOrElse(v, unknown(v))
-
     val expecting: String =
       s"enumeration: [${values.map(_.stringValue).mkString(", ")}]"
 
-    private val decode: (JsonReader, Int) => E = tag match {
-      case EnumTag.OpenIntEnum(unknown) =>
-        (_, i) => fromOrdinalOpen(i, unknown)
-      case _ =>
+    private val decode: (JsonReader, Int) => E = tag.unknown match {
+      case Some(unknown) =>
+        (_, i) => intValueMap.getOrElse(i, unknown(i))
+      case None =>
         (in, i) =>
-          fromOrdinal(i) match {
+          intValueMap.get(i) match {
             case Some(value) => value
             case None        => in.enumValueError(i)
           }

--- a/modules/scalacheck/src/smithy4s/scalacheck/SchemaVisitorGen.scala
+++ b/modules/scalacheck/src/smithy4s/scalacheck/SchemaVisitorGen.scala
@@ -85,8 +85,7 @@ abstract class SchemaVisitorGen extends SchemaVisitor[Gen] { self =>
       shapeId: ShapeId,
       hints: Hints,
       tag: EnumTag[E],
-      values: List[EnumValue[E]],
-      total: E => EnumValue[E]
+      values: List[EnumValue[E]]
   ): Gen[E] =
     Gen.oneOf(values.map(_.value))
   def struct[S](

--- a/modules/test-utils/src/smithy4s/tests/DefaultSchemaVisitor.scala
+++ b/modules/test-utils/src/smithy4s/tests/DefaultSchemaVisitor.scala
@@ -83,8 +83,7 @@ object DefaultSchemaVisitor extends SchemaVisitor[Id] { self =>
       shapeId: ShapeId,
       hints: Hints,
       tag: EnumTag[E],
-      values: List[EnumValue[E]],
-      total: E => EnumValue[E]
+      values: List[EnumValue[E]]
   ): Id[E] = values.head.value
 
   override def struct[S](

--- a/modules/tests/src/smithy4s/tests/PizzaAdminServiceImpl.scala
+++ b/modules/tests/src/smithy4s/tests/PizzaAdminServiceImpl.scala
@@ -40,7 +40,7 @@ class PizzaAdminServiceImpl(ref: Ref[IO, State]) extends PizzaAdminService[IO] {
     IO.pure(ReservationOutput(message = s"Booked for $name"))
 
   def getEnum(theEnum: TheEnum): IO[GetEnumOutput] =
-    IO.pure(GetEnumOutput(result = Some(theEnum.value)))
+    IO.pure(GetEnumOutput(result = Some(theEnum.stringValue)))
 
   def getIntEnum(theEnum: EnumResult): IO[GetIntEnumOutput] =
     IO.pure(GetIntEnumOutput(theEnum))

--- a/modules/xml/src/smithy4s/xml/internals/XmlDecoderSchemaVisitor.scala
+++ b/modules/xml/src/smithy4s/xml/internals/XmlDecoderSchemaVisitor.scala
@@ -106,25 +106,25 @@ private[smithy4s] class XmlDecoderSchemaVisitor(
       values: List[EnumValue[E]]
   ): XmlDecoder[E] = {
     tag match {
-      case EnumTag.IntEnum(_, _) =>
+      case EnumTag.IntEnum(_, maybeUnknown) =>
         val desc = s"enum[${values.map(_.intValue).mkString(", ")}]"
         val valueMap = values.map(ev => ev.intValue -> ev.value).toMap
         val handler: String => Option[E] =
-          tag match {
-            case EnumTag.OpenIntEnum(unknown) =>
+          maybeUnknown match {
+            case Some(unknown) =>
               _.toIntOption.map(i => valueMap.getOrElse(i, unknown(i)))
-            case _ =>
+            case None =>
               _.toIntOption.flatMap(valueMap.get)
           }
         XmlDecoder.fromStringParser(desc, trim = true)(
           handler(_)
         )
-      case EnumTag.StringEnum(_, _) =>
+      case EnumTag.StringEnum(_, maybeUnknown) =>
         val desc = s"enum[${values.map(_.stringValue).mkString(", ")}]"
         val valueMap = values.map(ev => ev.stringValue -> ev.value).toMap
         val handler: String => Option[E] =
-          tag match {
-            case EnumTag.OpenStringEnum(unknown) =>
+          maybeUnknown match {
+            case Some(unknown) =>
               s => Some(valueMap.getOrElse(s, unknown(s)))
             case _ =>
               valueMap.get(_)

--- a/modules/xml/src/smithy4s/xml/internals/XmlDecoderSchemaVisitor.scala
+++ b/modules/xml/src/smithy4s/xml/internals/XmlDecoderSchemaVisitor.scala
@@ -103,11 +103,10 @@ private[smithy4s] class XmlDecoderSchemaVisitor(
       shapeId: ShapeId,
       hints: Hints,
       tag: EnumTag[E],
-      values: List[EnumValue[E]],
-      total: E => EnumValue[E]
+      values: List[EnumValue[E]]
   ): XmlDecoder[E] = {
     tag match {
-      case EnumTag.IntEnum() =>
+      case EnumTag.IntEnum(_, _) =>
         val desc = s"enum[${values.map(_.intValue).mkString(", ")}]"
         val valueMap = values.map(ev => ev.intValue -> ev.value).toMap
         val handler: String => Option[E] =
@@ -120,7 +119,7 @@ private[smithy4s] class XmlDecoderSchemaVisitor(
         XmlDecoder.fromStringParser(desc, trim = true)(
           handler(_)
         )
-      case _ =>
+      case EnumTag.StringEnum(_, _) =>
         val desc = s"enum[${values.map(_.stringValue).mkString(", ")}]"
         val valueMap = values.map(ev => ev.stringValue -> ev.value).toMap
         val handler: String => Option[E] =

--- a/modules/xml/src/smithy4s/xml/internals/XmlEncoderSchemaVisitor.scala
+++ b/modules/xml/src/smithy4s/xml/internals/XmlEncoderSchemaVisitor.scala
@@ -133,20 +133,19 @@ private[smithy4s] class XmlEncoderSchemaVisitor(
       shapeId: ShapeId,
       hints: Hints,
       tag: EnumTag[E],
-      values: List[EnumValue[E]],
-      total: E => EnumValue[E]
+      values: List[EnumValue[E]]
   ): XmlEncoder[E] = tag match {
-    case EnumTag.IntEnum() =>
+    case EnumTag.IntEnum(value, _) =>
       new XmlEncoder[E] {
-        def encode(value: E): List[XmlContent] = List(
-          XmlText(total(value).intValue.toString())
+        def encode(e: E): List[XmlContent] = List(
+          XmlText(value(e).toString())
         )
       }
 
-    case _ =>
+    case EnumTag.StringEnum(value, _) =>
       new XmlEncoder[E] {
-        def encode(value: E): List[XmlContent] = List(
-          XmlText(total(value).stringValue)
+        def encode(e: E): List[XmlContent] = List(
+          XmlText(value(e))
         )
       }
   }


### PR DESCRIPTION
* Changes the EnumTag modelling by having just two cases : IntEnum, StringEnum. The open/close aspect is determined by an optional function. Additionally, EnumTags now carry a `value` function allowing to extract the String/Int value out of the enumeration.
* Rework EnumerationSchema to avoid carrying a `total` function. The `value` function carried by the EnumerationSchema can now be used instead, which gets the logic closer to smithy semantics.
* Changes the dynamic data so that string enumerations are now represented by the string values, instead of integers.
* Rename the `value` method to `stringValue` in the EnumerationValue datatype.

- [x] Updated documentation
- [x] Updated changelog
