### PR TITLE
Ensure member names are escaped in hint values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.18.6
+
+* If a Smithy trait, being a structure shape, had a Scala keyword in its member names, compilation of the generated would fail. In addition, enumeration values that matched a known keyword would have their name erroneously escaped with an underscore in the string literal.
+These are now fixed in [#1344](https://github.com/disneystreaming/smithy4s/pull/1344).
+
 # 0.18.5
 
 * When encoding to `application/x-www-form-urlencoded`, omit optional fields set to the field's default value.

--- a/modules/bootstrapped/src/generated/smithy4s/example/collision/KeywordEnum.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/collision/KeywordEnum.scala
@@ -1,0 +1,32 @@
+package smithy4s.example.collision
+
+import smithy4s.Enumeration
+import smithy4s.Hints
+import smithy4s.Schema
+import smithy4s.ShapeId
+import smithy4s.ShapeTag
+import smithy4s.schema.EnumTag
+import smithy4s.schema.Schema.enumeration
+
+sealed abstract class KeywordEnum(_value: java.lang.String, _name: java.lang.String, _intValue: Int, _hints: Hints) extends Enumeration.Value {
+  override type EnumType = KeywordEnum
+  override val value: java.lang.String = _value
+  override val name: java.lang.String = _name
+  override val intValue: Int = _intValue
+  override val hints: Hints = _hints
+  override def enumeration: Enumeration[EnumType] = KeywordEnum
+  @inline final def widen: KeywordEnum = this
+}
+object KeywordEnum extends Enumeration[KeywordEnum] with ShapeTag.Companion[KeywordEnum] {
+  val id: ShapeId = ShapeId("smithy4s.example.collision", "KeywordEnum")
+
+  val hints: Hints = Hints.empty
+
+  case object _implicit extends KeywordEnum("implicit", "implicit", 0, Hints())
+
+  val values: List[KeywordEnum] = List(
+    _implicit,
+  )
+  val tag: EnumTag[KeywordEnum] = EnumTag.ClosedStringEnum
+  implicit val schema: Schema[KeywordEnum] = enumeration(tag, values).withId(id).addHints(hints)
+}

--- a/modules/bootstrapped/src/generated/smithy4s/example/collision/KeywordEnum.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/collision/KeywordEnum.scala
@@ -23,9 +23,11 @@ object KeywordEnum extends Enumeration[KeywordEnum] with ShapeTag.Companion[Keyw
   val hints: Hints = Hints.empty
 
   case object _implicit extends KeywordEnum("implicit", "implicit", 0, Hints())
+  case object _package extends KeywordEnum("class", "package", 1, Hints())
 
   val values: List[KeywordEnum] = List(
     _implicit,
+    _package,
   )
   val tag: EnumTag[KeywordEnum] = EnumTag.ClosedStringEnum
   implicit val schema: Schema[KeywordEnum] = enumeration(tag, values).withId(id).addHints(hints)

--- a/modules/bootstrapped/src/generated/smithy4s/example/collision/PackageUnion.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/collision/PackageUnion.scala
@@ -1,0 +1,55 @@
+package smithy4s.example.collision
+
+import smithy4s.Hints
+import smithy4s.Schema
+import smithy4s.ShapeId
+import smithy4s.ShapeTag
+import smithy4s.schema.Schema.bijection
+import smithy4s.schema.Schema.int
+import smithy4s.schema.Schema.union
+
+sealed trait PackageUnion extends scala.Product with scala.Serializable { self =>
+  @inline final def widen: PackageUnion = this
+  def $ordinal: Int
+
+  object project {
+    def _class: Option[Int] = PackageUnion.ClassCase.alt.project.lift(self).map(_._class)
+  }
+
+  def accept[A](visitor: PackageUnion.Visitor[A]): A = this match {
+    case value: PackageUnion.ClassCase => visitor._class(value._class)
+  }
+}
+object PackageUnion extends ShapeTag.Companion[PackageUnion] {
+
+  def _class(_class: Int): PackageUnion = ClassCase(_class)
+
+  val id: ShapeId = ShapeId("smithy4s.example.collision", "PackageUnion")
+
+  val hints: Hints = Hints.empty
+
+  final case class ClassCase(_class: Int) extends PackageUnion { final def $ordinal: Int = 0 }
+
+  object ClassCase {
+    val hints: Hints = Hints.empty
+    val schema: Schema[PackageUnion.ClassCase] = bijection(int.addHints(hints), PackageUnion.ClassCase(_), _._class)
+    val alt = schema.oneOf[PackageUnion]("class")
+  }
+
+  trait Visitor[A] {
+    def _class(value: Int): A
+  }
+
+  object Visitor {
+    trait Default[A] extends Visitor[A] {
+      def default: A
+      def _class(value: Int): A = default
+    }
+  }
+
+  implicit val schema: Schema[PackageUnion] = union(
+    PackageUnion.ClassCase.alt,
+  ){
+    _.$ordinal
+  }.withId(id).addHints(hints)
+}

--- a/modules/bootstrapped/src/generated/smithy4s/example/collision/Packagee.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/collision/Packagee.scala
@@ -1,0 +1,22 @@
+package smithy4s.example.collision
+
+import smithy4s.Hints
+import smithy4s.Schema
+import smithy4s.ShapeId
+import smithy4s.ShapeTag
+import smithy4s.schema.Schema.int
+import smithy4s.schema.Schema.struct
+
+final case class Packagee(_class: Option[Int] = None)
+
+object Packagee extends ShapeTag.Companion[Packagee] {
+  val id: ShapeId = ShapeId("smithy4s.example.collision", "Packagee")
+
+  val hints: Hints = Hints.empty
+
+  implicit val schema: Schema[Packagee] = struct(
+    int.optional[Packagee]("class", _._class),
+  ){
+    Packagee.apply
+  }.withId(id).addHints(hints)
+}

--- a/modules/bootstrapped/src/generated/smithy4s/example/collision/ReservedKeywordStructTrait.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/collision/ReservedKeywordStructTrait.scala
@@ -1,0 +1,25 @@
+package smithy4s.example.collision
+
+import smithy4s.Hints
+import smithy4s.Schema
+import smithy4s.ShapeId
+import smithy4s.ShapeTag
+import smithy4s.schema.Schema.recursive
+import smithy4s.schema.Schema.struct
+
+final case class ReservedKeywordStructTrait(_implicit: String, _package: Option[Packagee] = None)
+
+object ReservedKeywordStructTrait extends ShapeTag.Companion[ReservedKeywordStructTrait] {
+  val id: ShapeId = ShapeId("smithy4s.example.collision", "reservedKeywordStructTrait")
+
+  val hints: Hints = Hints(
+    smithy.api.Trait(selector = None, structurallyExclusive = None, conflicts = None, breakingChanges = None),
+  )
+
+  implicit val schema: Schema[ReservedKeywordStructTrait] = recursive(struct(
+    String.schema.required[ReservedKeywordStructTrait]("implicit", _._implicit),
+    Packagee.schema.optional[ReservedKeywordStructTrait]("package", _._package),
+  ){
+    ReservedKeywordStructTrait.apply
+  }.withId(id).addHints(hints))
+}

--- a/modules/bootstrapped/src/generated/smithy4s/example/collision/ReservedKeywordTraitExampleCollection.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/collision/ReservedKeywordTraitExampleCollection.scala
@@ -1,0 +1,17 @@
+package smithy4s.example.collision
+
+import smithy4s.Hints
+import smithy4s.Newtype
+import smithy4s.Schema
+import smithy4s.ShapeId
+import smithy4s.schema.Schema.bijection
+import smithy4s.schema.Schema.list
+
+object ReservedKeywordTraitExampleCollection extends Newtype[List[String]] {
+  val id: ShapeId = ShapeId("smithy4s.example.collision", "ReservedKeywordTraitExampleCollection")
+  val hints: Hints = Hints(
+    smithy4s.example.collision.ReservedKeywordStructTrait(_implicit = smithy4s.example.collision.String("demo"), _package = Some(smithy4s.example.collision.Packagee(_class = Some(42)))),
+  )
+  val underlyingSchema: Schema[List[String]] = list(String.schema.addMemberHints(smithy4s.example.collision.ReservedKeywordStructTrait(_implicit = smithy4s.example.collision.String("demo"), _package = Some(smithy4s.example.collision.Packagee(_class = Some(42)))))).withId(id).addHints(hints)
+  implicit val schema: Schema[ReservedKeywordTraitExampleCollection] = bijection(underlyingSchema, asBijection)
+}

--- a/modules/bootstrapped/src/generated/smithy4s/example/collision/ReservedKeywordTraitExamplePrimitive.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/collision/ReservedKeywordTraitExamplePrimitive.scala
@@ -1,0 +1,17 @@
+package smithy4s.example.collision
+
+import smithy4s.Hints
+import smithy4s.Newtype
+import smithy4s.Schema
+import smithy4s.ShapeId
+import smithy4s.schema.Schema.bijection
+import smithy4s.schema.Schema.string
+
+object ReservedKeywordTraitExamplePrimitive extends Newtype[java.lang.String] {
+  val id: ShapeId = ShapeId("smithy4s.example.collision", "ReservedKeywordTraitExamplePrimitive")
+  val hints: Hints = Hints(
+    smithy4s.example.collision.ReservedKeywordStructTrait(_implicit = smithy4s.example.collision.String("demo"), _package = Some(smithy4s.example.collision.Packagee(_class = Some(42)))),
+  )
+  val underlyingSchema: Schema[java.lang.String] = string.withId(id).addHints(hints)
+  implicit val schema: Schema[ReservedKeywordTraitExamplePrimitive] = bijection(underlyingSchema, asBijection)
+}

--- a/modules/bootstrapped/src/generated/smithy4s/example/collision/ReservedKeywordTraitExampleStruct.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/collision/ReservedKeywordTraitExampleStruct.scala
@@ -1,0 +1,24 @@
+package smithy4s.example.collision
+
+import smithy4s.Hints
+import smithy4s.Schema
+import smithy4s.ShapeId
+import smithy4s.ShapeTag
+import smithy4s.schema.Schema.struct
+
+final case class ReservedKeywordTraitExampleStruct(member: Option[String] = None)
+
+object ReservedKeywordTraitExampleStruct extends ShapeTag.Companion[ReservedKeywordTraitExampleStruct] {
+  val id: ShapeId = ShapeId("smithy4s.example.collision", "ReservedKeywordTraitExampleStruct")
+
+  val hints: Hints = Hints(
+    smithy4s.example.collision.ReservedKeywordStructTrait(_implicit = smithy4s.example.collision.String("demo"), _package = Some(smithy4s.example.collision.Packagee(_class = Some(42)))),
+    smithy4s.example.collision.ReservedKeywordUnionTrait.PackageCase(smithy4s.example.collision.PackageUnion.ClassCase(42).widen).widen,
+  )
+
+  implicit val schema: Schema[ReservedKeywordTraitExampleStruct] = struct(
+    String.schema.optional[ReservedKeywordTraitExampleStruct]("member", _.member).addHints(smithy4s.example.collision.ReservedKeywordStructTrait(_implicit = smithy4s.example.collision.String("demo"), _package = Some(smithy4s.example.collision.Packagee(_class = Some(42)))), smithy4s.example.collision.ReservedKeywordUnionTrait.PackageCase(smithy4s.example.collision.PackageUnion.ClassCase(42).widen).widen),
+  ){
+    ReservedKeywordTraitExampleStruct.apply
+  }.withId(id).addHints(hints)
+}

--- a/modules/bootstrapped/src/generated/smithy4s/example/collision/ReservedKeywordTraitExampleUnion.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/collision/ReservedKeywordTraitExampleUnion.scala
@@ -1,0 +1,58 @@
+package smithy4s.example.collision
+
+import smithy4s.Hints
+import smithy4s.Schema
+import smithy4s.ShapeId
+import smithy4s.ShapeTag
+import smithy4s.schema.Schema.bijection
+import smithy4s.schema.Schema.union
+
+sealed trait ReservedKeywordTraitExampleUnion extends scala.Product with scala.Serializable { self =>
+  @inline final def widen: ReservedKeywordTraitExampleUnion = this
+  def $ordinal: Int
+
+  object project {
+    def member: Option[String] = ReservedKeywordTraitExampleUnion.MemberCase.alt.project.lift(self).map(_.member)
+  }
+
+  def accept[A](visitor: ReservedKeywordTraitExampleUnion.Visitor[A]): A = this match {
+    case value: ReservedKeywordTraitExampleUnion.MemberCase => visitor.member(value.member)
+  }
+}
+object ReservedKeywordTraitExampleUnion extends ShapeTag.Companion[ReservedKeywordTraitExampleUnion] {
+
+  def member(member: String): ReservedKeywordTraitExampleUnion = MemberCase(member)
+
+  val id: ShapeId = ShapeId("smithy4s.example.collision", "ReservedKeywordTraitExampleUnion")
+
+  val hints: Hints = Hints(
+    smithy4s.example.collision.ReservedKeywordStructTrait(_implicit = smithy4s.example.collision.String("demo"), _package = Some(smithy4s.example.collision.Packagee(_class = Some(42)))),
+  )
+
+  final case class MemberCase(member: String) extends ReservedKeywordTraitExampleUnion { final def $ordinal: Int = 0 }
+
+  object MemberCase {
+    val hints: Hints = Hints(
+      smithy4s.example.collision.ReservedKeywordStructTrait(_implicit = smithy4s.example.collision.String("demo"), _package = Some(smithy4s.example.collision.Packagee(_class = Some(42)))),
+    )
+    val schema: Schema[ReservedKeywordTraitExampleUnion.MemberCase] = bijection(String.schema.addHints(hints), ReservedKeywordTraitExampleUnion.MemberCase(_), _.member)
+    val alt = schema.oneOf[ReservedKeywordTraitExampleUnion]("member")
+  }
+
+  trait Visitor[A] {
+    def member(value: String): A
+  }
+
+  object Visitor {
+    trait Default[A] extends Visitor[A] {
+      def default: A
+      def member(value: String): A = default
+    }
+  }
+
+  implicit val schema: Schema[ReservedKeywordTraitExampleUnion] = union(
+    ReservedKeywordTraitExampleUnion.MemberCase.alt,
+  ){
+    _.$ordinal
+  }.withId(id).addHints(hints)
+}

--- a/modules/bootstrapped/src/generated/smithy4s/example/collision/ReservedKeywordUnionTrait.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/collision/ReservedKeywordUnionTrait.scala
@@ -1,0 +1,57 @@
+package smithy4s.example.collision
+
+import smithy4s.Hints
+import smithy4s.Schema
+import smithy4s.ShapeId
+import smithy4s.ShapeTag
+import smithy4s.schema.Schema.bijection
+import smithy4s.schema.Schema.recursive
+import smithy4s.schema.Schema.union
+
+sealed trait ReservedKeywordUnionTrait extends scala.Product with scala.Serializable { self =>
+  @inline final def widen: ReservedKeywordUnionTrait = this
+  def $ordinal: Int
+
+  object project {
+    def _package: Option[PackageUnion] = ReservedKeywordUnionTrait.PackageCase.alt.project.lift(self).map(_._package)
+  }
+
+  def accept[A](visitor: ReservedKeywordUnionTrait.Visitor[A]): A = this match {
+    case value: ReservedKeywordUnionTrait.PackageCase => visitor._package(value._package)
+  }
+}
+object ReservedKeywordUnionTrait extends ShapeTag.Companion[ReservedKeywordUnionTrait] {
+
+  def _package(_package: PackageUnion): ReservedKeywordUnionTrait = PackageCase(_package)
+
+  val id: ShapeId = ShapeId("smithy4s.example.collision", "reservedKeywordUnionTrait")
+
+  val hints: Hints = Hints(
+    smithy.api.Trait(selector = None, structurallyExclusive = None, conflicts = None, breakingChanges = None),
+  )
+
+  final case class PackageCase(_package: PackageUnion) extends ReservedKeywordUnionTrait { final def $ordinal: Int = 0 }
+
+  object PackageCase {
+    val hints: Hints = Hints.empty
+    val schema: Schema[ReservedKeywordUnionTrait.PackageCase] = bijection(PackageUnion.schema.addHints(hints), ReservedKeywordUnionTrait.PackageCase(_), _._package)
+    val alt = schema.oneOf[ReservedKeywordUnionTrait]("package")
+  }
+
+  trait Visitor[A] {
+    def _package(value: PackageUnion): A
+  }
+
+  object Visitor {
+    trait Default[A] extends Visitor[A] {
+      def default: A
+      def _package(value: PackageUnion): A = default
+    }
+  }
+
+  implicit val schema: Schema[ReservedKeywordUnionTrait] = recursive(union(
+    ReservedKeywordUnionTrait.PackageCase.alt,
+  ){
+    _.$ordinal
+  }.withId(id).addHints(hints))
+}

--- a/modules/bootstrapped/src/generated/smithy4s/example/collision/package.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/collision/package.scala
@@ -7,6 +7,8 @@ package object collision {
   type MyList = smithy4s.example.collision.MyList.Type
   type String = smithy4s.example.collision.String.Type
   type MyMap = smithy4s.example.collision.MyMap.Type
+  type ReservedKeywordTraitExampleCollection = smithy4s.example.collision.ReservedKeywordTraitExampleCollection.Type
+  type ReservedKeywordTraitExamplePrimitive = smithy4s.example.collision.ReservedKeywordTraitExamplePrimitive.Type
   type MySet = smithy4s.example.collision.MySet.Type
 
 }

--- a/modules/codegen/src/smithy4s/codegen/internals/CollisionAvoidance.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/CollisionAvoidance.scala
@@ -201,7 +201,12 @@ private[internals] object CollisionAvoidance {
         case EnumerationTN(ref, value, intValue, name) =>
           EnumerationTN(modRef(ref), value, intValue, name)
         case StructureTN(ref, fields) =>
-          StructureTN(modRef(ref), fields)
+          StructureTN(
+            ref = modRef(ref),
+            fields = fields.map { case (k, v) =>
+              protectKeyword(k) -> v
+            }
+          )
         case NewTypeTN(ref, target) =>
           NewTypeTN(modRef(ref), target)
         case AltTN(ref, altName, alt) =>

--- a/modules/codegen/src/smithy4s/codegen/internals/CollisionAvoidance.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/CollisionAvoidance.scala
@@ -88,8 +88,14 @@ private[internals] object CollisionAvoidance {
         )
       case Enumeration(shapeId, name, tag, values, hints) =>
         val newValues = values.map {
-          case EnumValue(value, intValue, name, hints) =>
-            EnumValue(value, intValue, protectKeyword(name), hints.map(modHint))
+          case EnumValue(value, intValue, name, realName, hints) =>
+            EnumValue(
+              value = value,
+              intValue = intValue,
+              name = protectKeyword(name),
+              realName = realName,
+              hints.map(modHint)
+            )
         }
         Enumeration(
           shapeId,

--- a/modules/codegen/src/smithy4s/codegen/internals/IR.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/IR.scala
@@ -113,6 +113,7 @@ private[internals] case class EnumValue(
     value: String,
     intValue: Int,
     name: String,
+    realName: String,
     hints: List[Hint]
 )
 

--- a/modules/codegen/src/smithy4s/codegen/internals/Renderer.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/Renderer.scala
@@ -1247,14 +1247,14 @@ private[internals] class Renderer(compilationUnit: CompilationUnit) { self =>
         renderHintsVal(hints),
         newline,
         renderPrismsEnum(name, values, hints, isOpen),
-        values.map { case e @ EnumValue(value, intValue, _, hints) =>
+        values.map { case e @ EnumValue(value, intValue, _, _, hints) =>
           val valueName = NameRef(e.name)
           val valueHints = line"$Hints_(${memberHints(e.hints)})"
 
           lines(
             documentationAnnotation(hints),
             deprecationAnnotation(hints),
-            line"""case object $valueName extends $name("$value", "${e.name}", $intValue, $valueHints)"""
+            line"""case object $valueName extends $name("$value", "${e.realName}", $intValue, $valueHints)"""
           )
         },
         if (isOpen) {

--- a/modules/codegen/src/smithy4s/codegen/internals/SmithyToIR.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/SmithyToIR.scala
@@ -1056,8 +1056,8 @@ private[codegen] class SmithyToIR(model: Model, namespace: String) {
     def fields: List[Field] = fieldsInternal(hintsExtractor = hints)
 
     /**
-      * Should be used only on the call site 
-      * of the trait application where there is no need to call `unfoldTrait` for every hint of the trait. 
+      * Should be used only on the call site
+      * of the trait application where there is no need to call `unfoldTrait` for every hint of the trait.
       */
     def getFieldsPlain: List[Field] =
       fieldsInternal(hintsExtractor = _ => List.empty)

--- a/modules/codegen/src/smithy4s/codegen/internals/SmithyToIR.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/SmithyToIR.scala
@@ -352,7 +352,13 @@ private[codegen] class SmithyToIR(model: Model, namespace: String) {
           .map { case ((name, value), index) =>
             val member = shape.getMember(name).get()
 
-            EnumValue(value, index, name, hints(member))
+            EnumValue(
+              value = value,
+              intValue = index,
+              name = name,
+              realName = name,
+              hints = hints(member)
+            )
           }
           .toList
 
@@ -375,7 +381,13 @@ private[codegen] class SmithyToIR(model: Model, namespace: String) {
           .map { case (name, value) =>
             val member = shape.getMember(name).get()
 
-            EnumValue(name, value, name, hints(member))
+            EnumValue(
+              value = name,
+              intValue = value,
+              name = name,
+              realName = name,
+              hints = hints(member)
+            )
           }
           .toList
 

--- a/sampleSpecs/reservednames.smithy
+++ b/sampleSpecs/reservednames.smithy
@@ -139,4 +139,5 @@ structure ReservedKeywordTraitExampleStruct {
 
 enum KeywordEnum {
     implicit
+    package = "class"
 }

--- a/sampleSpecs/reservednames.smithy
+++ b/sampleSpecs/reservednames.smithy
@@ -7,15 +7,20 @@ use smithy4s.example.package#MyPackageString
 
 @simpleRestJson
 service ReservedNameService {
-    version: "1.0.0",
-    operations: [Set,List,Map,Option]
+    version: "1.0.0"
+    operations: [
+        Set
+        List
+        Map
+        Option
+    ]
 }
 
 @http(method: "POST", uri: "/api/set/", code: 204)
 operation Set {
     input := {
-       @required
-       set:MySet
+        @required
+        set: MySet
     }
 }
 
@@ -60,4 +65,74 @@ string String
 
 structure TestReservedNamespaceImport {
     package: MyPackageString
+}
+
+// trait def
+@trait
+structure reservedKeywordStructTrait {
+    @required
+    implicit: String
+    package: Packagee
+}
+
+// note: can't name this Package because of #1343
+structure Packagee {
+    class: Integer
+}
+
+// trait usages
+@reservedKeywordStructTrait(implicit: "demo", package: {
+    class: 42
+})
+structure ReservedKeywordTraitExampleStruct {
+    @reservedKeywordStructTrait(implicit: "demo", package: {
+        class: 42
+    })
+    member: String
+}
+
+@reservedKeywordStructTrait(implicit: "demo", package: {
+    class: 42
+})
+union ReservedKeywordTraitExampleUnion {
+    @reservedKeywordStructTrait(implicit: "demo", package: {
+        class: 42
+    })
+    member: String
+}
+
+@reservedKeywordStructTrait(implicit: "demo", package: {
+    class: 42
+})
+string ReservedKeywordTraitExamplePrimitive
+
+@reservedKeywordStructTrait(implicit: "demo", package: {
+    class: 42
+})
+list ReservedKeywordTraitExampleCollection {
+    @reservedKeywordStructTrait(implicit: "demo", package: {
+        class: 42
+    })
+    member: String
+}
+
+// trait def, as a union
+@trait
+union reservedKeywordUnionTrait {
+    package: PackageUnion
+}
+
+union PackageUnion {
+    class: Integer
+}
+
+// trait usages
+@reservedKeywordUnionTrait(package: {
+    class: 42
+})
+structure ReservedKeywordTraitExampleStruct {
+    @reservedKeywordUnionTrait(package: {
+        class: 42
+    })
+    member: String
 }

--- a/sampleSpecs/reservednames.smithy
+++ b/sampleSpecs/reservednames.smithy
@@ -136,3 +136,7 @@ structure ReservedKeywordTraitExampleStruct {
     })
     member: String
 }
+
+enum KeywordEnum {
+    implicit
+}


### PR DESCRIPTION
Closes #1342. Additionally, enum member names were previously escaped, and I'm pretty sure they shouldn't be.

## PR Checklist (not all items are relevant to all PRs)

- ~~Added unit-tests (for runtime code)~~
- [x] Added bootstrapped code + smoke tests (when the rendering logic is modified) - **added bootstrapped code which is checked via compilation**
- ~~Added build-plugins integration tests (when reflection loading is required at codegen-time)~~
- ~~Added alloy compliance tests (when simpleRestJson protocol behaviour is expanded/updated)~~
- ~~Updated dynamic module to match generated-code behaviour~~ collisions aren't a thing in Dynamic
- ~~Added documentation~~
- [x] Updated changelog
