### PR TITLE
WIP: escape smart constructor name for ADTs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.18.6
+
+* `@adt` union members that match a keyword wouldn't have their "smart constructors"' names escaped, possibly failing compilation. This is now fixed.
+
 # 0.18.5
 
 * When encoding to `application/x-www-form-urlencoded`, omit optional fields set to the field's default value.

--- a/modules/bootstrapped/src/generated/smithy4s/example/DeprecatedUnion.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/DeprecatedUnion.scala
@@ -33,9 +33,9 @@ object DeprecatedUnion extends ShapeTag.Companion[DeprecatedUnion] {
   @deprecated(message = "N/A", since = "N/A")
   def s(s: String): DeprecatedUnion = SCase(s)
   def s_V2(s_V2: String): DeprecatedUnion = S_V2Case(s_V2)
-  def deprecatedUnionProductCase():DeprecatedUnionProductCase = DeprecatedUnionProductCase()
+  def deprecatedUnionProductCase(): DeprecatedUnionProductCase = DeprecatedUnionProductCase()
   @deprecated(message = "N/A", since = "N/A")
-  def unionProductCaseDeprecatedAtCallSite():UnionProductCaseDeprecatedAtCallSite = UnionProductCaseDeprecatedAtCallSite()
+  def unionProductCaseDeprecatedAtCallSite(): UnionProductCaseDeprecatedAtCallSite = UnionProductCaseDeprecatedAtCallSite()
 
   val id: ShapeId = ShapeId("smithy4s.example", "DeprecatedUnion")
 

--- a/modules/bootstrapped/src/generated/smithy4s/example/OrderType.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/OrderType.scala
@@ -33,7 +33,7 @@ object OrderType extends ShapeTag.Companion[OrderType] {
 
   def online(online: OrderNumber): OrderType = OnlineCase(online)
   /** For an InStoreOrder a location ID isn't needed */
-  def inStoreOrder(id: OrderNumber, locationId: Option[String] = None):InStoreOrder = InStoreOrder(id, locationId)
+  def inStoreOrder(id: OrderNumber, locationId: Option[String] = None): InStoreOrder = InStoreOrder(id, locationId)
   def preview(): OrderType = OrderType.PreviewCase
 
   val id: ShapeId = ShapeId("smithy4s.example", "OrderType")

--- a/modules/bootstrapped/src/generated/smithy4s/example/Podcast.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/Podcast.scala
@@ -27,8 +27,8 @@ sealed trait Podcast extends PodcastCommon with scala.Product with scala.Seriali
 }
 object Podcast extends ShapeTag.Companion[Podcast] {
 
-  def video(title: Option[String] = None, url: Option[String] = None, durationMillis: Option[Long] = None):Video = Video(title, url, durationMillis)
-  def audio(title: Option[String] = None, url: Option[String] = None, durationMillis: Option[Long] = None):Audio = Audio(title, url, durationMillis)
+  def video(title: Option[String] = None, url: Option[String] = None, durationMillis: Option[Long] = None): Video = Video(title, url, durationMillis)
+  def audio(title: Option[String] = None, url: Option[String] = None, durationMillis: Option[Long] = None): Audio = Audio(title, url, durationMillis)
 
   val id: ShapeId = ShapeId("smithy4s.example", "Podcast")
 

--- a/modules/bootstrapped/src/generated/smithy4s/example/TestAdt.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/TestAdt.scala
@@ -29,8 +29,8 @@ sealed trait TestAdt extends AdtMixinOne with AdtMixinTwo with scala.Product wit
 }
 object TestAdt extends ShapeTag.Companion[TestAdt] {
 
-  def adtOne(lng: Option[Long] = None, sht: Option[Short] = None, blb: Option[Blob] = None, str: Option[String] = None):AdtOne = AdtOne(lng, sht, blb, str)
-  def adtTwo(lng: Option[Long] = None, sht: Option[Short] = None, int: Option[Int] = None):AdtTwo = AdtTwo(lng, sht, int)
+  def adtOne(lng: Option[Long] = None, sht: Option[Short] = None, blb: Option[Blob] = None, str: Option[String] = None): AdtOne = AdtOne(lng, sht, blb, str)
+  def adtTwo(lng: Option[Long] = None, sht: Option[Short] = None, int: Option[Int] = None): AdtTwo = AdtTwo(lng, sht, int)
 
   val id: ShapeId = ShapeId("smithy4s.example", "TestAdt")
 

--- a/modules/bootstrapped/src/generated/smithy4s/example/TestMixinAdt.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/TestMixinAdt.scala
@@ -23,7 +23,7 @@ sealed trait TestMixinAdt extends scala.Product with scala.Serializable { self =
 }
 object TestMixinAdt extends ShapeTag.Companion[TestMixinAdt] {
 
-  def testAdtMemberWithMixin(a: Option[String] = None, b: Option[Int] = None):TestAdtMemberWithMixin = TestAdtMemberWithMixin(a, b)
+  def testAdtMemberWithMixin(a: Option[String] = None, b: Option[Int] = None): TestAdtMemberWithMixin = TestAdtMemberWithMixin(a, b)
 
   val id: ShapeId = ShapeId("smithy4s.example", "TestMixinAdt")
 

--- a/modules/bootstrapped/src/generated/smithy4s/example/collision/HasKeywordUnionAdt.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/collision/HasKeywordUnionAdt.scala
@@ -1,0 +1,61 @@
+package smithy4s.example.collision
+
+import smithy4s.Hints
+import smithy4s.Schema
+import smithy4s.ShapeId
+import smithy4s.ShapeTag
+import smithy4s.schema.Schema.constant
+import smithy4s.schema.Schema.union
+
+sealed trait HasKeywordUnionAdt extends scala.Product with scala.Serializable { self =>
+  @inline final def widen: HasKeywordUnionAdt = this
+  def $ordinal: Int
+
+  object project {
+    def one: Option[HasKeywordUnionAdt.Implicit] = HasKeywordUnionAdt.Implicit.alt.project.lift(self)
+  }
+
+  def accept[A](visitor: HasKeywordUnionAdt.Visitor[A]): A = this match {
+    case value: HasKeywordUnionAdt.Implicit => visitor.one(value)
+  }
+}
+object HasKeywordUnionAdt extends ShapeTag.Companion[HasKeywordUnionAdt] {
+
+  def _implicit(): Implicit = Implicit()
+
+  val id: ShapeId = ShapeId("smithy4s.example.collision", "HasKeywordUnionAdt")
+
+  val hints: Hints = Hints.empty
+
+  final case class Implicit() extends HasKeywordUnionAdt {
+    def $ordinal: Int = 0
+  }
+
+  object Implicit extends ShapeTag.Companion[Implicit] {
+    val id: ShapeId = ShapeId("smithy4s.example.collision", "implicit")
+
+    val hints: Hints = Hints.empty
+
+    implicit val schema: Schema[Implicit] = constant(Implicit()).withId(id).addHints(hints)
+
+    val alt = schema.oneOf[HasKeywordUnionAdt]("one")
+  }
+
+
+  trait Visitor[A] {
+    def one(value: HasKeywordUnionAdt.Implicit): A
+  }
+
+  object Visitor {
+    trait Default[A] extends Visitor[A] {
+      def default: A
+      def one(value: HasKeywordUnionAdt.Implicit): A = default
+    }
+  }
+
+  implicit val schema: Schema[HasKeywordUnionAdt] = union(
+    HasKeywordUnionAdt.Implicit.alt,
+  ){
+    _.$ordinal
+  }.withId(id).addHints(hints)
+}

--- a/modules/codegen/src/smithy4s/codegen/internals/CollisionAvoidance.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/CollisionAvoidance.scala
@@ -184,13 +184,17 @@ private[internals] object CollisionAvoidance {
   private def modProduct(p: Product): Product = {
     import p._
     Product(
-      p.shapeId,
-      protectKeyword(name.capitalize),
-      fields.map(modField),
-      mixins.map(modType),
-      recursive,
-      hints.map(modHint),
-      isMixin
+      shapeId = p.shapeId,
+      name = protectKeyword(name.capitalize),
+      safeName = protectKeyword(name) match {
+        case s"_$rest" => s"_${rest.capitalize}"
+        case untouched => untouched.capitalize
+      },
+      fields = fields.map(modField),
+      mixins = mixins.map(modType),
+      recursive = recursive,
+      hints = hints.map(modHint),
+      isMixin = isMixin
     )
   }
 

--- a/modules/codegen/src/smithy4s/codegen/internals/IR.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/IR.scala
@@ -77,12 +77,15 @@ private[internals] case class Operation(
 private[internals] case class Product(
     shapeId: ShapeId,
     name: String,
+    safeName: String,
     fields: List[Field],
     mixins: List[Type],
     recursive: Boolean = false,
     hints: List[Hint] = Nil,
     isMixin: Boolean = false
-) extends Decl
+) extends Decl {
+  def safeNameRef: NameRef = NameRef(List.empty, safeName, List.empty)
+}
 
 private[internals] case class Union(
     shapeId: ShapeId,

--- a/modules/codegen/src/smithy4s/codegen/internals/Renderer.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/Renderer.scala
@@ -1008,12 +1008,18 @@ private[internals] class Renderer(compilationUnit: CompilationUnit) { self =>
         case UnionMember.ProductCase(product) =>
           val args = renderArgs(product.fields)
           val values = product.fields.map(_.name).intercalate(", ")
-          line"def ${uncapitalise(product.nameDef.name)}($args):${product.nameRef} = ${product.nameRef}($values)"
+
+          // Q: should we just use the label instead, rather than the product name? It'd be consistent with optics.
+          // Q2: any better way to use the existing fields? Currently all collision avoidance is in CollisionAvoidance so I wouldn't want to do it here.
+          line"def ${uncapitalise(product.safeNameRef.name)}($args): ${product.nameRef} = ${product.nameRef}($values)"
+
         case UnionMember.UnitCase =>
           line"$prefix(): $name = ${caseName(name, alt)}"
+
         case UnionMember.TypeCase(tpe) =>
           line"$prefix($ident: $tpe): $name = $cn($ident)"
       }
+
       lines(
         documentationAnnotation(alt.hints),
         deprecationAnnotation(alt.hints),

--- a/modules/codegen/src/smithy4s/codegen/internals/SmithyToIR.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/SmithyToIR.scala
@@ -217,13 +217,14 @@ private[codegen] class SmithyToIR(model: Model, namespace: String) {
 
         val p =
           Product(
-            shape.getId(),
-            shape.name,
-            fields,
-            mixins,
-            rec,
-            hints,
-            isMixin
+            shapeId = shape.getId(),
+            name = shape.name,
+            safeName = shape.name,
+            fields = fields,
+            mixins = mixins,
+            recursive = rec,
+            hints = hints,
+            isMixin = isMixin
           ).some
         if (isPartOfAdt(shape)) {
           if (renderAdtMemberStructures) p else None

--- a/sampleSpecs/reservednames.smithy
+++ b/sampleSpecs/reservednames.smithy
@@ -56,6 +56,13 @@ operation Option {
     }
 }
 
+@smithy4s.meta#adt
+union HasKeywordUnionAdt {
+    one: implicit
+}
+
+structure implicit {}
+
 string String
 
 structure TestReservedNamespaceImport {


### PR DESCRIPTION
Showcasing option C of #1347.

## PR Checklist (not all items are relevant to all PRs)

- [ ] Added unit-tests (for runtime code)
- [ ] Added bootstrapped code + smoke tests (when the rendering logic is modified)
- [ ] Added build-plugins integration tests (when reflection loading is required at codegen-time)
- [ ] Added alloy compliance tests (when simpleRestJson protocol behaviour is expanded/updated)
- [ ] Updated dynamic module to match generated-code behaviour
- [ ] Added documentation
- [ ] Updated changelog
