### PR TITLE
Fix typo in creating-your-own-traits

### DIFF
--- a/modules/docs/markdown/02-the-smithy-idl/02-traits.md
+++ b/modules/docs/markdown/02-the-smithy-idl/02-traits.md
@@ -45,7 +45,7 @@ Smithy makes it really easy to create your own traits:
 ```kotlin
 namespace foo
 
-@trait(selector: is(structure))
+@trait(selector: ":is(structure)")
 string customThing
 
 @customThing("hello")


### PR DESCRIPTION
Minor PR fixing a typo on the selector in the creating-your-own-traits section.
