### PR TITLE
a project depends on a non-jar dependencies, extract fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.18.7
+
+* Smithy4s specific logic to extract manifest from jars can run on files that are not jars. Fixed in https://github.com/disneystreaming/smithy4s/pull/1351
+
 # 0.18.6
 
 * If a Smithy trait, being a structure shape, had a Scala keyword in its member names, compilation of the generated would fail. In addition, enumeration values that matched a known keyword would have their name erroneously escaped with an underscore in the string literal.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,9 @@
-# 0.18.7
-
-* Smithy4s specific logic to extract manifest from jars can run on files that are not jars. Fixed in https://github.com/disneystreaming/smithy4s/pull/1351
-
 # 0.18.6
 
 * If a Smithy trait, being a structure shape, had a Scala keyword in its member names, compilation of the generated would fail. In addition, enumeration values that matched a known keyword would have their name erroneously escaped with an underscore in the string literal.
 These are now fixed in [#1344](https://github.com/disneystreaming/smithy4s/pull/1344).
+
+* Smithy4s specific logic to extract manifest from jars should not run on jar. Fixed in [#1351](https://github.com/disneystreaming/smithy4s/pull/1351).
 
 # 0.18.5
 

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/dependencies-only/build.sbt
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/dependencies-only/build.sbt
@@ -7,5 +7,11 @@ lazy val p1 = project
     ),
     libraryDependencies += "com.disneystreaming.smithy4s" %% "smithy4s-core" % smithy4sVersion.value,
     libraryDependencies += "software.amazon.smithy" % "smithy-aws-iam-traits" % smithy4s.codegen.BuildInfo.smithyVersion % Smithy4s,
+    libraryDependencies += "com.google.protobuf" % "protoc" % "3.18.2" withExplicitArtifacts Vector(
+      Artifact("protoc")
+        .withType("jar")
+        .withExtension("exe")
+        .withClassifier(Some("osx-aarch_64"))
+    ),
     Compile / smithy4sOutputDir := baseDirectory.value / "smithy_output"
   )

--- a/modules/codegen-plugin/src/smithy4s/codegen/Smithy4sCodegenPlugin.scala
+++ b/modules/codegen-plugin/src/smithy4s/codegen/Smithy4sCodegenPlugin.scala
@@ -210,7 +210,8 @@ object Smithy4sCodegenPlugin extends AutoPlugin {
     config / smithy4sExternallyTrackedDependencies := {
       (config / externalDependencyClasspath).value
         .map(_.data)
-        .flatMap(extract)
+        .filter(_.ext == "jar")
+        .flatMap(extractJar)
         .distinct
     },
     config / smithy4sNormalExternalDependencies := {
@@ -386,7 +387,7 @@ object Smithy4sCodegenPlugin extends AutoPlugin {
 
   private lazy val simple = raw"([^:]*):([^:]*):([^:]*)".r
   private lazy val cross = raw"([^:]*)::([^:]*):([^:]*)".r
-  private def extract(jarFile: java.io.File): Seq[ModuleID] = {
+  private def extractJar(jarFile: java.io.File): Seq[ModuleID] = {
     JarUtils
       .extractSmithy4sDependencies(jarFile)
       .collect {


### PR DESCRIPTION
## PR Checklist (not all items are relevant to all PRs)

- [x] Added build-plugins integration tests (when reflection loading is required at codegen-time)
- [x] Updated changelog

if not filtered, it could fail like:

```
[info] [error] java.util.zip.ZipException: zip END header not found
[info] [error]  at java.base/java.util.zip.ZipFile$Source.findEND(ZipFile.java:1469)
[info] [error]  at java.base/java.util.zip.ZipFile$Source.initCEN(ZipFile.java:1477)
[info] [error]  at java.base/java.util.zip.ZipFile$Source.<init>(ZipFile.java:1315)
[info] [error]  at java.base/java.util.zip.ZipFile$Source.get(ZipFile.java:1277)
[info] [error]  at java.base/java.util.zip.ZipFile$CleanableResource.<init>(ZipFile.java:709)
[info] [error]  at java.base/java.util.zip.ZipFile.<init>(ZipFile.java:243)
[info] [error]  at java.base/java.util.zip.ZipFile.<init>(ZipFile.java:172)
[info] [error]  at java.base/java.util.jar.JarFile.<init>(JarFile.java:347)
[info] [error]  at java.base/java.util.jar.JarFile.<init>(JarFile.java:318)
[info] [error]  at java.base/java.util.jar.JarFile.<init>(JarFile.java:284)
[info] [error]  at smithy4s.codegen.JarUtils$.extractJarManifestAttribute(JarUtils.scala:24)
[info] [error]  at smithy4s.codegen.JarUtils$.extractSmithy4sDependencies(JarUtils.scala:31)
[info] [error]  at smithy4s.codegen.Smithy4sCodegenPlugin$.extractJar(Smithy4sCodegenPlugin.scala:392)
[info] [error]  at smithy4s.codegen.Smithy4sCodegenPlugin$.$anonfun$defaultSettings$19(Smithy4sCodegenPlugin.scala:214)
```

- [ ] Added unit-tests (for runtime code)
- [ ] Added bootstrapped code + smoke tests (when the rendering logic is modified)
- [ ] Added build-plugins integration tests (when reflection loading is required at codegen-time)
- [ ] Added alloy compliance tests (when simpleRestJson protocol behaviour is expanded/updated)
- [ ] Updated dynamic module to match generated-code behaviour
- [ ] Added documentation
- [ ] Updated changelog

## PR Checklist (not all items are relevant to all PRs)

- [ ] Added unit-tests (for runtime code)
- [ ] Added bootstrapped code + smoke tests (when the rendering logic is modified)
- [ ] Added build-plugins integration tests (when reflection loading is required at codegen-time)
- [ ] Added alloy compliance tests (when simpleRestJson protocol behaviour is expanded/updated)
- [ ] Updated dynamic module to match generated-code behaviour
- [ ] Added documentation
- [ ] Updated changelog
