### PR TITLE
 Use member name for smart constructor names in ADTs 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 Previously, URIs constructed with a base URI of `/` would have `localhost` as the host. In some cases, that may not be desirable, such as in the case of frontend clients that want to reuse the window's origin. This is now fixed: hostnames are optional in the smithy4s URI model, and default to `None`.
 
+## Smart constructors for `@adt` union members have been renamed in [#1370](https://github.com/disneystreaming/smithy4s/pull/1370)
+
+Previously they'd be named after the **member target**, now they will use the name of the member itself (same as in the case of non-ADT unions).
+
 # 0.18.6
 
 * If a Smithy trait, being a structure shape, had a Scala keyword in its member names, compilation of the generated would fail. In addition, enumeration values that matched a known keyword would have their name erroneously escaped with an underscore in the string literal.

--- a/modules/bootstrapped/src/generated/smithy4s/example/DeprecatedUnion.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/DeprecatedUnion.scala
@@ -33,9 +33,9 @@ object DeprecatedUnion extends ShapeTag.Companion[DeprecatedUnion] {
   @deprecated(message = "N/A", since = "N/A")
   def s(s: String): DeprecatedUnion = SCase(s)
   def s_V2(s_V2: String): DeprecatedUnion = S_V2Case(s_V2)
-  def deprecatedUnionProductCase():DeprecatedUnionProductCase = DeprecatedUnionProductCase()
+  def p(): DeprecatedUnionProductCase = DeprecatedUnionProductCase()
   @deprecated(message = "N/A", since = "N/A")
-  def unionProductCaseDeprecatedAtCallSite():UnionProductCaseDeprecatedAtCallSite = UnionProductCaseDeprecatedAtCallSite()
+  def p2(): UnionProductCaseDeprecatedAtCallSite = UnionProductCaseDeprecatedAtCallSite()
 
   val id: ShapeId = ShapeId("smithy4s.example", "DeprecatedUnion")
 

--- a/modules/bootstrapped/src/generated/smithy4s/example/OrderType.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/OrderType.scala
@@ -33,7 +33,7 @@ object OrderType extends ShapeTag.Companion[OrderType] {
 
   def online(online: OrderNumber): OrderType = OnlineCase(online)
   /** For an InStoreOrder a location ID isn't needed */
-  def inStoreOrder(id: OrderNumber, locationId: Option[String] = None):InStoreOrder = InStoreOrder(id, locationId)
+  def inStore(id: OrderNumber, locationId: Option[String] = None): InStoreOrder = InStoreOrder(id, locationId)
   def preview(): OrderType = OrderType.PreviewCase
 
   val id: ShapeId = ShapeId("smithy4s.example", "OrderType")

--- a/modules/bootstrapped/src/generated/smithy4s/example/Podcast.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/Podcast.scala
@@ -27,8 +27,8 @@ sealed trait Podcast extends PodcastCommon with scala.Product with scala.Seriali
 }
 object Podcast extends ShapeTag.Companion[Podcast] {
 
-  def video(title: Option[String] = None, url: Option[String] = None, durationMillis: Option[Long] = None):Video = Video(title, url, durationMillis)
-  def audio(title: Option[String] = None, url: Option[String] = None, durationMillis: Option[Long] = None):Audio = Audio(title, url, durationMillis)
+  def video(title: Option[String] = None, url: Option[String] = None, durationMillis: Option[Long] = None): Video = Video(title, url, durationMillis)
+  def audio(title: Option[String] = None, url: Option[String] = None, durationMillis: Option[Long] = None): Audio = Audio(title, url, durationMillis)
 
   val id: ShapeId = ShapeId("smithy4s.example", "Podcast")
 

--- a/modules/bootstrapped/src/generated/smithy4s/example/TestAdt.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/TestAdt.scala
@@ -29,8 +29,8 @@ sealed trait TestAdt extends AdtMixinOne with AdtMixinTwo with scala.Product wit
 }
 object TestAdt extends ShapeTag.Companion[TestAdt] {
 
-  def adtOne(lng: Option[Long] = None, sht: Option[Short] = None, blb: Option[Blob] = None, str: Option[String] = None):AdtOne = AdtOne(lng, sht, blb, str)
-  def adtTwo(lng: Option[Long] = None, sht: Option[Short] = None, int: Option[Int] = None):AdtTwo = AdtTwo(lng, sht, int)
+  def one(lng: Option[Long] = None, sht: Option[Short] = None, blb: Option[Blob] = None, str: Option[String] = None): AdtOne = AdtOne(lng, sht, blb, str)
+  def two(lng: Option[Long] = None, sht: Option[Short] = None, int: Option[Int] = None): AdtTwo = AdtTwo(lng, sht, int)
 
   val id: ShapeId = ShapeId("smithy4s.example", "TestAdt")
 

--- a/modules/bootstrapped/src/generated/smithy4s/example/TestMixinAdt.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/TestMixinAdt.scala
@@ -23,7 +23,7 @@ sealed trait TestMixinAdt extends scala.Product with scala.Serializable { self =
 }
 object TestMixinAdt extends ShapeTag.Companion[TestMixinAdt] {
 
-  def testAdtMemberWithMixin(a: Option[String] = None, b: Option[Int] = None):TestAdtMemberWithMixin = TestAdtMemberWithMixin(a, b)
+  def test(a: Option[String] = None, b: Option[Int] = None): TestAdtMemberWithMixin = TestAdtMemberWithMixin(a, b)
 
   val id: ShapeId = ShapeId("smithy4s.example", "TestMixinAdt")
 

--- a/modules/bootstrapped/src/generated/smithy4s/example/collision/HasKeywordUnionAdt.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/collision/HasKeywordUnionAdt.scala
@@ -1,0 +1,61 @@
+package smithy4s.example.collision
+
+import smithy4s.Hints
+import smithy4s.Schema
+import smithy4s.ShapeId
+import smithy4s.ShapeTag
+import smithy4s.schema.Schema.constant
+import smithy4s.schema.Schema.union
+
+sealed trait HasKeywordUnionAdt extends scala.Product with scala.Serializable { self =>
+  @inline final def widen: HasKeywordUnionAdt = this
+  def $ordinal: Int
+
+  object project {
+    def one: Option[HasKeywordUnionAdt.Implicit] = HasKeywordUnionAdt.Implicit.alt.project.lift(self)
+  }
+
+  def accept[A](visitor: HasKeywordUnionAdt.Visitor[A]): A = this match {
+    case value: HasKeywordUnionAdt.Implicit => visitor.one(value)
+  }
+}
+object HasKeywordUnionAdt extends ShapeTag.Companion[HasKeywordUnionAdt] {
+
+  def one(): Implicit = Implicit()
+
+  val id: ShapeId = ShapeId("smithy4s.example.collision", "HasKeywordUnionAdt")
+
+  val hints: Hints = Hints.empty
+
+  final case class Implicit() extends HasKeywordUnionAdt {
+    def $ordinal: Int = 0
+  }
+
+  object Implicit extends ShapeTag.Companion[Implicit] {
+    val id: ShapeId = ShapeId("smithy4s.example.collision", "implicit")
+
+    val hints: Hints = Hints.empty
+
+    implicit val schema: Schema[Implicit] = constant(Implicit()).withId(id).addHints(hints)
+
+    val alt = schema.oneOf[HasKeywordUnionAdt]("one")
+  }
+
+
+  trait Visitor[A] {
+    def one(value: HasKeywordUnionAdt.Implicit): A
+  }
+
+  object Visitor {
+    trait Default[A] extends Visitor[A] {
+      def default: A
+      def one(value: HasKeywordUnionAdt.Implicit): A = default
+    }
+  }
+
+  implicit val schema: Schema[HasKeywordUnionAdt] = union(
+    HasKeywordUnionAdt.Implicit.alt,
+  ){
+    _.$ordinal
+  }.withId(id).addHints(hints)
+}

--- a/modules/codegen/src/smithy4s/codegen/internals/CollisionAvoidance.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/CollisionAvoidance.scala
@@ -190,13 +190,13 @@ private[internals] object CollisionAvoidance {
   private def modProduct(p: Product): Product = {
     import p._
     Product(
-      p.shapeId,
-      protectKeyword(name.capitalize),
-      fields.map(modField),
-      mixins.map(modType),
-      recursive,
-      hints.map(modHint),
-      isMixin
+      shapeId = p.shapeId,
+      name = protectKeyword(name.capitalize),
+      fields = fields.map(modField),
+      mixins = mixins.map(modType),
+      recursive = recursive,
+      hints = hints.map(modHint),
+      isMixin = isMixin
     )
   }
 

--- a/modules/codegen/src/smithy4s/codegen/internals/Renderer.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/Renderer.scala
@@ -1008,12 +1008,16 @@ private[internals] class Renderer(compilationUnit: CompilationUnit) { self =>
         case UnionMember.ProductCase(product) =>
           val args = renderArgs(product.fields)
           val values = product.fields.map(_.name).intercalate(", ")
-          line"def ${uncapitalise(product.nameDef.name)}($args):${product.nameRef} = ${product.nameRef}($values)"
+
+          line"$prefix($args): ${product.nameRef} = ${product.nameRef}($values)"
+
         case UnionMember.UnitCase =>
           line"$prefix(): $name = ${caseName(name, alt)}"
+
         case UnionMember.TypeCase(tpe) =>
           line"$prefix($ident: $tpe): $name = $cn($ident)"
       }
+
       lines(
         documentationAnnotation(alt.hints),
         deprecationAnnotation(alt.hints),

--- a/modules/codegen/src/smithy4s/codegen/internals/SmithyToIR.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/SmithyToIR.scala
@@ -217,13 +217,13 @@ private[codegen] class SmithyToIR(model: Model, namespace: String) {
 
         val p =
           Product(
-            shape.getId(),
-            shape.name,
-            fields,
-            mixins,
-            rec,
-            hints,
-            isMixin
+            shapeId = shape.getId(),
+            name = shape.name,
+            fields = fields,
+            mixins = mixins,
+            recursive = rec,
+            hints = hints,
+            isMixin = isMixin
           ).some
         if (isPartOfAdt(shape)) {
           if (renderAdtMemberStructures) p else None

--- a/sampleSpecs/reservednames.smithy
+++ b/sampleSpecs/reservednames.smithy
@@ -61,6 +61,13 @@ operation Option {
     }
 }
 
+@smithy4s.meta#adt
+union HasKeywordUnionAdt {
+    one: implicit
+}
+
+structure implicit {}
+
 string String
 
 structure TestReservedNamespaceImport {


### PR DESCRIPTION
Waiting for #1369 first.

Closes #1347.

## PR Checklist (not all items are relevant to all PRs)

- :x: Added unit-tests (for runtime code)
- [x] Added bootstrapped code + smoke tests (when the rendering logic is modified)
- :x: Added build-plugins integration tests (when reflection loading is required at codegen-time)
- :x: Added alloy compliance tests (when simpleRestJson protocol behaviour is expanded/updated)
- :x: Updated dynamic module to match generated-code behaviour
- :x: Added documentation
- [x] Updated changelog
