### PR TITLE
Run organizeimport on core

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,6 @@ import java.io.File
 import sys.process._
 
 ThisBuild / commands ++= createBuildCommands(allModules)
-ThisBuild / scalafixDependencies += "com.github.liancheng" %% "organize-imports" % "0.5.0"
 ThisBuild / dynverSeparator := "-"
 ThisBuild / versionScheme := Some("early-semver")
 ThisBuild / mimaBaseVersion := "0.19.0"

--- a/modules/codegen/src/smithy4s/codegen/internals/SmithyToIR.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/SmithyToIR.scala
@@ -28,6 +28,7 @@ import smithy4s.meta.VectorTrait
 import smithy4s.meta.AdtTrait
 import smithy4s.meta.GenerateServiceProductTrait
 import smithy4s.meta.GenerateOpticsTrait
+import smithy4s.meta.TypeclassTrait
 import alloy.StructurePatternTrait
 import software.amazon.smithy.aws.traits.ServiceTrait
 import software.amazon.smithy.model.Model
@@ -42,7 +43,6 @@ import scala.annotation.nowarn
 import scala.jdk.CollectionConverters._
 
 import Type.Alias
-import smithy4s.meta.TypeclassTrait
 
 private[codegen] object SmithyToIR {
 

--- a/modules/core/src-jvm-native/smithy4s/Timestamp.scala
+++ b/modules/core/src-jvm-native/smithy4s/Timestamp.scala
@@ -17,7 +17,9 @@
 package smithy4s
 
 import smithy.api.TimestampFormat
-import scala.util.control.{NoStackTrace, NonFatal}
+
+import scala.util.control.NoStackTrace
+import scala.util.control.NonFatal
 
 case class Timestamp private (epochSecond: Long, nano: Int)
     extends TimestampPlatform {

--- a/modules/core/src-jvm/smithy4s/TimestampPlatform.scala
+++ b/modules/core/src-jvm/smithy4s/TimestampPlatform.scala
@@ -17,8 +17,8 @@
 package smithy4s
 
 import java.time.Instant
-import java.time.ZoneOffset
 import java.time.OffsetDateTime
+import java.time.ZoneOffset
 
 private[smithy4s] trait TimestampPlatform { self: Timestamp =>
 

--- a/modules/core/src/smithy4s/Blob.scala
+++ b/modules/core/src/smithy4s/Blob.scala
@@ -16,11 +16,11 @@
 
 package smithy4s
 
+import java.io.OutputStream
 import java.nio.ByteBuffer
+import java.nio.charset.StandardCharsets
 import java.util.Base64
 import scala.collection.immutable.Queue
-import java.nio.charset.StandardCharsets
-import java.io.OutputStream
 
 // scalafmt: {maxColumn = 120}
 /**

--- a/modules/core/src/smithy4s/Document.scala
+++ b/modules/core/src/smithy4s/Document.scala
@@ -17,10 +17,11 @@
 package smithy4s
 
 import smithy4s.Document._
+import smithy4s.codecs.PayloadError
 import smithy4s.schema.CachedSchemaCompiler
+
 import internals.DocumentDecoderSchemaVisitor
 import internals.DocumentEncoderSchemaVisitor
-import smithy4s.codecs.PayloadError
 
 /**
   * A json-like free-form structure serving as a model for

--- a/modules/core/src/smithy4s/Endpoint.scala
+++ b/modules/core/src/smithy4s/Endpoint.scala
@@ -17,6 +17,7 @@
 package smithy4s
 
 import smithy4s.schema._
+
 import schema.ErrorSchema
 
 /**

--- a/modules/core/src/smithy4s/codecs/Decoder.scala
+++ b/modules/core/src/smithy4s/codecs/Decoder.scala
@@ -16,9 +16,9 @@
 
 package smithy4s.codecs
 
-import smithy4s.kinds._
 import smithy4s.capability.Covariant
 import smithy4s.capability.Zipper
+import smithy4s.kinds._
 
 /**
   * An abstraction that codifies the action of reading data from some input.

--- a/modules/core/src/smithy4s/codecs/Encoder.scala
+++ b/modules/core/src/smithy4s/codecs/Encoder.scala
@@ -16,9 +16,9 @@
 
 package smithy4s.codecs
 
-import smithy4s.schema.CachedSchemaCompiler
-import smithy4s.kinds.PolyFunction
 import smithy4s.capability.EncoderK
+import smithy4s.kinds.PolyFunction
+import smithy4s.schema.CachedSchemaCompiler
 
 /**
   * An abstraction that codifies the notion of transforming a piece of data into some output.

--- a/modules/core/src/smithy4s/codecs/PayloadError.scala
+++ b/modules/core/src/smithy4s/codecs/PayloadError.scala
@@ -16,8 +16,8 @@
 
 package smithy4s.codecs
 
-import smithy4s.schema._
 import smithy4s.schema.Schema._
+import smithy4s.schema._
 
 case class PayloadError(
     path: PayloadPath,

--- a/modules/core/src/smithy4s/codecs/StringAndBlobCodecs.scala
+++ b/modules/core/src/smithy4s/codecs/StringAndBlobCodecs.scala
@@ -17,9 +17,10 @@
 package smithy4s
 package codecs
 
-import schema._
-import smithy4s.schema.Primitive._
 import smithy4s.capability.instances.either._
+import smithy4s.schema.Primitive._
+
+import schema._
 
 object StringAndBlobCodecs {
 

--- a/modules/core/src/smithy4s/codecs/Writer.scala
+++ b/modules/core/src/smithy4s/codecs/Writer.scala
@@ -16,8 +16,8 @@
 
 package smithy4s.codecs
 
-import smithy4s.schema._
 import smithy4s.capability.EncoderK
+import smithy4s.schema._
 
 /**
   * An abstraction that codifies the notion of modifying a message with some additional information.

--- a/modules/core/src/smithy4s/http/HostPrefix.scala
+++ b/modules/core/src/smithy4s/http/HostPrefix.scala
@@ -16,8 +16,8 @@
 
 package smithy4s.http
 
-import smithy4s.http.internals.HostPrefixSchemaVisitor
 import smithy4s.codecs.Writer
+import smithy4s.http.internals.HostPrefixSchemaVisitor
 import smithy4s.schema.OperationSchema
 
 object HttpHostPrefix {

--- a/modules/core/src/smithy4s/http/HttpContractError.scala
+++ b/modules/core/src/smithy4s/http/HttpContractError.scala
@@ -17,12 +17,12 @@
 package smithy4s
 package http
 
-import smithy4s.schema._
-import smithy4s.schema.Schema._
+import smithy4s.capability.MonadThrowLike
 import smithy4s.codecs.PayloadError
 import smithy4s.codecs.PayloadPath
-import smithy4s.capability.MonadThrowLike
 import smithy4s.kinds.PolyFunction
+import smithy4s.schema.Schema._
+import smithy4s.schema._
 
 sealed trait HttpContractError
     extends Throwable

--- a/modules/core/src/smithy4s/http/HttpEndpoint.scala
+++ b/modules/core/src/smithy4s/http/HttpEndpoint.scala
@@ -17,9 +17,9 @@
 package smithy4s
 package http
 
-import smithy4s.schema.OperationSchema
 import smithy.api.Http
 import smithy4s.http.internals.SchemaVisitorPathEncoder
+import smithy4s.schema.OperationSchema
 
 trait HttpEndpoint[I] {
   // Returns a list of path segments that should be appended to the base URL. These are not URL-encoded.

--- a/modules/core/src/smithy4s/http/HttpErrorSelector.scala
+++ b/modules/core/src/smithy4s/http/HttpErrorSelector.scala
@@ -18,12 +18,12 @@ package smithy4s
 package http
 
 import smithy.api.Error
-import smithy4s.schema.Alt
 import smithy.api.HttpError
-import smithy4s.schema.CachedSchemaCompiler
-import smithy4s.schema.ErrorSchema
 import smithy4s.capability.Covariant
 import smithy4s.kinds.PolyFunction
+import smithy4s.schema.Alt
+import smithy4s.schema.CachedSchemaCompiler
+import smithy4s.schema.ErrorSchema
 
 /**
   * Utility function to help find the decoder matching a certain discriminator

--- a/modules/core/src/smithy4s/http/HttpMediaType.scala
+++ b/modules/core/src/smithy4s/http/HttpMediaType.scala
@@ -17,8 +17,8 @@
 package smithy4s
 package http
 
-import smithy4s.schema._
 import smithy4s.Newtype
+import smithy4s.schema._
 
 object HttpMediaType extends Newtype[String] {
 

--- a/modules/core/src/smithy4s/http/HttpRequest.scala
+++ b/modules/core/src/smithy4s/http/HttpRequest.scala
@@ -16,11 +16,11 @@
 
 package smithy4s.http
 
-import smithy4s.kinds._
 import smithy4s.capability.Covariant
-import smithy4s.schema._
-import smithy4s.codecs.{Decoder => GenericDecoder}
 import smithy4s.capability.MonadThrowLike
+import smithy4s.codecs.{Decoder => GenericDecoder}
+import smithy4s.kinds._
+import smithy4s.schema._
 
 final case class HttpRequest[+A](
     method: HttpMethod,

--- a/modules/core/src/smithy4s/http/HttpResponse.scala
+++ b/modules/core/src/smithy4s/http/HttpResponse.scala
@@ -16,15 +16,15 @@
 
 package smithy4s.http
 
-import smithy4s.codecs.{Decoder => GenericDecoder}
-import smithy4s.codecs.Writer
-import smithy4s.kinds.PolyFunction
-import smithy4s.schema.CachedSchemaCompiler
-import smithy4s.schema.Alt
-import smithy4s.schema.Schema
-import smithy4s.capability.MonadThrowLike
 import smithy4s.Blob
+import smithy4s.capability.MonadThrowLike
+import smithy4s.codecs.Writer
+import smithy4s.codecs.{Decoder => GenericDecoder}
+import smithy4s.kinds.PolyFunction
+import smithy4s.schema.Alt
+import smithy4s.schema.CachedSchemaCompiler
 import smithy4s.schema.ErrorSchema
+import smithy4s.schema.Schema
 
 final case class HttpResponse[+A](
     statusCode: Int,

--- a/modules/core/src/smithy4s/http/HttpUnaryClientCodecs.scala
+++ b/modules/core/src/smithy4s/http/HttpUnaryClientCodecs.scala
@@ -17,15 +17,16 @@
 package smithy4s
 package http
 
+import smithy4s.capability.MonadThrowLike
 import smithy4s.client.UnaryClientCodecs
-import smithy4s.codecs.{BlobEncoder, BlobDecoder}
-import smithy4s.codecs.{Decoder}
-import smithy4s.codecs.Writer
+import smithy4s.codecs.BlobDecoder
+import smithy4s.codecs.BlobEncoder
+import smithy4s.codecs.Decoder
 import smithy4s.codecs.PayloadError
+import smithy4s.codecs.Writer
+import smithy4s.kinds.PolyFunction5
 import smithy4s.schema.CachedSchemaCompiler
 import smithy4s.schema.OperationSchema
-import smithy4s.capability.MonadThrowLike
-import smithy4s.kinds.PolyFunction5
 
 // scalafmt: { maxColumn = 120 }
 object HttpUnaryClientCodecs {

--- a/modules/core/src/smithy4s/http/HttpUnaryServerCodecs.scala
+++ b/modules/core/src/smithy4s/http/HttpUnaryServerCodecs.scala
@@ -17,14 +17,15 @@
 package smithy4s
 package http
 
-import smithy4s.server.UnaryServerCodecs
-import smithy4s.codecs.{BlobEncoder, BlobDecoder}
 import smithy4s.capability.MonadThrowLike
+import smithy4s.codecs.BlobDecoder
+import smithy4s.codecs.BlobEncoder
+import smithy4s.codecs.Decoder
+import smithy4s.codecs.PayloadError
 import smithy4s.codecs.Writer
 import smithy4s.schema.CachedSchemaCompiler
 import smithy4s.schema.OperationSchema
-import smithy4s.codecs.Decoder
-import smithy4s.codecs.PayloadError
+import smithy4s.server.UnaryServerCodecs
 
 // scalafmt: {maxColumn = 120}
 object HttpUnaryServerCodecs {

--- a/modules/core/src/smithy4s/http/HttpUnaryServerRouter.scala
+++ b/modules/core/src/smithy4s/http/HttpUnaryServerRouter.scala
@@ -17,9 +17,10 @@
 package smithy4s
 package http
 
+import smithy4s.capability.MonadThrowLike
 import smithy4s.kinds._
 import smithy4s.server.UnaryServerCodecs
-import smithy4s.capability.MonadThrowLike
+
 import scala.annotation.nowarn
 
 // scalafmt: {maxColumn = 120}

--- a/modules/core/src/smithy4s/http/internals/HostPrefixSchemaVisitor.scala
+++ b/modules/core/src/smithy4s/http/internals/HostPrefixSchemaVisitor.scala
@@ -16,8 +16,10 @@
 
 package smithy4s.http.internals
 
-import smithy4s.Schema
-import smithy4s._
+import smithy4s.Bijection
+import smithy4s.Hints
+import smithy4s.Refinement
+import smithy4s.ShapeId
 import smithy4s.codecs.Writer
 import smithy4s.schema._
 

--- a/modules/core/src/smithy4s/http/internals/HostPrefixSchemaVisitor.scala
+++ b/modules/core/src/smithy4s/http/internals/HostPrefixSchemaVisitor.scala
@@ -16,9 +16,11 @@
 
 package smithy4s.http.internals
 
-import smithy4s.{Schema, _}
-import smithy4s.schema._
+import smithy4s.Schema
+import smithy4s._
 import smithy4s.codecs.Writer
+import smithy4s.schema._
+
 import HostPrefixSegment._
 
 object HostPrefixSchemaVisitor

--- a/modules/core/src/smithy4s/http/internals/HttpResponseCodeSchemaVisitor.scala
+++ b/modules/core/src/smithy4s/http/internals/HttpResponseCodeSchemaVisitor.scala
@@ -16,23 +16,19 @@
 
 package smithy4s.http.internals
 
-import smithy4s.capability.Contravariant
 import smithy4s.Hints
-import smithy4s.schema.{
-  EnumTag,
-  EnumValue,
-  Primitive,
-  Schema,
-  Field,
-  SchemaVisitor
-}
 import smithy4s.ShapeId
-import smithy4s.http.internals.HttpResponseCodeSchemaVisitor.{
-  NoResponseCode,
-  OptionalResponseCode,
-  RequiredResponseCode,
-  ResponseCodeExtractor
-}
+import smithy4s.capability.Contravariant
+import smithy4s.http.internals.HttpResponseCodeSchemaVisitor.NoResponseCode
+import smithy4s.http.internals.HttpResponseCodeSchemaVisitor.OptionalResponseCode
+import smithy4s.http.internals.HttpResponseCodeSchemaVisitor.RequiredResponseCode
+import smithy4s.http.internals.HttpResponseCodeSchemaVisitor.ResponseCodeExtractor
+import smithy4s.schema.EnumTag
+import smithy4s.schema.EnumValue
+import smithy4s.schema.Field
+import smithy4s.schema.Primitive
+import smithy4s.schema.Schema
+import smithy4s.schema.SchemaVisitor
 
 class HttpResponseCodeSchemaVisitor()
     extends SchemaVisitor.Default[ResponseCodeExtractor] {

--- a/modules/core/src/smithy4s/http/internals/MetaEncode.scala
+++ b/modules/core/src/smithy4s/http/internals/MetaEncode.scala
@@ -19,6 +19,7 @@ package http
 package internals
 
 import smithy4s.capability.Contravariant
+
 import HttpBinding._
 import MetaEncode._
 

--- a/modules/core/src/smithy4s/http/internals/SchemaVisitorHeaderMerge.scala
+++ b/modules/core/src/smithy4s/http/internals/SchemaVisitorHeaderMerge.scala
@@ -17,11 +17,12 @@
 package smithy4s
 package http.internals
 
-import smithy4s.schema._
-import smithy4s.{Hints, ShapeId}
 import smithy4s.Bijection
+import smithy4s.Hints
 import smithy4s.Refinement
+import smithy4s.ShapeId
 import smithy4s.schema.Primitive.PString
+import smithy4s.schema._
 
 /**
   * A schema visitor that allows to merge several values into a single, comma-separated header value.

--- a/modules/core/src/smithy4s/http/internals/SchemaVisitorHeaderSplit.scala
+++ b/modules/core/src/smithy4s/http/internals/SchemaVisitorHeaderSplit.scala
@@ -16,12 +16,13 @@
 
 package smithy4s.http.internals
 
-import smithy4s.schema._
-import smithy4s.{Hints, ShapeId}
-import smithy4s.Bijection
-import smithy4s.Refinement
-import smithy4s.schema.Primitive.PTimestamp
 import smithy.api.TimestampFormat
+import smithy4s.Bijection
+import smithy4s.Hints
+import smithy4s.Refinement
+import smithy4s.ShapeId
+import smithy4s.schema.Primitive.PTimestamp
+import smithy4s.schema._
 
 /**
   * A schema visitor that allows to formulate a function that splits a single header value

--- a/modules/core/src/smithy4s/http/internals/SchemaVisitorMetadataReader.scala
+++ b/modules/core/src/smithy4s/http/internals/SchemaVisitorMetadataReader.scala
@@ -18,17 +18,15 @@ package smithy4s
 package http
 package internals
 
-import smithy4s.http.internals.MetaDecode.{
-  EmptyMetaDecode,
-  PutField,
-  StringListMapMetaDecode,
-  StringCollectionMetaDecode,
-  StringMapMetaDecode,
-  StringValueMetaDecode,
-  StructureMetaDecode
-}
-import smithy4s.schema._
+import smithy4s.http.internals.MetaDecode.EmptyMetaDecode
+import smithy4s.http.internals.MetaDecode.PutField
+import smithy4s.http.internals.MetaDecode.StringCollectionMetaDecode
+import smithy4s.http.internals.MetaDecode.StringListMapMetaDecode
+import smithy4s.http.internals.MetaDecode.StringMapMetaDecode
+import smithy4s.http.internals.MetaDecode.StringValueMetaDecode
+import smithy4s.http.internals.MetaDecode.StructureMetaDecode
 import smithy4s.internals.SchemaDescription
+import smithy4s.schema._
 
 import java.util.Base64
 

--- a/modules/core/src/smithy4s/http/internals/SchemaVisitorMetadataWriter.scala
+++ b/modules/core/src/smithy4s/http/internals/SchemaVisitorMetadataWriter.scala
@@ -21,16 +21,15 @@ package internals
 import smithy.api.HttpQueryParams
 import smithy4s.http.HttpBinding
 import smithy4s.http.internals.MetaEncode._
-import smithy4s.schema.{
-  CollectionTag,
-  EnumTag,
-  EnumValue,
-  Field,
-  Primitive,
-  SchemaVisitor
-}
 import smithy4s.schema.Alt
+import smithy4s.schema.CollectionTag
 import smithy4s.schema.CompilationCache
+import smithy4s.schema.EnumTag
+import smithy4s.schema.EnumValue
+import smithy4s.schema.Field
+import smithy4s.schema.Primitive
+import smithy4s.schema.SchemaVisitor
+
 import java.util.Base64
 
 /**

--- a/modules/core/src/smithy4s/http/internals/SchemaVisitorPathEncoder.scala
+++ b/modules/core/src/smithy4s/http/internals/SchemaVisitorPathEncoder.scala
@@ -16,14 +16,20 @@
 
 package smithy4s.http.internals
 
-import smithy4s.schema._
-import PathEncode.MaybePathEncode
+import smithy.api.Http
 import smithy.api.TimestampFormat
 import smithy4s.Bijection
+import smithy4s.Hints
+import smithy4s.Lazy
+import smithy4s.Refinement
+import smithy4s.ShapeId
 import smithy4s.http.PathSegment
-import smithy4s.http.PathSegment.{GreedySegment, LabelSegment, StaticSegment}
-import smithy4s.{Hints, Lazy, Refinement, ShapeId}
-import smithy.api.Http
+import smithy4s.http.PathSegment.GreedySegment
+import smithy4s.http.PathSegment.LabelSegment
+import smithy4s.http.PathSegment.StaticSegment
+import smithy4s.schema._
+
+import PathEncode.MaybePathEncode
 
 object SchemaVisitorPathEncoder
     extends SchemaVisitor[MaybePathEncode]

--- a/modules/core/src/smithy4s/internals/DocumentEncoderSchemaVisitor.scala
+++ b/modules/core/src/smithy4s/internals/DocumentEncoderSchemaVisitor.scala
@@ -17,33 +17,33 @@
 package smithy4s
 package internals
 
+import alloy.Discriminated
+import alloy.Untagged
 import smithy.api.JsonName
 import smithy.api.TimestampFormat
 import smithy.api.TimestampFormat.DATE_TIME
 import smithy.api.TimestampFormat.EPOCH_SECONDS
 import smithy.api.TimestampFormat.HTTP_DATE
-import alloy.Discriminated
 import smithy4s.capability.EncoderK
+import smithy4s.schema.Primitive.PBigDecimal
+import smithy4s.schema.Primitive.PBigInt
+import smithy4s.schema.Primitive.PBlob
+import smithy4s.schema.Primitive.PBoolean
+import smithy4s.schema.Primitive.PByte
+import smithy4s.schema.Primitive.PDocument
+import smithy4s.schema.Primitive.PDouble
+import smithy4s.schema.Primitive.PFloat
+import smithy4s.schema.Primitive.PInt
+import smithy4s.schema.Primitive.PLong
+import smithy4s.schema.Primitive.PShort
+import smithy4s.schema.Primitive.PString
+import smithy4s.schema.Primitive.PTimestamp
+import smithy4s.schema.Primitive.PUUID
 import smithy4s.schema._
 
 import scala.collection.mutable.Builder
 
 import Document._
-import smithy4s.schema.Primitive.PShort
-import smithy4s.schema.Primitive.PBigInt
-import smithy4s.schema.Primitive.PBoolean
-import smithy4s.schema.Primitive.PByte
-import smithy4s.schema.Primitive.PBigDecimal
-import smithy4s.schema.Primitive.PInt
-import smithy4s.schema.Primitive.PBlob
-import smithy4s.schema.Primitive.PTimestamp
-import smithy4s.schema.Primitive.PDocument
-import smithy4s.schema.Primitive.PFloat
-import smithy4s.schema.Primitive.PUUID
-import smithy4s.schema.Primitive.PDouble
-import smithy4s.schema.Primitive.PLong
-import smithy4s.schema.Primitive.PString
-import alloy.Untagged
 
 trait DocumentEncoder[A] { self =>
 

--- a/modules/core/src/smithy4s/internals/DocumentKeyDecoder.scala
+++ b/modules/core/src/smithy4s/internals/DocumentKeyDecoder.scala
@@ -16,16 +16,16 @@
 
 package smithy4s.internals
 
-import java.util.Base64
-import java.util.UUID
-
-import smithy4s._
 import smithy4s.Document._
+import smithy4s._
+import smithy4s.schema.EnumTag
 import smithy4s.schema.EnumValue
 import smithy4s.schema.Primitive
 import smithy4s.schema.Primitive._
 import smithy4s.schema.SchemaVisitor
-import smithy4s.schema.EnumTag
+
+import java.util.Base64
+import java.util.UUID
 
 trait DocumentKeyDecoder[A] { self =>
   def apply(v: Document): Either[DocumentKeyDecoder.DecodeError, A] =

--- a/modules/core/src/smithy4s/internals/DocumentKeyEncoder.scala
+++ b/modules/core/src/smithy4s/internals/DocumentKeyEncoder.scala
@@ -19,12 +19,12 @@ package smithy4s.internals
 import smithy.api.TimestampFormat
 import smithy.api.TimestampFormat._
 import smithy4s._
+import smithy4s.schema.EnumTag
 import smithy4s.schema.EnumValue
 import smithy4s.schema.Primitive
 import smithy4s.schema.Primitive._
-import smithy4s.schema.SchemaVisitor
 import smithy4s.schema.Schema
-import smithy4s.schema.EnumTag
+import smithy4s.schema.SchemaVisitor
 
 trait DocumentKeyEncoder[A] { self =>
   def apply(a: A): String

--- a/modules/core/src/smithy4s/internals/PatternSegment.scala
+++ b/modules/core/src/smithy4s/internals/PatternSegment.scala
@@ -16,7 +16,8 @@
 
 package smithy4s.internals
 
-import scala.collection.mutable.{ListBuffer, ArrayBuffer}
+import scala.collection.mutable.ArrayBuffer
+import scala.collection.mutable.ListBuffer
 
 private[internals] sealed abstract class PatternSegment(value: String)
     extends Product

--- a/modules/core/src/smithy4s/internals/SchemaDescription.scala
+++ b/modules/core/src/smithy4s/internals/SchemaDescription.scala
@@ -17,8 +17,8 @@
 package smithy4s
 package internals
 
-import smithy4s.schema._
 import smithy4s.schema.Primitive.PTimestamp
+import smithy4s.schema._
 
 object SchemaDescription extends SchemaVisitor[SchemaDescription] {
   // format: off

--- a/modules/core/src/smithy4s/internals/SchemaVisitorPatternDecoder.scala
+++ b/modules/core/src/smithy4s/internals/SchemaVisitorPatternDecoder.scala
@@ -16,10 +16,13 @@
 
 package smithy4s.internals
 
-import smithy4s.schema._
-import smithy4s.internals.PatternDecode.MaybePatternDecode
 import smithy4s.Bijection
-import smithy4s.{Hints, Lazy, Refinement, ShapeId}
+import smithy4s.Hints
+import smithy4s.Lazy
+import smithy4s.Refinement
+import smithy4s.ShapeId
+import smithy4s.internals.PatternDecode.MaybePatternDecode
+import smithy4s.schema._
 
 private[internals] final class SchemaVisitorPatternDecoder(
     segments: List[PatternSegment]

--- a/modules/core/src/smithy4s/internals/SchemaVisitorPatternEncoder.scala
+++ b/modules/core/src/smithy4s/internals/SchemaVisitorPatternEncoder.scala
@@ -16,11 +16,14 @@
 
 package smithy4s.internals
 
-import smithy4s.schema._
+import smithy4s.Bijection
+import smithy4s.Hints
+import smithy4s.Lazy
+import smithy4s.Refinement
+import smithy4s.ShapeId
 import smithy4s.http.internals.PathEncode
 import smithy4s.http.internals.PathEncode.MaybePathEncode
-import smithy4s.Bijection
-import smithy4s.{Hints, Lazy, Refinement, ShapeId}
+import smithy4s.schema._
 
 private[internals] final class SchemaVisitorPatternEncoder(
     segments: List[PatternSegment]

--- a/modules/core/src/smithy4s/internals/StructurePatternRefinementProvider.scala
+++ b/modules/core/src/smithy4s/internals/StructurePatternRefinementProvider.scala
@@ -18,8 +18,9 @@ package smithy4s.internals
 
 import alloy.StructurePattern
 import smithy4s._
-import scala.util.control.NoStackTrace
 import smithy4s.http.internals.PathEncode
+
+import scala.util.control.NoStackTrace
 
 private[internals] final case class StructurePatternError(message: String)
     extends RuntimeException(message)

--- a/modules/core/src/smithy4s/schema/Alt.scala
+++ b/modules/core/src/smithy4s/schema/Alt.scala
@@ -18,6 +18,7 @@ package smithy4s
 package schema
 
 import smithy4s.capability.EncoderK
+
 import kinds._
 
 /**

--- a/modules/core/src/smithy4s/schema/ErrorSchema.scala
+++ b/modules/core/src/smithy4s/schema/ErrorSchema.scala
@@ -16,8 +16,8 @@
 
 package smithy4s.schema
 
-import smithy4s.ShapeTag
 import smithy4s.Hints
+import smithy4s.ShapeTag
 import smithy4s.kinds.PolyFunction
 
 /**

--- a/modules/core/src/smithy4s/schema/Primitive.scala
+++ b/modules/core/src/smithy4s/schema/Primitive.scala
@@ -17,9 +17,9 @@
 package smithy4s
 package schema
 
-import smithy4s.kinds.PolyFunction
-import smithy4s.http.HttpBinding
 import smithy.api.TimestampFormat
+import smithy4s.http.HttpBinding
+import smithy4s.kinds.PolyFunction
 
 sealed trait Primitive[T] {
   final def schema(shapeId: ShapeId): Schema[T] =

--- a/modules/core/src/smithy4s/schema/Schema.scala
+++ b/modules/core/src/smithy4s/schema/Schema.scala
@@ -17,8 +17,9 @@
 package smithy4s
 package schema
 
-import Schema._
 import scala.reflect.ClassTag
+
+import Schema._
 
 // format: off
 sealed trait Schema[A]{

--- a/modules/core/src/smithy4s/schema/SchemaPartition.scala
+++ b/modules/core/src/smithy4s/schema/SchemaPartition.scala
@@ -18,6 +18,7 @@ package smithy4s.schema
 
 import smithy4s.PartialData
 import smithy4s.kinds.PolyFunction
+
 import Schema._
 
 /**

--- a/modules/core/src/smithy4s/schema/SchemaVisitor.scala
+++ b/modules/core/src/smithy4s/schema/SchemaVisitor.scala
@@ -17,8 +17,9 @@
 package smithy4s
 package schema
 
-import Schema._
 import smithy4s.kinds.OptionK
+
+import Schema._
 
 // format: off
 trait SchemaVisitor[F[_]] extends (Schema ~> F) { self =>

--- a/modules/core/src/smithy4s/server/UnaryServerCodecs.scala
+++ b/modules/core/src/smithy4s/server/UnaryServerCodecs.scala
@@ -16,8 +16,8 @@
 
 package smithy4s.server
 
-import smithy4s.schema.OperationSchema
 import smithy4s.capability.MonadThrowLike
+import smithy4s.schema.OperationSchema
 
 // scalafmt: {maxColumn = 120}
 final class UnaryServerCodecs[F[_], Request, Response, I, E, O](

--- a/modules/core/src/smithy4s/server/UnaryServerEndpoint.scala
+++ b/modules/core/src/smithy4s/server/UnaryServerEndpoint.scala
@@ -18,7 +18,6 @@ package smithy4s
 package server
 
 import smithy4s.capability.MonadThrowLike
-
 import smithy4s.kinds._
 
 // scalafmt: {maxColumn: 120}


### PR DESCRIPTION
Running organize import on core. If this is not desired, we can just close and I'll remove the rule from the config
