### PR TITLE
Support unions with status codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.18.9
+
+* Added support for `@httpResponseCode` on unions.
+
 # 0.18.8
 
 * Fix collision avoidance algorithm to cover Scala 3 keywords

--- a/modules/bootstrapped/test/src/smithy4s/http/internals/HttpResponseCodeSchemaVisitorSpec.scala
+++ b/modules/bootstrapped/test/src/smithy4s/http/internals/HttpResponseCodeSchemaVisitorSpec.scala
@@ -239,9 +239,16 @@ class HttpResponseCodeSchemaVisitorSpec() extends FunSuite {
       id,
       hints,
       Vector(
-        Schema.int.biject(Variant1.apply(_))(_.value).oneOf[Union1]("Variant1").addHints(smithy.api.HttpResponseCode()),
-        Schema.string.biject(Variant2.apply(_))(_.value).oneOf[Union1]("Variant2"),
-        SampleResponse1.schema.biject(Variant3.apply(_))(_.value).oneOf[Union1]("Variant3")
+        Schema.int
+          .biject(Variant1.apply(_))(_.value)
+          .oneOf[Union1]("Variant1")
+          .addHints(smithy.api.HttpResponseCode()),
+        Schema.string
+          .biject(Variant2.apply(_))(_.value)
+          .oneOf[Union1]("Variant2"),
+        SampleResponse1.schema
+          .biject(Variant3.apply(_))(_.value)
+          .oneOf[Union1]("Variant3")
       ),
       {
         case _: Variant1 => 1
@@ -276,7 +283,9 @@ class HttpResponseCodeSchemaVisitorSpec() extends FunSuite {
       hints,
       Vector(
         Schema.int.biject(Variant1.apply(_))(_.value).oneOf[Union2]("Variant1"),
-        Schema.string.biject(Variant2.apply(_))(_.value).oneOf[Union2]("Variant2"),
+        Schema.string
+          .biject(Variant2.apply(_))(_.value)
+          .oneOf[Union2]("Variant2")
       ),
       {
         case _: Variant1 => 1
@@ -290,6 +299,5 @@ class HttpResponseCodeSchemaVisitorSpec() extends FunSuite {
       Union2.schema.compile(visitor)
     assert(res == HttpResponseCodeSchemaVisitor.NoResponseCode)
   }
-
 
 }

--- a/modules/core/src/smithy4s/http/internals/HttpResponseCodeSchemaVisitor.scala
+++ b/modules/core/src/smithy4s/http/internals/HttpResponseCodeSchemaVisitor.scala
@@ -96,7 +96,7 @@ class HttpResponseCodeSchemaVisitor()
       dispatch: Alt.Dispatcher[U]
   ): ResponseCodeExtractor[U] = {
     import HttpResponseCodeSchemaVisitor.VariantResponseCodeExtractor
-    val variants = alternatives.map { alt: Alt[U, _] =>
+    val variants = alternatives.map { (alt: Alt[U, _]) =>
       VariantResponseCodeExtractor.fromAlt(this, alt)
     }
     val allAreNoResponseCode = variants.forall { _.extractor == NoResponseCode }


### PR DESCRIPTION
Added support for unions that have status codes.
Also, should I also add a case for when the union itself has the trait? In this case, would it override any of the variants in case they would also have it?