### PR TITLE
Remove aws-sandbox from aggregate

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -63,7 +63,6 @@ lazy val allModules = Seq(
   decline,
   codegenPlugin,
   benchmark,
-  `aws-sandbox`,
   protocol,
   protocolTests,
   `aws-kernel`,


### PR DESCRIPTION
This module is meant for manual testing of the AWS interpreters, not for CI purposes. It takes too long to compile to keep in CI