### PR TITLE
Prevent XML attributes from escaping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 0.18.9
 
-* Supports error responses with `@httpResponseCode` fields.
+* Fix bug that would lead to special characters being escaped in XML attributes, which are already quoted
+* Generalise implementation of `@httpResponseCode` to later allow for its use in error responses.
 
 # 0.18.8
 

--- a/modules/aws-http4s/src/smithy4s/aws/internals/AwsRestXmlCodecs.scala
+++ b/modules/aws-http4s/src/smithy4s/aws/internals/AwsRestXmlCodecs.scala
@@ -36,7 +36,7 @@ private[aws] object AwsRestXmlCodecs {
     )
 
     HttpUnaryClientCodecs.builder
-      .withBodyEncoders(Xml.encoders)
+      .withBodyEncoders(Xml.encoders.withEscapeAttributes(true))
       .withSuccessBodyDecoders(Xml.decoders)
       .withErrorBodyDecoders(errorDecoders)
       .withErrorDiscriminator(AwsErrorTypeDecoder.fromResponse(errorDecoders))

--- a/modules/http4s/test/src/smithy4s/http4s/NullsAndDefaultEncodingSuite.scala
+++ b/modules/http4s/test/src/smithy4s/http4s/NullsAndDefaultEncodingSuite.scala
@@ -1,3 +1,19 @@
+/*
+ *  Copyright 2021-2024 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 package smithy4s.http4s
 
 import weaver._

--- a/modules/xml/src/smithy4s/xml/Xml.scala
+++ b/modules/xml/src/smithy4s/xml/Xml.scala
@@ -78,24 +78,8 @@ object Xml {
       fromSchema(schema, createCache())
   }
 
-  val encoders: BlobEncoder.Compiler = new BlobEncoder.Compiler {
-    type Cache = XmlDocument.Encoder.Cache
-    def createCache(): Cache = XmlDocument.Encoder.createCache()
-    def fromSchema[A](schema: Schema[A], cache: Cache): BlobEncoder[A] = {
-      val xmlDocumentEncoder = XmlDocument.Encoder.fromSchema(schema, cache)
-      (a: A) =>
-        Blob {
-          XmlDocument.documentEventifier
-            .eventify(xmlDocumentEncoder.encode(a))
-            .through(render(collapseEmpty = false))
-            .through(fs2.text.utf8.encode[fs2.Pure])
-            .compile
-            .to(Collector.supportsArray(Array))
-        }
-    }
-    def fromSchema[A](schema: Schema[A]): BlobEncoder[A] =
-      fromSchema(schema, createCache())
-  }
+  object encoders
+      extends smithy4s.xml.internals.XmlPayloadEncoderCompilerImpl(false)
 
   private val decoderCacheGlobal = XmlDocument.Decoder.createCache()
   private val encoderCacheGlobal = XmlDocument.Encoder.createCache()

--- a/modules/xml/src/smithy4s/xml/XmlDocument.scala
+++ b/modules/xml/src/smithy4s/xml/XmlDocument.scala
@@ -246,7 +246,7 @@ object XmlDocument {
 
       private def toAttr(attr: XmlAttr): Attr = Attr(
         toQName(attr.name),
-        attr.values.map(text => XmlEvent.XmlString(escape(text.text), isCDATA = false))
+        attr.values.map(text => XmlEvent.XmlString(text.text, isCDATA = false))
       )
 
       private def toQName(name: XmlQName): QName = QName(name.prefix, name.name)

--- a/modules/xml/src/smithy4s/xml/XmlPayloadEncoderCompiler.scala
+++ b/modules/xml/src/smithy4s/xml/XmlPayloadEncoderCompiler.scala
@@ -1,0 +1,31 @@
+/*
+ *  Copyright 2021-2024 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package smithy4s.xml
+
+import smithy4s.schema.CachedSchemaCompiler
+
+// scalafmt: {maxColumn = 120}
+import smithy4s.codecs.PayloadEncoder
+
+trait XmlPayloadEncoderCompiler extends CachedSchemaCompiler[PayloadEncoder] {
+
+  /**
+    * States whether XML special characters should be escaped in XML attributes
+    */
+  def withEscapeAttributes(escapeAttributes: Boolean): XmlPayloadEncoderCompiler
+
+}

--- a/modules/xml/src/smithy4s/xml/internals/XmlPayloadEncoderCompilerImpl.scala
+++ b/modules/xml/src/smithy4s/xml/internals/XmlPayloadEncoderCompilerImpl.scala
@@ -1,0 +1,49 @@
+/*
+ *  Copyright 2021-2024 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package smithy4s.xml
+package internals
+
+import fs2.Collector
+import smithy4s.Blob
+import smithy4s.codecs.BlobEncoder
+import smithy4s.schema.Schema
+
+private[xml] class XmlPayloadEncoderCompilerImpl(escapeAttributes: Boolean)
+    extends XmlPayloadEncoderCompiler {
+  type Cache = XmlDocument.Encoder.Cache
+  def createCache(): Cache = XmlDocument.Encoder.createCache()
+  def fromSchema[A](schema: Schema[A], cache: Cache): BlobEncoder[A] = {
+    val xmlDocumentEncoder = XmlDocument.Encoder.fromSchema(schema, cache)
+    val eventifier = XmlDocument.makeDocumentEventifier(escapeAttributes)
+    (a: A) =>
+      Blob {
+        eventifier
+          .eventify(xmlDocumentEncoder.encode(a))
+          .through(fs2.data.xml.render(collapseEmpty = false))
+          .through(fs2.text.utf8.encode[fs2.Pure])
+          .compile
+          .to(Collector.supportsArray(Array))
+      }
+  }
+  def fromSchema[A](schema: Schema[A]): BlobEncoder[A] =
+    fromSchema(schema, createCache())
+
+  def withEscapeAttributes(
+      escapeAttributes: Boolean
+  ): XmlPayloadEncoderCompiler =
+    new XmlPayloadEncoderCompilerImpl(escapeAttributes)
+}


### PR DESCRIPTION
They are quoted and do not need escaping

## PR Checklist (not all items are relevant to all PRs)

- [x] Added unit-tests (for runtime code)
- [x] Updated changelog
