### PR TITLE
Retain original field ordering in schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.18.11
+
+* smithy4s Structure schemas are now retaining the original order of fields, as per the specification.
+
 # 0.18.10
 
 * Bumps alloy to 0.3.1. This is required as otherwise the `alloy#nullable` hints get filtered out when using SimpleRestJsonBuilder.

--- a/modules/bootstrapped/src/generated/com/amazonaws/dynamodb/DescribeEndpointsRequest.scala
+++ b/modules/bootstrapped/src/generated/com/amazonaws/dynamodb/DescribeEndpointsRequest.scala
@@ -13,5 +13,6 @@ object DescribeEndpointsRequest extends ShapeTag.Companion[DescribeEndpointsRequ
 
   val hints: Hints = Hints.empty
 
+
   implicit val schema: Schema[DescribeEndpointsRequest] = constant(DescribeEndpointsRequest()).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/com/amazonaws/dynamodb/DescribeEndpointsResponse.scala
+++ b/modules/bootstrapped/src/generated/com/amazonaws/dynamodb/DescribeEndpointsResponse.scala
@@ -21,7 +21,5 @@ object DescribeEndpointsResponse extends ShapeTag.Companion[DescribeEndpointsRes
 
   implicit val schema: Schema[DescribeEndpointsResponse] = struct(
     Endpoints.underlyingSchema.required[DescribeEndpointsResponse]("Endpoints", _.endpoints).addHints(smithy.api.Documentation("<p>List of endpoints.</p>")),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/com/amazonaws/dynamodb/DescribeEndpointsResponse.scala
+++ b/modules/bootstrapped/src/generated/com/amazonaws/dynamodb/DescribeEndpointsResponse.scala
@@ -16,9 +16,12 @@ object DescribeEndpointsResponse extends ShapeTag.Companion[DescribeEndpointsRes
 
   val hints: Hints = Hints.empty
 
+  // constructor using the original order from the spec
+  private def make(endpoints: List[Endpoint]): DescribeEndpointsResponse = DescribeEndpointsResponse(endpoints)
+
   implicit val schema: Schema[DescribeEndpointsResponse] = struct(
     Endpoints.underlyingSchema.required[DescribeEndpointsResponse]("Endpoints", _.endpoints).addHints(smithy.api.Documentation("<p>List of endpoints.</p>")),
   ){
-    DescribeEndpointsResponse.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/com/amazonaws/dynamodb/Endpoint.scala
+++ b/modules/bootstrapped/src/generated/com/amazonaws/dynamodb/Endpoint.scala
@@ -23,10 +23,13 @@ object Endpoint extends ShapeTag.Companion[Endpoint] {
     smithy.api.Documentation("<p>An endpoint information details.</p>"),
   ).lazily
 
+  // constructor using the original order from the spec
+  private def make(address: String, cachePeriodInMinutes: Long): Endpoint = Endpoint(address, cachePeriodInMinutes)
+
   implicit val schema: Schema[Endpoint] = struct(
     string.required[Endpoint]("Address", _.address).addHints(smithy.api.Documentation("<p>IP address of the endpoint.</p>")),
     long.required[Endpoint]("CachePeriodInMinutes", _.cachePeriodInMinutes).addHints(smithy.api.Default(smithy4s.Document.fromDouble(0.0d)), smithy.api.Documentation("<p>Endpoint cache time to live (TTL) value.</p>")),
   ){
-    Endpoint.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/com/amazonaws/dynamodb/Endpoint.scala
+++ b/modules/bootstrapped/src/generated/com/amazonaws/dynamodb/Endpoint.scala
@@ -29,7 +29,5 @@ object Endpoint extends ShapeTag.Companion[Endpoint] {
   implicit val schema: Schema[Endpoint] = struct(
     string.required[Endpoint]("Address", _.address).addHints(smithy.api.Documentation("<p>IP address of the endpoint.</p>")),
     long.required[Endpoint]("CachePeriodInMinutes", _.cachePeriodInMinutes).addHints(smithy.api.Default(smithy4s.Document.fromDouble(0.0d)), smithy.api.Documentation("<p>Endpoint cache time to live (TTL) value.</p>")),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/com/amazonaws/dynamodb/InternalServerError.scala
+++ b/modules/bootstrapped/src/generated/com/amazonaws/dynamodb/InternalServerError.scala
@@ -23,9 +23,12 @@ object InternalServerError extends ShapeTag.Companion[InternalServerError] {
     smithy.api.Error.SERVER.widen,
   ).lazily
 
+  // constructor using the original order from the spec
+  private def make(message: Option[ErrorMessage]): InternalServerError = InternalServerError(message)
+
   implicit val schema: Schema[InternalServerError] = struct(
     ErrorMessage.schema.optional[InternalServerError]("message", _.message).addHints(smithy.api.Documentation("<p>The server encountered an internal error trying to fulfill the request.</p>")),
   ){
-    InternalServerError.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/com/amazonaws/dynamodb/InternalServerError.scala
+++ b/modules/bootstrapped/src/generated/com/amazonaws/dynamodb/InternalServerError.scala
@@ -28,7 +28,5 @@ object InternalServerError extends ShapeTag.Companion[InternalServerError] {
 
   implicit val schema: Schema[InternalServerError] = struct(
     ErrorMessage.schema.optional[InternalServerError]("message", _.message).addHints(smithy.api.Documentation("<p>The server encountered an internal error trying to fulfill the request.</p>")),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/com/amazonaws/dynamodb/InvalidEndpointException.scala
+++ b/modules/bootstrapped/src/generated/com/amazonaws/dynamodb/InvalidEndpointException.scala
@@ -20,9 +20,12 @@ object InvalidEndpointException extends ShapeTag.Companion[InvalidEndpointExcept
     smithy.api.HttpError(421),
   ).lazily
 
+  // constructor using the original order from the spec
+  private def make(message: Option[String]): InvalidEndpointException = InvalidEndpointException(message)
+
   implicit val schema: Schema[InvalidEndpointException] = struct(
     string.optional[InvalidEndpointException]("Message", _.message),
   ){
-    InvalidEndpointException.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/com/amazonaws/dynamodb/InvalidEndpointException.scala
+++ b/modules/bootstrapped/src/generated/com/amazonaws/dynamodb/InvalidEndpointException.scala
@@ -25,7 +25,5 @@ object InvalidEndpointException extends ShapeTag.Companion[InvalidEndpointExcept
 
   implicit val schema: Schema[InvalidEndpointException] = struct(
     string.optional[InvalidEndpointException]("Message", _.message),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/com/amazonaws/dynamodb/ListTablesInput.scala
+++ b/modules/bootstrapped/src/generated/com/amazonaws/dynamodb/ListTablesInput.scala
@@ -29,7 +29,5 @@ object ListTablesInput extends ShapeTag.Companion[ListTablesInput] {
   implicit val schema: Schema[ListTablesInput] = struct(
     TableName.schema.optional[ListTablesInput]("ExclusiveStartTableName", _.exclusiveStartTableName).addHints(smithy.api.Documentation("<p>The first table name that this operation will evaluate. Use the value that was returned for\n        <code>LastEvaluatedTableName</code> in a previous operation, so that you can obtain the next page\n      of results.</p>")),
     ListTablesInputLimit.schema.optional[ListTablesInput]("Limit", _.limit).addHints(smithy.api.Documentation("<p>A maximum number of table names to return. If this parameter is not specified, the limit is 100.</p>")),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/com/amazonaws/dynamodb/ListTablesInput.scala
+++ b/modules/bootstrapped/src/generated/com/amazonaws/dynamodb/ListTablesInput.scala
@@ -23,10 +23,13 @@ object ListTablesInput extends ShapeTag.Companion[ListTablesInput] {
     smithy.api.Documentation("<p>Represents the input of a <code>ListTables</code> operation.</p>"),
   ).lazily
 
+  // constructor using the original order from the spec
+  private def make(exclusiveStartTableName: Option[TableName], limit: Option[ListTablesInputLimit]): ListTablesInput = ListTablesInput(exclusiveStartTableName, limit)
+
   implicit val schema: Schema[ListTablesInput] = struct(
     TableName.schema.optional[ListTablesInput]("ExclusiveStartTableName", _.exclusiveStartTableName).addHints(smithy.api.Documentation("<p>The first table name that this operation will evaluate. Use the value that was returned for\n        <code>LastEvaluatedTableName</code> in a previous operation, so that you can obtain the next page\n      of results.</p>")),
     ListTablesInputLimit.schema.optional[ListTablesInput]("Limit", _.limit).addHints(smithy.api.Documentation("<p>A maximum number of table names to return. If this parameter is not specified, the limit is 100.</p>")),
   ){
-    ListTablesInput.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/com/amazonaws/dynamodb/ListTablesOutput.scala
+++ b/modules/bootstrapped/src/generated/com/amazonaws/dynamodb/ListTablesOutput.scala
@@ -34,7 +34,5 @@ object ListTablesOutput extends ShapeTag.Companion[ListTablesOutput] {
   implicit val schema: Schema[ListTablesOutput] = struct(
     TableNameList.underlyingSchema.optional[ListTablesOutput]("TableNames", _.tableNames).addHints(smithy.api.Documentation("<p>The names of the tables associated with the current account at the current endpoint. The maximum size of this array is 100.</p>\n         <p>If <code>LastEvaluatedTableName</code> also appears in the output, you can use this value as the\n        <code>ExclusiveStartTableName</code> parameter in a subsequent <code>ListTables</code> request and\n      obtain the next page of results.</p>")),
     TableName.schema.optional[ListTablesOutput]("LastEvaluatedTableName", _.lastEvaluatedTableName).addHints(smithy.api.Documentation("<p>The name of the last table in the current page of results. Use this value as the\n        <code>ExclusiveStartTableName</code> in a new request to obtain the next page of results, until\n      all the table names are returned.</p>\n         <p>If you do not receive a <code>LastEvaluatedTableName</code> value in the response, this means that\n      there are no more table names to be retrieved.</p>")),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/com/amazonaws/dynamodb/ListTablesOutput.scala
+++ b/modules/bootstrapped/src/generated/com/amazonaws/dynamodb/ListTablesOutput.scala
@@ -28,10 +28,13 @@ object ListTablesOutput extends ShapeTag.Companion[ListTablesOutput] {
     smithy.api.Documentation("<p>Represents the output of a <code>ListTables</code> operation.</p>"),
   ).lazily
 
+  // constructor using the original order from the spec
+  private def make(tableNames: Option[List[TableName]], lastEvaluatedTableName: Option[TableName]): ListTablesOutput = ListTablesOutput(tableNames, lastEvaluatedTableName)
+
   implicit val schema: Schema[ListTablesOutput] = struct(
     TableNameList.underlyingSchema.optional[ListTablesOutput]("TableNames", _.tableNames).addHints(smithy.api.Documentation("<p>The names of the tables associated with the current account at the current endpoint. The maximum size of this array is 100.</p>\n         <p>If <code>LastEvaluatedTableName</code> also appears in the output, you can use this value as the\n        <code>ExclusiveStartTableName</code> parameter in a subsequent <code>ListTables</code> request and\n      obtain the next page of results.</p>")),
     TableName.schema.optional[ListTablesOutput]("LastEvaluatedTableName", _.lastEvaluatedTableName).addHints(smithy.api.Documentation("<p>The name of the last table in the current page of results. Use this value as the\n        <code>ExclusiveStartTableName</code> in a new request to obtain the next page of results, until\n      all the table names are returned.</p>\n         <p>If you do not receive a <code>LastEvaluatedTableName</code> value in the response, this means that\n      there are no more table names to be retrieved.</p>")),
   ){
-    ListTablesOutput.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/benchmark/Attributes.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/benchmark/Attributes.scala
@@ -35,7 +35,5 @@ object Attributes extends ShapeTag.Companion[Attributes] {
     boolean.optional[Attributes]("backedUp", _.backedUp),
     ListMetadata.underlyingSchema.optional[Attributes]("metadata", _.metadata),
     Encryption.schema.optional[Attributes]("encryption", _.encryption),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/benchmark/Attributes.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/benchmark/Attributes.scala
@@ -18,6 +18,9 @@ object Attributes extends ShapeTag.Companion[Attributes] {
 
   val hints: Hints = Hints.empty
 
+  // constructor using the original order from the spec
+  private def make(user: String, public: Boolean, size: Long, creationDate: Timestamp, region: String, queryable: Option[Boolean], queryableLastChange: Option[Timestamp], blockPublicAccess: Option[Boolean], permissions: Option[List[Permission]], tags: Option[List[String]], backedUp: Option[Boolean], metadata: Option[List[Metadata]], encryption: Option[Encryption]): Attributes = Attributes(user, public, size, creationDate, region, queryable, queryableLastChange, blockPublicAccess, permissions, tags, backedUp, metadata, encryption)
+
   implicit val schema: Schema[Attributes] = struct(
     string.required[Attributes]("user", _.user),
     boolean.required[Attributes]("public", _.public),
@@ -33,6 +36,6 @@ object Attributes extends ShapeTag.Companion[Attributes] {
     ListMetadata.underlyingSchema.optional[Attributes]("metadata", _.metadata),
     Encryption.schema.optional[Attributes]("encryption", _.encryption),
   ){
-    Attributes.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/benchmark/CreateObjectInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/benchmark/CreateObjectInput.scala
@@ -14,11 +14,14 @@ object CreateObjectInput extends ShapeTag.Companion[CreateObjectInput] {
 
   val hints: Hints = Hints.empty
 
+  // constructor using the original order from the spec
+  private def make(key: String, bucketName: String, payload: S3Object): CreateObjectInput = CreateObjectInput(key, bucketName, payload)
+
   implicit val schema: Schema[CreateObjectInput] = struct(
     string.required[CreateObjectInput]("key", _.key).addHints(smithy.api.HttpLabel()),
     string.required[CreateObjectInput]("bucketName", _.bucketName).addHints(smithy.api.HttpLabel()),
     S3Object.schema.required[CreateObjectInput]("payload", _.payload).addHints(smithy.api.HttpPayload()),
   ){
-    CreateObjectInput.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/benchmark/CreateObjectInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/benchmark/CreateObjectInput.scala
@@ -21,7 +21,5 @@ object CreateObjectInput extends ShapeTag.Companion[CreateObjectInput] {
     string.required[CreateObjectInput]("key", _.key).addHints(smithy.api.HttpLabel()),
     string.required[CreateObjectInput]("bucketName", _.bucketName).addHints(smithy.api.HttpLabel()),
     S3Object.schema.required[CreateObjectInput]("payload", _.payload).addHints(smithy.api.HttpPayload()),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/benchmark/Creds.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/benchmark/Creds.scala
@@ -14,10 +14,13 @@ object Creds extends ShapeTag.Companion[Creds] {
 
   val hints: Hints = Hints.empty
 
+  // constructor using the original order from the spec
+  private def make(user: Option[String], key: Option[String]): Creds = Creds(user, key)
+
   implicit val schema: Schema[Creds] = struct(
     string.optional[Creds]("user", _.user),
     string.optional[Creds]("key", _.key),
   ){
-    Creds.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/benchmark/Creds.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/benchmark/Creds.scala
@@ -20,7 +20,5 @@ object Creds extends ShapeTag.Companion[Creds] {
   implicit val schema: Schema[Creds] = struct(
     string.optional[Creds]("user", _.user),
     string.optional[Creds]("key", _.key),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/benchmark/Encryption.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/benchmark/Encryption.scala
@@ -16,11 +16,14 @@ object Encryption extends ShapeTag.Companion[Encryption] {
 
   val hints: Hints = Hints.empty
 
+  // constructor using the original order from the spec
+  private def make(user: Option[String], date: Option[Timestamp], metadata: Option[EncryptionMetadata]): Encryption = Encryption(user, date, metadata)
+
   implicit val schema: Schema[Encryption] = struct(
     string.optional[Encryption]("user", _.user),
     timestamp.optional[Encryption]("date", _.date).addHints(smithy.api.TimestampFormat.EPOCH_SECONDS.widen),
     EncryptionMetadata.schema.optional[Encryption]("metadata", _.metadata),
   ){
-    Encryption.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/benchmark/Encryption.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/benchmark/Encryption.scala
@@ -23,7 +23,5 @@ object Encryption extends ShapeTag.Companion[Encryption] {
     string.optional[Encryption]("user", _.user),
     timestamp.optional[Encryption]("date", _.date).addHints(smithy.api.TimestampFormat.EPOCH_SECONDS.widen),
     EncryptionMetadata.schema.optional[Encryption]("metadata", _.metadata),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/benchmark/EncryptionMetadata.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/benchmark/EncryptionMetadata.scala
@@ -15,11 +15,14 @@ object EncryptionMetadata extends ShapeTag.Companion[EncryptionMetadata] {
 
   val hints: Hints = Hints.empty
 
+  // constructor using the original order from the spec
+  private def make(system: Option[String], credentials: Option[Creds], partial: Option[Boolean]): EncryptionMetadata = EncryptionMetadata(system, credentials, partial)
+
   implicit val schema: Schema[EncryptionMetadata] = struct(
     string.optional[EncryptionMetadata]("system", _.system),
     Creds.schema.optional[EncryptionMetadata]("credentials", _.credentials),
     boolean.optional[EncryptionMetadata]("partial", _.partial),
   ){
-    EncryptionMetadata.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/benchmark/EncryptionMetadata.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/benchmark/EncryptionMetadata.scala
@@ -22,7 +22,5 @@ object EncryptionMetadata extends ShapeTag.Companion[EncryptionMetadata] {
     string.optional[EncryptionMetadata]("system", _.system),
     Creds.schema.optional[EncryptionMetadata]("credentials", _.credentials),
     boolean.optional[EncryptionMetadata]("partial", _.partial),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/benchmark/Metadata.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/benchmark/Metadata.scala
@@ -26,7 +26,5 @@ object Metadata extends ShapeTag.Companion[Metadata] {
     string.optional[Metadata]("checkSum", _.checkSum),
     boolean.optional[Metadata]("pendingDeletion", _.pendingDeletion),
     string.optional[Metadata]("etag", _.etag),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/benchmark/Metadata.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/benchmark/Metadata.scala
@@ -17,6 +17,9 @@ object Metadata extends ShapeTag.Companion[Metadata] {
 
   val hints: Hints = Hints.empty
 
+  // constructor using the original order from the spec
+  private def make(contentType: Option[String], lastModified: Option[Timestamp], checkSum: Option[String], pendingDeletion: Option[Boolean], etag: Option[String]): Metadata = Metadata(contentType, lastModified, checkSum, pendingDeletion, etag)
+
   implicit val schema: Schema[Metadata] = struct(
     string.optional[Metadata]("contentType", _.contentType),
     timestamp.optional[Metadata]("lastModified", _.lastModified).addHints(smithy.api.TimestampFormat.EPOCH_SECONDS.widen),
@@ -24,6 +27,6 @@ object Metadata extends ShapeTag.Companion[Metadata] {
     boolean.optional[Metadata]("pendingDeletion", _.pendingDeletion),
     string.optional[Metadata]("etag", _.etag),
   ){
-    Metadata.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/benchmark/Permission.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/benchmark/Permission.scala
@@ -14,11 +14,14 @@ object Permission extends ShapeTag.Companion[Permission] {
 
   val hints: Hints = Hints.empty
 
+  // constructor using the original order from the spec
+  private def make(read: Option[Boolean], write: Option[Boolean], directory: Option[Boolean]): Permission = Permission(read, write, directory)
+
   implicit val schema: Schema[Permission] = struct(
     boolean.optional[Permission]("read", _.read),
     boolean.optional[Permission]("write", _.write),
     boolean.optional[Permission]("directory", _.directory),
   ){
-    Permission.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/benchmark/Permission.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/benchmark/Permission.scala
@@ -21,7 +21,5 @@ object Permission extends ShapeTag.Companion[Permission] {
     boolean.optional[Permission]("read", _.read),
     boolean.optional[Permission]("write", _.write),
     boolean.optional[Permission]("directory", _.directory),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/benchmark/S3Object.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/benchmark/S3Object.scala
@@ -24,7 +24,5 @@ object S3Object extends ShapeTag.Companion[S3Object] {
     string.required[S3Object]("owner", _.owner),
     Attributes.schema.required[S3Object]("attributes", _.attributes),
     bytes.required[S3Object]("data", _.data),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/benchmark/S3Object.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/benchmark/S3Object.scala
@@ -16,12 +16,15 @@ object S3Object extends ShapeTag.Companion[S3Object] {
 
   val hints: Hints = Hints.empty
 
+  // constructor using the original order from the spec
+  private def make(id: String, owner: String, attributes: Attributes, data: Blob): S3Object = S3Object(id, owner, attributes, data)
+
   implicit val schema: Schema[S3Object] = struct(
     string.required[S3Object]("id", _.id),
     string.required[S3Object]("owner", _.owner),
     Attributes.schema.required[S3Object]("attributes", _.attributes),
     bytes.required[S3Object]("data", _.data),
   ){
-    S3Object.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/benchmark/SendStringInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/benchmark/SendStringInput.scala
@@ -21,7 +21,5 @@ object SendStringInput extends ShapeTag.Companion[SendStringInput] {
     string.required[SendStringInput]("key", _.key).addHints(smithy.api.HttpLabel()),
     string.required[SendStringInput]("bucketName", _.bucketName).addHints(smithy.api.HttpLabel()),
     string.required[SendStringInput]("body", _.body).addHints(smithy.api.HttpPayload()),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/benchmark/SendStringInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/benchmark/SendStringInput.scala
@@ -14,11 +14,14 @@ object SendStringInput extends ShapeTag.Companion[SendStringInput] {
 
   val hints: Hints = Hints.empty
 
+  // constructor using the original order from the spec
+  private def make(key: String, bucketName: String, body: String): SendStringInput = SendStringInput(key, bucketName, body)
+
   implicit val schema: Schema[SendStringInput] = struct(
     string.required[SendStringInput]("key", _.key).addHints(smithy.api.HttpLabel()),
     string.required[SendStringInput]("bucketName", _.bucketName).addHints(smithy.api.HttpLabel()),
     string.required[SendStringInput]("body", _.body).addHints(smithy.api.HttpPayload()),
   ){
-    SendStringInput.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/AStructure.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/AStructure.scala
@@ -16,9 +16,12 @@ object AStructure extends ShapeTag.Companion[AStructure] {
 
   val hints: Hints = Hints.empty
 
+  // constructor using the original order from the spec
+  private def make(astring: AString): AStructure = AStructure(astring)
+
   implicit val schema: Schema[AStructure] = struct(
     AString.schema.field[AStructure]("astring", _.astring).addHints(smithy.api.Default(smithy4s.Document.fromString("\"Hello World\" with \"quotes\""))),
   ){
-    AStructure.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/AStructure.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/AStructure.scala
@@ -21,7 +21,5 @@ object AStructure extends ShapeTag.Companion[AStructure] {
 
   implicit val schema: Schema[AStructure] = struct(
     AString.schema.field[AStructure]("astring", _.astring).addHints(smithy.api.Default(smithy4s.Document.fromString("\"Hello World\" with \"quotes\""))),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/AddBrandsInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/AddBrandsInput.scala
@@ -14,9 +14,12 @@ object AddBrandsInput extends ShapeTag.Companion[AddBrandsInput] {
 
   val hints: Hints = Hints.empty
 
+  // constructor using the original order from the spec
+  private def make(brands: Option[List[String]]): AddBrandsInput = AddBrandsInput(brands)
+
   implicit val schema: Schema[AddBrandsInput] = struct(
     BrandList.underlyingSchema.optional[AddBrandsInput]("brands", _.brands),
   ){
-    AddBrandsInput.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/AddBrandsInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/AddBrandsInput.scala
@@ -19,7 +19,5 @@ object AddBrandsInput extends ShapeTag.Companion[AddBrandsInput] {
 
   implicit val schema: Schema[AddBrandsInput] = struct(
     BrandList.underlyingSchema.optional[AddBrandsInput]("brands", _.brands),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/AddMenuItemRequest.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/AddMenuItemRequest.scala
@@ -14,10 +14,13 @@ object AddMenuItemRequest extends ShapeTag.Companion[AddMenuItemRequest] {
 
   val hints: Hints = Hints.empty
 
+  // constructor using the original order from the spec
+  private def make(restaurant: String, menuItem: MenuItem): AddMenuItemRequest = AddMenuItemRequest(restaurant, menuItem)
+
   implicit val schema: Schema[AddMenuItemRequest] = struct(
     string.required[AddMenuItemRequest]("restaurant", _.restaurant).addHints(smithy.api.HttpLabel()),
     MenuItem.schema.required[AddMenuItemRequest]("menuItem", _.menuItem).addHints(smithy.api.HttpPayload()),
   ){
-    AddMenuItemRequest.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/AddMenuItemRequest.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/AddMenuItemRequest.scala
@@ -20,7 +20,5 @@ object AddMenuItemRequest extends ShapeTag.Companion[AddMenuItemRequest] {
   implicit val schema: Schema[AddMenuItemRequest] = struct(
     string.required[AddMenuItemRequest]("restaurant", _.restaurant).addHints(smithy.api.HttpLabel()),
     MenuItem.schema.required[AddMenuItemRequest]("menuItem", _.menuItem).addHints(smithy.api.HttpPayload()),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/AddMenuItemResult.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/AddMenuItemResult.scala
@@ -22,7 +22,5 @@ object AddMenuItemResult extends ShapeTag.Companion[AddMenuItemResult] {
   implicit val schema: Schema[AddMenuItemResult] = struct(
     string.required[AddMenuItemResult]("itemId", _.itemId).addHints(smithy.api.HttpPayload()),
     timestamp.required[AddMenuItemResult]("added", _.added).addHints(smithy.api.TimestampFormat.EPOCH_SECONDS.widen, smithy.api.HttpHeader("X-ADDED-AT")),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/AddMenuItemResult.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/AddMenuItemResult.scala
@@ -16,10 +16,13 @@ object AddMenuItemResult extends ShapeTag.Companion[AddMenuItemResult] {
 
   val hints: Hints = Hints.empty
 
+  // constructor using the original order from the spec
+  private def make(itemId: String, added: Timestamp): AddMenuItemResult = AddMenuItemResult(itemId, added)
+
   implicit val schema: Schema[AddMenuItemResult] = struct(
     string.required[AddMenuItemResult]("itemId", _.itemId).addHints(smithy.api.HttpPayload()),
     timestamp.required[AddMenuItemResult]("added", _.added).addHints(smithy.api.TimestampFormat.EPOCH_SECONDS.widen, smithy.api.HttpHeader("X-ADDED-AT")),
   ){
-    AddMenuItemResult.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/AgeFormat.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/AgeFormat.scala
@@ -15,5 +15,6 @@ object AgeFormat extends ShapeTag.Companion[AgeFormat] {
     smithy.api.Trait(selector = Some(":test(integer, member > integer)"), structurallyExclusive = None, conflicts = None, breakingChanges = None),
   ).lazily
 
+
   implicit val schema: Schema[AgeFormat] = constant(AgeFormat()).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/ArbitraryDataTest.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/ArbitraryDataTest.scala
@@ -15,5 +15,6 @@ object ArbitraryDataTest extends ShapeTag.Companion[ArbitraryDataTest] {
     smithy4s.example.ArbitraryData(smithy4s.Document.obj("str" -> smithy4s.Document.fromString("hello"), "int" -> smithy4s.Document.fromDouble(1.0d), "bool" -> smithy4s.Document.fromBoolean(true), "arr" -> smithy4s.Document.array(smithy4s.Document.fromString("one"), smithy4s.Document.fromString("two"), smithy4s.Document.fromString("three")), "obj" -> smithy4s.Document.obj("str" -> smithy4s.Document.fromString("s"), "i" -> smithy4s.Document.fromDouble(1.0d)))),
   ).lazily
 
+
   implicit val schema: Schema[ArbitraryDataTest] = constant(ArbitraryDataTest()).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/BigStruct.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/BigStruct.scala
@@ -14,6 +14,9 @@ object BigStruct extends ShapeTag.Companion[BigStruct] {
 
   val hints: Hints = Hints.empty
 
+  // constructor using the original order from the spec
+  private def make(a1: Int, a2: Int, a3: Int, a4: Int, a5: Int, a6: Int, a7: Int, a8: Int, a9: Int, a10: Int, a11: Int, a12: Int, a13: Int, a14: Int, a15: Int, a16: Int, a17: Int, a18: Int, a19: Int, a20: Int, a21: Int, a22: Int, a23: Int): BigStruct = BigStruct(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23)
+
   implicit val schema: Schema[BigStruct] = struct.genericArity(
     int.required[BigStruct]("a1", _.a1),
     int.required[BigStruct]("a2", _.a2),
@@ -39,7 +42,7 @@ object BigStruct extends ShapeTag.Companion[BigStruct] {
     int.required[BigStruct]("a22", _.a22),
     int.required[BigStruct]("a23", _.a23),
   ){
-    arr => new BigStruct(
+    arr => make(
       arr(0).asInstanceOf[Int],
       arr(1).asInstanceOf[Int],
       arr(2).asInstanceOf[Int],

--- a/modules/bootstrapped/src/generated/smithy4s/example/Candy.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/Candy.scala
@@ -14,9 +14,12 @@ object Candy extends ShapeTag.Companion[Candy] {
 
   val hints: Hints = Hints.empty
 
+  // constructor using the original order from the spec
+  private def make(name: Option[String]): Candy = Candy(name)
+
   implicit val schema: Schema[Candy] = struct(
     string.optional[Candy]("name", _.name),
   ){
-    Candy.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/Candy.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/Candy.scala
@@ -19,7 +19,5 @@ object Candy extends ShapeTag.Companion[Candy] {
 
   implicit val schema: Schema[Candy] = struct(
     string.optional[Candy]("name", _.name),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/CityCoordinates.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/CityCoordinates.scala
@@ -14,10 +14,13 @@ object CityCoordinates extends ShapeTag.Companion[CityCoordinates] {
 
   val hints: Hints = Hints.empty
 
+  // constructor using the original order from the spec
+  private def make(latitude: Float, longitude: Float): CityCoordinates = CityCoordinates(latitude, longitude)
+
   implicit val schema: Schema[CityCoordinates] = struct(
     float.required[CityCoordinates]("latitude", _.latitude),
     float.required[CityCoordinates]("longitude", _.longitude),
   ){
-    CityCoordinates.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/CityCoordinates.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/CityCoordinates.scala
@@ -20,7 +20,5 @@ object CityCoordinates extends ShapeTag.Companion[CityCoordinates] {
   implicit val schema: Schema[CityCoordinates] = struct(
     float.required[CityCoordinates]("latitude", _.latitude),
     float.required[CityCoordinates]("longitude", _.longitude),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/CitySummary.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/CitySummary.scala
@@ -16,10 +16,13 @@ object CitySummary extends ShapeTag.Companion[CitySummary] {
     smithy.api.References(List(smithy.api.Reference(resource = smithy.api.NonEmptyString("smithy4s.example#City"), ids = None, service = None, rel = None))),
   ).lazily
 
+  // constructor using the original order from the spec
+  private def make(cityId: CityId, name: String): CitySummary = CitySummary(cityId, name)
+
   implicit val schema: Schema[CitySummary] = struct(
     CityId.schema.required[CitySummary]("cityId", _.cityId),
     string.required[CitySummary]("name", _.name),
   ){
-    CitySummary.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/CitySummary.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/CitySummary.scala
@@ -22,7 +22,5 @@ object CitySummary extends ShapeTag.Companion[CitySummary] {
   implicit val schema: Schema[CitySummary] = struct(
     CityId.schema.required[CitySummary]("cityId", _.cityId),
     string.required[CitySummary]("name", _.name),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/ClientError.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/ClientError.scala
@@ -19,10 +19,13 @@ object ClientError extends ShapeTag.Companion[ClientError] {
     smithy.api.Error.CLIENT.widen,
   ).lazily
 
+  // constructor using the original order from the spec
+  private def make(code: Int, details: String): ClientError = ClientError(code, details)
+
   implicit val schema: Schema[ClientError] = struct(
     int.required[ClientError]("code", _.code),
     string.required[ClientError]("details", _.details),
   ){
-    ClientError.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/ClientError.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/ClientError.scala
@@ -25,7 +25,5 @@ object ClientError extends ShapeTag.Companion[ClientError] {
   implicit val schema: Schema[ClientError] = struct(
     int.required[ClientError]("code", _.code),
     string.required[ClientError]("details", _.details),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/CustomCodeInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/CustomCodeInput.scala
@@ -19,7 +19,5 @@ object CustomCodeInput extends ShapeTag.Companion[CustomCodeInput] {
 
   implicit val schema: Schema[CustomCodeInput] = struct(
     int.required[CustomCodeInput]("code", _.code).addHints(smithy.api.HttpLabel()),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/CustomCodeInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/CustomCodeInput.scala
@@ -14,9 +14,12 @@ object CustomCodeInput extends ShapeTag.Companion[CustomCodeInput] {
 
   val hints: Hints = Hints.empty
 
+  // constructor using the original order from the spec
+  private def make(code: Int): CustomCodeInput = CustomCodeInput(code)
+
   implicit val schema: Schema[CustomCodeInput] = struct(
     int.required[CustomCodeInput]("code", _.code).addHints(smithy.api.HttpLabel()),
   ){
-    CustomCodeInput.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/CustomCodeOutput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/CustomCodeOutput.scala
@@ -19,7 +19,5 @@ object CustomCodeOutput extends ShapeTag.Companion[CustomCodeOutput] {
 
   implicit val schema: Schema[CustomCodeOutput] = struct(
     int.optional[CustomCodeOutput]("code", _.code).addHints(smithy.api.HttpResponseCode()),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/CustomCodeOutput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/CustomCodeOutput.scala
@@ -14,9 +14,12 @@ object CustomCodeOutput extends ShapeTag.Companion[CustomCodeOutput] {
 
   val hints: Hints = Hints.empty
 
+  // constructor using the original order from the spec
+  private def make(code: Option[Int]): CustomCodeOutput = CustomCodeOutput(code)
+
   implicit val schema: Schema[CustomCodeOutput] = struct(
     int.optional[CustomCodeOutput]("code", _.code).addHints(smithy.api.HttpResponseCode()),
   ){
-    CustomCodeOutput.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/DefaultInMixinUsageTest.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/DefaultInMixinUsageTest.scala
@@ -19,7 +19,5 @@ object DefaultInMixinUsageTest extends ShapeTag.Companion[DefaultInMixinUsageTes
 
   implicit val schema: Schema[DefaultInMixinUsageTest] = struct(
     string.field[DefaultInMixinUsageTest]("one", _.one).addHints(smithy.api.Default(smithy4s.Document.fromString("test"))),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/DefaultInMixinUsageTest.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/DefaultInMixinUsageTest.scala
@@ -14,9 +14,12 @@ object DefaultInMixinUsageTest extends ShapeTag.Companion[DefaultInMixinUsageTes
 
   val hints: Hints = Hints.empty
 
+  // constructor using the original order from the spec
+  private def make(one: String): DefaultInMixinUsageTest = DefaultInMixinUsageTest(one)
+
   implicit val schema: Schema[DefaultInMixinUsageTest] = struct(
     string.field[DefaultInMixinUsageTest]("one", _.one).addHints(smithy.api.Default(smithy4s.Document.fromString("test"))),
   ){
-    DefaultInMixinUsageTest.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/DefaultOrderingTest.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/DefaultOrderingTest.scala
@@ -22,7 +22,5 @@ object DefaultOrderingTest extends ShapeTag.Companion[DefaultOrderingTest] {
     int.field[DefaultOrderingTest]("one", _.one).addHints(smithy.api.Default(smithy4s.Document.fromDouble(1.0d))),
     string.optional[DefaultOrderingTest]("two", _.two),
     string.required[DefaultOrderingTest]("three", _.three),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/DefaultOrderingTest.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/DefaultOrderingTest.scala
@@ -15,11 +15,14 @@ object DefaultOrderingTest extends ShapeTag.Companion[DefaultOrderingTest] {
 
   val hints: Hints = Hints.empty
 
+  // constructor using the original order from the spec
+  private def make(one: Int, two: Option[String], three: String): DefaultOrderingTest = DefaultOrderingTest(three, one, two)
+
   implicit val schema: Schema[DefaultOrderingTest] = struct(
-    string.required[DefaultOrderingTest]("three", _.three),
     int.field[DefaultOrderingTest]("one", _.one).addHints(smithy.api.Default(smithy4s.Document.fromDouble(1.0d))),
     string.optional[DefaultOrderingTest]("two", _.two),
+    string.required[DefaultOrderingTest]("three", _.three),
   ){
-    DefaultOrderingTest.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/DefaultTest.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/DefaultTest.scala
@@ -49,7 +49,5 @@ object DefaultTest extends ShapeTag.Companion[DefaultTest] {
     byte.field[DefaultTest]("sixteen", _.sixteen).addHints(smithy.api.Default(smithy4s.Document.fromDouble(0.0d))),
     bytes.field[DefaultTest]("seventeen", _.seventeen).addHints(smithy.api.Default(smithy4s.Document.array())),
     boolean.field[DefaultTest]("eighteen", _.eighteen).addHints(smithy.api.Default(smithy4s.Document.fromBoolean(false))),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/DefaultTest.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/DefaultTest.scala
@@ -27,6 +27,9 @@ object DefaultTest extends ShapeTag.Companion[DefaultTest] {
 
   val hints: Hints = Hints.empty
 
+  // constructor using the original order from the spec
+  private def make(one: Int, two: String, three: List[String], four: List[String], five: String, six: Int, seven: Document, eight: Map[String, String], nine: Short, ten: Double, eleven: Float, twelve: Long, thirteen: Timestamp, fourteen: Timestamp, fifteen: Timestamp, sixteen: Byte, seventeen: Blob, eighteen: Boolean): DefaultTest = DefaultTest(one, two, three, four, five, six, seven, eight, nine, ten, eleven, twelve, thirteen, fourteen, fifteen, sixteen, seventeen, eighteen)
+
   implicit val schema: Schema[DefaultTest] = struct(
     int.field[DefaultTest]("one", _.one).addHints(smithy.api.Default(smithy4s.Document.fromDouble(1.0d))),
     string.field[DefaultTest]("two", _.two).addHints(smithy.api.Default(smithy4s.Document.fromString("test"))),
@@ -47,6 +50,6 @@ object DefaultTest extends ShapeTag.Companion[DefaultTest] {
     bytes.field[DefaultTest]("seventeen", _.seventeen).addHints(smithy.api.Default(smithy4s.Document.array())),
     boolean.field[DefaultTest]("eighteen", _.eighteen).addHints(smithy.api.Default(smithy4s.Document.fromBoolean(false))),
   ){
-    DefaultTest.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/DefaultVariants.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/DefaultVariants.scala
@@ -22,7 +22,5 @@ object DefaultVariants extends ShapeTag.Companion[DefaultVariants] {
     string.required[DefaultVariants]("reqDef", _.reqDef).addHints(smithy.api.Default(smithy4s.Document.fromString("default"))),
     string.optional[DefaultVariants]("opt", _.opt),
     string.field[DefaultVariants]("optDef", _.optDef).addHints(smithy.api.Default(smithy4s.Document.fromString("default"))),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/DefaultVariants.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/DefaultVariants.scala
@@ -14,12 +14,15 @@ object DefaultVariants extends ShapeTag.Companion[DefaultVariants] {
 
   val hints: Hints = Hints.empty
 
+  // constructor using the original order from the spec
+  private def make(req: String, reqDef: String, opt: Option[String], optDef: String): DefaultVariants = DefaultVariants(req, reqDef, optDef, opt)
+
   implicit val schema: Schema[DefaultVariants] = struct(
     string.required[DefaultVariants]("req", _.req),
     string.required[DefaultVariants]("reqDef", _.reqDef).addHints(smithy.api.Default(smithy4s.Document.fromString("default"))),
-    string.field[DefaultVariants]("optDef", _.optDef).addHints(smithy.api.Default(smithy4s.Document.fromString("default"))),
     string.optional[DefaultVariants]("opt", _.opt),
+    string.field[DefaultVariants]("optDef", _.optDef).addHints(smithy.api.Default(smithy4s.Document.fromString("default"))),
   ){
-    DefaultVariants.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/DeprecatedStructure.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/DeprecatedStructure.scala
@@ -25,7 +25,5 @@ object DeprecatedStructure extends ShapeTag.Companion[DeprecatedStructure] {
     Strings.underlyingSchema.optional[DeprecatedStructure]("other", _.other),
     string.optional[DeprecatedStructure]("name", _.name).addHints(smithy.api.Deprecated(message = None, since = None)),
     string.optional[DeprecatedStructure]("nameV2", _.nameV2),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/DeprecatedStructure.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/DeprecatedStructure.scala
@@ -17,12 +17,15 @@ object DeprecatedStructure extends ShapeTag.Companion[DeprecatedStructure] {
     smithy.api.Deprecated(message = Some("A compelling reason"), since = Some("0.0.1")),
   ).lazily
 
+  // constructor using the original order from the spec
+  private def make(strings: Option[List[String]], other: Option[List[String]], name: Option[String], nameV2: Option[String]): DeprecatedStructure = DeprecatedStructure(strings, other, name, nameV2)
+
   implicit val schema: Schema[DeprecatedStructure] = struct(
     Strings.underlyingSchema.optional[DeprecatedStructure]("strings", _.strings).addHints(smithy.api.Deprecated(message = None, since = None)),
     Strings.underlyingSchema.optional[DeprecatedStructure]("other", _.other),
     string.optional[DeprecatedStructure]("name", _.name).addHints(smithy.api.Deprecated(message = None, since = None)),
     string.optional[DeprecatedStructure]("nameV2", _.nameV2),
   ){
-    DeprecatedStructure.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/DeprecatedUnion.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/DeprecatedUnion.scala
@@ -58,6 +58,7 @@ object DeprecatedUnion extends ShapeTag.Companion[DeprecatedUnion] {
       smithy.api.Deprecated(message = None, since = None),
     ).lazily
 
+
     implicit val schema: Schema[DeprecatedUnionProductCase] = constant(DeprecatedUnionProductCase()).withId(id).addHints(hints)
 
     val alt = schema.oneOf[DeprecatedUnion]("p")
@@ -73,6 +74,7 @@ object DeprecatedUnion extends ShapeTag.Companion[DeprecatedUnion] {
     val hints: Hints = Hints(
       smithy.api.Deprecated(message = None, since = None),
     ).lazily
+
 
     implicit val schema: Schema[UnionProductCaseDeprecatedAtCallSite] = constant(UnionProductCaseDeprecatedAtCallSite()).withId(id).addHints(hints)
 

--- a/modules/bootstrapped/src/generated/smithy4s/example/DocTest.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/DocTest.scala
@@ -18,5 +18,6 @@ object DocTest extends ShapeTag.Companion[DocTest] {
     smithy.api.Documentation("Test if an at-sign is rendered appropriately\n@test"),
   ).lazily
 
+
   implicit val schema: Schema[DocTest] = constant(DocTest()).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/DocumentationComment.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/DocumentationComment.scala
@@ -20,9 +20,12 @@ object DocumentationComment extends ShapeTag.Companion[DocumentationComment] {
     smithy.api.Documentation("We should be able to use comments in documentation /* */"),
   ).lazily
 
+  // constructor using the original order from the spec
+  private def make(member: Option[String]): DocumentationComment = DocumentationComment(member)
+
   implicit val schema: Schema[DocumentationComment] = struct(
     string.optional[DocumentationComment]("member", _.member).addHints(smithy.api.Documentation("/*")),
   ){
-    DocumentationComment.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/DocumentationComment.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/DocumentationComment.scala
@@ -25,7 +25,5 @@ object DocumentationComment extends ShapeTag.Companion[DocumentationComment] {
 
   implicit val schema: Schema[DocumentationComment] = struct(
     string.optional[DocumentationComment]("member", _.member).addHints(smithy.api.Documentation("/*")),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/EHFallbackClientError.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/EHFallbackClientError.scala
@@ -19,9 +19,12 @@ object EHFallbackClientError extends ShapeTag.Companion[EHFallbackClientError] {
     smithy.api.Error.CLIENT.widen,
   ).lazily
 
+  // constructor using the original order from the spec
+  private def make(message: Option[String]): EHFallbackClientError = EHFallbackClientError(message)
+
   implicit val schema: Schema[EHFallbackClientError] = struct(
     string.optional[EHFallbackClientError]("message", _.message),
   ){
-    EHFallbackClientError.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/EHFallbackClientError.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/EHFallbackClientError.scala
@@ -24,7 +24,5 @@ object EHFallbackClientError extends ShapeTag.Companion[EHFallbackClientError] {
 
   implicit val schema: Schema[EHFallbackClientError] = struct(
     string.optional[EHFallbackClientError]("message", _.message),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/EHFallbackServerError.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/EHFallbackServerError.scala
@@ -24,7 +24,5 @@ object EHFallbackServerError extends ShapeTag.Companion[EHFallbackServerError] {
 
   implicit val schema: Schema[EHFallbackServerError] = struct(
     string.optional[EHFallbackServerError]("message", _.message),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/EHFallbackServerError.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/EHFallbackServerError.scala
@@ -19,9 +19,12 @@ object EHFallbackServerError extends ShapeTag.Companion[EHFallbackServerError] {
     smithy.api.Error.SERVER.widen,
   ).lazily
 
+  // constructor using the original order from the spec
+  private def make(message: Option[String]): EHFallbackServerError = EHFallbackServerError(message)
+
   implicit val schema: Schema[EHFallbackServerError] = struct(
     string.optional[EHFallbackServerError]("message", _.message),
   ){
-    EHFallbackServerError.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/EHNotFound.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/EHNotFound.scala
@@ -20,9 +20,12 @@ object EHNotFound extends ShapeTag.Companion[EHNotFound] {
     smithy.api.HttpError(404),
   ).lazily
 
+  // constructor using the original order from the spec
+  private def make(message: Option[String]): EHNotFound = EHNotFound(message)
+
   implicit val schema: Schema[EHNotFound] = struct(
     string.optional[EHNotFound]("message", _.message),
   ){
-    EHNotFound.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/EHNotFound.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/EHNotFound.scala
@@ -25,7 +25,5 @@ object EHNotFound extends ShapeTag.Companion[EHNotFound] {
 
   implicit val schema: Schema[EHNotFound] = struct(
     string.optional[EHNotFound]("message", _.message),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/EHServiceUnavailable.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/EHServiceUnavailable.scala
@@ -20,9 +20,12 @@ object EHServiceUnavailable extends ShapeTag.Companion[EHServiceUnavailable] {
     smithy.api.HttpError(503),
   ).lazily
 
+  // constructor using the original order from the spec
+  private def make(message: Option[String]): EHServiceUnavailable = EHServiceUnavailable(message)
+
   implicit val schema: Schema[EHServiceUnavailable] = struct(
     string.optional[EHServiceUnavailable]("message", _.message),
   ){
-    EHServiceUnavailable.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/EHServiceUnavailable.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/EHServiceUnavailable.scala
@@ -25,7 +25,5 @@ object EHServiceUnavailable extends ShapeTag.Companion[EHServiceUnavailable] {
 
   implicit val schema: Schema[EHServiceUnavailable] = struct(
     string.optional[EHServiceUnavailable]("message", _.message),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/EchoBody.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/EchoBody.scala
@@ -14,9 +14,12 @@ object EchoBody extends ShapeTag.Companion[EchoBody] {
 
   val hints: Hints = Hints.empty
 
+  // constructor using the original order from the spec
+  private def make(data: Option[String]): EchoBody = EchoBody(data)
+
   implicit val schema: Schema[EchoBody] = struct(
     string.validated(smithy.api.Length(min = Some(10L), max = None)).optional[EchoBody]("data", _.data),
   ){
-    EchoBody.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/EchoBody.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/EchoBody.scala
@@ -19,7 +19,5 @@ object EchoBody extends ShapeTag.Companion[EchoBody] {
 
   implicit val schema: Schema[EchoBody] = struct(
     string.validated(smithy.api.Length(min = Some(10L), max = None)).optional[EchoBody]("data", _.data),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/EchoInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/EchoInput.scala
@@ -21,7 +21,5 @@ object EchoInput extends ShapeTag.Companion[EchoInput] {
     string.validated(smithy.api.Length(min = Some(10L), max = None)).required[EchoInput]("pathParam", _.pathParam).addHints(smithy.api.HttpLabel()),
     string.validated(smithy.api.Length(min = Some(10L), max = None)).optional[EchoInput]("queryParam", _.queryParam).addHints(smithy.api.HttpQuery("queryParam")),
     EchoBody.schema.required[EchoInput]("body", _.body).addHints(smithy.api.HttpPayload()),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/EchoInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/EchoInput.scala
@@ -14,11 +14,14 @@ object EchoInput extends ShapeTag.Companion[EchoInput] {
 
   val hints: Hints = Hints.empty
 
+  // constructor using the original order from the spec
+  private def make(pathParam: String, queryParam: Option[String], body: EchoBody): EchoInput = EchoInput(pathParam, body, queryParam)
+
   implicit val schema: Schema[EchoInput] = struct(
     string.validated(smithy.api.Length(min = Some(10L), max = None)).required[EchoInput]("pathParam", _.pathParam).addHints(smithy.api.HttpLabel()),
-    EchoBody.schema.required[EchoInput]("body", _.body).addHints(smithy.api.HttpPayload()),
     string.validated(smithy.api.Length(min = Some(10L), max = None)).optional[EchoInput]("queryParam", _.queryParam).addHints(smithy.api.HttpQuery("queryParam")),
+    EchoBody.schema.required[EchoInput]("body", _.body).addHints(smithy.api.HttpPayload()),
   ){
-    EchoInput.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/EnvVarString.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/EnvVarString.scala
@@ -25,7 +25,5 @@ object EnvVarString extends ShapeTag.Companion[EnvVarString] {
 
   implicit val schema: Schema[EnvVarString] = struct(
     string.optional[EnvVarString]("member", _.member).addHints(smithy.api.Documentation(s"This is meant to be used with $$ENV_VAR")),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/EnvVarString.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/EnvVarString.scala
@@ -20,9 +20,12 @@ object EnvVarString extends ShapeTag.Companion[EnvVarString] {
     smithy.api.Documentation(s"This is meant to be used with $${ENV_VAR}"),
   ).lazily
 
+  // constructor using the original order from the spec
+  private def make(member: Option[String]): EnvVarString = EnvVarString(member)
+
   implicit val schema: Schema[EnvVarString] = struct(
     string.optional[EnvVarString]("member", _.member).addHints(smithy.api.Documentation(s"This is meant to be used with $$ENV_VAR")),
   ){
-    EnvVarString.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/ErrorCustomTypeMessage.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/ErrorCustomTypeMessage.scala
@@ -18,9 +18,12 @@ object ErrorCustomTypeMessage extends ShapeTag.Companion[ErrorCustomTypeMessage]
     smithy.api.Error.SERVER.widen,
   ).lazily
 
+  // constructor using the original order from the spec
+  private def make(message: Option[CustomErrorMessageType]): ErrorCustomTypeMessage = ErrorCustomTypeMessage(message)
+
   implicit val schema: Schema[ErrorCustomTypeMessage] = struct(
     CustomErrorMessageType.schema.optional[ErrorCustomTypeMessage]("message", _.message),
   ){
-    ErrorCustomTypeMessage.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/ErrorCustomTypeMessage.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/ErrorCustomTypeMessage.scala
@@ -23,7 +23,5 @@ object ErrorCustomTypeMessage extends ShapeTag.Companion[ErrorCustomTypeMessage]
 
   implicit val schema: Schema[ErrorCustomTypeMessage] = struct(
     CustomErrorMessageType.schema.optional[ErrorCustomTypeMessage]("message", _.message),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/ErrorCustomTypeRequiredMessage.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/ErrorCustomTypeRequiredMessage.scala
@@ -18,9 +18,12 @@ object ErrorCustomTypeRequiredMessage extends ShapeTag.Companion[ErrorCustomType
     smithy.api.Error.SERVER.widen,
   ).lazily
 
+  // constructor using the original order from the spec
+  private def make(message: CustomErrorMessageType): ErrorCustomTypeRequiredMessage = ErrorCustomTypeRequiredMessage(message)
+
   implicit val schema: Schema[ErrorCustomTypeRequiredMessage] = struct(
     CustomErrorMessageType.schema.required[ErrorCustomTypeRequiredMessage]("message", _.message),
   ){
-    ErrorCustomTypeRequiredMessage.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/ErrorCustomTypeRequiredMessage.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/ErrorCustomTypeRequiredMessage.scala
@@ -23,7 +23,5 @@ object ErrorCustomTypeRequiredMessage extends ShapeTag.Companion[ErrorCustomType
 
   implicit val schema: Schema[ErrorCustomTypeRequiredMessage] = struct(
     CustomErrorMessageType.schema.required[ErrorCustomTypeRequiredMessage]("message", _.message),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/ErrorHandlingOperationInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/ErrorHandlingOperationInput.scala
@@ -21,7 +21,5 @@ object ErrorHandlingOperationInput extends ShapeTag.Companion[ErrorHandlingOpera
 
   implicit val schema: Schema[ErrorHandlingOperationInput] = struct(
     string.optional[ErrorHandlingOperationInput]("in", _.in),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/ErrorHandlingOperationInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/ErrorHandlingOperationInput.scala
@@ -16,9 +16,12 @@ object ErrorHandlingOperationInput extends ShapeTag.Companion[ErrorHandlingOpera
     smithy.api.Input(),
   ).lazily
 
+  // constructor using the original order from the spec
+  private def make(in: Option[String]): ErrorHandlingOperationInput = ErrorHandlingOperationInput(in)
+
   implicit val schema: Schema[ErrorHandlingOperationInput] = struct(
     string.optional[ErrorHandlingOperationInput]("in", _.in),
   ){
-    ErrorHandlingOperationInput.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/ErrorHandlingOperationOutput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/ErrorHandlingOperationOutput.scala
@@ -16,9 +16,12 @@ object ErrorHandlingOperationOutput extends ShapeTag.Companion[ErrorHandlingOper
     smithy.api.Output(),
   ).lazily
 
+  // constructor using the original order from the spec
+  private def make(out: Option[String]): ErrorHandlingOperationOutput = ErrorHandlingOperationOutput(out)
+
   implicit val schema: Schema[ErrorHandlingOperationOutput] = struct(
     string.optional[ErrorHandlingOperationOutput]("out", _.out),
   ){
-    ErrorHandlingOperationOutput.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/ErrorHandlingOperationOutput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/ErrorHandlingOperationOutput.scala
@@ -21,7 +21,5 @@ object ErrorHandlingOperationOutput extends ShapeTag.Companion[ErrorHandlingOper
 
   implicit val schema: Schema[ErrorHandlingOperationOutput] = struct(
     string.optional[ErrorHandlingOperationOutput]("out", _.out),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/ErrorNullableCustomTypeMessage.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/ErrorNullableCustomTypeMessage.scala
@@ -19,9 +19,12 @@ object ErrorNullableCustomTypeMessage extends ShapeTag.Companion[ErrorNullableCu
     smithy.api.Error.SERVER.widen,
   ).lazily
 
+  // constructor using the original order from the spec
+  private def make(message: Option[Nullable[CustomErrorMessageType]]): ErrorNullableCustomTypeMessage = ErrorNullableCustomTypeMessage(message)
+
   implicit val schema: Schema[ErrorNullableCustomTypeMessage] = struct(
     CustomErrorMessageType.schema.nullable.optional[ErrorNullableCustomTypeMessage]("message", _.message),
   ){
-    ErrorNullableCustomTypeMessage.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/ErrorNullableCustomTypeMessage.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/ErrorNullableCustomTypeMessage.scala
@@ -24,7 +24,5 @@ object ErrorNullableCustomTypeMessage extends ShapeTag.Companion[ErrorNullableCu
 
   implicit val schema: Schema[ErrorNullableCustomTypeMessage] = struct(
     CustomErrorMessageType.schema.nullable.optional[ErrorNullableCustomTypeMessage]("message", _.message),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/ErrorNullableCustomTypeRequiredMessage.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/ErrorNullableCustomTypeRequiredMessage.scala
@@ -19,9 +19,12 @@ object ErrorNullableCustomTypeRequiredMessage extends ShapeTag.Companion[ErrorNu
     smithy.api.Error.SERVER.widen,
   ).lazily
 
+  // constructor using the original order from the spec
+  private def make(message: Nullable[CustomErrorMessageType]): ErrorNullableCustomTypeRequiredMessage = ErrorNullableCustomTypeRequiredMessage(message)
+
   implicit val schema: Schema[ErrorNullableCustomTypeRequiredMessage] = struct(
     CustomErrorMessageType.schema.nullable.required[ErrorNullableCustomTypeRequiredMessage]("message", _.message),
   ){
-    ErrorNullableCustomTypeRequiredMessage.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/ErrorNullableCustomTypeRequiredMessage.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/ErrorNullableCustomTypeRequiredMessage.scala
@@ -24,7 +24,5 @@ object ErrorNullableCustomTypeRequiredMessage extends ShapeTag.Companion[ErrorNu
 
   implicit val schema: Schema[ErrorNullableCustomTypeRequiredMessage] = struct(
     CustomErrorMessageType.schema.nullable.required[ErrorNullableCustomTypeRequiredMessage]("message", _.message),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/ErrorNullableMessage.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/ErrorNullableMessage.scala
@@ -20,9 +20,12 @@ object ErrorNullableMessage extends ShapeTag.Companion[ErrorNullableMessage] {
     smithy.api.Error.CLIENT.widen,
   ).lazily
 
+  // constructor using the original order from the spec
+  private def make(message: Option[Nullable[String]]): ErrorNullableMessage = ErrorNullableMessage(message)
+
   implicit val schema: Schema[ErrorNullableMessage] = struct(
     string.nullable.optional[ErrorNullableMessage]("message", _.message),
   ){
-    ErrorNullableMessage.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/ErrorNullableMessage.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/ErrorNullableMessage.scala
@@ -25,7 +25,5 @@ object ErrorNullableMessage extends ShapeTag.Companion[ErrorNullableMessage] {
 
   implicit val schema: Schema[ErrorNullableMessage] = struct(
     string.nullable.optional[ErrorNullableMessage]("message", _.message),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/ErrorNullableRequiredMessage.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/ErrorNullableRequiredMessage.scala
@@ -20,9 +20,12 @@ object ErrorNullableRequiredMessage extends ShapeTag.Companion[ErrorNullableRequ
     smithy.api.Error.SERVER.widen,
   ).lazily
 
+  // constructor using the original order from the spec
+  private def make(message: Nullable[String]): ErrorNullableRequiredMessage = ErrorNullableRequiredMessage(message)
+
   implicit val schema: Schema[ErrorNullableRequiredMessage] = struct(
     string.nullable.required[ErrorNullableRequiredMessage]("message", _.message),
   ){
-    ErrorNullableRequiredMessage.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/ErrorNullableRequiredMessage.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/ErrorNullableRequiredMessage.scala
@@ -25,7 +25,5 @@ object ErrorNullableRequiredMessage extends ShapeTag.Companion[ErrorNullableRequ
 
   implicit val schema: Schema[ErrorNullableRequiredMessage] = struct(
     string.nullable.required[ErrorNullableRequiredMessage]("message", _.message),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/ErrorRequiredMessage.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/ErrorRequiredMessage.scala
@@ -24,7 +24,5 @@ object ErrorRequiredMessage extends ShapeTag.Companion[ErrorRequiredMessage] {
 
   implicit val schema: Schema[ErrorRequiredMessage] = struct(
     string.required[ErrorRequiredMessage]("message", _.message),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/ErrorRequiredMessage.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/ErrorRequiredMessage.scala
@@ -19,9 +19,12 @@ object ErrorRequiredMessage extends ShapeTag.Companion[ErrorRequiredMessage] {
     smithy.api.Error.CLIENT.widen,
   ).lazily
 
+  // constructor using the original order from the spec
+  private def make(message: String): ErrorRequiredMessage = ErrorRequiredMessage(message)
+
   implicit val schema: Schema[ErrorRequiredMessage] = struct(
     string.required[ErrorRequiredMessage]("message", _.message),
   ){
-    ErrorRequiredMessage.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/ExtraErrorOperationInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/ExtraErrorOperationInput.scala
@@ -16,9 +16,12 @@ object ExtraErrorOperationInput extends ShapeTag.Companion[ExtraErrorOperationIn
     smithy.api.Input(),
   ).lazily
 
+  // constructor using the original order from the spec
+  private def make(in: Option[String]): ExtraErrorOperationInput = ExtraErrorOperationInput(in)
+
   implicit val schema: Schema[ExtraErrorOperationInput] = struct(
     string.optional[ExtraErrorOperationInput]("in", _.in),
   ){
-    ExtraErrorOperationInput.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/ExtraErrorOperationInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/ExtraErrorOperationInput.scala
@@ -21,7 +21,5 @@ object ExtraErrorOperationInput extends ShapeTag.Companion[ExtraErrorOperationIn
 
   implicit val schema: Schema[ExtraErrorOperationInput] = struct(
     string.optional[ExtraErrorOperationInput]("in", _.in),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/FallbackError.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/FallbackError.scala
@@ -18,9 +18,12 @@ object FallbackError extends ShapeTag.Companion[FallbackError] {
     smithy.api.Error.CLIENT.widen,
   ).lazily
 
+  // constructor using the original order from the spec
+  private def make(error: String): FallbackError = FallbackError(error)
+
   implicit val schema: Schema[FallbackError] = struct(
     string.required[FallbackError]("error", _.error),
   ){
-    FallbackError.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/FallbackError.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/FallbackError.scala
@@ -23,7 +23,5 @@ object FallbackError extends ShapeTag.Companion[FallbackError] {
 
   implicit val schema: Schema[FallbackError] = struct(
     string.required[FallbackError]("error", _.error),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/FallbackError2.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/FallbackError2.scala
@@ -23,7 +23,5 @@ object FallbackError2 extends ShapeTag.Companion[FallbackError2] {
 
   implicit val schema: Schema[FallbackError2] = struct(
     string.required[FallbackError2]("error", _.error),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/FallbackError2.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/FallbackError2.scala
@@ -18,9 +18,12 @@ object FallbackError2 extends ShapeTag.Companion[FallbackError2] {
     smithy.api.Error.CLIENT.widen,
   ).lazily
 
+  // constructor using the original order from the spec
+  private def make(error: String): FallbackError2 = FallbackError2(error)
+
   implicit val schema: Schema[FallbackError2] = struct(
     string.required[FallbackError2]("error", _.error),
   ){
-    FallbackError2.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/FancyListFormat.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/FancyListFormat.scala
@@ -15,5 +15,6 @@ object FancyListFormat extends ShapeTag.Companion[FancyListFormat] {
     smithy.api.Trait(selector = Some("list:test(> member > string)"), structurallyExclusive = None, conflicts = None, breakingChanges = None),
   ).lazily
 
+
   implicit val schema: Schema[FancyListFormat] = constant(FancyListFormat()).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/Four.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/Four.scala
@@ -14,9 +14,12 @@ object Four extends ShapeTag.Companion[Four] {
 
   val hints: Hints = Hints.empty
 
+  // constructor using the original order from the spec
+  private def make(four: Int): Four = Four(four)
+
   implicit val schema: Schema[Four] = struct(
     int.required[Four]("four", _.four),
   ){
-    Four.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/Four.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/Four.scala
@@ -19,7 +19,5 @@ object Four extends ShapeTag.Companion[Four] {
 
   implicit val schema: Schema[Four] = struct(
     int.required[Four]("four", _.four),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/GenericClientError.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/GenericClientError.scala
@@ -20,9 +20,12 @@ object GenericClientError extends ShapeTag.Companion[GenericClientError] {
     smithy.api.HttpError(418),
   ).lazily
 
+  // constructor using the original order from the spec
+  private def make(message: String): GenericClientError = GenericClientError(message)
+
   implicit val schema: Schema[GenericClientError] = struct(
     string.required[GenericClientError]("message", _.message),
   ){
-    GenericClientError.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/GenericClientError.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/GenericClientError.scala
@@ -25,7 +25,5 @@ object GenericClientError extends ShapeTag.Companion[GenericClientError] {
 
   implicit val schema: Schema[GenericClientError] = struct(
     string.required[GenericClientError]("message", _.message),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/GenericServerError.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/GenericServerError.scala
@@ -25,7 +25,5 @@ object GenericServerError extends ShapeTag.Companion[GenericServerError] {
 
   implicit val schema: Schema[GenericServerError] = struct(
     string.required[GenericServerError]("message", _.message),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/GenericServerError.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/GenericServerError.scala
@@ -20,9 +20,12 @@ object GenericServerError extends ShapeTag.Companion[GenericServerError] {
     smithy.api.HttpError(502),
   ).lazily
 
+  // constructor using the original order from the spec
+  private def make(message: String): GenericServerError = GenericServerError(message)
+
   implicit val schema: Schema[GenericServerError] = struct(
     string.required[GenericServerError]("message", _.message),
   ){
-    GenericServerError.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/GetCityInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/GetCityInput.scala
@@ -18,9 +18,12 @@ object GetCityInput extends ShapeTag.Companion[GetCityInput] {
     val cityId: Lens[GetCityInput, CityId] = Lens[GetCityInput, CityId](_.cityId)(n => a => a.copy(cityId = n))
   }
 
+  // constructor using the original order from the spec
+  private def make(cityId: CityId): GetCityInput = GetCityInput(cityId)
+
   implicit val schema: Schema[GetCityInput] = struct(
     CityId.schema.required[GetCityInput]("cityId", _.cityId),
   ){
-    GetCityInput.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/GetCityInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/GetCityInput.scala
@@ -23,7 +23,5 @@ object GetCityInput extends ShapeTag.Companion[GetCityInput] {
 
   implicit val schema: Schema[GetCityInput] = struct(
     CityId.schema.required[GetCityInput]("cityId", _.cityId),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/GetCityOutput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/GetCityOutput.scala
@@ -14,10 +14,13 @@ object GetCityOutput extends ShapeTag.Companion[GetCityOutput] {
 
   val hints: Hints = Hints.empty
 
+  // constructor using the original order from the spec
+  private def make(name: String, coordinates: CityCoordinates): GetCityOutput = GetCityOutput(name, coordinates)
+
   implicit val schema: Schema[GetCityOutput] = struct(
     string.required[GetCityOutput]("name", _.name),
     CityCoordinates.schema.required[GetCityOutput]("coordinates", _.coordinates),
   ){
-    GetCityOutput.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/GetCityOutput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/GetCityOutput.scala
@@ -20,7 +20,5 @@ object GetCityOutput extends ShapeTag.Companion[GetCityOutput] {
   implicit val schema: Schema[GetCityOutput] = struct(
     string.required[GetCityOutput]("name", _.name),
     CityCoordinates.schema.required[GetCityOutput]("coordinates", _.coordinates),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/GetCurrentTimeOutput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/GetCurrentTimeOutput.scala
@@ -20,7 +20,5 @@ object GetCurrentTimeOutput extends ShapeTag.Companion[GetCurrentTimeOutput] {
 
   implicit val schema: Schema[GetCurrentTimeOutput] = struct(
     timestamp.required[GetCurrentTimeOutput]("time", _.time),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/GetCurrentTimeOutput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/GetCurrentTimeOutput.scala
@@ -15,9 +15,12 @@ object GetCurrentTimeOutput extends ShapeTag.Companion[GetCurrentTimeOutput] {
 
   val hints: Hints = Hints.empty
 
+  // constructor using the original order from the spec
+  private def make(time: Timestamp): GetCurrentTimeOutput = GetCurrentTimeOutput(time)
+
   implicit val schema: Schema[GetCurrentTimeOutput] = struct(
     timestamp.required[GetCurrentTimeOutput]("time", _.time),
   ){
-    GetCurrentTimeOutput.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/GetEnumInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/GetEnumInput.scala
@@ -18,7 +18,5 @@ object GetEnumInput extends ShapeTag.Companion[GetEnumInput] {
 
   implicit val schema: Schema[GetEnumInput] = struct(
     TheEnum.schema.required[GetEnumInput]("aa", _.aa).addHints(smithy.api.HttpLabel()),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/GetEnumInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/GetEnumInput.scala
@@ -13,9 +13,12 @@ object GetEnumInput extends ShapeTag.Companion[GetEnumInput] {
 
   val hints: Hints = Hints.empty
 
+  // constructor using the original order from the spec
+  private def make(aa: TheEnum): GetEnumInput = GetEnumInput(aa)
+
   implicit val schema: Schema[GetEnumInput] = struct(
     TheEnum.schema.required[GetEnumInput]("aa", _.aa).addHints(smithy.api.HttpLabel()),
   ){
-    GetEnumInput.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/GetEnumOutput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/GetEnumOutput.scala
@@ -14,9 +14,12 @@ object GetEnumOutput extends ShapeTag.Companion[GetEnumOutput] {
 
   val hints: Hints = Hints.empty
 
+  // constructor using the original order from the spec
+  private def make(result: Option[String]): GetEnumOutput = GetEnumOutput(result)
+
   implicit val schema: Schema[GetEnumOutput] = struct(
     string.optional[GetEnumOutput]("result", _.result),
   ){
-    GetEnumOutput.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/GetEnumOutput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/GetEnumOutput.scala
@@ -19,7 +19,5 @@ object GetEnumOutput extends ShapeTag.Companion[GetEnumOutput] {
 
   implicit val schema: Schema[GetEnumOutput] = struct(
     string.optional[GetEnumOutput]("result", _.result),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/GetFooOutput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/GetFooOutput.scala
@@ -18,9 +18,12 @@ object GetFooOutput extends ShapeTag.Companion[GetFooOutput] {
 
   val hints: Hints = Hints.empty
 
+  // constructor using the original order from the spec
+  private def make(foo: Option[Foo]): GetFooOutput = GetFooOutput(foo)
+
   implicit val schema: Schema[GetFooOutput] = struct(
     Foo.schema.optional[GetFooOutput]("foo", _.foo),
   ){
-    GetFooOutput.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/GetFooOutput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/GetFooOutput.scala
@@ -23,7 +23,5 @@ object GetFooOutput extends ShapeTag.Companion[GetFooOutput] {
 
   implicit val schema: Schema[GetFooOutput] = struct(
     Foo.schema.optional[GetFooOutput]("foo", _.foo),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/GetForecastInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/GetForecastInput.scala
@@ -13,9 +13,12 @@ object GetForecastInput extends ShapeTag.Companion[GetForecastInput] {
 
   val hints: Hints = Hints.empty
 
+  // constructor using the original order from the spec
+  private def make(cityId: CityId): GetForecastInput = GetForecastInput(cityId)
+
   implicit val schema: Schema[GetForecastInput] = struct(
     CityId.schema.required[GetForecastInput]("cityId", _.cityId),
   ){
-    GetForecastInput.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/GetForecastInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/GetForecastInput.scala
@@ -18,7 +18,5 @@ object GetForecastInput extends ShapeTag.Companion[GetForecastInput] {
 
   implicit val schema: Schema[GetForecastInput] = struct(
     CityId.schema.required[GetForecastInput]("cityId", _.cityId),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/GetForecastOutput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/GetForecastOutput.scala
@@ -23,7 +23,5 @@ object GetForecastOutput extends ShapeTag.Companion[GetForecastOutput] {
 
   implicit val schema: Schema[GetForecastOutput] = struct(
     ForecastResult.schema.optional[GetForecastOutput]("forecast", _.forecast),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/GetForecastOutput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/GetForecastOutput.scala
@@ -18,9 +18,12 @@ object GetForecastOutput extends ShapeTag.Companion[GetForecastOutput] {
     val forecast: Lens[GetForecastOutput, Option[ForecastResult]] = Lens[GetForecastOutput, Option[ForecastResult]](_.forecast)(n => a => a.copy(forecast = n))
   }
 
+  // constructor using the original order from the spec
+  private def make(forecast: Option[ForecastResult]): GetForecastOutput = GetForecastOutput(forecast)
+
   implicit val schema: Schema[GetForecastOutput] = struct(
     ForecastResult.schema.optional[GetForecastOutput]("forecast", _.forecast),
   ){
-    GetForecastOutput.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/GetIntEnumInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/GetIntEnumInput.scala
@@ -15,9 +15,12 @@ object GetIntEnumInput extends ShapeTag.Companion[GetIntEnumInput] {
     smithy.api.Input(),
   ).lazily
 
+  // constructor using the original order from the spec
+  private def make(aa: EnumResult): GetIntEnumInput = GetIntEnumInput(aa)
+
   implicit val schema: Schema[GetIntEnumInput] = struct(
     EnumResult.schema.required[GetIntEnumInput]("aa", _.aa).addHints(smithy.api.HttpLabel()),
   ){
-    GetIntEnumInput.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/GetIntEnumInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/GetIntEnumInput.scala
@@ -20,7 +20,5 @@ object GetIntEnumInput extends ShapeTag.Companion[GetIntEnumInput] {
 
   implicit val schema: Schema[GetIntEnumInput] = struct(
     EnumResult.schema.required[GetIntEnumInput]("aa", _.aa).addHints(smithy.api.HttpLabel()),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/GetIntEnumOutput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/GetIntEnumOutput.scala
@@ -20,7 +20,5 @@ object GetIntEnumOutput extends ShapeTag.Companion[GetIntEnumOutput] {
 
   implicit val schema: Schema[GetIntEnumOutput] = struct(
     EnumResult.schema.required[GetIntEnumOutput]("result", _.result),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/GetIntEnumOutput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/GetIntEnumOutput.scala
@@ -15,9 +15,12 @@ object GetIntEnumOutput extends ShapeTag.Companion[GetIntEnumOutput] {
     smithy.api.Output(),
   ).lazily
 
+  // constructor using the original order from the spec
+  private def make(result: EnumResult): GetIntEnumOutput = GetIntEnumOutput(result)
+
   implicit val schema: Schema[GetIntEnumOutput] = struct(
     EnumResult.schema.required[GetIntEnumOutput]("result", _.result),
   ){
-    GetIntEnumOutput.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/GetMenuRequest.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/GetMenuRequest.scala
@@ -14,9 +14,12 @@ object GetMenuRequest extends ShapeTag.Companion[GetMenuRequest] {
 
   val hints: Hints = Hints.empty
 
+  // constructor using the original order from the spec
+  private def make(restaurant: String): GetMenuRequest = GetMenuRequest(restaurant)
+
   implicit val schema: Schema[GetMenuRequest] = struct(
     string.required[GetMenuRequest]("restaurant", _.restaurant).addHints(smithy.api.HttpLabel()),
   ){
-    GetMenuRequest.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/GetMenuRequest.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/GetMenuRequest.scala
@@ -19,7 +19,5 @@ object GetMenuRequest extends ShapeTag.Companion[GetMenuRequest] {
 
   implicit val schema: Schema[GetMenuRequest] = struct(
     string.required[GetMenuRequest]("restaurant", _.restaurant).addHints(smithy.api.HttpLabel()),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/GetMenuResult.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/GetMenuResult.scala
@@ -13,9 +13,12 @@ object GetMenuResult extends ShapeTag.Companion[GetMenuResult] {
 
   val hints: Hints = Hints.empty
 
+  // constructor using the original order from the spec
+  private def make(menu: Map[String, MenuItem]): GetMenuResult = GetMenuResult(menu)
+
   implicit val schema: Schema[GetMenuResult] = struct(
     Menu.underlyingSchema.required[GetMenuResult]("menu", _.menu).addHints(smithy.api.HttpPayload()),
   ){
-    GetMenuResult.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/GetMenuResult.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/GetMenuResult.scala
@@ -18,7 +18,5 @@ object GetMenuResult extends ShapeTag.Companion[GetMenuResult] {
 
   implicit val schema: Schema[GetMenuResult] = struct(
     Menu.underlyingSchema.required[GetMenuResult]("menu", _.menu).addHints(smithy.api.HttpPayload()),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/GetObjectInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/GetObjectInput.scala
@@ -32,7 +32,5 @@ object GetObjectInput extends ShapeTag.Companion[GetObjectInput] {
   implicit val schema: Schema[GetObjectInput] = struct(
     ObjectKey.schema.required[GetObjectInput]("key", _.key).addHints(smithy.api.Documentation("Sent in the URI label named \"key\".\nKey can also be seen as the filename\nIt is always required for a GET operation"), smithy.api.HttpLabel()),
     BucketName.schema.required[GetObjectInput]("bucketName", _.bucketName).addHints(smithy.api.Documentation("Sent in the URI label named \"bucketName\"."), smithy.api.HttpLabel()),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/GetObjectInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/GetObjectInput.scala
@@ -26,10 +26,13 @@ object GetObjectInput extends ShapeTag.Companion[GetObjectInput] {
     smithy.api.Documentation("Input for getting an Object\nall fields are required\nand are given through HTTP labels\nSee https://smithy.io/2.0/spec/http-bindings.html?highlight=httppayload#http-uri-label"),
   ).lazily
 
+  // constructor using the original order from the spec
+  private def make(key: ObjectKey, bucketName: BucketName): GetObjectInput = GetObjectInput(key, bucketName)
+
   implicit val schema: Schema[GetObjectInput] = struct(
     ObjectKey.schema.required[GetObjectInput]("key", _.key).addHints(smithy.api.Documentation("Sent in the URI label named \"key\".\nKey can also be seen as the filename\nIt is always required for a GET operation"), smithy.api.HttpLabel()),
     BucketName.schema.required[GetObjectInput]("bucketName", _.bucketName).addHints(smithy.api.Documentation("Sent in the URI label named \"bucketName\"."), smithy.api.HttpLabel()),
   ){
-    GetObjectInput.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/GetObjectOutput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/GetObjectOutput.scala
@@ -14,10 +14,13 @@ object GetObjectOutput extends ShapeTag.Companion[GetObjectOutput] {
 
   val hints: Hints = Hints.empty
 
+  // constructor using the original order from the spec
+  private def make(size: ObjectSize, data: Option[String]): GetObjectOutput = GetObjectOutput(size, data)
+
   implicit val schema: Schema[GetObjectOutput] = struct(
     ObjectSize.schema.required[GetObjectOutput]("size", _.size).addHints(smithy.api.HttpHeader("X-Size")),
     string.optional[GetObjectOutput]("data", _.data).addHints(smithy.api.HttpPayload()),
   ){
-    GetObjectOutput.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/GetObjectOutput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/GetObjectOutput.scala
@@ -20,7 +20,5 @@ object GetObjectOutput extends ShapeTag.Companion[GetObjectOutput] {
   implicit val schema: Schema[GetObjectOutput] = struct(
     ObjectSize.schema.required[GetObjectOutput]("size", _.size).addHints(smithy.api.HttpHeader("X-Size")),
     string.optional[GetObjectOutput]("data", _.data).addHints(smithy.api.HttpPayload()),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/GetStreamedObjectInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/GetStreamedObjectInput.scala
@@ -19,7 +19,5 @@ object GetStreamedObjectInput extends ShapeTag.Companion[GetStreamedObjectInput]
 
   implicit val schema: Schema[GetStreamedObjectInput] = struct(
     string.required[GetStreamedObjectInput]("key", _.key),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/GetStreamedObjectInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/GetStreamedObjectInput.scala
@@ -14,9 +14,12 @@ object GetStreamedObjectInput extends ShapeTag.Companion[GetStreamedObjectInput]
 
   val hints: Hints = Hints.empty
 
+  // constructor using the original order from the spec
+  private def make(key: String): GetStreamedObjectInput = GetStreamedObjectInput(key)
+
   implicit val schema: Schema[GetStreamedObjectInput] = struct(
     string.required[GetStreamedObjectInput]("key", _.key),
   ){
-    GetStreamedObjectInput.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/GetStreamedObjectOutput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/GetStreamedObjectOutput.scala
@@ -13,5 +13,6 @@ object GetStreamedObjectOutput extends ShapeTag.Companion[GetStreamedObjectOutpu
 
   val hints: Hints = Hints.empty
 
+
   implicit val schema: Schema[GetStreamedObjectOutput] = constant(GetStreamedObjectOutput()).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/Hash.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/Hash.scala
@@ -15,5 +15,6 @@ object Hash extends ShapeTag.Companion[Hash] {
     smithy.api.Trait(selector = None, structurallyExclusive = None, conflicts = None, breakingChanges = None),
   ).lazily
 
+
   implicit val schema: Schema[Hash] = constant(Hash()).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/HeadRequestOutput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/HeadRequestOutput.scala
@@ -14,9 +14,12 @@ object HeadRequestOutput extends ShapeTag.Companion[HeadRequestOutput] {
 
   val hints: Hints = Hints.empty
 
+  // constructor using the original order from the spec
+  private def make(test: String): HeadRequestOutput = HeadRequestOutput(test)
+
   implicit val schema: Schema[HeadRequestOutput] = struct(
     string.required[HeadRequestOutput]("test", _.test).addHints(smithy.api.HttpHeader("Test")),
   ){
-    HeadRequestOutput.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/HeadRequestOutput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/HeadRequestOutput.scala
@@ -19,7 +19,5 @@ object HeadRequestOutput extends ShapeTag.Companion[HeadRequestOutput] {
 
   implicit val schema: Schema[HeadRequestOutput] = struct(
     string.required[HeadRequestOutput]("test", _.test).addHints(smithy.api.HttpHeader("Test")),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/HeaderEndpointData.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/HeaderEndpointData.scala
@@ -22,7 +22,5 @@ object HeaderEndpointData extends ShapeTag.Companion[HeaderEndpointData] {
     string.optional[HeaderEndpointData]("capitalizedHeader", _.capitalizedHeader).addHints(smithy.api.HttpHeader("X-Capitalized-Header")),
     string.optional[HeaderEndpointData]("lowercaseHeader", _.lowercaseHeader).addHints(smithy.api.HttpHeader("x-lowercase-header")),
     string.optional[HeaderEndpointData]("mixedHeader", _.mixedHeader).addHints(smithy.api.HttpHeader("x-MiXeD-hEaDEr")),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/HeaderEndpointData.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/HeaderEndpointData.scala
@@ -14,12 +14,15 @@ object HeaderEndpointData extends ShapeTag.Companion[HeaderEndpointData] {
 
   val hints: Hints = Hints.empty
 
+  // constructor using the original order from the spec
+  private def make(uppercaseHeader: Option[String], capitalizedHeader: Option[String], lowercaseHeader: Option[String], mixedHeader: Option[String]): HeaderEndpointData = HeaderEndpointData(uppercaseHeader, capitalizedHeader, lowercaseHeader, mixedHeader)
+
   implicit val schema: Schema[HeaderEndpointData] = struct(
     string.optional[HeaderEndpointData]("uppercaseHeader", _.uppercaseHeader).addHints(smithy.api.HttpHeader("X-UPPERCASE-HEADER")),
     string.optional[HeaderEndpointData]("capitalizedHeader", _.capitalizedHeader).addHints(smithy.api.HttpHeader("X-Capitalized-Header")),
     string.optional[HeaderEndpointData]("lowercaseHeader", _.lowercaseHeader).addHints(smithy.api.HttpHeader("x-lowercase-header")),
     string.optional[HeaderEndpointData]("mixedHeader", _.mixedHeader).addHints(smithy.api.HttpHeader("x-MiXeD-hEaDEr")),
   ){
-    HeaderEndpointData.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/HeadersStruct.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/HeadersStruct.scala
@@ -18,6 +18,9 @@ object HeadersStruct extends ShapeTag.Companion[HeadersStruct] {
 
   val hints: Hints = Hints.empty
 
+  // constructor using the original order from the spec
+  private def make(str: Option[String], int: Option[Int], ts1: Option[Timestamp], ts2: Option[Timestamp], ts3: Option[Timestamp], ts4: Option[Timestamp], b: Option[Boolean], sl: Option[List[String]], ie: Option[Numbers], on: Option[OpenNums], ons: Option[OpenNumsStr], slm: Option[Map[String, String]]): HeadersStruct = HeadersStruct(str, int, ts1, ts2, ts3, ts4, b, sl, ie, on, ons, slm)
+
   implicit val schema: Schema[HeadersStruct] = struct(
     string.optional[HeadersStruct]("str", _.str).addHints(smithy.api.HttpHeader("str")),
     int.optional[HeadersStruct]("int", _.int).addHints(smithy.api.HttpHeader("int")),
@@ -32,6 +35,6 @@ object HeadersStruct extends ShapeTag.Companion[HeadersStruct] {
     OpenNumsStr.schema.optional[HeadersStruct]("ons", _.ons).addHints(smithy.api.HttpHeader("openNumsStr")),
     StringMap.underlyingSchema.optional[HeadersStruct]("slm", _.slm).addHints(smithy.api.HttpPrefixHeaders("foo-")),
   ){
-    HeadersStruct.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/HeadersStruct.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/HeadersStruct.scala
@@ -34,7 +34,5 @@ object HeadersStruct extends ShapeTag.Companion[HeadersStruct] {
     OpenNums.schema.optional[HeadersStruct]("on", _.on).addHints(smithy.api.HttpHeader("openNums")),
     OpenNumsStr.schema.optional[HeadersStruct]("ons", _.ons).addHints(smithy.api.HttpHeader("openNumsStr")),
     StringMap.underlyingSchema.optional[HeadersStruct]("slm", _.slm).addHints(smithy.api.HttpPrefixHeaders("foo-")),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/HeadersWithDefaults.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/HeadersWithDefaults.scala
@@ -19,7 +19,5 @@ object HeadersWithDefaults extends ShapeTag.Companion[HeadersWithDefaults] {
 
   implicit val schema: Schema[HeadersWithDefaults] = struct(
     string.field[HeadersWithDefaults]("dflt", _.dflt).addHints(smithy.api.Default(smithy4s.Document.fromString("test")), smithy.api.HttpHeader("dflt")),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/HeadersWithDefaults.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/HeadersWithDefaults.scala
@@ -14,9 +14,12 @@ object HeadersWithDefaults extends ShapeTag.Companion[HeadersWithDefaults] {
 
   val hints: Hints = Hints.empty
 
+  // constructor using the original order from the spec
+  private def make(dflt: String): HeadersWithDefaults = HeadersWithDefaults(dflt)
+
   implicit val schema: Schema[HeadersWithDefaults] = struct(
     string.field[HeadersWithDefaults]("dflt", _.dflt).addHints(smithy.api.Default(smithy4s.Document.fromString("test")), smithy.api.HttpHeader("dflt")),
   ){
-    HeadersWithDefaults.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/HealthRequest.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/HealthRequest.scala
@@ -19,7 +19,5 @@ object HealthRequest extends ShapeTag.Companion[HealthRequest] {
 
   implicit val schema: Schema[HealthRequest] = struct(
     string.validated(smithy.api.Length(min = Some(0L), max = Some(5L))).optional[HealthRequest]("query", _.query).addHints(smithy.api.HttpQuery("query")),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/HealthRequest.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/HealthRequest.scala
@@ -14,9 +14,12 @@ object HealthRequest extends ShapeTag.Companion[HealthRequest] {
 
   val hints: Hints = Hints.empty
 
+  // constructor using the original order from the spec
+  private def make(query: Option[String]): HealthRequest = HealthRequest(query)
+
   implicit val schema: Schema[HealthRequest] = struct(
     string.validated(smithy.api.Length(min = Some(0L), max = Some(5L))).optional[HealthRequest]("query", _.query).addHints(smithy.api.HttpQuery("query")),
   ){
-    HealthRequest.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/HealthResponse.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/HealthResponse.scala
@@ -16,9 +16,12 @@ object HealthResponse extends ShapeTag.Companion[HealthResponse] {
     smithy4s.example.FreeForm(smithy4s.Document.obj("i" -> smithy4s.Document.fromDouble(1.0d), "a" -> smithy4s.Document.fromDouble(2.0d))),
   ).lazily
 
+  // constructor using the original order from the spec
+  private def make(status: String): HealthResponse = HealthResponse(status)
+
   implicit val schema: Schema[HealthResponse] = struct(
     string.required[HealthResponse]("status", _.status),
   ){
-    HealthResponse.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/HealthResponse.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/HealthResponse.scala
@@ -21,7 +21,5 @@ object HealthResponse extends ShapeTag.Companion[HealthResponse] {
 
   implicit val schema: Schema[HealthResponse] = struct(
     string.required[HealthResponse]("status", _.status),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/HostLabelInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/HostLabelInput.scala
@@ -21,7 +21,5 @@ object HostLabelInput extends ShapeTag.Companion[HostLabelInput] {
     string.required[HostLabelInput]("label1", _.label1).addHints(smithy.api.HostLabel()),
     string.required[HostLabelInput]("label2", _.label2).addHints(smithy.api.HostLabel()),
     HostLabelEnum.schema.required[HostLabelInput]("label3", _.label3).addHints(smithy.api.HostLabel()),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/HostLabelInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/HostLabelInput.scala
@@ -14,11 +14,14 @@ object HostLabelInput extends ShapeTag.Companion[HostLabelInput] {
 
   val hints: Hints = Hints.empty
 
+  // constructor using the original order from the spec
+  private def make(label1: String, label2: String, label3: HostLabelEnum): HostLabelInput = HostLabelInput(label1, label2, label3)
+
   implicit val schema: Schema[HostLabelInput] = struct(
     string.required[HostLabelInput]("label1", _.label1).addHints(smithy.api.HostLabel()),
     string.required[HostLabelInput]("label2", _.label2).addHints(smithy.api.HostLabel()),
     HostLabelEnum.schema.required[HostLabelInput]("label3", _.label3).addHints(smithy.api.HostLabel()),
   ){
-    HostLabelInput.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/IntList.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/IntList.scala
@@ -21,7 +21,5 @@ object IntList extends ShapeTag.Companion[IntList] {
   implicit val schema: Schema[IntList] = recursive(struct(
     int.required[IntList]("head", _.head),
     smithy4s.example.IntList.schema.optional[IntList]("tail", _.tail),
-  ){
-    make
-  }.withId(id).addHints(hints))
+  )(make).withId(id).addHints(hints))
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/IntList.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/IntList.scala
@@ -15,10 +15,13 @@ object IntList extends ShapeTag.Companion[IntList] {
 
   val hints: Hints = Hints.empty
 
+  // constructor using the original order from the spec
+  private def make(head: Int, tail: Option[smithy4s.example.IntList]): IntList = IntList(head, tail)
+
   implicit val schema: Schema[IntList] = recursive(struct(
     int.required[IntList]("head", _.head),
     smithy4s.example.IntList.schema.optional[IntList]("tail", _.tail),
   ){
-    IntList.apply
+    make
   }.withId(id).addHints(hints))
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/Key.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/Key.scala
@@ -19,7 +19,5 @@ object Key extends ShapeTag.Companion[Key] {
 
   implicit val schema: Schema[Key] = struct(
     string.required[Key]("key", _.key),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/Key.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/Key.scala
@@ -14,9 +14,12 @@ object Key extends ShapeTag.Companion[Key] {
 
   val hints: Hints = Hints.empty
 
+  // constructor using the original order from the spec
+  private def make(key: String): Key = Key(key)
+
   implicit val schema: Schema[Key] = struct(
     string.required[Key]("key", _.key),
   ){
-    Key.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/KeyNotFoundError.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/KeyNotFoundError.scala
@@ -19,9 +19,12 @@ object KeyNotFoundError extends ShapeTag.Companion[KeyNotFoundError] {
     smithy.api.Error.CLIENT.widen,
   ).lazily
 
+  // constructor using the original order from the spec
+  private def make(message: String): KeyNotFoundError = KeyNotFoundError(message)
+
   implicit val schema: Schema[KeyNotFoundError] = struct(
     string.required[KeyNotFoundError]("message", _.message),
   ){
-    KeyNotFoundError.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/KeyNotFoundError.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/KeyNotFoundError.scala
@@ -24,7 +24,5 @@ object KeyNotFoundError extends ShapeTag.Companion[KeyNotFoundError] {
 
   implicit val schema: Schema[KeyNotFoundError] = struct(
     string.required[KeyNotFoundError]("message", _.message),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/KeyValue.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/KeyValue.scala
@@ -14,10 +14,13 @@ object KeyValue extends ShapeTag.Companion[KeyValue] {
 
   val hints: Hints = Hints.empty
 
+  // constructor using the original order from the spec
+  private def make(key: String, value: String): KeyValue = KeyValue(key, value)
+
   implicit val schema: Schema[KeyValue] = struct(
     string.required[KeyValue]("key", _.key),
     string.required[KeyValue]("value", _.value),
   ){
-    KeyValue.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/KeyValue.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/KeyValue.scala
@@ -20,7 +20,5 @@ object KeyValue extends ShapeTag.Companion[KeyValue] {
   implicit val schema: Schema[KeyValue] = struct(
     string.required[KeyValue]("key", _.key),
     string.required[KeyValue]("value", _.value),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/ListCitiesInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/ListCitiesInput.scala
@@ -21,7 +21,5 @@ object ListCitiesInput extends ShapeTag.Companion[ListCitiesInput] {
   implicit val schema: Schema[ListCitiesInput] = struct(
     string.optional[ListCitiesInput]("nextToken", _.nextToken),
     int.optional[ListCitiesInput]("pageSize", _.pageSize),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/ListCitiesInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/ListCitiesInput.scala
@@ -15,10 +15,13 @@ object ListCitiesInput extends ShapeTag.Companion[ListCitiesInput] {
 
   val hints: Hints = Hints.empty
 
+  // constructor using the original order from the spec
+  private def make(nextToken: Option[String], pageSize: Option[Int]): ListCitiesInput = ListCitiesInput(nextToken, pageSize)
+
   implicit val schema: Schema[ListCitiesInput] = struct(
     string.optional[ListCitiesInput]("nextToken", _.nextToken),
     int.optional[ListCitiesInput]("pageSize", _.pageSize),
   ){
-    ListCitiesInput.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/ListCitiesOutput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/ListCitiesOutput.scala
@@ -20,7 +20,5 @@ object ListCitiesOutput extends ShapeTag.Companion[ListCitiesOutput] {
   implicit val schema: Schema[ListCitiesOutput] = struct(
     string.optional[ListCitiesOutput]("nextToken", _.nextToken),
     CitySummaries.underlyingSchema.required[ListCitiesOutput]("items", _.items),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/ListCitiesOutput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/ListCitiesOutput.scala
@@ -14,10 +14,13 @@ object ListCitiesOutput extends ShapeTag.Companion[ListCitiesOutput] {
 
   val hints: Hints = Hints.empty
 
+  // constructor using the original order from the spec
+  private def make(nextToken: Option[String], items: List[CitySummary]): ListCitiesOutput = ListCitiesOutput(items, nextToken)
+
   implicit val schema: Schema[ListCitiesOutput] = struct(
-    CitySummaries.underlyingSchema.required[ListCitiesOutput]("items", _.items),
     string.optional[ListCitiesOutput]("nextToken", _.nextToken),
+    CitySummaries.underlyingSchema.required[ListCitiesOutput]("items", _.items),
   ){
-    ListCitiesOutput.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/ListPublishersOutput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/ListPublishersOutput.scala
@@ -20,7 +20,5 @@ object ListPublishersOutput extends ShapeTag.Companion[ListPublishersOutput] {
 
   implicit val schema: Schema[ListPublishersOutput] = struct(
     PublishersList.underlyingSchema.required[ListPublishersOutput]("publishers", _.publishers),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/ListPublishersOutput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/ListPublishersOutput.scala
@@ -15,9 +15,12 @@ object ListPublishersOutput extends ShapeTag.Companion[ListPublishersOutput] {
     smithy.api.Output(),
   ).lazily
 
+  // constructor using the original order from the spec
+  private def make(publishers: List[PublisherId]): ListPublishersOutput = ListPublishersOutput(publishers)
+
   implicit val schema: Schema[ListPublishersOutput] = struct(
     PublishersList.underlyingSchema.required[ListPublishersOutput]("publishers", _.publishers),
   ){
-    ListPublishersOutput.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/MenuItem.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/MenuItem.scala
@@ -14,10 +14,13 @@ object MenuItem extends ShapeTag.Companion[MenuItem] {
 
   val hints: Hints = Hints.empty
 
+  // constructor using the original order from the spec
+  private def make(food: Food, price: Float): MenuItem = MenuItem(food, price)
+
   implicit val schema: Schema[MenuItem] = struct(
     Food.schema.required[MenuItem]("food", _.food),
     float.required[MenuItem]("price", _.price),
   ){
-    MenuItem.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/MenuItem.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/MenuItem.scala
@@ -20,7 +20,5 @@ object MenuItem extends ShapeTag.Companion[MenuItem] {
   implicit val schema: Schema[MenuItem] = struct(
     Food.schema.required[MenuItem]("food", _.food),
     float.required[MenuItem]("price", _.price),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/MixinErrorExample.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/MixinErrorExample.scala
@@ -21,12 +21,15 @@ object MixinErrorExample extends ShapeTag.Companion[MixinErrorExample] {
     smithy.api.Error.CLIENT.widen,
   ).lazily
 
+  // constructor using the original order from the spec
+  private def make(a: Option[String], b: Option[Int], c: Option[Long], d: Option[Boolean]): MixinErrorExample = MixinErrorExample(a, b, c, d)
+
   implicit val schema: Schema[MixinErrorExample] = struct(
     string.optional[MixinErrorExample]("a", _.a),
     int.optional[MixinErrorExample]("b", _.b),
     long.optional[MixinErrorExample]("c", _.c),
     boolean.optional[MixinErrorExample]("d", _.d),
   ){
-    MixinErrorExample.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/MixinErrorExample.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/MixinErrorExample.scala
@@ -29,7 +29,5 @@ object MixinErrorExample extends ShapeTag.Companion[MixinErrorExample] {
     int.optional[MixinErrorExample]("b", _.b),
     long.optional[MixinErrorExample]("c", _.c),
     boolean.optional[MixinErrorExample]("d", _.d),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/MixinExample.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/MixinExample.scala
@@ -17,12 +17,15 @@ object MixinExample extends ShapeTag.Companion[MixinExample] {
 
   val hints: Hints = Hints.empty
 
+  // constructor using the original order from the spec
+  private def make(a: Option[String], b: Option[Int], c: Option[Long], d: Option[Boolean]): MixinExample = MixinExample(a, b, c, d)
+
   implicit val schema: Schema[MixinExample] = struct(
     string.optional[MixinExample]("a", _.a),
     int.optional[MixinExample]("b", _.b),
     long.optional[MixinExample]("c", _.c),
     boolean.optional[MixinExample]("d", _.d),
   ){
-    MixinExample.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/MixinExample.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/MixinExample.scala
@@ -25,7 +25,5 @@ object MixinExample extends ShapeTag.Companion[MixinExample] {
     int.optional[MixinExample]("b", _.b),
     long.optional[MixinExample]("c", _.c),
     boolean.optional[MixinExample]("d", _.d),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/MixinOptionalMemberDefaultAdded.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/MixinOptionalMemberDefaultAdded.scala
@@ -14,9 +14,12 @@ object MixinOptionalMemberDefaultAdded extends ShapeTag.Companion[MixinOptionalM
 
   val hints: Hints = Hints.empty
 
+  // constructor using the original order from the spec
+  private def make(a: String): MixinOptionalMemberDefaultAdded = MixinOptionalMemberDefaultAdded(a)
+
   implicit val schema: Schema[MixinOptionalMemberDefaultAdded] = struct(
     string.field[MixinOptionalMemberDefaultAdded]("a", _.a).addHints(smithy.api.Default(smithy4s.Document.fromString("test"))),
   ){
-    MixinOptionalMemberDefaultAdded.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/MixinOptionalMemberDefaultAdded.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/MixinOptionalMemberDefaultAdded.scala
@@ -19,7 +19,5 @@ object MixinOptionalMemberDefaultAdded extends ShapeTag.Companion[MixinOptionalM
 
   implicit val schema: Schema[MixinOptionalMemberDefaultAdded] = struct(
     string.field[MixinOptionalMemberDefaultAdded]("a", _.a).addHints(smithy.api.Default(smithy4s.Document.fromString("test"))),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/MixinOptionalMemberOverride.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/MixinOptionalMemberOverride.scala
@@ -14,9 +14,12 @@ object MixinOptionalMemberOverride extends ShapeTag.Companion[MixinOptionalMembe
 
   val hints: Hints = Hints.empty
 
+  // constructor using the original order from the spec
+  private def make(a: String): MixinOptionalMemberOverride = MixinOptionalMemberOverride(a)
+
   implicit val schema: Schema[MixinOptionalMemberOverride] = struct(
     string.required[MixinOptionalMemberOverride]("a", _.a),
   ){
-    MixinOptionalMemberOverride.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/MixinOptionalMemberOverride.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/MixinOptionalMemberOverride.scala
@@ -19,7 +19,5 @@ object MixinOptionalMemberOverride extends ShapeTag.Companion[MixinOptionalMembe
 
   implicit val schema: Schema[MixinOptionalMemberOverride] = struct(
     string.required[MixinOptionalMemberOverride]("a", _.a),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/MovieTheater.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/MovieTheater.scala
@@ -22,9 +22,7 @@ object MovieTheater extends ShapeTag.Companion[MovieTheater] {
 
   implicit val schema: Schema[MovieTheater] = struct(
     string.optional[MovieTheater]("name", _.name),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 
   implicit val movieTheaterHash: cats.Hash[MovieTheater] = SchemaVisitorHash.fromSchema(schema)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/MovieTheater.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/MovieTheater.scala
@@ -17,10 +17,13 @@ object MovieTheater extends ShapeTag.Companion[MovieTheater] {
     smithy4s.example.Hash(),
   ).lazily
 
+  // constructor using the original order from the spec
+  private def make(name: Option[String]): MovieTheater = MovieTheater(name)
+
   implicit val schema: Schema[MovieTheater] = struct(
     string.optional[MovieTheater]("name", _.name),
   ){
-    MovieTheater.apply
+    make
   }.withId(id).addHints(hints)
 
   implicit val movieTheaterHash: cats.Hash[MovieTheater] = SchemaVisitorHash.fromSchema(schema)

--- a/modules/bootstrapped/src/generated/smithy4s/example/MyOpError.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/MyOpError.scala
@@ -17,5 +17,6 @@ object MyOpError extends ShapeTag.Companion[MyOpError] {
     smithy.api.Error.CLIENT.widen,
   ).lazily
 
+
   implicit val schema: Schema[MyOpError] = constant(MyOpError()).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/NameFormat.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/NameFormat.scala
@@ -15,5 +15,6 @@ object NameFormat extends ShapeTag.Companion[NameFormat] {
     smithy.api.Trait(selector = Some("string"), structurallyExclusive = None, conflicts = None, breakingChanges = None),
   ).lazily
 
+
   implicit val schema: Schema[NameFormat] = constant(NameFormat()).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/NoMoreSpace.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/NoMoreSpace.scala
@@ -25,10 +25,13 @@ object NoMoreSpace extends ShapeTag.Companion[NoMoreSpace] {
     smithy.api.HttpError(507),
   ).lazily
 
+  // constructor using the original order from the spec
+  private def make(message: String, foo: Option[Foo]): NoMoreSpace = NoMoreSpace(message, foo)
+
   implicit val schema: Schema[NoMoreSpace] = struct(
     string.required[NoMoreSpace]("message", _.message),
     Foo.schema.optional[NoMoreSpace]("foo", _.foo),
   ){
-    NoMoreSpace.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/NoMoreSpace.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/NoMoreSpace.scala
@@ -31,7 +31,5 @@ object NoMoreSpace extends ShapeTag.Companion[NoMoreSpace] {
   implicit val schema: Schema[NoMoreSpace] = struct(
     string.required[NoMoreSpace]("message", _.message),
     Foo.schema.optional[NoMoreSpace]("foo", _.foo),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/NoSuchResource.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/NoSuchResource.scala
@@ -18,9 +18,12 @@ object NoSuchResource extends ShapeTag.Companion[NoSuchResource] {
     smithy.api.Error.CLIENT.widen,
   ).lazily
 
+  // constructor using the original order from the spec
+  private def make(resourceType: String): NoSuchResource = NoSuchResource(resourceType)
+
   implicit val schema: Schema[NoSuchResource] = struct(
     string.required[NoSuchResource]("resourceType", _.resourceType),
   ){
-    NoSuchResource.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/NoSuchResource.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/NoSuchResource.scala
@@ -23,7 +23,5 @@ object NoSuchResource extends ShapeTag.Companion[NoSuchResource] {
 
   implicit val schema: Schema[NoSuchResource] = struct(
     string.required[NoSuchResource]("resourceType", _.resourceType),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/NonEmptyListFormat.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/NonEmptyListFormat.scala
@@ -15,5 +15,6 @@ object NonEmptyListFormat extends ShapeTag.Companion[NonEmptyListFormat] {
     smithy.api.Trait(selector = Some("list"), structurallyExclusive = None, conflicts = None, breakingChanges = None),
   ).lazily
 
+
   implicit val schema: Schema[NonEmptyListFormat] = constant(NonEmptyListFormat()).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/NonEmptyMapFormat.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/NonEmptyMapFormat.scala
@@ -15,5 +15,6 @@ object NonEmptyMapFormat extends ShapeTag.Companion[NonEmptyMapFormat] {
     smithy.api.Trait(selector = Some("map"), structurallyExclusive = None, conflicts = None, breakingChanges = None),
   ).lazily
 
+
   implicit val schema: Schema[NonEmptyMapFormat] = constant(NonEmptyMapFormat()).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/NotFoundError.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/NotFoundError.scala
@@ -19,9 +19,12 @@ object NotFoundError extends ShapeTag.Companion[NotFoundError] {
     smithy.api.HttpError(404),
   ).lazily
 
+  // constructor using the original order from the spec
+  private def make(name: String): NotFoundError = NotFoundError(name)
+
   implicit val schema: Schema[NotFoundError] = struct(
     string.required[NotFoundError]("name", _.name),
   ){
-    NotFoundError.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/NotFoundError.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/NotFoundError.scala
@@ -24,7 +24,5 @@ object NotFoundError extends ShapeTag.Companion[NotFoundError] {
 
   implicit val schema: Schema[NotFoundError] = struct(
     string.required[NotFoundError]("name", _.name),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/Numeric.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/Numeric.scala
@@ -20,6 +20,9 @@ object Numeric extends ShapeTag.Companion[Numeric] {
 
   val hints: Hints = Hints.empty
 
+  // constructor using the original order from the spec
+  private def make(i: Int, f: Float, d: Double, s: Short, l: Long, bi: BigInt, bd: BigDecimal): Numeric = Numeric(i, f, d, s, l, bi, bd)
+
   implicit val schema: Schema[Numeric] = struct(
     int.field[Numeric]("i", _.i).addHints(smithy.api.Default(smithy4s.Document.fromDouble(1.0d))),
     float.field[Numeric]("f", _.f).addHints(smithy.api.Default(smithy4s.Document.fromDouble(1.0d))),
@@ -29,6 +32,6 @@ object Numeric extends ShapeTag.Companion[Numeric] {
     bigint.field[Numeric]("bi", _.bi).addHints(smithy.api.Default(smithy4s.Document.fromDouble(1.0d))),
     bigdecimal.field[Numeric]("bd", _.bd).addHints(smithy.api.Default(smithy4s.Document.fromDouble(1.0d))),
   ){
-    Numeric.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/Numeric.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/Numeric.scala
@@ -31,7 +31,5 @@ object Numeric extends ShapeTag.Companion[Numeric] {
     long.field[Numeric]("l", _.l).addHints(smithy.api.Default(smithy4s.Document.fromDouble(1.0d))),
     bigint.field[Numeric]("bi", _.bi).addHints(smithy.api.Default(smithy4s.Document.fromDouble(1.0d))),
     bigdecimal.field[Numeric]("bd", _.bd).addHints(smithy.api.Default(smithy4s.Document.fromDouble(1.0d))),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/One.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/One.scala
@@ -14,9 +14,12 @@ object One extends ShapeTag.Companion[One] {
 
   val hints: Hints = Hints.empty
 
+  // constructor using the original order from the spec
+  private def make(value: Option[String]): One = One(value)
+
   implicit val schema: Schema[One] = struct(
     string.optional[One]("value", _.value),
   ){
-    One.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/One.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/One.scala
@@ -19,7 +19,5 @@ object One extends ShapeTag.Companion[One] {
 
   implicit val schema: Schema[One] = struct(
     string.optional[One]("value", _.value),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/OperationInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/OperationInput.scala
@@ -16,18 +16,21 @@ object OperationInput extends ShapeTag.Companion[OperationInput] {
     smithy.api.Input(),
   ).lazily
 
+  // constructor using the original order from the spec
+  private def make(optional: Option[String], optionalWithDefault: String, requiredLabel: String, requiredWithDefault: String, optionalHeader: Option[String], optionalHeaderWithDefault: String, requiredHeaderWithDefault: String, optionalQuery: Option[String], optionalQueryWithDefault: String, requiredQueryWithDefault: String): OperationInput = OperationInput(optionalWithDefault, requiredLabel, requiredWithDefault, optionalHeaderWithDefault, requiredHeaderWithDefault, optionalQueryWithDefault, requiredQueryWithDefault, optional, optionalHeader, optionalQuery)
+
   implicit val schema: Schema[OperationInput] = struct(
+    string.optional[OperationInput]("optional", _.optional),
     string.field[OperationInput]("optionalWithDefault", _.optionalWithDefault).addHints(smithy.api.Default(smithy4s.Document.fromString("optional-default"))),
     string.required[OperationInput]("requiredLabel", _.requiredLabel).addHints(smithy.api.Default(smithy4s.Document.fromString("required-label-with-default")), smithy.api.HttpLabel()),
     string.required[OperationInput]("requiredWithDefault", _.requiredWithDefault).addHints(smithy.api.Default(smithy4s.Document.fromString("required-default"))),
+    string.optional[OperationInput]("optionalHeader", _.optionalHeader).addHints(smithy.api.HttpHeader("optional-header")),
     string.field[OperationInput]("optionalHeaderWithDefault", _.optionalHeaderWithDefault).addHints(smithy.api.Default(smithy4s.Document.fromString("optional-header-with-default")), smithy.api.HttpHeader("optional-header-with-default")),
     string.required[OperationInput]("requiredHeaderWithDefault", _.requiredHeaderWithDefault).addHints(smithy.api.Default(smithy4s.Document.fromString("required-header-with-default")), smithy.api.HttpHeader("required-header-with-default")),
+    string.optional[OperationInput]("optionalQuery", _.optionalQuery).addHints(smithy.api.HttpQuery("optional-query")),
     string.field[OperationInput]("optionalQueryWithDefault", _.optionalQueryWithDefault).addHints(smithy.api.Default(smithy4s.Document.fromString("optional-query-with-default")), smithy.api.HttpQuery("optional-query-with-default")),
     string.field[OperationInput]("requiredQueryWithDefault", _.requiredQueryWithDefault).addHints(smithy.api.Default(smithy4s.Document.fromString("required-query-with-default")), smithy.api.HttpQuery("required-query-with-default")),
-    string.optional[OperationInput]("optional", _.optional),
-    string.optional[OperationInput]("optionalHeader", _.optionalHeader).addHints(smithy.api.HttpHeader("optional-header")),
-    string.optional[OperationInput]("optionalQuery", _.optionalQuery).addHints(smithy.api.HttpQuery("optional-query")),
   ){
-    OperationInput.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/OperationInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/OperationInput.scala
@@ -30,7 +30,5 @@ object OperationInput extends ShapeTag.Companion[OperationInput] {
     string.optional[OperationInput]("optionalQuery", _.optionalQuery).addHints(smithy.api.HttpQuery("optional-query")),
     string.field[OperationInput]("optionalQueryWithDefault", _.optionalQueryWithDefault).addHints(smithy.api.Default(smithy4s.Document.fromString("optional-query-with-default")), smithy.api.HttpQuery("optional-query-with-default")),
     string.field[OperationInput]("requiredQueryWithDefault", _.requiredQueryWithDefault).addHints(smithy.api.Default(smithy4s.Document.fromString("required-query-with-default")), smithy.api.HttpQuery("required-query-with-default")),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/OperationOutput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/OperationOutput.scala
@@ -26,7 +26,5 @@ object OperationOutput extends ShapeTag.Companion[OperationOutput] {
     string.optional[OperationOutput]("optionalHeader", _.optionalHeader).addHints(smithy.api.HttpHeader("optional-header")),
     string.field[OperationOutput]("optionalHeaderWithDefault", _.optionalHeaderWithDefault).addHints(smithy.api.Default(smithy4s.Document.fromString("optional-header-with-default")), smithy.api.HttpHeader("optional-header-with-default")),
     string.required[OperationOutput]("requiredHeaderWithDefault", _.requiredHeaderWithDefault).addHints(smithy.api.Default(smithy4s.Document.fromString("required-header-with-default")), smithy.api.HttpHeader("required-header-with-default")),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/OperationOutput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/OperationOutput.scala
@@ -16,14 +16,17 @@ object OperationOutput extends ShapeTag.Companion[OperationOutput] {
     smithy.api.Output(),
   ).lazily
 
+  // constructor using the original order from the spec
+  private def make(optional: Option[String], optionalWithDefault: String, requiredWithDefault: String, optionalHeader: Option[String], optionalHeaderWithDefault: String, requiredHeaderWithDefault: String): OperationOutput = OperationOutput(optionalWithDefault, requiredWithDefault, optionalHeaderWithDefault, requiredHeaderWithDefault, optional, optionalHeader)
+
   implicit val schema: Schema[OperationOutput] = struct(
+    string.optional[OperationOutput]("optional", _.optional),
     string.field[OperationOutput]("optionalWithDefault", _.optionalWithDefault).addHints(smithy.api.Default(smithy4s.Document.fromString("optional-default"))),
     string.required[OperationOutput]("requiredWithDefault", _.requiredWithDefault).addHints(smithy.api.Default(smithy4s.Document.fromString("required-default"))),
+    string.optional[OperationOutput]("optionalHeader", _.optionalHeader).addHints(smithy.api.HttpHeader("optional-header")),
     string.field[OperationOutput]("optionalHeaderWithDefault", _.optionalHeaderWithDefault).addHints(smithy.api.Default(smithy4s.Document.fromString("optional-header-with-default")), smithy.api.HttpHeader("optional-header-with-default")),
     string.required[OperationOutput]("requiredHeaderWithDefault", _.requiredHeaderWithDefault).addHints(smithy.api.Default(smithy4s.Document.fromString("required-header-with-default")), smithy.api.HttpHeader("required-header-with-default")),
-    string.optional[OperationOutput]("optional", _.optional),
-    string.optional[OperationOutput]("optionalHeader", _.optionalHeader).addHints(smithy.api.HttpHeader("optional-header")),
   ){
-    OperationOutput.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/OpticsStructure.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/OpticsStructure.scala
@@ -18,9 +18,12 @@ object OpticsStructure extends ShapeTag.Companion[OpticsStructure] {
     val two: Lens[OpticsStructure, Option[OpticsEnum]] = Lens[OpticsStructure, Option[OpticsEnum]](_.two)(n => a => a.copy(two = n))
   }
 
+  // constructor using the original order from the spec
+  private def make(two: Option[OpticsEnum]): OpticsStructure = OpticsStructure(two)
+
   implicit val schema: Schema[OpticsStructure] = struct(
     OpticsEnum.schema.optional[OpticsStructure]("two", _.two),
   ){
-    OpticsStructure.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/OpticsStructure.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/OpticsStructure.scala
@@ -23,7 +23,5 @@ object OpticsStructure extends ShapeTag.Companion[OpticsStructure] {
 
   implicit val schema: Schema[OpticsStructure] = struct(
     OpticsEnum.schema.optional[OpticsStructure]("two", _.two),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/OptionalOutputOutput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/OptionalOutputOutput.scala
@@ -16,9 +16,12 @@ object OptionalOutputOutput extends ShapeTag.Companion[OptionalOutputOutput] {
     smithy.api.Output(),
   ).lazily
 
+  // constructor using the original order from the spec
+  private def make(body: Option[String]): OptionalOutputOutput = OptionalOutputOutput(body)
+
   implicit val schema: Schema[OptionalOutputOutput] = struct(
     string.optional[OptionalOutputOutput]("body", _.body).addHints(smithy.api.HttpPayload()),
   ){
-    OptionalOutputOutput.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/OptionalOutputOutput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/OptionalOutputOutput.scala
@@ -21,7 +21,5 @@ object OptionalOutputOutput extends ShapeTag.Companion[OptionalOutputOutput] {
 
   implicit val schema: Schema[OptionalOutputOutput] = struct(
     string.optional[OptionalOutputOutput]("body", _.body).addHints(smithy.api.HttpPayload()),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/OrderType.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/OrderType.scala
@@ -55,11 +55,14 @@ object OrderType extends ShapeTag.Companion[OrderType] {
       smithy.api.Documentation("For an InStoreOrder a location ID isn\'t needed"),
     ).lazily
 
+    // constructor using the original order from the spec
+    private def make(id: OrderNumber, locationId: Option[String]): InStoreOrder = InStoreOrder(id, locationId)
+
     val schema: Schema[InStoreOrder] = struct(
       OrderNumber.schema.required[InStoreOrder]("id", _.id),
       string.optional[InStoreOrder]("locationId", _.locationId),
     ){
-      InStoreOrder.apply
+      make
     }.withId(id).addHints(hints)
 
     val alt = schema.oneOf[OrderType]("inStore")

--- a/modules/bootstrapped/src/generated/smithy4s/example/OrderType.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/OrderType.scala
@@ -61,9 +61,7 @@ object OrderType extends ShapeTag.Companion[OrderType] {
     val schema: Schema[InStoreOrder] = struct(
       OrderNumber.schema.required[InStoreOrder]("id", _.id),
       string.optional[InStoreOrder]("locationId", _.locationId),
-    ){
-      make
-    }.withId(id).addHints(hints)
+    )(make).withId(id).addHints(hints)
 
     val alt = schema.oneOf[OrderType]("inStore")
   }

--- a/modules/bootstrapped/src/generated/smithy4s/example/PackedInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/PackedInput.scala
@@ -14,9 +14,12 @@ object PackedInput extends ShapeTag.Companion[PackedInput] {
 
   val hints: Hints = Hints.empty
 
+  // constructor using the original order from the spec
+  private def make(key: String): PackedInput = PackedInput(key)
+
   implicit val schema: Schema[PackedInput] = struct(
     string.required[PackedInput]("key", _.key),
   ){
-    PackedInput.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/PackedInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/PackedInput.scala
@@ -19,7 +19,5 @@ object PackedInput extends ShapeTag.Companion[PackedInput] {
 
   implicit val schema: Schema[PackedInput] = struct(
     string.required[PackedInput]("key", _.key),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/Patchable.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/Patchable.scala
@@ -15,9 +15,12 @@ object Patchable extends ShapeTag.Companion[Patchable] {
 
   val hints: Hints = Hints.empty
 
+  // constructor using the original order from the spec
+  private def make(allowExplicitNull: Option[Nullable[Int]]): Patchable = Patchable(allowExplicitNull)
+
   implicit val schema: Schema[Patchable] = struct(
     int.nullable.optional[Patchable]("allowExplicitNull", _.allowExplicitNull),
   ){
-    Patchable.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/Patchable.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/Patchable.scala
@@ -20,7 +20,5 @@ object Patchable extends ShapeTag.Companion[Patchable] {
 
   implicit val schema: Schema[Patchable] = struct(
     int.nullable.optional[Patchable]("allowExplicitNull", _.allowExplicitNull),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/PatchableEdgeCases.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/PatchableEdgeCases.scala
@@ -25,7 +25,5 @@ object PatchableEdgeCases extends ShapeTag.Companion[PatchableEdgeCases] {
     int.nullable.required[PatchableEdgeCases]("requiredDefaultNull", _.requiredDefaultNull).addHints(smithy.api.Default(smithy4s.Document.nullDoc)),
     int.nullable.field[PatchableEdgeCases]("defaultValue", _.defaultValue).addHints(smithy.api.Default(smithy4s.Document.fromDouble(5.0d))),
     int.nullable.field[PatchableEdgeCases]("defaultNull", _.defaultNull).addHints(smithy.api.Default(smithy4s.Document.nullDoc)),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/PatchableEdgeCases.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/PatchableEdgeCases.scala
@@ -16,6 +16,9 @@ object PatchableEdgeCases extends ShapeTag.Companion[PatchableEdgeCases] {
 
   val hints: Hints = Hints.empty
 
+  // constructor using the original order from the spec
+  private def make(required: Nullable[Int], requiredDefaultValue: Nullable[Int], requiredDefaultNull: Nullable[Int], defaultValue: Nullable[Int], defaultNull: Nullable[Int]): PatchableEdgeCases = PatchableEdgeCases(required, requiredDefaultValue, requiredDefaultNull, defaultValue, defaultNull)
+
   implicit val schema: Schema[PatchableEdgeCases] = struct(
     int.nullable.required[PatchableEdgeCases]("required", _.required),
     int.nullable.required[PatchableEdgeCases]("requiredDefaultValue", _.requiredDefaultValue).addHints(smithy.api.Default(smithy4s.Document.fromDouble(3.0d))),
@@ -23,6 +26,6 @@ object PatchableEdgeCases extends ShapeTag.Companion[PatchableEdgeCases] {
     int.nullable.field[PatchableEdgeCases]("defaultValue", _.defaultValue).addHints(smithy.api.Default(smithy4s.Document.fromDouble(5.0d))),
     int.nullable.field[PatchableEdgeCases]("defaultNull", _.defaultNull).addHints(smithy.api.Default(smithy4s.Document.nullDoc)),
   ){
-    PatchableEdgeCases.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/PathParams.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/PathParams.scala
@@ -30,7 +30,5 @@ object PathParams extends ShapeTag.Companion[PathParams] {
     timestamp.required[PathParams]("ts4", _.ts4).addHints(smithy.api.TimestampFormat.HTTP_DATE.widen, smithy.api.HttpLabel()),
     boolean.required[PathParams]("b", _.b).addHints(smithy.api.HttpLabel()),
     Numbers.schema.required[PathParams]("ie", _.ie).addHints(smithy.api.HttpLabel()),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/PathParams.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/PathParams.scala
@@ -18,6 +18,9 @@ object PathParams extends ShapeTag.Companion[PathParams] {
 
   val hints: Hints = Hints.empty
 
+  // constructor using the original order from the spec
+  private def make(str: String, int: Int, ts1: Timestamp, ts2: Timestamp, ts3: Timestamp, ts4: Timestamp, b: Boolean, ie: Numbers): PathParams = PathParams(str, int, ts1, ts2, ts3, ts4, b, ie)
+
   implicit val schema: Schema[PathParams] = struct(
     string.required[PathParams]("str", _.str).addHints(smithy.api.HttpLabel()),
     int.required[PathParams]("int", _.int).addHints(smithy.api.HttpLabel()),
@@ -28,6 +31,6 @@ object PathParams extends ShapeTag.Companion[PathParams] {
     boolean.required[PathParams]("b", _.b).addHints(smithy.api.HttpLabel()),
     Numbers.schema.required[PathParams]("ie", _.ie).addHints(smithy.api.HttpLabel()),
   ){
-    PathParams.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/PayloadData.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/PayloadData.scala
@@ -18,7 +18,5 @@ object PayloadData extends ShapeTag.Companion[PayloadData] {
 
   implicit val schema: Schema[PayloadData] = struct(
     TestBiggerUnion.schema.optional[PayloadData]("testBiggerUnion", _.testBiggerUnion),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/PayloadData.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/PayloadData.scala
@@ -13,9 +13,12 @@ object PayloadData extends ShapeTag.Companion[PayloadData] {
 
   val hints: Hints = Hints.empty
 
+  // constructor using the original order from the spec
+  private def make(testBiggerUnion: Option[TestBiggerUnion]): PayloadData = PayloadData(testBiggerUnion)
+
   implicit val schema: Schema[PayloadData] = struct(
     TestBiggerUnion.schema.optional[PayloadData]("testBiggerUnion", _.testBiggerUnion),
   ){
-    PayloadData.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/Pizza.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/Pizza.scala
@@ -21,7 +21,5 @@ object Pizza extends ShapeTag.Companion[Pizza] {
     string.required[Pizza]("name", _.name),
     PizzaBase.schema.required[Pizza]("base", _.base),
     Ingredients.underlyingSchema.required[Pizza]("toppings", _.toppings),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/Pizza.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/Pizza.scala
@@ -14,11 +14,14 @@ object Pizza extends ShapeTag.Companion[Pizza] {
 
   val hints: Hints = Hints.empty
 
+  // constructor using the original order from the spec
+  private def make(name: String, base: PizzaBase, toppings: List[Ingredient]): Pizza = Pizza(name, base, toppings)
+
   implicit val schema: Schema[Pizza] = struct(
     string.required[Pizza]("name", _.name),
     PizzaBase.schema.required[Pizza]("base", _.base),
     Ingredients.underlyingSchema.required[Pizza]("toppings", _.toppings),
   ){
-    Pizza.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/Podcast.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/Podcast.scala
@@ -54,12 +54,15 @@ object Podcast extends ShapeTag.Companion[Podcast] {
       val durationMillis: Lens[Video, Option[Long]] = Lens[Video, Option[Long]](_.durationMillis)(n => a => a.copy(durationMillis = n))
     }
 
+    // constructor using the original order from the spec
+    private def make(title: Option[String], url: Option[String], durationMillis: Option[Long]): Video = Video(title, url, durationMillis)
+
     val schema: Schema[Video] = struct(
       string.optional[Video]("title", _.title),
       string.optional[Video]("url", _.url),
       long.optional[Video]("durationMillis", _.durationMillis),
     ){
-      Video.apply
+      make
     }.withId(id).addHints(hints)
 
     val alt = schema.oneOf[Podcast]("video")
@@ -79,12 +82,15 @@ object Podcast extends ShapeTag.Companion[Podcast] {
       val durationMillis: Lens[Audio, Option[Long]] = Lens[Audio, Option[Long]](_.durationMillis)(n => a => a.copy(durationMillis = n))
     }
 
+    // constructor using the original order from the spec
+    private def make(title: Option[String], url: Option[String], durationMillis: Option[Long]): Audio = Audio(title, url, durationMillis)
+
     val schema: Schema[Audio] = struct(
       string.optional[Audio]("title", _.title),
       string.optional[Audio]("url", _.url),
       long.optional[Audio]("durationMillis", _.durationMillis),
     ){
-      Audio.apply
+      make
     }.withId(id).addHints(hints)
 
     val alt = schema.oneOf[Podcast]("audio")

--- a/modules/bootstrapped/src/generated/smithy4s/example/Podcast.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/Podcast.scala
@@ -61,9 +61,7 @@ object Podcast extends ShapeTag.Companion[Podcast] {
       string.optional[Video]("title", _.title),
       string.optional[Video]("url", _.url),
       long.optional[Video]("durationMillis", _.durationMillis),
-    ){
-      make
-    }.withId(id).addHints(hints)
+    )(make).withId(id).addHints(hints)
 
     val alt = schema.oneOf[Podcast]("video")
   }
@@ -89,9 +87,7 @@ object Podcast extends ShapeTag.Companion[Podcast] {
       string.optional[Audio]("title", _.title),
       string.optional[Audio]("url", _.url),
       long.optional[Audio]("durationMillis", _.durationMillis),
-    ){
-      make
-    }.withId(id).addHints(hints)
+    )(make).withId(id).addHints(hints)
 
     val alt = schema.oneOf[Podcast]("audio")
   }

--- a/modules/bootstrapped/src/generated/smithy4s/example/PriceError.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/PriceError.scala
@@ -20,10 +20,13 @@ object PriceError extends ShapeTag.Companion[PriceError] {
     smithy.api.Error.CLIENT.widen,
   ).lazily
 
+  // constructor using the original order from the spec
+  private def make(message: String, code: Int): PriceError = PriceError(message, code)
+
   implicit val schema: Schema[PriceError] = struct(
     string.required[PriceError]("message", _.message),
     int.required[PriceError]("code", _.code).addHints(smithy.api.HttpHeader("X-CODE")),
   ){
-    PriceError.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/PriceError.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/PriceError.scala
@@ -26,7 +26,5 @@ object PriceError extends ShapeTag.Companion[PriceError] {
   implicit val schema: Schema[PriceError] = struct(
     string.required[PriceError]("message", _.message),
     int.required[PriceError]("code", _.code).addHints(smithy.api.HttpHeader("X-CODE")),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/Product.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/Product.scala
@@ -13,5 +13,6 @@ object Product extends ShapeTag.Companion[Product] {
 
   val hints: Hints = Hints.empty
 
+
   implicit val schema: Schema[Product] = constant(Product()).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/PutObjectInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/PutObjectInput.scala
@@ -26,7 +26,5 @@ object PutObjectInput extends ShapeTag.Companion[PutObjectInput] {
     LowHigh.schema.optional[PutObjectInput]("foo", _.foo).addHints(smithy.api.HttpHeader("X-Foo")),
     SomeValue.schema.optional[PutObjectInput]("someValue", _.someValue).addHints(smithy.api.HttpQuery("paramName")),
     string.required[PutObjectInput]("data", _.data).addHints(smithy.api.HttpPayload()),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/PutObjectInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/PutObjectInput.scala
@@ -17,13 +17,16 @@ object PutObjectInput extends ShapeTag.Companion[PutObjectInput] {
     smithy.api.Documentation("A key and bucket is always required for putting a new file in a bucket"),
   ).lazily
 
+  // constructor using the original order from the spec
+  private def make(key: ObjectKey, bucketName: BucketName, foo: Option[LowHigh], someValue: Option[SomeValue], data: String): PutObjectInput = PutObjectInput(key, bucketName, data, foo, someValue)
+
   implicit val schema: Schema[PutObjectInput] = struct(
     ObjectKey.schema.required[PutObjectInput]("key", _.key).addHints(smithy.api.HttpLabel()),
     BucketName.schema.required[PutObjectInput]("bucketName", _.bucketName).addHints(smithy.api.HttpLabel()),
-    string.required[PutObjectInput]("data", _.data).addHints(smithy.api.HttpPayload()),
     LowHigh.schema.optional[PutObjectInput]("foo", _.foo).addHints(smithy.api.HttpHeader("X-Foo")),
     SomeValue.schema.optional[PutObjectInput]("someValue", _.someValue).addHints(smithy.api.HttpQuery("paramName")),
+    string.required[PutObjectInput]("data", _.data).addHints(smithy.api.HttpPayload()),
   ){
-    PutObjectInput.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/PutStreamedObjectInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/PutStreamedObjectInput.scala
@@ -19,7 +19,5 @@ object PutStreamedObjectInput extends ShapeTag.Companion[PutStreamedObjectInput]
 
   implicit val schema: Schema[PutStreamedObjectInput] = struct(
     string.required[PutStreamedObjectInput]("key", _.key),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/PutStreamedObjectInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/PutStreamedObjectInput.scala
@@ -14,9 +14,12 @@ object PutStreamedObjectInput extends ShapeTag.Companion[PutStreamedObjectInput]
 
   val hints: Hints = Hints.empty
 
+  // constructor using the original order from the spec
+  private def make(key: String): PutStreamedObjectInput = PutStreamedObjectInput(key)
+
   implicit val schema: Schema[PutStreamedObjectInput] = struct(
     string.required[PutStreamedObjectInput]("key", _.key),
   ){
-    PutStreamedObjectInput.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/Queries.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/Queries.scala
@@ -18,6 +18,9 @@ object Queries extends ShapeTag.Companion[Queries] {
 
   val hints: Hints = Hints.empty
 
+  // constructor using the original order from the spec
+  private def make(str: Option[String], int: Option[Int], ts1: Option[Timestamp], ts2: Option[Timestamp], ts3: Option[Timestamp], ts4: Option[Timestamp], b: Option[Boolean], sl: Option[List[String]], ie: Option[Numbers], on: Option[OpenNums], ons: Option[OpenNumsStr], slm: Option[Map[String, String]]): Queries = Queries(str, int, ts1, ts2, ts3, ts4, b, sl, ie, on, ons, slm)
+
   implicit val schema: Schema[Queries] = struct(
     string.optional[Queries]("str", _.str).addHints(smithy.api.HttpQuery("str")),
     int.optional[Queries]("int", _.int).addHints(smithy.api.HttpQuery("int")),
@@ -32,6 +35,6 @@ object Queries extends ShapeTag.Companion[Queries] {
     OpenNumsStr.schema.optional[Queries]("ons", _.ons).addHints(smithy.api.HttpQuery("openNumsStr")),
     StringMap.underlyingSchema.optional[Queries]("slm", _.slm).addHints(smithy.api.HttpQueryParams()),
   ){
-    Queries.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/Queries.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/Queries.scala
@@ -34,7 +34,5 @@ object Queries extends ShapeTag.Companion[Queries] {
     OpenNums.schema.optional[Queries]("on", _.on).addHints(smithy.api.HttpQuery("openNums")),
     OpenNumsStr.schema.optional[Queries]("ons", _.ons).addHints(smithy.api.HttpQuery("openNumsStr")),
     StringMap.underlyingSchema.optional[Queries]("slm", _.slm).addHints(smithy.api.HttpQueryParams()),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/QueriesWithDefaults.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/QueriesWithDefaults.scala
@@ -19,7 +19,5 @@ object QueriesWithDefaults extends ShapeTag.Companion[QueriesWithDefaults] {
 
   implicit val schema: Schema[QueriesWithDefaults] = struct(
     string.field[QueriesWithDefaults]("dflt", _.dflt).addHints(smithy.api.Default(smithy4s.Document.fromString("test")), smithy.api.HttpQuery("dflt")),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/QueriesWithDefaults.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/QueriesWithDefaults.scala
@@ -14,9 +14,12 @@ object QueriesWithDefaults extends ShapeTag.Companion[QueriesWithDefaults] {
 
   val hints: Hints = Hints.empty
 
+  // constructor using the original order from the spec
+  private def make(dflt: String): QueriesWithDefaults = QueriesWithDefaults(dflt)
+
   implicit val schema: Schema[QueriesWithDefaults] = struct(
     string.field[QueriesWithDefaults]("dflt", _.dflt).addHints(smithy.api.Default(smithy4s.Document.fromString("test")), smithy.api.HttpQuery("dflt")),
   ){
-    QueriesWithDefaults.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/RandomOtherClientError.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/RandomOtherClientError.scala
@@ -19,9 +19,12 @@ object RandomOtherClientError extends ShapeTag.Companion[RandomOtherClientError]
     smithy.api.Error.CLIENT.widen,
   ).lazily
 
+  // constructor using the original order from the spec
+  private def make(message: Option[String]): RandomOtherClientError = RandomOtherClientError(message)
+
   implicit val schema: Schema[RandomOtherClientError] = struct(
     string.optional[RandomOtherClientError]("message", _.message),
   ){
-    RandomOtherClientError.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/RandomOtherClientError.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/RandomOtherClientError.scala
@@ -24,7 +24,5 @@ object RandomOtherClientError extends ShapeTag.Companion[RandomOtherClientError]
 
   implicit val schema: Schema[RandomOtherClientError] = struct(
     string.optional[RandomOtherClientError]("message", _.message),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/RandomOtherClientErrorWithCode.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/RandomOtherClientErrorWithCode.scala
@@ -20,9 +20,12 @@ object RandomOtherClientErrorWithCode extends ShapeTag.Companion[RandomOtherClie
     smithy.api.HttpError(404),
   ).lazily
 
+  // constructor using the original order from the spec
+  private def make(message: Option[String]): RandomOtherClientErrorWithCode = RandomOtherClientErrorWithCode(message)
+
   implicit val schema: Schema[RandomOtherClientErrorWithCode] = struct(
     string.optional[RandomOtherClientErrorWithCode]("message", _.message),
   ){
-    RandomOtherClientErrorWithCode.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/RandomOtherClientErrorWithCode.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/RandomOtherClientErrorWithCode.scala
@@ -25,7 +25,5 @@ object RandomOtherClientErrorWithCode extends ShapeTag.Companion[RandomOtherClie
 
   implicit val schema: Schema[RandomOtherClientErrorWithCode] = struct(
     string.optional[RandomOtherClientErrorWithCode]("message", _.message),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/RandomOtherServerError.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/RandomOtherServerError.scala
@@ -24,7 +24,5 @@ object RandomOtherServerError extends ShapeTag.Companion[RandomOtherServerError]
 
   implicit val schema: Schema[RandomOtherServerError] = struct(
     string.optional[RandomOtherServerError]("message", _.message),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/RandomOtherServerError.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/RandomOtherServerError.scala
@@ -19,9 +19,12 @@ object RandomOtherServerError extends ShapeTag.Companion[RandomOtherServerError]
     smithy.api.Error.SERVER.widen,
   ).lazily
 
+  // constructor using the original order from the spec
+  private def make(message: Option[String]): RandomOtherServerError = RandomOtherServerError(message)
+
   implicit val schema: Schema[RandomOtherServerError] = struct(
     string.optional[RandomOtherServerError]("message", _.message),
   ){
-    RandomOtherServerError.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/RandomOtherServerErrorWithCode.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/RandomOtherServerErrorWithCode.scala
@@ -20,9 +20,12 @@ object RandomOtherServerErrorWithCode extends ShapeTag.Companion[RandomOtherServ
     smithy.api.HttpError(503),
   ).lazily
 
+  // constructor using the original order from the spec
+  private def make(message: Option[String]): RandomOtherServerErrorWithCode = RandomOtherServerErrorWithCode(message)
+
   implicit val schema: Schema[RandomOtherServerErrorWithCode] = struct(
     string.optional[RandomOtherServerErrorWithCode]("message", _.message),
   ){
-    RandomOtherServerErrorWithCode.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/RandomOtherServerErrorWithCode.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/RandomOtherServerErrorWithCode.scala
@@ -25,7 +25,5 @@ object RandomOtherServerErrorWithCode extends ShapeTag.Companion[RandomOtherServ
 
   implicit val schema: Schema[RandomOtherServerErrorWithCode] = struct(
     string.optional[RandomOtherServerErrorWithCode]("message", _.message),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/RangeCheck.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/RangeCheck.scala
@@ -21,7 +21,5 @@ object RangeCheck extends ShapeTag.Companion[RangeCheck] {
 
   implicit val schema: Schema[RangeCheck] = struct(
     int.validated(smithy.api.Range(min = Some(scala.math.BigDecimal(1.0)), max = None)).required[RangeCheck]("qty", _.qty),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/RangeCheck.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/RangeCheck.scala
@@ -16,9 +16,12 @@ object RangeCheck extends ShapeTag.Companion[RangeCheck] {
     smithy.api.Suppress(List("UnreferencedShape")),
   ).lazily
 
+  // constructor using the original order from the spec
+  private def make(qty: Int): RangeCheck = RangeCheck(qty)
+
   implicit val schema: Schema[RangeCheck] = struct(
     int.validated(smithy.api.Range(min = Some(scala.math.BigDecimal(1.0)), max = None)).required[RangeCheck]("qty", _.qty),
   ){
-    RangeCheck.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/RecursiveInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/RecursiveInput.scala
@@ -14,9 +14,12 @@ object RecursiveInput extends ShapeTag.Companion[RecursiveInput] {
 
   val hints: Hints = Hints.empty
 
+  // constructor using the original order from the spec
+  private def make(hello: Option[smithy4s.example.RecursiveInput]): RecursiveInput = RecursiveInput(hello)
+
   implicit val schema: Schema[RecursiveInput] = recursive(struct(
     smithy4s.example.RecursiveInput.schema.optional[RecursiveInput]("hello", _.hello),
   ){
-    RecursiveInput.apply
+    make
   }.withId(id).addHints(hints))
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/RecursiveInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/RecursiveInput.scala
@@ -19,7 +19,5 @@ object RecursiveInput extends ShapeTag.Companion[RecursiveInput] {
 
   implicit val schema: Schema[RecursiveInput] = recursive(struct(
     smithy4s.example.RecursiveInput.schema.optional[RecursiveInput]("hello", _.hello),
-  ){
-    make
-  }.withId(id).addHints(hints))
+  )(make).withId(id).addHints(hints))
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/RecursiveTraitStructure.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/RecursiveTraitStructure.scala
@@ -17,9 +17,12 @@ object RecursiveTraitStructure extends ShapeTag.Companion[RecursiveTraitStructur
     smithy.api.Trait(selector = None, structurallyExclusive = None, conflicts = None, breakingChanges = None),
   ).lazily
 
+  // constructor using the original order from the spec
+  private def make(name: Option[String]): RecursiveTraitStructure = RecursiveTraitStructure(name)
+
   implicit val schema: Schema[RecursiveTraitStructure] = recursive(struct(
     string.optional[RecursiveTraitStructure]("name", _.name).addHints(smithy4s.example.RecursiveTraitStructure(name = None)),
   ){
-    RecursiveTraitStructure.apply
+    make
   }.withId(id).addHints(hints))
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/RecursiveTraitStructure.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/RecursiveTraitStructure.scala
@@ -22,7 +22,5 @@ object RecursiveTraitStructure extends ShapeTag.Companion[RecursiveTraitStructur
 
   implicit val schema: Schema[RecursiveTraitStructure] = recursive(struct(
     string.optional[RecursiveTraitStructure]("name", _.name).addHints(smithy4s.example.RecursiveTraitStructure(name = None)),
-  ){
-    make
-  }.withId(id).addHints(hints))
+  )(make).withId(id).addHints(hints))
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/ReservationInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/ReservationInput.scala
@@ -16,10 +16,13 @@ object ReservationInput extends ShapeTag.Companion[ReservationInput] {
     smithy.api.Input(),
   ).lazily
 
+  // constructor using the original order from the spec
+  private def make(name: String, town: Option[String]): ReservationInput = ReservationInput(name, town)
+
   implicit val schema: Schema[ReservationInput] = struct(
     string.required[ReservationInput]("name", _.name).addHints(smithy.api.HttpLabel()),
     string.optional[ReservationInput]("town", _.town).addHints(smithy.api.HttpQuery("town")),
   ){
-    ReservationInput.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/ReservationInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/ReservationInput.scala
@@ -22,7 +22,5 @@ object ReservationInput extends ShapeTag.Companion[ReservationInput] {
   implicit val schema: Schema[ReservationInput] = struct(
     string.required[ReservationInput]("name", _.name).addHints(smithy.api.HttpLabel()),
     string.optional[ReservationInput]("town", _.town).addHints(smithy.api.HttpQuery("town")),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/ReservationOutput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/ReservationOutput.scala
@@ -16,9 +16,12 @@ object ReservationOutput extends ShapeTag.Companion[ReservationOutput] {
     smithy.api.Output(),
   ).lazily
 
+  // constructor using the original order from the spec
+  private def make(message: String): ReservationOutput = ReservationOutput(message)
+
   implicit val schema: Schema[ReservationOutput] = struct(
     string.required[ReservationOutput]("message", _.message),
   ){
-    ReservationOutput.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/ReservationOutput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/ReservationOutput.scala
@@ -21,7 +21,5 @@ object ReservationOutput extends ShapeTag.Companion[ReservationOutput] {
 
   implicit val schema: Schema[ReservationOutput] = struct(
     string.required[ReservationOutput]("message", _.message),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/RoundTripData.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/RoundTripData.scala
@@ -14,12 +14,15 @@ object RoundTripData extends ShapeTag.Companion[RoundTripData] {
 
   val hints: Hints = Hints.empty
 
+  // constructor using the original order from the spec
+  private def make(label: String, header: Option[String], query: Option[String], body: Option[String]): RoundTripData = RoundTripData(label, header, query, body)
+
   implicit val schema: Schema[RoundTripData] = struct(
     string.required[RoundTripData]("label", _.label).addHints(smithy.api.HttpLabel()),
     string.optional[RoundTripData]("header", _.header).addHints(smithy.api.HttpHeader("HEADER")),
     string.optional[RoundTripData]("query", _.query).addHints(smithy.api.HttpQuery("query")),
     string.optional[RoundTripData]("body", _.body),
   ){
-    RoundTripData.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/RoundTripData.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/RoundTripData.scala
@@ -22,7 +22,5 @@ object RoundTripData extends ShapeTag.Companion[RoundTripData] {
     string.optional[RoundTripData]("header", _.header).addHints(smithy.api.HttpHeader("HEADER")),
     string.optional[RoundTripData]("query", _.query).addHints(smithy.api.HttpQuery("query")),
     string.optional[RoundTripData]("body", _.body),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/Salad.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/Salad.scala
@@ -20,7 +20,5 @@ object Salad extends ShapeTag.Companion[Salad] {
   implicit val schema: Schema[Salad] = struct(
     string.required[Salad]("name", _.name),
     Ingredients.underlyingSchema.required[Salad]("ingredients", _.ingredients),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/Salad.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/Salad.scala
@@ -14,10 +14,13 @@ object Salad extends ShapeTag.Companion[Salad] {
 
   val hints: Hints = Hints.empty
 
+  // constructor using the original order from the spec
+  private def make(name: String, ingredients: List[Ingredient]): Salad = Salad(name, ingredients)
+
   implicit val schema: Schema[Salad] = struct(
     string.required[Salad]("name", _.name),
     Ingredients.underlyingSchema.required[Salad]("ingredients", _.ingredients),
   ){
-    Salad.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/Serializable.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/Serializable.scala
@@ -13,5 +13,6 @@ object Serializable extends ShapeTag.Companion[Serializable] {
 
   val hints: Hints = Hints.empty
 
+
   implicit val schema: Schema[Serializable] = constant(Serializable()).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/ServerError.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/ServerError.scala
@@ -24,7 +24,5 @@ object ServerError extends ShapeTag.Companion[ServerError] {
 
   implicit val schema: Schema[ServerError] = struct(
     string.optional[ServerError]("message", _.message),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/ServerError.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/ServerError.scala
@@ -19,9 +19,12 @@ object ServerError extends ShapeTag.Companion[ServerError] {
     smithy.api.Error.SERVER.widen,
   ).lazily
 
+  // constructor using the original order from the spec
+  private def make(message: Option[String]): ServerError = ServerError(message)
+
   implicit val schema: Schema[ServerError] = struct(
     string.optional[ServerError]("message", _.message),
   ){
-    ServerError.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/ServerErrorCustomMessage.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/ServerErrorCustomMessage.scala
@@ -19,9 +19,12 @@ object ServerErrorCustomMessage extends ShapeTag.Companion[ServerErrorCustomMess
     smithy.api.Error.SERVER.widen,
   ).lazily
 
+  // constructor using the original order from the spec
+  private def make(messageField: Option[String]): ServerErrorCustomMessage = ServerErrorCustomMessage(messageField)
+
   implicit val schema: Schema[ServerErrorCustomMessage] = struct(
     string.optional[ServerErrorCustomMessage]("messageField", _.messageField),
   ){
-    ServerErrorCustomMessage.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/ServerErrorCustomMessage.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/ServerErrorCustomMessage.scala
@@ -24,7 +24,5 @@ object ServerErrorCustomMessage extends ShapeTag.Companion[ServerErrorCustomMess
 
   implicit val schema: Schema[ServerErrorCustomMessage] = struct(
     string.optional[ServerErrorCustomMessage]("messageField", _.messageField),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/SomeCollections.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/SomeCollections.scala
@@ -16,11 +16,14 @@ object SomeCollections extends ShapeTag.Companion[SomeCollections] {
     smithy.api.Trait(selector = None, structurallyExclusive = None, conflicts = None, breakingChanges = None),
   ).lazily
 
+  // constructor using the original order from the spec
+  private def make(someList: List[String], someSet: Set[String], someMap: Map[String, String]): SomeCollections = SomeCollections(someList, someSet, someMap)
+
   implicit val schema: Schema[SomeCollections] = recursive(struct(
     StringList.underlyingSchema.required[SomeCollections]("someList", _.someList),
     StringSet.underlyingSchema.required[SomeCollections]("someSet", _.someSet),
     StringMap.underlyingSchema.required[SomeCollections]("someMap", _.someMap),
   ){
-    SomeCollections.apply
+    make
   }.withId(id).addHints(hints))
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/SomeCollections.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/SomeCollections.scala
@@ -23,7 +23,5 @@ object SomeCollections extends ShapeTag.Companion[SomeCollections] {
     StringList.underlyingSchema.required[SomeCollections]("someList", _.someList),
     StringSet.underlyingSchema.required[SomeCollections]("someSet", _.someSet),
     StringMap.underlyingSchema.required[SomeCollections]("someMap", _.someMap),
-  ){
-    make
-  }.withId(id).addHints(hints))
+  )(make).withId(id).addHints(hints))
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/StructureConstrainingEnum.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/StructureConstrainingEnum.scala
@@ -22,7 +22,5 @@ object StructureConstrainingEnum extends ShapeTag.Companion[StructureConstrainin
   implicit val schema: Schema[StructureConstrainingEnum] = struct(
     Letters.schema.validated(smithy.api.Length(min = Some(2L), max = None)).validated(smithy.api.Pattern(s"$$aaa$$")).optional[StructureConstrainingEnum]("letter", _.letter),
     FaceCard.schema.validated(smithy.api.Range(min = None, max = Some(scala.math.BigDecimal(1.0)))).optional[StructureConstrainingEnum]("card", _.card),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/StructureConstrainingEnum.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/StructureConstrainingEnum.scala
@@ -16,10 +16,13 @@ object StructureConstrainingEnum extends ShapeTag.Companion[StructureConstrainin
 
   val hints: Hints = Hints.empty
 
+  // constructor using the original order from the spec
+  private def make(letter: Option[Letters], card: Option[FaceCard]): StructureConstrainingEnum = StructureConstrainingEnum(letter, card)
+
   implicit val schema: Schema[StructureConstrainingEnum] = struct(
     Letters.schema.validated(smithy.api.Length(min = Some(2L), max = None)).validated(smithy.api.Pattern(s"$$aaa$$")).optional[StructureConstrainingEnum]("letter", _.letter),
     FaceCard.schema.validated(smithy.api.Range(min = None, max = Some(scala.math.BigDecimal(1.0)))).optional[StructureConstrainingEnum]("card", _.card),
   ){
-    StructureConstrainingEnum.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/StructureWithRefinedMember.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/StructureWithRefinedMember.scala
@@ -20,7 +20,5 @@ object StructureWithRefinedMember extends ShapeTag.Companion[StructureWithRefine
 
   implicit val schema: Schema[StructureWithRefinedMember] = struct(
     int.refined[smithy4s.refined.Age](smithy4s.example.AgeFormat()).optional[StructureWithRefinedMember]("otherAge", _.otherAge),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/StructureWithRefinedMember.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/StructureWithRefinedMember.scala
@@ -15,9 +15,12 @@ object StructureWithRefinedMember extends ShapeTag.Companion[StructureWithRefine
 
   val hints: Hints = Hints.empty
 
+  // constructor using the original order from the spec
+  private def make(otherAge: Option[smithy4s.refined.Age]): StructureWithRefinedMember = StructureWithRefinedMember(otherAge)
+
   implicit val schema: Schema[StructureWithRefinedMember] = struct(
     int.refined[smithy4s.refined.Age](smithy4s.example.AgeFormat()).optional[StructureWithRefinedMember]("otherAge", _.otherAge),
   ){
-    StructureWithRefinedMember.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/StructureWithRefinedTypes.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/StructureWithRefinedTypes.scala
@@ -13,6 +13,9 @@ object StructureWithRefinedTypes extends ShapeTag.Companion[StructureWithRefined
 
   val hints: Hints = Hints.empty
 
+  // constructor using the original order from the spec
+  private def make(age: Age, personAge: PersonAge, requiredAge: Age, fancyList: Option[smithy4s.example.FancyList], unwrappedFancyList: Option[smithy4s.refined.FancyList], name: Option[smithy4s.example.Name], dogName: Option[smithy4s.refined.Name]): StructureWithRefinedTypes = StructureWithRefinedTypes(age, personAge, requiredAge, fancyList, unwrappedFancyList, name, dogName)
+
   implicit val schema: Schema[StructureWithRefinedTypes] = struct(
     Age.schema.field[StructureWithRefinedTypes]("age", _.age).addHints(smithy.api.Default(smithy4s.Document.fromDouble(0.0d))),
     PersonAge.schema.field[StructureWithRefinedTypes]("personAge", _.personAge).addHints(smithy.api.Default(smithy4s.Document.fromDouble(0.0d))),
@@ -22,6 +25,6 @@ object StructureWithRefinedTypes extends ShapeTag.Companion[StructureWithRefined
     smithy4s.example.Name.schema.optional[StructureWithRefinedTypes]("name", _.name),
     DogName.underlyingSchema.optional[StructureWithRefinedTypes]("dogName", _.dogName),
   ){
-    StructureWithRefinedTypes.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/StructureWithRefinedTypes.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/StructureWithRefinedTypes.scala
@@ -24,7 +24,5 @@ object StructureWithRefinedTypes extends ShapeTag.Companion[StructureWithRefined
     UnwrappedFancyList.underlyingSchema.optional[StructureWithRefinedTypes]("unwrappedFancyList", _.unwrappedFancyList),
     smithy4s.example.Name.schema.optional[StructureWithRefinedTypes]("name", _.name),
     DogName.underlyingSchema.optional[StructureWithRefinedTypes]("dogName", _.dogName),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/TestAdt.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/TestAdt.scala
@@ -53,9 +53,7 @@ object TestAdt extends ShapeTag.Companion[TestAdt] {
       short.optional[AdtOne]("sht", _.sht),
       bytes.optional[AdtOne]("blb", _.blb),
       string.optional[AdtOne]("str", _.str),
-    ){
-      make
-    }.withId(id).addHints(hints)
+    )(make).withId(id).addHints(hints)
 
     val alt = schema.oneOf[TestAdt]("one")
   }
@@ -75,9 +73,7 @@ object TestAdt extends ShapeTag.Companion[TestAdt] {
       long.optional[AdtTwo]("lng", _.lng),
       short.optional[AdtTwo]("sht", _.sht),
       int.optional[AdtTwo]("int", _.int),
-    ){
-      make
-    }.withId(id).addHints(hints)
+    )(make).withId(id).addHints(hints)
 
     val alt = schema.oneOf[TestAdt]("two")
   }

--- a/modules/bootstrapped/src/generated/smithy4s/example/TestAdt.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/TestAdt.scala
@@ -45,13 +45,16 @@ object TestAdt extends ShapeTag.Companion[TestAdt] {
 
     val hints: Hints = Hints.empty
 
+    // constructor using the original order from the spec
+    private def make(lng: Option[Long], sht: Option[Short], blb: Option[Blob], str: Option[String]): AdtOne = AdtOne(lng, sht, blb, str)
+
     val schema: Schema[AdtOne] = struct(
       long.optional[AdtOne]("lng", _.lng),
       short.optional[AdtOne]("sht", _.sht),
       bytes.optional[AdtOne]("blb", _.blb),
       string.optional[AdtOne]("str", _.str),
     ){
-      AdtOne.apply
+      make
     }.withId(id).addHints(hints)
 
     val alt = schema.oneOf[TestAdt]("one")
@@ -65,12 +68,15 @@ object TestAdt extends ShapeTag.Companion[TestAdt] {
 
     val hints: Hints = Hints.empty
 
+    // constructor using the original order from the spec
+    private def make(lng: Option[Long], sht: Option[Short], int: Option[Int]): AdtTwo = AdtTwo(lng, sht, int)
+
     val schema: Schema[AdtTwo] = struct(
       long.optional[AdtTwo]("lng", _.lng),
       short.optional[AdtTwo]("sht", _.sht),
       int.optional[AdtTwo]("int", _.int),
     ){
-      AdtTwo.apply
+      make
     }.withId(id).addHints(hints)
 
     val alt = schema.oneOf[TestAdt]("two")

--- a/modules/bootstrapped/src/generated/smithy4s/example/TestBody.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/TestBody.scala
@@ -24,7 +24,5 @@ object TestBody extends ShapeTag.Companion[TestBody] {
 
   implicit val schema: Schema[TestBody] = struct(
     string.validated(smithy.api.Length(min = Some(10L), max = None)).optional[TestBody]("data", _.data),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/TestBody.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/TestBody.scala
@@ -19,9 +19,12 @@ object TestBody extends ShapeTag.Companion[TestBody] {
     val data: Lens[TestBody, Option[String]] = Lens[TestBody, Option[String]](_.data)(n => a => a.copy(data = n))
   }
 
+  // constructor using the original order from the spec
+  private def make(data: Option[String]): TestBody = TestBody(data)
+
   implicit val schema: Schema[TestBody] = struct(
     string.validated(smithy.api.Length(min = Some(10L), max = None)).optional[TestBody]("data", _.data),
   ){
-    TestBody.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/TestDiscriminatedInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/TestDiscriminatedInput.scala
@@ -14,9 +14,12 @@ object TestDiscriminatedInput extends ShapeTag.Companion[TestDiscriminatedInput]
 
   val hints: Hints = Hints.empty
 
+  // constructor using the original order from the spec
+  private def make(key: String): TestDiscriminatedInput = TestDiscriminatedInput(key)
+
   implicit val schema: Schema[TestDiscriminatedInput] = struct(
     string.required[TestDiscriminatedInput]("key", _.key).addHints(smithy.api.HttpLabel()),
   ){
-    TestDiscriminatedInput.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/TestDiscriminatedInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/TestDiscriminatedInput.scala
@@ -19,7 +19,5 @@ object TestDiscriminatedInput extends ShapeTag.Companion[TestDiscriminatedInput]
 
   implicit val schema: Schema[TestDiscriminatedInput] = struct(
     string.required[TestDiscriminatedInput]("key", _.key).addHints(smithy.api.HttpLabel()),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/TestDiscriminatedOutput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/TestDiscriminatedOutput.scala
@@ -18,7 +18,5 @@ object TestDiscriminatedOutput extends ShapeTag.Companion[TestDiscriminatedOutpu
 
   implicit val schema: Schema[TestDiscriminatedOutput] = struct(
     PayloadData.schema.optional[TestDiscriminatedOutput]("data", _.data).addHints(smithy.api.HttpPayload()),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/TestDiscriminatedOutput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/TestDiscriminatedOutput.scala
@@ -13,9 +13,12 @@ object TestDiscriminatedOutput extends ShapeTag.Companion[TestDiscriminatedOutpu
 
   val hints: Hints = Hints.empty
 
+  // constructor using the original order from the spec
+  private def make(data: Option[PayloadData]): TestDiscriminatedOutput = TestDiscriminatedOutput(data)
+
   implicit val schema: Schema[TestDiscriminatedOutput] = struct(
     PayloadData.schema.optional[TestDiscriminatedOutput]("data", _.data).addHints(smithy.api.HttpPayload()),
   ){
-    TestDiscriminatedOutput.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/TestEmptyMixin.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/TestEmptyMixin.scala
@@ -14,9 +14,12 @@ object TestEmptyMixin extends ShapeTag.Companion[TestEmptyMixin] {
 
   val hints: Hints = Hints.empty
 
+  // constructor using the original order from the spec
+  private def make(a: Option[Long]): TestEmptyMixin = TestEmptyMixin(a)
+
   implicit val schema: Schema[TestEmptyMixin] = struct(
     long.optional[TestEmptyMixin]("a", _.a),
   ){
-    TestEmptyMixin.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/TestEmptyMixin.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/TestEmptyMixin.scala
@@ -19,7 +19,5 @@ object TestEmptyMixin extends ShapeTag.Companion[TestEmptyMixin] {
 
   implicit val schema: Schema[TestEmptyMixin] = struct(
     long.optional[TestEmptyMixin]("a", _.a),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/TestIdRef.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/TestIdRef.scala
@@ -14,10 +14,13 @@ object TestIdRef extends ShapeTag.Companion[TestIdRef] {
 
   val hints: Hints = Hints.empty
 
+  // constructor using the original order from the spec
+  private def make(test: Option[ShapeId], test2: Option[TestIdRefTwo]): TestIdRef = TestIdRef(test, test2)
+
   implicit val schema: Schema[TestIdRef] = struct(
     string.refined[ShapeId](smithy.api.IdRef(selector = "*", failWhenMissing = None, errorMessage = None)).optional[TestIdRef]("test", _.test),
     TestIdRefTwo.schema.optional[TestIdRef]("test2", _.test2),
   ){
-    TestIdRef.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/TestIdRef.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/TestIdRef.scala
@@ -20,7 +20,5 @@ object TestIdRef extends ShapeTag.Companion[TestIdRef] {
   implicit val schema: Schema[TestIdRef] = struct(
     string.refined[ShapeId](smithy.api.IdRef(selector = "*", failWhenMissing = None, errorMessage = None)).optional[TestIdRef]("test", _.test),
     TestIdRefTwo.schema.optional[TestIdRef]("test2", _.test2),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/TestInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/TestInput.scala
@@ -28,7 +28,5 @@ object TestInput extends ShapeTag.Companion[TestInput] {
     string.validated(smithy.api.Length(min = Some(10L), max = None)).required[TestInput]("pathParam", _.pathParam).addHints(smithy.api.HttpLabel()),
     string.validated(smithy.api.Length(min = Some(10L), max = None)).optional[TestInput]("queryParam", _.queryParam).addHints(smithy.api.HttpQuery("queryParam")),
     TestBody.schema.required[TestInput]("body", _.body).addHints(smithy.api.HttpPayload()),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/TestInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/TestInput.scala
@@ -21,11 +21,14 @@ object TestInput extends ShapeTag.Companion[TestInput] {
     val queryParam: Lens[TestInput, Option[String]] = Lens[TestInput, Option[String]](_.queryParam)(n => a => a.copy(queryParam = n))
   }
 
+  // constructor using the original order from the spec
+  private def make(pathParam: String, queryParam: Option[String], body: TestBody): TestInput = TestInput(pathParam, body, queryParam)
+
   implicit val schema: Schema[TestInput] = struct(
     string.validated(smithy.api.Length(min = Some(10L), max = None)).required[TestInput]("pathParam", _.pathParam).addHints(smithy.api.HttpLabel()),
-    TestBody.schema.required[TestInput]("body", _.body).addHints(smithy.api.HttpPayload()),
     string.validated(smithy.api.Length(min = Some(10L), max = None)).optional[TestInput]("queryParam", _.queryParam).addHints(smithy.api.HttpQuery("queryParam")),
+    TestBody.schema.required[TestInput]("body", _.body).addHints(smithy.api.HttpPayload()),
   ){
-    TestInput.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/TestMixinAdt.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/TestMixinAdt.scala
@@ -44,9 +44,7 @@ object TestMixinAdt extends ShapeTag.Companion[TestMixinAdt] {
     val schema: Schema[TestAdtMemberWithMixin] = struct(
       string.optional[TestAdtMemberWithMixin]("a", _.a),
       int.optional[TestAdtMemberWithMixin]("b", _.b),
-    ){
-      make
-    }.withId(id).addHints(hints)
+    )(make).withId(id).addHints(hints)
 
     val alt = schema.oneOf[TestMixinAdt]("test")
   }

--- a/modules/bootstrapped/src/generated/smithy4s/example/TestMixinAdt.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/TestMixinAdt.scala
@@ -38,11 +38,14 @@ object TestMixinAdt extends ShapeTag.Companion[TestMixinAdt] {
 
     val hints: Hints = Hints.empty
 
+    // constructor using the original order from the spec
+    private def make(a: Option[String], b: Option[Int]): TestAdtMemberWithMixin = TestAdtMemberWithMixin(a, b)
+
     val schema: Schema[TestAdtMemberWithMixin] = struct(
       string.optional[TestAdtMemberWithMixin]("a", _.a),
       int.optional[TestAdtMemberWithMixin]("b", _.b),
     ){
-      TestAdtMemberWithMixin.apply
+      make
     }.withId(id).addHints(hints)
 
     val alt = schema.oneOf[TestMixinAdt]("test")

--- a/modules/bootstrapped/src/generated/smithy4s/example/TestStructurePatternTarget.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/TestStructurePatternTarget.scala
@@ -15,10 +15,13 @@ object TestStructurePatternTarget extends ShapeTag.Companion[TestStructurePatter
 
   val hints: Hints = Hints.empty
 
+  // constructor using the original order from the spec
+  private def make(one: String, two: Int): TestStructurePatternTarget = TestStructurePatternTarget(one, two)
+
   implicit val schema: Schema[TestStructurePatternTarget] = struct(
     string.required[TestStructurePatternTarget]("one", _.one),
     int.required[TestStructurePatternTarget]("two", _.two),
   ){
-    TestStructurePatternTarget.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/TestStructurePatternTarget.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/TestStructurePatternTarget.scala
@@ -21,7 +21,5 @@ object TestStructurePatternTarget extends ShapeTag.Companion[TestStructurePatter
   implicit val schema: Schema[TestStructurePatternTarget] = struct(
     string.required[TestStructurePatternTarget]("one", _.one),
     int.required[TestStructurePatternTarget]("two", _.two),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/TestTrait.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/TestTrait.scala
@@ -20,9 +20,12 @@ object TestTrait extends ShapeTag.Companion[TestTrait] {
     smithy.api.Trait(selector = None, structurallyExclusive = None, conflicts = None, breakingChanges = None),
   ).lazily
 
+  // constructor using the original order from the spec
+  private def make(orderType: Option[OrderType]): TestTrait = TestTrait(orderType)
+
   implicit val schema: Schema[TestTrait] = recursive(struct(
     OrderType.schema.optional[TestTrait]("orderType", _.orderType),
   ){
-    TestTrait.apply
+    make
   }.withId(id).addHints(hints))
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/TestTrait.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/TestTrait.scala
@@ -25,7 +25,5 @@ object TestTrait extends ShapeTag.Companion[TestTrait] {
 
   implicit val schema: Schema[TestTrait] = recursive(struct(
     OrderType.schema.optional[TestTrait]("orderType", _.orderType),
-  ){
-    make
-  }.withId(id).addHints(hints))
+  )(make).withId(id).addHints(hints))
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/Three.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/Three.scala
@@ -19,7 +19,5 @@ object Three extends ShapeTag.Companion[Three] {
 
   implicit val schema: Schema[Three] = struct(
     string.required[Three]("three", _.three),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/Three.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/Three.scala
@@ -14,9 +14,12 @@ object Three extends ShapeTag.Companion[Three] {
 
   val hints: Hints = Hints.empty
 
+  // constructor using the original order from the spec
+  private def make(three: String): Three = Three(three)
+
   implicit val schema: Schema[Three] = struct(
     string.required[Three]("three", _.three),
   ){
-    Three.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/Two.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/Two.scala
@@ -19,7 +19,5 @@ object Two extends ShapeTag.Companion[Two] {
 
   implicit val schema: Schema[Two] = struct(
     int.optional[Two]("value", _.value),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/Two.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/Two.scala
@@ -14,9 +14,12 @@ object Two extends ShapeTag.Companion[Two] {
 
   val hints: Hints = Hints.empty
 
+  // constructor using the original order from the spec
+  private def make(value: Option[Int]): Two = Two(value)
+
   implicit val schema: Schema[Two] = struct(
     int.optional[Two]("value", _.value),
   ){
-    Two.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/UnauthorizedError.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/UnauthorizedError.scala
@@ -23,7 +23,5 @@ object UnauthorizedError extends ShapeTag.Companion[UnauthorizedError] {
 
   implicit val schema: Schema[UnauthorizedError] = struct(
     string.required[UnauthorizedError]("reason", _.reason),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/UnauthorizedError.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/UnauthorizedError.scala
@@ -18,9 +18,12 @@ object UnauthorizedError extends ShapeTag.Companion[UnauthorizedError] {
     smithy.api.Error.CLIENT.widen,
   ).lazily
 
+  // constructor using the original order from the spec
+  private def make(reason: String): UnauthorizedError = UnauthorizedError(reason)
+
   implicit val schema: Schema[UnauthorizedError] = struct(
     string.required[UnauthorizedError]("reason", _.reason),
   ){
-    UnauthorizedError.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/UnknownServerError.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/UnknownServerError.scala
@@ -26,7 +26,5 @@ object UnknownServerError extends ShapeTag.Companion[UnknownServerError] {
     UnknownServerErrorCode.schema.required[UnknownServerError]("errorCode", _.errorCode),
     string.optional[UnknownServerError]("description", _.description),
     string.optional[UnknownServerError]("stateHash", _.stateHash),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/UnknownServerError.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/UnknownServerError.scala
@@ -19,11 +19,14 @@ object UnknownServerError extends ShapeTag.Companion[UnknownServerError] {
     smithy.api.HttpError(500),
   ).lazily
 
+  // constructor using the original order from the spec
+  private def make(errorCode: UnknownServerErrorCode, description: Option[String], stateHash: Option[String]): UnknownServerError = UnknownServerError(errorCode, description, stateHash)
+
   implicit val schema: Schema[UnknownServerError] = struct(
     UnknownServerErrorCode.schema.required[UnknownServerError]("errorCode", _.errorCode),
     string.optional[UnknownServerError]("description", _.description),
     string.optional[UnknownServerError]("stateHash", _.stateHash),
   ){
-    UnknownServerError.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/ValidationChecks.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/ValidationChecks.scala
@@ -15,11 +15,14 @@ object ValidationChecks extends ShapeTag.Companion[ValidationChecks] {
 
   val hints: Hints = Hints.empty
 
+  // constructor using the original order from the spec
+  private def make(str: Option[String], lst: Option[List[String]], int: Option[Int]): ValidationChecks = ValidationChecks(str, lst, int)
+
   implicit val schema: Schema[ValidationChecks] = struct(
     string.validated(smithy.api.Length(min = Some(1L), max = Some(10L))).optional[ValidationChecks]("str", _.str).addHints(smithy.api.HttpQuery("str")),
     StringList.underlyingSchema.validated(smithy.api.Length(min = Some(1L), max = Some(10L))).optional[ValidationChecks]("lst", _.lst).addHints(smithy.api.HttpQuery("lst")),
     int.validated(smithy.api.Range(min = Some(scala.math.BigDecimal(1.0)), max = Some(scala.math.BigDecimal(10.0)))).optional[ValidationChecks]("int", _.int).addHints(smithy.api.HttpQuery("int")),
   ){
-    ValidationChecks.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/ValidationChecks.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/ValidationChecks.scala
@@ -22,7 +22,5 @@ object ValidationChecks extends ShapeTag.Companion[ValidationChecks] {
     string.validated(smithy.api.Length(min = Some(1L), max = Some(10L))).optional[ValidationChecks]("str", _.str).addHints(smithy.api.HttpQuery("str")),
     StringList.underlyingSchema.validated(smithy.api.Length(min = Some(1L), max = Some(10L))).optional[ValidationChecks]("lst", _.lst).addHints(smithy.api.HttpQuery("lst")),
     int.validated(smithy.api.Range(min = Some(scala.math.BigDecimal(1.0)), max = Some(scala.math.BigDecimal(10.0)))).optional[ValidationChecks]("int", _.int).addHints(smithy.api.HttpQuery("int")),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/Value.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/Value.scala
@@ -14,9 +14,12 @@ object Value extends ShapeTag.Companion[Value] {
 
   val hints: Hints = Hints.empty
 
+  // constructor using the original order from the spec
+  private def make(value: String): Value = Value(value)
+
   implicit val schema: Schema[Value] = struct(
     string.required[Value]("value", _.value),
   ){
-    Value.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/Value.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/Value.scala
@@ -19,7 +19,5 @@ object Value extends ShapeTag.Companion[Value] {
 
   implicit val schema: Schema[Value] = struct(
     string.required[Value]("value", _.value),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/VersionOutput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/VersionOutput.scala
@@ -19,7 +19,5 @@ object VersionOutput extends ShapeTag.Companion[VersionOutput] {
 
   implicit val schema: Schema[VersionOutput] = struct(
     string.required[VersionOutput]("version", _.version).addHints(smithy.api.HttpPayload()),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/VersionOutput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/VersionOutput.scala
@@ -14,9 +14,12 @@ object VersionOutput extends ShapeTag.Companion[VersionOutput] {
 
   val hints: Hints = Hints.empty
 
+  // constructor using the original order from the spec
+  private def make(version: String): VersionOutput = VersionOutput(version)
+
   implicit val schema: Schema[VersionOutput] = struct(
     string.required[VersionOutput]("version", _.version).addHints(smithy.api.HttpPayload()),
   ){
-    VersionOutput.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/collision/ListInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/collision/ListInput.scala
@@ -15,9 +15,12 @@ object ListInput extends ShapeTag.Companion[ListInput] {
     smithy.api.Input(),
   ).lazily
 
+  // constructor using the original order from the spec
+  private def make(list: List[String]): ListInput = ListInput(list)
+
   implicit val schema: Schema[ListInput] = struct(
     MyList.underlyingSchema.required[ListInput]("list", _.list),
   ){
-    ListInput.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/collision/ListInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/collision/ListInput.scala
@@ -20,7 +20,5 @@ object ListInput extends ShapeTag.Companion[ListInput] {
 
   implicit val schema: Schema[ListInput] = struct(
     MyList.underlyingSchema.required[ListInput]("list", _.list),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/collision/MapInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/collision/MapInput.scala
@@ -20,7 +20,5 @@ object MapInput extends ShapeTag.Companion[MapInput] {
 
   implicit val schema: Schema[MapInput] = struct(
     MyMap.underlyingSchema.required[MapInput]("value", _.value),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/collision/MapInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/collision/MapInput.scala
@@ -15,9 +15,12 @@ object MapInput extends ShapeTag.Companion[MapInput] {
     smithy.api.Input(),
   ).lazily
 
+  // constructor using the original order from the spec
+  private def make(value: Map[String, String]): MapInput = MapInput(value)
+
   implicit val schema: Schema[MapInput] = struct(
     MyMap.underlyingSchema.required[MapInput]("value", _.value),
   ){
-    MapInput.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/collision/OptionInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/collision/OptionInput.scala
@@ -15,9 +15,12 @@ object OptionInput extends ShapeTag.Companion[OptionInput] {
     smithy.api.Input(),
   ).lazily
 
+  // constructor using the original order from the spec
+  private def make(value: Option[String]): OptionInput = OptionInput(value)
+
   implicit val schema: Schema[OptionInput] = struct(
     String.schema.optional[OptionInput]("value", _.value),
   ){
-    OptionInput.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/collision/OptionInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/collision/OptionInput.scala
@@ -20,7 +20,5 @@ object OptionInput extends ShapeTag.Companion[OptionInput] {
 
   implicit val schema: Schema[OptionInput] = struct(
     String.schema.optional[OptionInput]("value", _.value),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/collision/Packagee.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/collision/Packagee.scala
@@ -19,7 +19,5 @@ object Packagee extends ShapeTag.Companion[Packagee] {
 
   implicit val schema: Schema[Packagee] = struct(
     int.optional[Packagee]("class", _._class),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/collision/Packagee.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/collision/Packagee.scala
@@ -14,9 +14,12 @@ object Packagee extends ShapeTag.Companion[Packagee] {
 
   val hints: Hints = Hints.empty
 
+  // constructor using the original order from the spec
+  private def make(_class: Option[Int]): Packagee = Packagee(_class)
+
   implicit val schema: Schema[Packagee] = struct(
     int.optional[Packagee]("class", _._class),
   ){
-    Packagee.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/collision/ReservedKeywordStructTrait.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/collision/ReservedKeywordStructTrait.scala
@@ -22,7 +22,5 @@ object ReservedKeywordStructTrait extends ShapeTag.Companion[ReservedKeywordStru
   implicit val schema: Schema[ReservedKeywordStructTrait] = recursive(struct(
     String.schema.required[ReservedKeywordStructTrait]("implicit", _._implicit),
     Packagee.schema.optional[ReservedKeywordStructTrait]("package", _._package),
-  ){
-    make
-  }.withId(id).addHints(hints))
+  )(make).withId(id).addHints(hints))
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/collision/ReservedKeywordStructTrait.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/collision/ReservedKeywordStructTrait.scala
@@ -16,10 +16,13 @@ object ReservedKeywordStructTrait extends ShapeTag.Companion[ReservedKeywordStru
     smithy.api.Trait(selector = None, structurallyExclusive = None, conflicts = None, breakingChanges = None),
   ).lazily
 
+  // constructor using the original order from the spec
+  private def make(_implicit: String, _package: Option[Packagee]): ReservedKeywordStructTrait = ReservedKeywordStructTrait(_implicit, _package)
+
   implicit val schema: Schema[ReservedKeywordStructTrait] = recursive(struct(
     String.schema.required[ReservedKeywordStructTrait]("implicit", _._implicit),
     Packagee.schema.optional[ReservedKeywordStructTrait]("package", _._package),
   ){
-    ReservedKeywordStructTrait.apply
+    make
   }.withId(id).addHints(hints))
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/collision/ReservedKeywordTraitExampleStruct.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/collision/ReservedKeywordTraitExampleStruct.scala
@@ -21,7 +21,5 @@ object ReservedKeywordTraitExampleStruct extends ShapeTag.Companion[ReservedKeyw
 
   implicit val schema: Schema[ReservedKeywordTraitExampleStruct] = struct(
     String.schema.optional[ReservedKeywordTraitExampleStruct]("member", _.member).addHints(smithy4s.example.collision.ReservedKeywordStructTrait(_implicit = smithy4s.example.collision.String("demo"), _package = Some(smithy4s.example.collision.Packagee(_class = Some(42)))), smithy4s.example.collision.ReservedKeywordUnionTrait.PackageCase(smithy4s.example.collision.PackageUnion.ClassCase(42).widen).widen),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/collision/ReservedKeywordTraitExampleStruct.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/collision/ReservedKeywordTraitExampleStruct.scala
@@ -16,9 +16,12 @@ object ReservedKeywordTraitExampleStruct extends ShapeTag.Companion[ReservedKeyw
     smithy4s.example.collision.ReservedKeywordUnionTrait.PackageCase(smithy4s.example.collision.PackageUnion.ClassCase(42).widen).widen,
   ).lazily
 
+  // constructor using the original order from the spec
+  private def make(member: Option[String]): ReservedKeywordTraitExampleStruct = ReservedKeywordTraitExampleStruct(member)
+
   implicit val schema: Schema[ReservedKeywordTraitExampleStruct] = struct(
     String.schema.optional[ReservedKeywordTraitExampleStruct]("member", _.member).addHints(smithy4s.example.collision.ReservedKeywordStructTrait(_implicit = smithy4s.example.collision.String("demo"), _package = Some(smithy4s.example.collision.Packagee(_class = Some(42)))), smithy4s.example.collision.ReservedKeywordUnionTrait.PackageCase(smithy4s.example.collision.PackageUnion.ClassCase(42).widen).widen),
   ){
-    ReservedKeywordTraitExampleStruct.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/collision/Scala3ReservedKeywords.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/collision/Scala3ReservedKeywords.scala
@@ -19,7 +19,5 @@ object Scala3ReservedKeywords extends ShapeTag.Companion[Scala3ReservedKeywords]
   implicit val schema: Schema[Scala3ReservedKeywords] = struct(
     String.schema.optional[Scala3ReservedKeywords]("export", _._export),
     String.schema.optional[Scala3ReservedKeywords]("enum", _._enum),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/collision/Scala3ReservedKeywords.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/collision/Scala3ReservedKeywords.scala
@@ -13,10 +13,13 @@ object Scala3ReservedKeywords extends ShapeTag.Companion[Scala3ReservedKeywords]
 
   val hints: Hints = Hints.empty
 
+  // constructor using the original order from the spec
+  private def make(_export: Option[String], _enum: Option[String]): Scala3ReservedKeywords = Scala3ReservedKeywords(_export, _enum)
+
   implicit val schema: Schema[Scala3ReservedKeywords] = struct(
     String.schema.optional[Scala3ReservedKeywords]("export", _._export),
     String.schema.optional[Scala3ReservedKeywords]("enum", _._enum),
   ){
-    Scala3ReservedKeywords.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/collision/SetInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/collision/SetInput.scala
@@ -15,9 +15,12 @@ object SetInput extends ShapeTag.Companion[SetInput] {
     smithy.api.Input(),
   ).lazily
 
+  // constructor using the original order from the spec
+  private def make(set: Set[String]): SetInput = SetInput(set)
+
   implicit val schema: Schema[SetInput] = struct(
     MySet.underlyingSchema.required[SetInput]("set", _.set),
   ){
-    SetInput.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/collision/SetInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/collision/SetInput.scala
@@ -20,7 +20,5 @@ object SetInput extends ShapeTag.Companion[SetInput] {
 
   implicit val schema: Schema[SetInput] = struct(
     MySet.underlyingSchema.required[SetInput]("set", _.set),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/collision/TestReservedNamespaceImport.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/collision/TestReservedNamespaceImport.scala
@@ -19,7 +19,5 @@ object TestReservedNamespaceImport extends ShapeTag.Companion[TestReservedNamesp
 
   implicit val schema: Schema[TestReservedNamespaceImport] = struct(
     MyPackageString.schema.optional[TestReservedNamespaceImport]("package", _._package),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/collision/TestReservedNamespaceImport.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/collision/TestReservedNamespaceImport.scala
@@ -14,9 +14,12 @@ object TestReservedNamespaceImport extends ShapeTag.Companion[TestReservedNamesp
 
   val hints: Hints = Hints.empty
 
+  // constructor using the original order from the spec
+  private def make(_package: Option[MyPackageString]): TestReservedNamespaceImport = TestReservedNamespaceImport(_package)
+
   implicit val schema: Schema[TestReservedNamespaceImport] = struct(
     MyPackageString.schema.optional[TestReservedNamespaceImport]("package", _._package),
   ){
-    TestReservedNamespaceImport.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/error/NotFoundError.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/error/NotFoundError.scala
@@ -24,7 +24,5 @@ object NotFoundError extends ShapeTag.Companion[NotFoundError] {
 
   implicit val schema: Schema[NotFoundError] = struct(
     string.optional[NotFoundError]("error", _.error),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/error/NotFoundError.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/error/NotFoundError.scala
@@ -19,9 +19,12 @@ object NotFoundError extends ShapeTag.Companion[NotFoundError] {
     smithy.api.HttpError(404),
   ).lazily
 
+  // constructor using the original order from the spec
+  private def make(error: Option[String]): NotFoundError = NotFoundError(error)
+
   implicit val schema: Schema[NotFoundError] = struct(
     string.optional[NotFoundError]("error", _.error),
   ){
-    NotFoundError.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/greet/GreetInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/greet/GreetInput.scala
@@ -21,7 +21,5 @@ object GreetInput extends ShapeTag.Companion[GreetInput] {
 
   implicit val schema: Schema[GreetInput] = struct(
     string.required[GreetInput]("name", _.name),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/greet/GreetInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/greet/GreetInput.scala
@@ -16,9 +16,12 @@ object GreetInput extends ShapeTag.Companion[GreetInput] {
     smithy.api.Input(),
   ).lazily
 
+  // constructor using the original order from the spec
+  private def make(name: String): GreetInput = GreetInput(name)
+
   implicit val schema: Schema[GreetInput] = struct(
     string.required[GreetInput]("name", _.name),
   ){
-    GreetInput.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/greet/GreetOutput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/greet/GreetOutput.scala
@@ -21,7 +21,5 @@ object GreetOutput extends ShapeTag.Companion[GreetOutput] {
 
   implicit val schema: Schema[GreetOutput] = struct(
     string.required[GreetOutput]("message", _.message),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/greet/GreetOutput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/greet/GreetOutput.scala
@@ -16,9 +16,12 @@ object GreetOutput extends ShapeTag.Companion[GreetOutput] {
     smithy.api.Output(),
   ).lazily
 
+  // constructor using the original order from the spec
+  private def make(message: String): GreetOutput = GreetOutput(message)
+
   implicit val schema: Schema[GreetOutput] = struct(
     string.required[GreetOutput]("message", _.message),
   ){
-    GreetOutput.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/guides/auth/HealthCheckOutput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/guides/auth/HealthCheckOutput.scala
@@ -16,9 +16,12 @@ object HealthCheckOutput extends ShapeTag.Companion[HealthCheckOutput] {
     smithy.api.Output(),
   ).lazily
 
+  // constructor using the original order from the spec
+  private def make(message: String): HealthCheckOutput = HealthCheckOutput(message)
+
   implicit val schema: Schema[HealthCheckOutput] = struct(
     string.required[HealthCheckOutput]("message", _.message),
   ){
-    HealthCheckOutput.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/guides/auth/HealthCheckOutput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/guides/auth/HealthCheckOutput.scala
@@ -21,7 +21,5 @@ object HealthCheckOutput extends ShapeTag.Companion[HealthCheckOutput] {
 
   implicit val schema: Schema[HealthCheckOutput] = struct(
     string.required[HealthCheckOutput]("message", _.message),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/guides/auth/NotAuthorizedError.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/guides/auth/NotAuthorizedError.scala
@@ -25,7 +25,5 @@ object NotAuthorizedError extends ShapeTag.Companion[NotAuthorizedError] {
 
   implicit val schema: Schema[NotAuthorizedError] = struct(
     string.required[NotAuthorizedError]("message", _.message),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/guides/auth/NotAuthorizedError.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/guides/auth/NotAuthorizedError.scala
@@ -20,9 +20,12 @@ object NotAuthorizedError extends ShapeTag.Companion[NotAuthorizedError] {
     smithy.api.HttpError(401),
   ).lazily
 
+  // constructor using the original order from the spec
+  private def make(message: String): NotAuthorizedError = NotAuthorizedError(message)
+
   implicit val schema: Schema[NotAuthorizedError] = struct(
     string.required[NotAuthorizedError]("message", _.message),
   ){
-    NotAuthorizedError.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/guides/auth/World.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/guides/auth/World.scala
@@ -19,7 +19,5 @@ object World extends ShapeTag.Companion[World] {
 
   implicit val schema: Schema[World] = struct(
     string.field[World]("message", _.message).addHints(smithy.api.Default(smithy4s.Document.fromString("World !"))),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/guides/auth/World.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/guides/auth/World.scala
@@ -14,9 +14,12 @@ object World extends ShapeTag.Companion[World] {
 
   val hints: Hints = Hints.empty
 
+  // constructor using the original order from the spec
+  private def make(message: String): World = World(message)
+
   implicit val schema: Schema[World] = struct(
     string.field[World]("message", _.message).addHints(smithy.api.Default(smithy4s.Document.fromString("World !"))),
   ){
-    World.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/guides/hello/World.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/guides/hello/World.scala
@@ -19,7 +19,5 @@ object World extends ShapeTag.Companion[World] {
 
   implicit val schema: Schema[World] = struct(
     string.field[World]("message", _.message).addHints(smithy.api.Default(smithy4s.Document.fromString("World !"))),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/guides/hello/World.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/guides/hello/World.scala
@@ -14,9 +14,12 @@ object World extends ShapeTag.Companion[World] {
 
   val hints: Hints = Hints.empty
 
+  // constructor using the original order from the spec
+  private def make(message: String): World = World(message)
+
   implicit val schema: Schema[World] = struct(
     string.field[World]("message", _.message).addHints(smithy.api.Default(smithy4s.Document.fromString("World !"))),
   ){
-    World.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/hello/GenericServerError.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/hello/GenericServerError.scala
@@ -20,9 +20,12 @@ object GenericServerError extends ShapeTag.Companion[GenericServerError] {
     smithy.api.HttpError(500),
   ).lazily
 
+  // constructor using the original order from the spec
+  private def make(message: Option[String]): GenericServerError = GenericServerError(message)
+
   implicit val schema: Schema[GenericServerError] = struct(
     string.optional[GenericServerError]("message", _.message),
   ){
-    GenericServerError.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/hello/GenericServerError.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/hello/GenericServerError.scala
@@ -25,7 +25,5 @@ object GenericServerError extends ShapeTag.Companion[GenericServerError] {
 
   implicit val schema: Schema[GenericServerError] = struct(
     string.optional[GenericServerError]("message", _.message),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/hello/Greeting.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/hello/Greeting.scala
@@ -19,7 +19,5 @@ object Greeting extends ShapeTag.Companion[Greeting] {
 
   implicit val schema: Schema[Greeting] = struct(
     string.required[Greeting]("message", _.message),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/hello/Greeting.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/hello/Greeting.scala
@@ -14,9 +14,12 @@ object Greeting extends ShapeTag.Companion[Greeting] {
 
   val hints: Hints = Hints.empty
 
+  // constructor using the original order from the spec
+  private def make(message: String): Greeting = Greeting(message)
+
   implicit val schema: Schema[Greeting] = struct(
     string.required[Greeting]("message", _.message),
   ){
-    Greeting.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/hello/Person.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/hello/Person.scala
@@ -20,7 +20,5 @@ object Person extends ShapeTag.Companion[Person] {
   implicit val schema: Schema[Person] = struct(
     string.required[Person]("name", _.name).addHints(smithy.api.HttpLabel()),
     string.optional[Person]("town", _.town).addHints(smithy.api.HttpQuery("town")),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/hello/Person.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/hello/Person.scala
@@ -14,10 +14,13 @@ object Person extends ShapeTag.Companion[Person] {
 
   val hints: Hints = Hints.empty
 
+  // constructor using the original order from the spec
+  private def make(name: String, town: Option[String]): Person = Person(name, town)
+
   implicit val schema: Schema[Person] = struct(
     string.required[Person]("name", _.name).addHints(smithy.api.HttpLabel()),
     string.optional[Person]("town", _.town).addHints(smithy.api.HttpQuery("town")),
   ){
-    Person.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/hello/SpecificServerError.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/hello/SpecificServerError.scala
@@ -25,7 +25,5 @@ object SpecificServerError extends ShapeTag.Companion[SpecificServerError] {
 
   implicit val schema: Schema[SpecificServerError] = struct(
     string.optional[SpecificServerError]("message", _.message),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/hello/SpecificServerError.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/hello/SpecificServerError.scala
@@ -20,9 +20,12 @@ object SpecificServerError extends ShapeTag.Companion[SpecificServerError] {
     smithy.api.HttpError(599),
   ).lazily
 
+  // constructor using the original order from the spec
+  private def make(message: Option[String]): SpecificServerError = SpecificServerError(message)
+
   implicit val schema: Schema[SpecificServerError] = struct(
     string.optional[SpecificServerError]("message", _.message),
   ){
-    SpecificServerError.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/import_test/OpOutput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/import_test/OpOutput.scala
@@ -19,7 +19,5 @@ object OpOutput extends ShapeTag.Companion[OpOutput] {
 
   implicit val schema: Schema[OpOutput] = struct(
     string.required[OpOutput]("output", _.output).addHints(smithy.api.HttpPayload()),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/import_test/OpOutput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/import_test/OpOutput.scala
@@ -14,9 +14,12 @@ object OpOutput extends ShapeTag.Companion[OpOutput] {
 
   val hints: Hints = Hints.empty
 
+  // constructor using the original order from the spec
+  private def make(output: String): OpOutput = OpOutput(output)
+
   implicit val schema: Schema[OpOutput] = struct(
     string.required[OpOutput]("output", _.output).addHints(smithy.api.HttpPayload()),
   ){
-    OpOutput.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/product/ExampleOperationInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/product/ExampleOperationInput.scala
@@ -16,9 +16,12 @@ object ExampleOperationInput extends ShapeTag.Companion[ExampleOperationInput] {
     smithy.api.Input(),
   ).lazily
 
+  // constructor using the original order from the spec
+  private def make(a: String): ExampleOperationInput = ExampleOperationInput(a)
+
   implicit val schema: Schema[ExampleOperationInput] = struct(
     string.required[ExampleOperationInput]("a", _.a),
   ){
-    ExampleOperationInput.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/product/ExampleOperationInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/product/ExampleOperationInput.scala
@@ -21,7 +21,5 @@ object ExampleOperationInput extends ShapeTag.Companion[ExampleOperationInput] {
 
   implicit val schema: Schema[ExampleOperationInput] = struct(
     string.required[ExampleOperationInput]("a", _.a),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/product/ExampleOperationOutput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/product/ExampleOperationOutput.scala
@@ -21,7 +21,5 @@ object ExampleOperationOutput extends ShapeTag.Companion[ExampleOperationOutput]
 
   implicit val schema: Schema[ExampleOperationOutput] = struct(
     string.required[ExampleOperationOutput]("b", _.b),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/product/ExampleOperationOutput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/product/ExampleOperationOutput.scala
@@ -16,9 +16,12 @@ object ExampleOperationOutput extends ShapeTag.Companion[ExampleOperationOutput]
     smithy.api.Output(),
   ).lazily
 
+  // constructor using the original order from the spec
+  private def make(b: String): ExampleOperationOutput = ExampleOperationOutput(b)
+
   implicit val schema: Schema[ExampleOperationOutput] = struct(
     string.required[ExampleOperationOutput]("b", _.b),
   ){
-    ExampleOperationOutput.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/reservedNameOverride/Set.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/reservedNameOverride/Set.scala
@@ -21,7 +21,5 @@ object Set extends ShapeTag.Companion[Set] {
   implicit val schema: Schema[Set] = struct(
     string.required[Set]("someField", _.someField),
     int.required[Set]("otherField", _.otherField),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/reservedNameOverride/Set.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/reservedNameOverride/Set.scala
@@ -15,10 +15,13 @@ object Set extends ShapeTag.Companion[Set] {
 
   val hints: Hints = Hints.empty
 
+  // constructor using the original order from the spec
+  private def make(someField: String, otherField: Int): Set = Set(someField, otherField)
+
   implicit val schema: Schema[Set] = struct(
     string.required[Set]("someField", _.someField),
     int.required[Set]("otherField", _.otherField),
   ){
-    Set.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/reservedNameOverride/SetOpInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/reservedNameOverride/SetOpInput.scala
@@ -20,7 +20,5 @@ object SetOpInput extends ShapeTag.Companion[SetOpInput] {
 
   implicit val schema: Schema[SetOpInput] = struct(
     Set.schema.required[SetOpInput]("set", _.set),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/reservedNameOverride/SetOpInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/reservedNameOverride/SetOpInput.scala
@@ -15,9 +15,12 @@ object SetOpInput extends ShapeTag.Companion[SetOpInput] {
     smithy.api.Input(),
   ).lazily
 
+  // constructor using the original order from the spec
+  private def make(set: Set): SetOpInput = SetOpInput(set)
+
   implicit val schema: Schema[SetOpInput] = struct(
     Set.schema.required[SetOpInput]("set", _.set),
   ){
-    SetOpInput.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/test/ComplexError.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/test/ComplexError.scala
@@ -22,11 +22,14 @@ object ComplexError extends ShapeTag.Companion[ComplexError] {
     smithy.test.HttpResponseTests(List(smithy.test.HttpResponseTestCase(id = "complex_error", protocol = smithy4s.ShapeId(namespace = "alloy", name = "simpleRestJson"), code = 504, authScheme = None, headers = None, forbidHeaders = None, requireHeaders = Some(List("X-Error-Type")), body = Some("{\"value\":-1,\"message\":\"some error message\",\"details\":{\"date\":123,\"location\":\"NYC\"}}"), bodyMediaType = Some("application/json"), params = Some(smithy4s.Document.obj("value" -> smithy4s.Document.fromDouble(-1.0d), "message" -> smithy4s.Document.fromString("some error message"), "details" -> smithy4s.Document.obj("date" -> smithy4s.Document.fromDouble(123.0d), "location" -> smithy4s.Document.fromString("NYC")))), vendorParams = None, vendorParamsShape = None, documentation = None, tags = None, appliesTo = None), smithy.test.HttpResponseTestCase(id = "complex_error_no_details", protocol = smithy4s.ShapeId(namespace = "alloy", name = "simpleRestJson"), code = 504, authScheme = None, headers = None, forbidHeaders = None, requireHeaders = Some(List("X-Error-Type")), body = Some("{\"value\":-1,\"message\":\"some error message\"}"), bodyMediaType = Some("application/json"), params = Some(smithy4s.Document.obj("value" -> smithy4s.Document.fromDouble(-1.0d), "message" -> smithy4s.Document.fromString("some error message"))), vendorParams = None, vendorParamsShape = None, documentation = None, tags = None, appliesTo = None))),
   ).lazily
 
+  // constructor using the original order from the spec
+  private def make(value: Int, message: String, details: Option[ErrorDetails]): ComplexError = ComplexError(value, message, details)
+
   implicit val schema: Schema[ComplexError] = struct(
     int.required[ComplexError]("value", _.value),
     string.required[ComplexError]("message", _.message),
     ErrorDetails.schema.optional[ComplexError]("details", _.details),
   ){
-    ComplexError.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/test/ComplexError.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/test/ComplexError.scala
@@ -29,7 +29,5 @@ object ComplexError extends ShapeTag.Companion[ComplexError] {
     int.required[ComplexError]("value", _.value),
     string.required[ComplexError]("message", _.message),
     ErrorDetails.schema.optional[ComplexError]("details", _.details),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/test/ErrorDetails.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/test/ErrorDetails.scala
@@ -22,7 +22,5 @@ object ErrorDetails extends ShapeTag.Companion[ErrorDetails] {
   implicit val schema: Schema[ErrorDetails] = struct(
     timestamp.required[ErrorDetails]("date", _.date).addHints(smithy.api.TimestampFormat.EPOCH_SECONDS.widen),
     string.required[ErrorDetails]("location", _.location),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/test/ErrorDetails.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/test/ErrorDetails.scala
@@ -16,10 +16,13 @@ object ErrorDetails extends ShapeTag.Companion[ErrorDetails] {
 
   val hints: Hints = Hints.empty
 
+  // constructor using the original order from the spec
+  private def make(date: Timestamp, location: String): ErrorDetails = ErrorDetails(date, location)
+
   implicit val schema: Schema[ErrorDetails] = struct(
     timestamp.required[ErrorDetails]("date", _.date).addHints(smithy.api.TimestampFormat.EPOCH_SECONDS.widen),
     string.required[ErrorDetails]("location", _.location),
   ){
-    ErrorDetails.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/test/HelloInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/test/HelloInput.scala
@@ -16,9 +16,12 @@ object HelloInput extends ShapeTag.Companion[HelloInput] {
     smithy.api.Input(),
   ).lazily
 
+  // constructor using the original order from the spec
+  private def make(name: String): HelloInput = HelloInput(name)
+
   implicit val schema: Schema[HelloInput] = struct(
     string.required[HelloInput]("name", _.name).addHints(smithy.api.HttpLabel()),
   ){
-    HelloInput.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/test/HelloInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/test/HelloInput.scala
@@ -21,7 +21,5 @@ object HelloInput extends ShapeTag.Companion[HelloInput] {
 
   implicit val schema: Schema[HelloInput] = struct(
     string.required[HelloInput]("name", _.name).addHints(smithy.api.HttpLabel()),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/test/HelloOutput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/test/HelloOutput.scala
@@ -21,7 +21,5 @@ object HelloOutput extends ShapeTag.Companion[HelloOutput] {
 
   implicit val schema: Schema[HelloOutput] = struct(
     string.required[HelloOutput]("message", _.message),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/test/HelloOutput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/test/HelloOutput.scala
@@ -16,9 +16,12 @@ object HelloOutput extends ShapeTag.Companion[HelloOutput] {
     smithy.api.Output(),
   ).lazily
 
+  // constructor using the original order from the spec
+  private def make(message: String): HelloOutput = HelloOutput(message)
+
   implicit val schema: Schema[HelloOutput] = struct(
     string.required[HelloOutput]("message", _.message),
   ){
-    HelloOutput.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/test/SayHelloInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/test/SayHelloInput.scala
@@ -23,7 +23,5 @@ object SayHelloInput extends ShapeTag.Companion[SayHelloInput] {
     string.optional[SayHelloInput]("greeting", _.greeting).addHints(smithy.api.HttpHeader("X-Greeting")),
     string.optional[SayHelloInput]("query", _.query).addHints(smithy.api.HttpQuery("Hi")),
     string.optional[SayHelloInput]("name", _.name),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/test/SayHelloInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/test/SayHelloInput.scala
@@ -16,11 +16,14 @@ object SayHelloInput extends ShapeTag.Companion[SayHelloInput] {
     smithy.api.Input(),
   ).lazily
 
+  // constructor using the original order from the spec
+  private def make(greeting: Option[String], query: Option[String], name: Option[String]): SayHelloInput = SayHelloInput(greeting, query, name)
+
   implicit val schema: Schema[SayHelloInput] = struct(
     string.optional[SayHelloInput]("greeting", _.greeting).addHints(smithy.api.HttpHeader("X-Greeting")),
     string.optional[SayHelloInput]("query", _.query).addHints(smithy.api.HttpQuery("Hi")),
     string.optional[SayHelloInput]("name", _.name),
   ){
-    SayHelloInput.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/test/SayHelloOutput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/test/SayHelloOutput.scala
@@ -20,7 +20,5 @@ object SayHelloOutput extends ShapeTag.Companion[SayHelloOutput] {
   implicit val schema: Schema[SayHelloOutput] = struct(
     SayHelloPayload.schema.required[SayHelloOutput]("payload", _.payload).addHints(smithy.api.HttpPayload()),
     string.required[SayHelloOutput]("header1", _.header1).addHints(smithy.api.HttpHeader("X-H1")),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/test/SayHelloOutput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/test/SayHelloOutput.scala
@@ -14,10 +14,13 @@ object SayHelloOutput extends ShapeTag.Companion[SayHelloOutput] {
 
   val hints: Hints = Hints.empty
 
+  // constructor using the original order from the spec
+  private def make(payload: SayHelloPayload, header1: String): SayHelloOutput = SayHelloOutput(payload, header1)
+
   implicit val schema: Schema[SayHelloOutput] = struct(
     SayHelloPayload.schema.required[SayHelloOutput]("payload", _.payload).addHints(smithy.api.HttpPayload()),
     string.required[SayHelloOutput]("header1", _.header1).addHints(smithy.api.HttpHeader("X-H1")),
   ){
-    SayHelloOutput.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/test/SayHelloPayload.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/test/SayHelloPayload.scala
@@ -14,9 +14,12 @@ object SayHelloPayload extends ShapeTag.Companion[SayHelloPayload] {
 
   val hints: Hints = Hints.empty
 
+  // constructor using the original order from the spec
+  private def make(result: String): SayHelloPayload = SayHelloPayload(result)
+
   implicit val schema: Schema[SayHelloPayload] = struct(
     string.required[SayHelloPayload]("result", _.result),
   ){
-    SayHelloPayload.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/test/SayHelloPayload.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/test/SayHelloPayload.scala
@@ -19,7 +19,5 @@ object SayHelloPayload extends ShapeTag.Companion[SayHelloPayload] {
 
   implicit val schema: Schema[SayHelloPayload] = struct(
     string.required[SayHelloPayload]("result", _.result),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/test/SimpleError.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/test/SimpleError.scala
@@ -24,7 +24,5 @@ object SimpleError extends ShapeTag.Companion[SimpleError] {
 
   implicit val schema: Schema[SimpleError] = struct(
     int.required[SimpleError]("expected", _.expected),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/test/SimpleError.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/test/SimpleError.scala
@@ -19,9 +19,12 @@ object SimpleError extends ShapeTag.Companion[SimpleError] {
     smithy.test.HttpResponseTests(List(smithy.test.HttpResponseTestCase(id = "simple_error", protocol = smithy4s.ShapeId(namespace = "alloy", name = "simpleRestJson"), code = 400, authScheme = None, headers = None, forbidHeaders = None, requireHeaders = Some(List("X-Error-Type")), body = Some("{\"expected\":-1}"), bodyMediaType = Some("application/json"), params = Some(smithy4s.Document.obj("expected" -> smithy4s.Document.fromDouble(-1.0d))), vendorParams = None, vendorParamsShape = None, documentation = None, tags = None, appliesTo = None))),
   ).lazily
 
+  // constructor using the original order from the spec
+  private def make(expected: Int): SimpleError = SimpleError(expected)
+
   implicit val schema: Schema[SimpleError] = struct(
     int.required[SimpleError]("expected", _.expected),
   ){
-    SimpleError.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/test/TestPathInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/test/TestPathInput.scala
@@ -16,9 +16,12 @@ object TestPathInput extends ShapeTag.Companion[TestPathInput] {
     smithy.api.Input(),
   ).lazily
 
+  // constructor using the original order from the spec
+  private def make(path: String): TestPathInput = TestPathInput(path)
+
   implicit val schema: Schema[TestPathInput] = struct(
     string.required[TestPathInput]("path", _.path).addHints(smithy.api.HttpLabel()),
   ){
-    TestPathInput.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/test/TestPathInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/test/TestPathInput.scala
@@ -21,7 +21,5 @@ object TestPathInput extends ShapeTag.Companion[TestPathInput] {
 
   implicit val schema: Schema[TestPathInput] = struct(
     string.required[TestPathInput]("path", _.path).addHints(smithy.api.HttpLabel()),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/weather/Dog.scala
+++ b/modules/bootstrapped/src/generated/weather/Dog.scala
@@ -14,9 +14,12 @@ object Dog extends ShapeTag.Companion[Dog] {
 
   val hints: Hints = Hints.empty
 
+  // constructor using the original order from the spec
+  private def make(name: String): Dog = Dog(name)
+
   implicit val schema: Schema[Dog] = struct(
     string.required[Dog]("name", _.name),
   ){
-    Dog.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/weather/Dog.scala
+++ b/modules/bootstrapped/src/generated/weather/Dog.scala
@@ -19,7 +19,5 @@ object Dog extends ShapeTag.Companion[Dog] {
 
   implicit val schema: Schema[Dog] = struct(
     string.required[Dog]("name", _.name),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/weather/GetWeatherInput.scala
+++ b/modules/bootstrapped/src/generated/weather/GetWeatherInput.scala
@@ -16,9 +16,12 @@ object GetWeatherInput extends ShapeTag.Companion[GetWeatherInput] {
     smithy.api.Input(),
   ).lazily
 
+  // constructor using the original order from the spec
+  private def make(city: String): GetWeatherInput = GetWeatherInput(city)
+
   implicit val schema: Schema[GetWeatherInput] = struct(
     string.required[GetWeatherInput]("city", _.city).addHints(smithy.api.HttpLabel()),
   ){
-    GetWeatherInput.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/weather/GetWeatherInput.scala
+++ b/modules/bootstrapped/src/generated/weather/GetWeatherInput.scala
@@ -21,7 +21,5 @@ object GetWeatherInput extends ShapeTag.Companion[GetWeatherInput] {
 
   implicit val schema: Schema[GetWeatherInput] = struct(
     string.required[GetWeatherInput]("city", _.city).addHints(smithy.api.HttpLabel()),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/weather/GetWeatherOutput.scala
+++ b/modules/bootstrapped/src/generated/weather/GetWeatherOutput.scala
@@ -21,7 +21,5 @@ object GetWeatherOutput extends ShapeTag.Companion[GetWeatherOutput] {
 
   implicit val schema: Schema[GetWeatherOutput] = struct(
     string.required[GetWeatherOutput]("weather", _.weather),
-  ){
-    make
-  }.withId(id).addHints(hints)
+  )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/weather/GetWeatherOutput.scala
+++ b/modules/bootstrapped/src/generated/weather/GetWeatherOutput.scala
@@ -16,9 +16,12 @@ object GetWeatherOutput extends ShapeTag.Companion[GetWeatherOutput] {
     smithy.api.Output(),
   ).lazily
 
+  // constructor using the original order from the spec
+  private def make(weather: String): GetWeatherOutput = GetWeatherOutput(weather)
+
   implicit val schema: Schema[GetWeatherOutput] = struct(
     string.required[GetWeatherOutput]("weather", _.weather),
   ){
-    GetWeatherOutput.apply
+    make
   }.withId(id).addHints(hints)
 }

--- a/modules/codegen/src/smithy4s/codegen/internals/CollisionAvoidance.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/CollisionAvoidance.scala
@@ -147,6 +147,7 @@ private[internals] object CollisionAvoidance {
       field.name,
       modType(field.tpe),
       field.modifier,
+      field.originalIndex,
       field.hints.map(modHint)
     )
   }

--- a/modules/codegen/src/smithy4s/codegen/internals/IR.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/IR.scala
@@ -132,6 +132,7 @@ private[internals] case class Field(
     realName: String,
     tpe: Type,
     modifier: Field.Modifier,
+    originalIndex: Int,
     hints: List[Hint]
 )
 
@@ -193,9 +194,10 @@ private[internals] object Field {
       name: String,
       tpe: Type,
       modifier: Modifier,
+      originalIndex: Int,
       hints: List[Hint] = Nil
   ): Field =
-    Field(name, name, tpe, modifier, hints)
+    Field(name, name, tpe, modifier, originalIndex, hints)
 
 }
 

--- a/modules/codegen/src/smithy4s/codegen/internals/Renderer.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/Renderer.scala
@@ -737,8 +737,7 @@ private[internals] class Renderer(compilationUnit: CompilationUnit) { self =>
               if (recursive) line"$recursive_($struct_" else line"$struct_"
             line"${schemaImplicit}val schema: $Schema_[${product.nameRef}] = $definition"
               .args(renderedFields)
-              .block(line"make")
-              .appendToLast(".withId(id).addHints(hints)")
+              .appendToLast("(make).withId(id).addHints(hints)")
               .appendToLast(if (recursive) ")" else "")
           } else {
             val definition =

--- a/modules/codegen/src/smithy4s/codegen/internals/Renderer.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/Renderer.scala
@@ -698,9 +698,19 @@ private[internals] class Renderer(compilationUnit: CompilationUnit) { self =>
         renderProtocol(product.nameRef, hints),
         newline,
         renderLenses(product, hints),
+        locally {
+          val params =
+            fields.sortBy(_.originalIndex).map(fieldToRenderLine(_, noDefault = true)).intercalate(Line.comma)
+          val args = fields.map(f => Line(f.name)).intercalate(Line.comma)
+          lines(
+            line"// constructor using the original order from the spec",
+            line"private def make($params): ${product.nameRef} = ${product.nameRef}($args)"
+          ).when(fields.nonEmpty)
+        },
+        newline,
         if (fields.nonEmpty) {
           val renderedFields =
-            fields.map { case Field(fieldName, realName, tpe, modifier, hints) =>
+            fields.sortBy(_.originalIndex).map { case Field(fieldName, realName, tpe, modifier, _, hints) =>
               val fieldBuilder = modifier.typeMod match {
                 case Field.TypeModification.None if modifier.required     => "required"
                 case Field.TypeModification.None                          => "field"
@@ -727,7 +737,7 @@ private[internals] class Renderer(compilationUnit: CompilationUnit) { self =>
               if (recursive) line"$recursive_($struct_" else line"$struct_"
             line"${schemaImplicit}val schema: $Schema_[${product.nameRef}] = $definition"
               .args(renderedFields)
-              .block(line"${product.nameRef}.apply")
+              .block(line"make")
               .appendToLast(".withId(id).addHints(hints)")
               .appendToLast(if (recursive) ")" else "")
           } else {
@@ -737,7 +747,7 @@ private[internals] class Renderer(compilationUnit: CompilationUnit) { self =>
             line"${schemaImplicit}val schema: $Schema_[${product.nameRef}] = $definition"
               .args(renderedFields)
               .block(
-                line"arr => new ${product.nameRef}".args(
+                line"arr => make".args(
                   fields.zipWithIndex.map { case (field, idx) =>
                     line"arr($idx).asInstanceOf[${Line.fieldType(field)}]"
                   }

--- a/modules/codegen/test/src/smithy4s/codegen/internals/DefaultRenderModeSpec.scala
+++ b/modules/codegen/test/src/smithy4s/codegen/internals/DefaultRenderModeSpec.scala
@@ -64,6 +64,9 @@ final class DefaultRenderModeSpec extends munit.FunSuite {
          |
          |  val hints: Hints = Hints.empty
          |
+         |  // constructor using the original order from the spec
+         |  private def make(one: Option[String], two: String, three: String, four: String, five: Option[Nullable[String]], six: Nullable[String], seven: Nullable[String], eight: Nullable[String]): Test = Test(one, two, three, four, five, six, seven, eight)
+         |
          |  implicit val schema: Schema[Test] = struct(
          |    string.optional[Test]("one", _.one),
          |    string.field[Test]("two", _.two).addHints(smithy.api.Default(smithy4s.Document.fromString("test"))),
@@ -74,7 +77,7 @@ final class DefaultRenderModeSpec extends munit.FunSuite {
          |    string.nullable.field[Test]("seven", _.seven).addHints(smithy.api.Default(smithy4s.Document.nullDoc)),
          |    string.nullable.required[Test]("eight", _.eight),
          |  ){
-         |    Test.apply
+         |    make
          |  }.withId(id).addHints(hints)
          |}""".stripMargin
 
@@ -127,17 +130,20 @@ final class DefaultRenderModeSpec extends munit.FunSuite {
          |
          |  val hints: Hints = Hints.empty
          |
+         |  // constructor using the original order from the spec
+         |  private def make(one: Option[String], two: String, three: String, four: String, five: Option[Nullable[String]], six: Nullable[String], seven: Nullable[String], eight: Nullable[String]): Test = Test(two, three, four, six, seven, eight, one, five)
+         |
          |  implicit val schema: Schema[Test] = struct(
+         |    string.optional[Test]("one", _.one),
          |    string.field[Test]("two", _.two).addHints(smithy.api.Default(smithy4s.Document.fromString("test"))),
          |    string.required[Test]("three", _.three),
          |    string.required[Test]("four", _.four).addHints(smithy.api.Default(smithy4s.Document.fromString("test"))),
+         |    string.nullable.optional[Test]("five", _.five),
          |    string.nullable.field[Test]("six", _.six).addHints(smithy.api.Default(smithy4s.Document.fromString("test"))),
          |    string.nullable.field[Test]("seven", _.seven).addHints(smithy.api.Default(smithy4s.Document.nullDoc)),
          |    string.nullable.required[Test]("eight", _.eight),
-         |    string.optional[Test]("one", _.one),
-         |    string.nullable.optional[Test]("five", _.five),
          |  ){
-         |    Test.apply
+         |    make
          |  }.withId(id).addHints(hints)
          |}""".stripMargin
 
@@ -192,17 +198,20 @@ final class DefaultRenderModeSpec extends munit.FunSuite {
          |
          |  val hints: Hints = Hints.empty
          |
+         |  // constructor using the original order from the spec
+         |  private def make(one: Option[String], two: String, three: String, four: String, five: Option[Nullable[String]], six: Nullable[String], seven: Nullable[String], eight: Nullable[String]): Test = Test(three, eight, two, four, six, seven, one, five)
+         |
          |  implicit val schema: Schema[Test] = struct(
-         |    string.required[Test]("three", _.three),
-         |    string.nullable.required[Test]("eight", _.eight),
+         |    string.optional[Test]("one", _.one),
          |    string.field[Test]("two", _.two).addHints(smithy.api.Default(smithy4s.Document.fromString("test"))),
+         |    string.required[Test]("three", _.three),
          |    string.required[Test]("four", _.four).addHints(smithy.api.Default(smithy4s.Document.fromString("test"))),
+         |    string.nullable.optional[Test]("five", _.five),
          |    string.nullable.field[Test]("six", _.six).addHints(smithy.api.Default(smithy4s.Document.fromString("test"))),
          |    string.nullable.field[Test]("seven", _.seven).addHints(smithy.api.Default(smithy4s.Document.nullDoc)),
-         |    string.optional[Test]("one", _.one),
-         |    string.nullable.optional[Test]("five", _.five),
+         |    string.nullable.required[Test]("eight", _.eight),
          |  ){
-         |    Test.apply
+         |    make
          |  }.withId(id).addHints(hints)
          |}
          |""".stripMargin

--- a/modules/codegen/test/src/smithy4s/codegen/internals/DefaultRenderModeSpec.scala
+++ b/modules/codegen/test/src/smithy4s/codegen/internals/DefaultRenderModeSpec.scala
@@ -76,9 +76,7 @@ final class DefaultRenderModeSpec extends munit.FunSuite {
          |    string.nullable.field[Test]("six", _.six).addHints(smithy.api.Default(smithy4s.Document.fromString("test"))),
          |    string.nullable.field[Test]("seven", _.seven).addHints(smithy.api.Default(smithy4s.Document.nullDoc)),
          |    string.nullable.required[Test]("eight", _.eight),
-         |  ){
-         |    make
-         |  }.withId(id).addHints(hints)
+         |  )(make).withId(id).addHints(hints)
          |}""".stripMargin
 
     TestUtils.runTest(smithy, scalaCode)
@@ -142,9 +140,7 @@ final class DefaultRenderModeSpec extends munit.FunSuite {
          |    string.nullable.field[Test]("six", _.six).addHints(smithy.api.Default(smithy4s.Document.fromString("test"))),
          |    string.nullable.field[Test]("seven", _.seven).addHints(smithy.api.Default(smithy4s.Document.nullDoc)),
          |    string.nullable.required[Test]("eight", _.eight),
-         |  ){
-         |    make
-         |  }.withId(id).addHints(hints)
+         |  )(make).withId(id).addHints(hints)
          |}""".stripMargin
 
     TestUtils.runTest(smithy, scalaCode)
@@ -210,9 +206,7 @@ final class DefaultRenderModeSpec extends munit.FunSuite {
          |    string.nullable.field[Test]("six", _.six).addHints(smithy.api.Default(smithy4s.Document.fromString("test"))),
          |    string.nullable.field[Test]("seven", _.seven).addHints(smithy.api.Default(smithy4s.Document.nullDoc)),
          |    string.nullable.required[Test]("eight", _.eight),
-         |  ){
-         |    make
-         |  }.withId(id).addHints(hints)
+         |  )(make).withId(id).addHints(hints)
          |}
          |""".stripMargin
 

--- a/modules/codegen/test/src/smithy4s/codegen/transformers/AwsStandardTypesTransformerSpec.scala
+++ b/modules/codegen/test/src/smithy4s/codegen/transformers/AwsStandardTypesTransformerSpec.scala
@@ -87,12 +87,15 @@ final class AwsStandardTypesTransformerSpec extends munit.FunSuite {
         |
         |  val hints: Hints = Hints.empty
         |
+        |  // constructor using the original order from the spec
+        |  private def make(i: Int, d: Option[Date], l: Option[Long]): TestStructure = TestStructure(i, d, l)
+        |
         |  implicit val schema: Schema[TestStructure] = struct(
         |    int.required[TestStructure]("i", _.i),
         |    Date.schema.optional[TestStructure]("d", _.d),
         |    Long.schema.optional[TestStructure]("l", _.l),
         |  ){
-        |    TestStructure.apply
+        |    make
         |  }.withId(id).addHints(hints)
         |}""".stripMargin
     )
@@ -149,10 +152,13 @@ final class AwsStandardTypesTransformerSpec extends munit.FunSuite {
         |
         |  val hints: Hints = Hints.empty
         |
+        |  // constructor using the original order from the spec
+        |  private def make(s: Option[String]): TestStructure = TestStructure(s)
+        |
         |  implicit val schema: Schema[TestStructure] = struct(
         |    string.validated(smithy.api.Length(min = Some(5L), max = Some(10L))).optional[TestStructure]("s", _.s),
         |  ){
-        |    TestStructure.apply
+        |    make
         |  }.withId(id).addHints(hints)
         |}""".stripMargin
     )
@@ -211,10 +217,13 @@ final class AwsStandardTypesTransformerSpec extends munit.FunSuite {
         |
         |  val hints: Hints = Hints.empty
         |
+        |  // constructor using the original order from the spec
+        |  private def make(i: Int): TestStructure = TestStructure(i)
+        |
         |  implicit val schema: Schema[TestStructure] = struct(
         |    int.field[TestStructure]("i", _.i).addHints(smithy.api.Default(smithy4s.Document.fromDouble(5.0d))),
         |  ){
-        |    TestStructure.apply
+        |    make
         |  }.withId(id).addHints(hints)
         |}""".stripMargin
     )

--- a/modules/codegen/test/src/smithy4s/codegen/transformers/AwsStandardTypesTransformerSpec.scala
+++ b/modules/codegen/test/src/smithy4s/codegen/transformers/AwsStandardTypesTransformerSpec.scala
@@ -94,9 +94,7 @@ final class AwsStandardTypesTransformerSpec extends munit.FunSuite {
         |    int.required[TestStructure]("i", _.i),
         |    Date.schema.optional[TestStructure]("d", _.d),
         |    Long.schema.optional[TestStructure]("l", _.l),
-        |  ){
-        |    make
-        |  }.withId(id).addHints(hints)
+        |  )(make).withId(id).addHints(hints)
         |}""".stripMargin
     )
   }
@@ -157,9 +155,7 @@ final class AwsStandardTypesTransformerSpec extends munit.FunSuite {
         |
         |  implicit val schema: Schema[TestStructure] = struct(
         |    string.validated(smithy.api.Length(min = Some(5L), max = Some(10L))).optional[TestStructure]("s", _.s),
-        |  ){
-        |    make
-        |  }.withId(id).addHints(hints)
+        |  )(make).withId(id).addHints(hints)
         |}""".stripMargin
     )
   }
@@ -222,9 +218,7 @@ final class AwsStandardTypesTransformerSpec extends munit.FunSuite {
         |
         |  implicit val schema: Schema[TestStructure] = struct(
         |    int.field[TestStructure]("i", _.i).addHints(smithy.api.Default(smithy4s.Document.fromDouble(5.0d))),
-        |  ){
-        |    make
-        |  }.withId(id).addHints(hints)
+        |  )(make).withId(id).addHints(hints)
         |}""".stripMargin
     )
   }


### PR DESCRIPTION
This changes the rendering logic to retain the original ordering of fields in Structure schemas, thus reflecting the spec more accurately. 

The original ordering of fields is important in some protocols, when positional information has semantic importance. 

NB for reviewers : the commits can be reviewed individually (in particular the first one)

## PR Checklist (not all items are relevant to all PRs)

- [x] Added unit-tests (for runtime code)
- [x] Added bootstrapped code + smoke tests (when the rendering logic is modified)
- [x] Updated changelog
