### PR TITLE
Enable code generation of alloy.proto in core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * smithy4s Structure schemas are now retaining the original order of fields, as per the specification.
 * Added a utility method, `Schema.transformTransitivelyK`, to help in recursively transforming schemas.
 In addition, the semantics of `transformHintsTransitively` have been changed: the transformation no longer modifies the hints on the result of the `total` function.
+* smithy4s-core now contains the generated code for the alloy.proto namespace
 
 # 0.18.10
 

--- a/build.sbt
+++ b/build.sbt
@@ -176,7 +176,8 @@ lazy val core = projectMatrix
       "smithy.api",
       "smithy.waiters",
       "alloy",
-      "alloy.common"
+      "alloy.common",
+      "alloy.proto"
     ),
     smithy4sDependencies ++= Seq(
       Dependencies.Smithy.waiters

--- a/modules/bootstrapped/src/generated/smithy4s/example/BigDecimalWrapper.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/BigDecimalWrapper.scala
@@ -1,0 +1,25 @@
+package smithy4s.example
+
+import smithy4s.Hints
+import smithy4s.Schema
+import smithy4s.ShapeId
+import smithy4s.ShapeTag
+import smithy4s.schema.Schema.bigdecimal
+import smithy4s.schema.Schema.struct
+
+final case class BigDecimalWrapper(bigDecimal: BigDecimal)
+
+object BigDecimalWrapper extends ShapeTag.Companion[BigDecimalWrapper] {
+  val id: ShapeId = ShapeId("smithy4s.example", "BigDecimalWrapper")
+
+  val hints: Hints = Hints(
+    alloy.proto.ProtoEnabled(),
+  ).lazily
+
+  // constructor using the original order from the spec
+  private def make(bigDecimal: BigDecimal): BigDecimalWrapper = BigDecimalWrapper(bigDecimal)
+
+  implicit val schema: Schema[BigDecimalWrapper] = struct(
+    bigdecimal.required[BigDecimalWrapper]("bigDecimal", _.bigDecimal).addHints(alloy.proto.ProtoIndex(1)),
+  )(make).withId(id).addHints(hints)
+}

--- a/modules/bootstrapped/src/generated/smithy4s/example/ClosedInt.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/ClosedInt.scala
@@ -1,0 +1,38 @@
+package smithy4s.example
+
+import smithy4s.Enumeration
+import smithy4s.Hints
+import smithy4s.Schema
+import smithy4s.ShapeId
+import smithy4s.ShapeTag
+import smithy4s.schema.EnumTag
+import smithy4s.schema.Schema.enumeration
+
+sealed abstract class ClosedInt(_value: String, _name: String, _intValue: Int, _hints: Hints) extends Enumeration.Value {
+  override type EnumType = ClosedInt
+  override val value: String = _value
+  override val name: String = _name
+  override val intValue: Int = _intValue
+  override val hints: Hints = _hints
+  override def enumeration: Enumeration[EnumType] = ClosedInt
+  @inline final def widen: ClosedInt = this
+}
+object ClosedInt extends Enumeration[ClosedInt] with ShapeTag.Companion[ClosedInt] {
+  val id: ShapeId = ShapeId("smithy4s.example", "ClosedInt")
+
+  val hints: Hints = Hints.empty
+
+  case object FOO extends ClosedInt("FOO", "FOO", 0, Hints.empty) {
+    override val hints: Hints = Hints(alloy.proto.ProtoIndex(0)).lazily
+  }
+  case object BAR extends ClosedInt("BAR", "BAR", 1, Hints.empty) {
+    override val hints: Hints = Hints(alloy.proto.ProtoIndex(1)).lazily
+  }
+
+  val values: List[ClosedInt] = List(
+    FOO,
+    BAR,
+  )
+  val tag: EnumTag[ClosedInt] = EnumTag.ClosedIntEnum
+  implicit val schema: Schema[ClosedInt] = enumeration(tag, values).withId(id).addHints(hints)
+}

--- a/modules/bootstrapped/src/generated/smithy4s/example/ClosedString.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/ClosedString.scala
@@ -1,0 +1,38 @@
+package smithy4s.example
+
+import smithy4s.Enumeration
+import smithy4s.Hints
+import smithy4s.Schema
+import smithy4s.ShapeId
+import smithy4s.ShapeTag
+import smithy4s.schema.EnumTag
+import smithy4s.schema.Schema.enumeration
+
+sealed abstract class ClosedString(_value: String, _name: String, _intValue: Int, _hints: Hints) extends Enumeration.Value {
+  override type EnumType = ClosedString
+  override val value: String = _value
+  override val name: String = _name
+  override val intValue: Int = _intValue
+  override val hints: Hints = _hints
+  override def enumeration: Enumeration[EnumType] = ClosedString
+  @inline final def widen: ClosedString = this
+}
+object ClosedString extends Enumeration[ClosedString] with ShapeTag.Companion[ClosedString] {
+  val id: ShapeId = ShapeId("smithy4s.example", "ClosedString")
+
+  val hints: Hints = Hints.empty
+
+  case object FOO extends ClosedString("FOO", "FOO", 0, Hints.empty) {
+    override val hints: Hints = Hints(alloy.proto.ProtoIndex(0)).lazily
+  }
+  case object BAR extends ClosedString("BAR", "BAR", 1, Hints.empty) {
+    override val hints: Hints = Hints(alloy.proto.ProtoIndex(1)).lazily
+  }
+
+  val values: List[ClosedString] = List(
+    FOO,
+    BAR,
+  )
+  val tag: EnumTag[ClosedString] = EnumTag.ClosedStringEnum
+  implicit val schema: Schema[ClosedString] = enumeration(tag, values).withId(id).addHints(hints)
+}

--- a/modules/bootstrapped/src/generated/smithy4s/example/DummyService.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/DummyService.scala
@@ -103,7 +103,7 @@ object DummyServiceOperation {
     val schema: OperationSchema[HostLabelInput, Nothing, Unit, Nothing, Nothing] = Schema.operation(ShapeId("smithy4s.example", "DummyHostPrefix"))
       .withInput(HostLabelInput.schema)
       .withOutput(unit)
-      .withHints(smithy.api.Http(method = smithy.api.NonEmptyString("GET"), uri = smithy.api.NonEmptyString("/dummy"), code = 200), smithy.api.Endpoint(hostPrefix = smithy.api.NonEmptyString("foo.{label1}--abc{label2}.{label3}.secure.")))
+      .withHints(smithy.api.Http(method = smithy.api.NonEmptyString("POST"), uri = smithy.api.NonEmptyString("/dummy"), code = 200), smithy.api.Endpoint(hostPrefix = smithy.api.NonEmptyString("foo.{label1}--abc{label2}.{label3}.secure.")))
     def wrap(input: HostLabelInput): DummyHostPrefix = DummyHostPrefix(input)
   }
   final case class DummyPath(input: PathParams) extends DummyServiceOperation[PathParams, Nothing, Unit, Nothing, Nothing] {

--- a/modules/bootstrapped/src/generated/smithy4s/example/Enums.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/Enums.scala
@@ -1,0 +1,27 @@
+package smithy4s.example
+
+import smithy4s.Hints
+import smithy4s.Schema
+import smithy4s.ShapeId
+import smithy4s.ShapeTag
+import smithy4s.schema.Schema.struct
+
+final case class Enums(closedString: ClosedString, openString: OpenString, closedInt: ClosedInt, openInt: OpenInt)
+
+object Enums extends ShapeTag.Companion[Enums] {
+  val id: ShapeId = ShapeId("smithy4s.example", "Enums")
+
+  val hints: Hints = Hints(
+    alloy.proto.ProtoEnabled(),
+  ).lazily
+
+  // constructor using the original order from the spec
+  private def make(closedString: ClosedString, openString: OpenString, closedInt: ClosedInt, openInt: OpenInt): Enums = Enums(closedString, openString, closedInt, openInt)
+
+  implicit val schema: Schema[Enums] = struct(
+    ClosedString.schema.required[Enums]("closedString", _.closedString).addHints(alloy.proto.ProtoIndex(1)),
+    OpenString.schema.required[Enums]("openString", _.openString).addHints(alloy.proto.ProtoIndex(2)),
+    ClosedInt.schema.required[Enums]("closedInt", _.closedInt).addHints(alloy.proto.ProtoIndex(3)),
+    OpenInt.schema.required[Enums]("openInt", _.openInt).addHints(alloy.proto.ProtoIndex(4)),
+  )(make).withId(id).addHints(hints)
+}

--- a/modules/bootstrapped/src/generated/smithy4s/example/InlinedUnionWrapper.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/InlinedUnionWrapper.scala
@@ -1,0 +1,24 @@
+package smithy4s.example
+
+import smithy4s.Hints
+import smithy4s.Schema
+import smithy4s.ShapeId
+import smithy4s.ShapeTag
+import smithy4s.schema.Schema.struct
+
+final case class InlinedUnionWrapper(myInlinedUnion: Option[MyInlinedUnion] = None)
+
+object InlinedUnionWrapper extends ShapeTag.Companion[InlinedUnionWrapper] {
+  val id: ShapeId = ShapeId("smithy4s.example", "InlinedUnionWrapper")
+
+  val hints: Hints = Hints(
+    alloy.proto.ProtoEnabled(),
+  ).lazily
+
+  // constructor using the original order from the spec
+  private def make(myInlinedUnion: Option[MyInlinedUnion]): InlinedUnionWrapper = InlinedUnionWrapper(myInlinedUnion)
+
+  implicit val schema: Schema[InlinedUnionWrapper] = struct(
+    MyInlinedUnion.schema.optional[InlinedUnionWrapper]("myInlinedUnion", _.myInlinedUnion),
+  )(make).withId(id).addHints(hints)
+}

--- a/modules/bootstrapped/src/generated/smithy4s/example/IntListWrapper.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/IntListWrapper.scala
@@ -1,0 +1,24 @@
+package smithy4s.example
+
+import smithy4s.Hints
+import smithy4s.Schema
+import smithy4s.ShapeId
+import smithy4s.ShapeTag
+import smithy4s.schema.Schema.struct
+
+final case class IntListWrapper(ints: IntList)
+
+object IntListWrapper extends ShapeTag.Companion[IntListWrapper] {
+  val id: ShapeId = ShapeId("smithy4s.example", "IntListWrapper")
+
+  val hints: Hints = Hints(
+    alloy.proto.ProtoEnabled(),
+  ).lazily
+
+  // constructor using the original order from the spec
+  private def make(ints: IntList): IntListWrapper = IntListWrapper(ints)
+
+  implicit val schema: Schema[IntListWrapper] = struct(
+    IntList.schema.required[IntListWrapper]("ints", _.ints).addHints(alloy.proto.ProtoIndex(1)),
+  )(make).withId(id).addHints(hints)
+}

--- a/modules/bootstrapped/src/generated/smithy4s/example/Integers.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/Integers.scala
@@ -1,0 +1,29 @@
+package smithy4s.example
+
+import smithy4s.Hints
+import smithy4s.Schema
+import smithy4s.ShapeId
+import smithy4s.ShapeTag
+import smithy4s.schema.Schema.int
+import smithy4s.schema.Schema.struct
+
+final case class Integers(int: Int, sint: Int, uint: Int, fixedUint: Int, fixedSint: Int)
+
+object Integers extends ShapeTag.Companion[Integers] {
+  val id: ShapeId = ShapeId("smithy4s.example", "Integers")
+
+  val hints: Hints = Hints(
+    alloy.proto.ProtoEnabled(),
+  ).lazily
+
+  // constructor using the original order from the spec
+  private def make(int: Int, sint: Int, uint: Int, fixedUint: Int, fixedSint: Int): Integers = Integers(int, sint, uint, fixedUint, fixedSint)
+
+  implicit val schema: Schema[Integers] = struct(
+    int.required[Integers]("int", _.int).addHints(alloy.proto.ProtoIndex(1)),
+    int.required[Integers]("sint", _.sint).addHints(alloy.proto.ProtoNumType.SIGNED.widen, alloy.proto.ProtoIndex(2)),
+    int.required[Integers]("uint", _.uint).addHints(alloy.proto.ProtoNumType.UNSIGNED.widen, alloy.proto.ProtoIndex(3)),
+    int.required[Integers]("fixedUint", _.fixedUint).addHints(alloy.proto.ProtoNumType.FIXED.widen, alloy.proto.ProtoIndex(4)),
+    int.required[Integers]("fixedSint", _.fixedSint).addHints(alloy.proto.ProtoNumType.FIXED_SIGNED.widen, alloy.proto.ProtoIndex(5)),
+  )(make).withId(id).addHints(hints)
+}

--- a/modules/bootstrapped/src/generated/smithy4s/example/Longs.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/Longs.scala
@@ -1,0 +1,29 @@
+package smithy4s.example
+
+import smithy4s.Hints
+import smithy4s.Schema
+import smithy4s.ShapeId
+import smithy4s.ShapeTag
+import smithy4s.schema.Schema.long
+import smithy4s.schema.Schema.struct
+
+final case class Longs(long: Long, slong: Long, ulong: Long, fixedLong: Long, fixedSlong: Long)
+
+object Longs extends ShapeTag.Companion[Longs] {
+  val id: ShapeId = ShapeId("smithy4s.example", "Longs")
+
+  val hints: Hints = Hints(
+    alloy.proto.ProtoEnabled(),
+  ).lazily
+
+  // constructor using the original order from the spec
+  private def make(long: Long, slong: Long, ulong: Long, fixedLong: Long, fixedSlong: Long): Longs = Longs(long, slong, ulong, fixedLong, fixedSlong)
+
+  implicit val schema: Schema[Longs] = struct(
+    long.required[Longs]("long", _.long).addHints(alloy.proto.ProtoIndex(1)),
+    long.required[Longs]("slong", _.slong).addHints(alloy.proto.ProtoNumType.SIGNED.widen, alloy.proto.ProtoIndex(2)),
+    long.required[Longs]("ulong", _.ulong).addHints(alloy.proto.ProtoNumType.UNSIGNED.widen, alloy.proto.ProtoIndex(3)),
+    long.required[Longs]("fixedLong", _.fixedLong).addHints(alloy.proto.ProtoNumType.FIXED.widen, alloy.proto.ProtoIndex(4)),
+    long.required[Longs]("fixedSlong", _.fixedSlong).addHints(alloy.proto.ProtoNumType.FIXED_SIGNED.widen, alloy.proto.ProtoIndex(5)),
+  )(make).withId(id).addHints(hints)
+}

--- a/modules/bootstrapped/src/generated/smithy4s/example/MessageWrapper.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/MessageWrapper.scala
@@ -1,0 +1,24 @@
+package smithy4s.example
+
+import smithy4s.Hints
+import smithy4s.Schema
+import smithy4s.ShapeId
+import smithy4s.ShapeTag
+import smithy4s.schema.Schema.struct
+
+final case class MessageWrapper(message: Integers)
+
+object MessageWrapper extends ShapeTag.Companion[MessageWrapper] {
+  val id: ShapeId = ShapeId("smithy4s.example", "MessageWrapper")
+
+  val hints: Hints = Hints(
+    alloy.proto.ProtoEnabled(),
+  ).lazily
+
+  // constructor using the original order from the spec
+  private def make(message: Integers): MessageWrapper = MessageWrapper(message)
+
+  implicit val schema: Schema[MessageWrapper] = struct(
+    Integers.schema.required[MessageWrapper]("message", _.message).addHints(alloy.proto.ProtoIndex(1)),
+  )(make).withId(id).addHints(hints)
+}

--- a/modules/bootstrapped/src/generated/smithy4s/example/MyInlinedUnion.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/MyInlinedUnion.scala
@@ -1,0 +1,73 @@
+package smithy4s.example
+
+import smithy4s.Hints
+import smithy4s.Schema
+import smithy4s.ShapeId
+import smithy4s.ShapeTag
+import smithy4s.schema.Schema.bijection
+import smithy4s.schema.Schema.boolean
+import smithy4s.schema.Schema.union
+
+sealed trait MyInlinedUnion extends scala.Product with scala.Serializable { self =>
+  @inline final def widen: MyInlinedUnion = this
+  def $ordinal: Int
+
+  object project {
+    def int: Option[Int] = MyInlinedUnion.IntCase.alt.project.lift(self).map(_.int)
+    def bool: Option[Boolean] = MyInlinedUnion.BoolCase.alt.project.lift(self).map(_.bool)
+  }
+
+  def accept[A](visitor: MyInlinedUnion.Visitor[A]): A = this match {
+    case value: MyInlinedUnion.IntCase => visitor.int(value.int)
+    case value: MyInlinedUnion.BoolCase => visitor.bool(value.bool)
+  }
+}
+object MyInlinedUnion extends ShapeTag.Companion[MyInlinedUnion] {
+
+  def int(int: Int): MyInlinedUnion = IntCase(int)
+  def bool(bool: Boolean): MyInlinedUnion = BoolCase(bool)
+
+  val id: ShapeId = ShapeId("smithy4s.example", "MyInlinedUnion")
+
+  val hints: Hints = Hints(
+    alloy.proto.ProtoInlinedOneOf(),
+  ).lazily
+
+  final case class IntCase(int: Int) extends MyInlinedUnion { final def $ordinal: Int = 0 }
+  final case class BoolCase(bool: Boolean) extends MyInlinedUnion { final def $ordinal: Int = 1 }
+
+  object IntCase {
+    val hints: Hints = Hints(
+      alloy.proto.ProtoIndex(1),
+    ).lazily
+    val schema: Schema[MyInlinedUnion.IntCase] = bijection(smithy4s.schema.Schema.int.addHints(hints), MyInlinedUnion.IntCase(_), _.int)
+    val alt = schema.oneOf[MyInlinedUnion]("int")
+  }
+  object BoolCase {
+    val hints: Hints = Hints(
+      alloy.proto.ProtoIndex(2),
+    ).lazily
+    val schema: Schema[MyInlinedUnion.BoolCase] = bijection(boolean.addHints(hints), MyInlinedUnion.BoolCase(_), _.bool)
+    val alt = schema.oneOf[MyInlinedUnion]("bool")
+  }
+
+  trait Visitor[A] {
+    def int(value: Int): A
+    def bool(value: Boolean): A
+  }
+
+  object Visitor {
+    trait Default[A] extends Visitor[A] {
+      def default: A
+      def int(value: Int): A = default
+      def bool(value: Boolean): A = default
+    }
+  }
+
+  implicit val schema: Schema[MyInlinedUnion] = union(
+    MyInlinedUnion.IntCase.alt,
+    MyInlinedUnion.BoolCase.alt,
+  ){
+    _.$ordinal
+  }.withId(id).addHints(hints)
+}

--- a/modules/bootstrapped/src/generated/smithy4s/example/MyInt.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/MyInt.scala
@@ -1,0 +1,15 @@
+package smithy4s.example
+
+import smithy4s.Hints
+import smithy4s.Newtype
+import smithy4s.Schema
+import smithy4s.ShapeId
+import smithy4s.schema.Schema.bijection
+import smithy4s.schema.Schema.int
+
+object MyInt extends Newtype[Int] {
+  val id: ShapeId = ShapeId("smithy4s.example", "MyInt")
+  val hints: Hints = Hints.empty
+  val underlyingSchema: Schema[Int] = int.withId(id).addHints(hints)
+  implicit val schema: Schema[MyInt] = bijection(underlyingSchema, asBijection)
+}

--- a/modules/bootstrapped/src/generated/smithy4s/example/MyIntList.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/MyIntList.scala
@@ -1,0 +1,15 @@
+package smithy4s.example
+
+import smithy4s.Hints
+import smithy4s.Newtype
+import smithy4s.Schema
+import smithy4s.ShapeId
+import smithy4s.schema.Schema.bijection
+import smithy4s.schema.Schema.list
+
+object MyIntList extends Newtype[List[MyInt]] {
+  val id: ShapeId = ShapeId("smithy4s.example", "MyIntList")
+  val hints: Hints = Hints.empty
+  val underlyingSchema: Schema[List[MyInt]] = list(MyInt.schema).withId(id).addHints(hints)
+  implicit val schema: Schema[MyIntList] = bijection(underlyingSchema, asBijection)
+}

--- a/modules/bootstrapped/src/generated/smithy4s/example/MyIntListWrapper.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/MyIntListWrapper.scala
@@ -1,0 +1,24 @@
+package smithy4s.example
+
+import smithy4s.Hints
+import smithy4s.Schema
+import smithy4s.ShapeId
+import smithy4s.ShapeTag
+import smithy4s.schema.Schema.struct
+
+final case class MyIntListWrapper(ints: List[MyInt])
+
+object MyIntListWrapper extends ShapeTag.Companion[MyIntListWrapper] {
+  val id: ShapeId = ShapeId("smithy4s.example", "MyIntListWrapper")
+
+  val hints: Hints = Hints(
+    alloy.proto.ProtoEnabled(),
+  ).lazily
+
+  // constructor using the original order from the spec
+  private def make(ints: List[MyInt]): MyIntListWrapper = MyIntListWrapper(ints)
+
+  implicit val schema: Schema[MyIntListWrapper] = struct(
+    MyIntList.underlyingSchema.required[MyIntListWrapper]("ints", _.ints).addHints(alloy.proto.ProtoIndex(1)),
+  )(make).withId(id).addHints(hints)
+}

--- a/modules/bootstrapped/src/generated/smithy4s/example/MyUnion.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/MyUnion.scala
@@ -1,0 +1,71 @@
+package smithy4s.example
+
+import smithy4s.Hints
+import smithy4s.Schema
+import smithy4s.ShapeId
+import smithy4s.ShapeTag
+import smithy4s.schema.Schema.bijection
+import smithy4s.schema.Schema.boolean
+import smithy4s.schema.Schema.union
+
+sealed trait MyUnion extends scala.Product with scala.Serializable { self =>
+  @inline final def widen: MyUnion = this
+  def $ordinal: Int
+
+  object project {
+    def int: Option[Int] = MyUnion.IntCase.alt.project.lift(self).map(_.int)
+    def bool: Option[Boolean] = MyUnion.BoolCase.alt.project.lift(self).map(_.bool)
+  }
+
+  def accept[A](visitor: MyUnion.Visitor[A]): A = this match {
+    case value: MyUnion.IntCase => visitor.int(value.int)
+    case value: MyUnion.BoolCase => visitor.bool(value.bool)
+  }
+}
+object MyUnion extends ShapeTag.Companion[MyUnion] {
+
+  def int(int: Int): MyUnion = IntCase(int)
+  def bool(bool: Boolean): MyUnion = BoolCase(bool)
+
+  val id: ShapeId = ShapeId("smithy4s.example", "MyUnion")
+
+  val hints: Hints = Hints.empty
+
+  final case class IntCase(int: Int) extends MyUnion { final def $ordinal: Int = 0 }
+  final case class BoolCase(bool: Boolean) extends MyUnion { final def $ordinal: Int = 1 }
+
+  object IntCase {
+    val hints: Hints = Hints(
+      alloy.proto.ProtoIndex(1),
+    ).lazily
+    val schema: Schema[MyUnion.IntCase] = bijection(smithy4s.schema.Schema.int.addHints(hints), MyUnion.IntCase(_), _.int)
+    val alt = schema.oneOf[MyUnion]("int")
+  }
+  object BoolCase {
+    val hints: Hints = Hints(
+      alloy.proto.ProtoIndex(2),
+    ).lazily
+    val schema: Schema[MyUnion.BoolCase] = bijection(boolean.addHints(hints), MyUnion.BoolCase(_), _.bool)
+    val alt = schema.oneOf[MyUnion]("bool")
+  }
+
+  trait Visitor[A] {
+    def int(value: Int): A
+    def bool(value: Boolean): A
+  }
+
+  object Visitor {
+    trait Default[A] extends Visitor[A] {
+      def default: A
+      def int(value: Int): A = default
+      def bool(value: Boolean): A = default
+    }
+  }
+
+  implicit val schema: Schema[MyUnion] = union(
+    MyUnion.IntCase.alt,
+    MyUnion.BoolCase.alt,
+  ){
+    _.$ordinal
+  }.withId(id).addHints(hints)
+}

--- a/modules/bootstrapped/src/generated/smithy4s/example/OpenInt.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/OpenInt.scala
@@ -1,0 +1,39 @@
+package smithy4s.example
+
+import smithy4s.Enumeration
+import smithy4s.Hints
+import smithy4s.Schema
+import smithy4s.ShapeId
+import smithy4s.ShapeTag
+import smithy4s.schema.EnumTag
+import smithy4s.schema.Schema.enumeration
+
+sealed abstract class OpenInt(_value: String, _name: String, _intValue: Int, _hints: Hints) extends Enumeration.Value {
+  override type EnumType = OpenInt
+  override val value: String = _value
+  override val name: String = _name
+  override val intValue: Int = _intValue
+  override val hints: Hints = _hints
+  override def enumeration: Enumeration[EnumType] = OpenInt
+  @inline final def widen: OpenInt = this
+}
+object OpenInt extends Enumeration[OpenInt] with ShapeTag.Companion[OpenInt] {
+  val id: ShapeId = ShapeId("smithy4s.example", "OpenInt")
+
+  val hints: Hints = Hints(
+    alloy.OpenEnum(),
+  ).lazily
+
+  case object FOO extends OpenInt("FOO", "FOO", 0, Hints.empty)
+  case object BAR extends OpenInt("BAR", "BAR", 1, Hints.empty)
+  final case class $Unknown(int: Int) extends OpenInt("$Unknown", "$Unknown", int, Hints.empty)
+
+  val $unknown: Int => OpenInt = $Unknown(_)
+
+  val values: List[OpenInt] = List(
+    FOO,
+    BAR,
+  )
+  val tag: EnumTag[OpenInt] = EnumTag.OpenIntEnum($unknown)
+  implicit val schema: Schema[OpenInt] = enumeration(tag, values).withId(id).addHints(hints)
+}

--- a/modules/bootstrapped/src/generated/smithy4s/example/OpenString.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/OpenString.scala
@@ -1,0 +1,39 @@
+package smithy4s.example
+
+import smithy4s.Enumeration
+import smithy4s.Hints
+import smithy4s.Schema
+import smithy4s.ShapeId
+import smithy4s.ShapeTag
+import smithy4s.schema.EnumTag
+import smithy4s.schema.Schema.enumeration
+
+sealed abstract class OpenString(_value: String, _name: String, _intValue: Int, _hints: Hints) extends Enumeration.Value {
+  override type EnumType = OpenString
+  override val value: String = _value
+  override val name: String = _name
+  override val intValue: Int = _intValue
+  override val hints: Hints = _hints
+  override def enumeration: Enumeration[EnumType] = OpenString
+  @inline final def widen: OpenString = this
+}
+object OpenString extends Enumeration[OpenString] with ShapeTag.Companion[OpenString] {
+  val id: ShapeId = ShapeId("smithy4s.example", "OpenString")
+
+  val hints: Hints = Hints(
+    alloy.OpenEnum(),
+  ).lazily
+
+  case object FOO extends OpenString("FOO", "FOO", 0, Hints.empty)
+  case object BAR extends OpenString("BAR", "BAR", 1, Hints.empty)
+  final case class $Unknown(str: String) extends OpenString(str, "$Unknown", -1, Hints.empty)
+
+  val $unknown: String => OpenString = $Unknown(_)
+
+  val values: List[OpenString] = List(
+    FOO,
+    BAR,
+  )
+  val tag: EnumTag[OpenString] = EnumTag.OpenStringEnum($unknown)
+  implicit val schema: Schema[OpenString] = enumeration(tag, values).withId(id).addHints(hints)
+}

--- a/modules/bootstrapped/src/generated/smithy4s/example/OptionalMessageWrapper.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/OptionalMessageWrapper.scala
@@ -1,0 +1,24 @@
+package smithy4s.example
+
+import smithy4s.Hints
+import smithy4s.Schema
+import smithy4s.ShapeId
+import smithy4s.ShapeTag
+import smithy4s.schema.Schema.struct
+
+final case class OptionalMessageWrapper(message: Option[Integers] = None)
+
+object OptionalMessageWrapper extends ShapeTag.Companion[OptionalMessageWrapper] {
+  val id: ShapeId = ShapeId("smithy4s.example", "OptionalMessageWrapper")
+
+  val hints: Hints = Hints(
+    alloy.proto.ProtoEnabled(),
+  ).lazily
+
+  // constructor using the original order from the spec
+  private def make(message: Option[Integers]): OptionalMessageWrapper = OptionalMessageWrapper(message)
+
+  implicit val schema: Schema[OptionalMessageWrapper] = struct(
+    Integers.schema.optional[OptionalMessageWrapper]("message", _.message).addHints(alloy.proto.ProtoIndex(1)),
+  )(make).withId(id).addHints(hints)
+}

--- a/modules/bootstrapped/src/generated/smithy4s/example/OptionalStringWrapper.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/OptionalStringWrapper.scala
@@ -1,0 +1,25 @@
+package smithy4s.example
+
+import smithy4s.Hints
+import smithy4s.Schema
+import smithy4s.ShapeId
+import smithy4s.ShapeTag
+import smithy4s.schema.Schema.string
+import smithy4s.schema.Schema.struct
+
+final case class OptionalStringWrapper(string: Option[String] = None)
+
+object OptionalStringWrapper extends ShapeTag.Companion[OptionalStringWrapper] {
+  val id: ShapeId = ShapeId("smithy4s.example", "OptionalStringWrapper")
+
+  val hints: Hints = Hints(
+    alloy.proto.ProtoEnabled(),
+  ).lazily
+
+  // constructor using the original order from the spec
+  private def make(string: Option[String]): OptionalStringWrapper = OptionalStringWrapper(string)
+
+  implicit val schema: Schema[OptionalStringWrapper] = struct(
+    string.optional[OptionalStringWrapper]("string", _.string).addHints(alloy.proto.ProtoIndex(1)),
+  )(make).withId(id).addHints(hints)
+}

--- a/modules/bootstrapped/src/generated/smithy4s/example/Other.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/Other.scala
@@ -1,0 +1,30 @@
+package smithy4s.example
+
+import java.util.UUID
+import smithy4s.Hints
+import smithy4s.Schema
+import smithy4s.ShapeId
+import smithy4s.ShapeTag
+import smithy4s.schema.Schema.bigdecimal
+import smithy4s.schema.Schema.bigint
+import smithy4s.schema.Schema.struct
+import smithy4s.schema.Schema.uuid
+
+final case class Other(bigDecimal: BigDecimal, bigInteger: BigInt, uuid: UUID)
+
+object Other extends ShapeTag.Companion[Other] {
+  val id: ShapeId = ShapeId("smithy4s.example", "Other")
+
+  val hints: Hints = Hints(
+    alloy.proto.ProtoEnabled(),
+  ).lazily
+
+  // constructor using the original order from the spec
+  private def make(bigDecimal: BigDecimal, bigInteger: BigInt, uuid: UUID): Other = Other(bigDecimal, bigInteger, uuid)
+
+  implicit val schema: Schema[Other] = struct(
+    bigdecimal.required[Other]("bigDecimal", _.bigDecimal).addHints(alloy.proto.ProtoIndex(3)),
+    bigint.required[Other]("bigInteger", _.bigInteger).addHints(alloy.proto.ProtoIndex(4)),
+    uuid.required[Other]("uuid", _.uuid).addHints(alloy.proto.ProtoIndex(5)),
+  )(make).withId(id).addHints(hints)
+}

--- a/modules/bootstrapped/src/generated/smithy4s/example/OtherScalars.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/OtherScalars.scala
@@ -1,0 +1,33 @@
+package smithy4s.example
+
+import smithy4s.Hints
+import smithy4s.Schema
+import smithy4s.ShapeId
+import smithy4s.ShapeTag
+import smithy4s.schema.Schema.boolean
+import smithy4s.schema.Schema.byte
+import smithy4s.schema.Schema.double
+import smithy4s.schema.Schema.float
+import smithy4s.schema.Schema.short
+import smithy4s.schema.Schema.struct
+
+final case class OtherScalars(boolean: Boolean, byte: Byte, float: Float, double: Double, short: Short)
+
+object OtherScalars extends ShapeTag.Companion[OtherScalars] {
+  val id: ShapeId = ShapeId("smithy4s.example", "OtherScalars")
+
+  val hints: Hints = Hints(
+    alloy.proto.ProtoEnabled(),
+  ).lazily
+
+  // constructor using the original order from the spec
+  private def make(boolean: Boolean, byte: Byte, float: Float, double: Double, short: Short): OtherScalars = OtherScalars(boolean, byte, float, double, short)
+
+  implicit val schema: Schema[OtherScalars] = struct(
+    boolean.required[OtherScalars]("boolean", _.boolean).addHints(alloy.proto.ProtoIndex(1)),
+    byte.required[OtherScalars]("byte", _.byte).addHints(alloy.proto.ProtoIndex(2)),
+    float.required[OtherScalars]("float", _.float).addHints(alloy.proto.ProtoIndex(3)),
+    double.required[OtherScalars]("double", _.double).addHints(alloy.proto.ProtoIndex(4)),
+    short.required[OtherScalars]("short", _.short).addHints(alloy.proto.ProtoIndex(5)),
+  )(make).withId(id).addHints(hints)
+}

--- a/modules/bootstrapped/src/generated/smithy4s/example/Recursive.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/Recursive.scala
@@ -1,0 +1,25 @@
+package smithy4s.example
+
+import smithy4s.Hints
+import smithy4s.Schema
+import smithy4s.ShapeId
+import smithy4s.ShapeTag
+import smithy4s.schema.Schema.recursive
+import smithy4s.schema.Schema.struct
+
+final case class Recursive(recursive: Option[smithy4s.example.Recursive] = None)
+
+object Recursive extends ShapeTag.Companion[Recursive] {
+  val id: ShapeId = ShapeId("smithy4s.example", "Recursive")
+
+  val hints: Hints = Hints(
+    alloy.proto.ProtoEnabled(),
+  ).lazily
+
+  // constructor using the original order from the spec
+  private def make(recursive: Option[smithy4s.example.Recursive]): Recursive = Recursive(recursive)
+
+  implicit val schema: Schema[Recursive] = recursive(struct(
+    smithy4s.example.Recursive.schema.optional[Recursive]("recursive", _.recursive).addHints(alloy.proto.ProtoIndex(1)),
+  )(make).withId(id).addHints(hints))
+}

--- a/modules/bootstrapped/src/generated/smithy4s/example/StringListWrapper.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/StringListWrapper.scala
@@ -1,0 +1,25 @@
+package smithy4s.example
+
+import smithy4s.Hints
+import smithy4s.Schema
+import smithy4s.ShapeId
+import smithy4s.ShapeTag
+import smithy4s.schema.Schema.struct
+
+final case class StringListWrapper(strings: List[String], wrappedStrings: List[String])
+
+object StringListWrapper extends ShapeTag.Companion[StringListWrapper] {
+  val id: ShapeId = ShapeId("smithy4s.example", "StringListWrapper")
+
+  val hints: Hints = Hints(
+    alloy.proto.ProtoEnabled(),
+  ).lazily
+
+  // constructor using the original order from the spec
+  private def make(strings: List[String], wrappedStrings: List[String]): StringListWrapper = StringListWrapper(strings, wrappedStrings)
+
+  implicit val schema: Schema[StringListWrapper] = struct(
+    StringList.underlyingSchema.required[StringListWrapper]("strings", _.strings).addHints(alloy.proto.ProtoIndex(1)),
+    WrappedStringList.underlyingSchema.required[StringListWrapper]("wrappedStrings", _.wrappedStrings).addHints(alloy.proto.ProtoIndex(2)),
+  )(make).withId(id).addHints(hints)
+}

--- a/modules/bootstrapped/src/generated/smithy4s/example/StringMapWrapper.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/StringMapWrapper.scala
@@ -1,0 +1,24 @@
+package smithy4s.example
+
+import smithy4s.Hints
+import smithy4s.Schema
+import smithy4s.ShapeId
+import smithy4s.ShapeTag
+import smithy4s.schema.Schema.struct
+
+final case class StringMapWrapper(values: Map[String, String])
+
+object StringMapWrapper extends ShapeTag.Companion[StringMapWrapper] {
+  val id: ShapeId = ShapeId("smithy4s.example", "StringMapWrapper")
+
+  val hints: Hints = Hints(
+    alloy.proto.ProtoEnabled(),
+  ).lazily
+
+  // constructor using the original order from the spec
+  private def make(values: Map[String, String]): StringMapWrapper = StringMapWrapper(values)
+
+  implicit val schema: Schema[StringMapWrapper] = struct(
+    StringMap.underlyingSchema.required[StringMapWrapper]("values", _.values).addHints(alloy.proto.ProtoIndex(1)),
+  )(make).withId(id).addHints(hints)
+}

--- a/modules/bootstrapped/src/generated/smithy4s/example/StringWrapper.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/StringWrapper.scala
@@ -1,0 +1,25 @@
+package smithy4s.example
+
+import smithy4s.Hints
+import smithy4s.Schema
+import smithy4s.ShapeId
+import smithy4s.ShapeTag
+import smithy4s.schema.Schema.string
+import smithy4s.schema.Schema.struct
+
+final case class StringWrapper(string: String)
+
+object StringWrapper extends ShapeTag.Companion[StringWrapper] {
+  val id: ShapeId = ShapeId("smithy4s.example", "StringWrapper")
+
+  val hints: Hints = Hints(
+    alloy.proto.ProtoEnabled(),
+  ).lazily
+
+  // constructor using the original order from the spec
+  private def make(string: String): StringWrapper = StringWrapper(string)
+
+  implicit val schema: Schema[StringWrapper] = struct(
+    string.required[StringWrapper]("string", _.string).addHints(alloy.proto.ProtoIndex(1)),
+  )(make).withId(id).addHints(hints)
+}

--- a/modules/bootstrapped/src/generated/smithy4s/example/UnionWrapper.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/UnionWrapper.scala
@@ -1,0 +1,24 @@
+package smithy4s.example
+
+import smithy4s.Hints
+import smithy4s.Schema
+import smithy4s.ShapeId
+import smithy4s.ShapeTag
+import smithy4s.schema.Schema.struct
+
+final case class UnionWrapper(myUnion: Option[MyUnion] = None)
+
+object UnionWrapper extends ShapeTag.Companion[UnionWrapper] {
+  val id: ShapeId = ShapeId("smithy4s.example", "UnionWrapper")
+
+  val hints: Hints = Hints(
+    alloy.proto.ProtoEnabled(),
+  ).lazily
+
+  // constructor using the original order from the spec
+  private def make(myUnion: Option[MyUnion]): UnionWrapper = UnionWrapper(myUnion)
+
+  implicit val schema: Schema[UnionWrapper] = struct(
+    MyUnion.schema.optional[UnionWrapper]("myUnion", _.myUnion).addHints(alloy.proto.ProtoIndex(1)),
+  )(make).withId(id).addHints(hints)
+}

--- a/modules/bootstrapped/src/generated/smithy4s/example/WrappedScalars.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/WrappedScalars.scala
@@ -1,0 +1,27 @@
+package smithy4s.example
+
+import smithy4s.Hints
+import smithy4s.Schema
+import smithy4s.ShapeId
+import smithy4s.ShapeTag
+import smithy4s.schema.Schema.boolean
+import smithy4s.schema.Schema.int
+import smithy4s.schema.Schema.struct
+
+final case class WrappedScalars(int: Option[Int] = None, bool: Option[Boolean] = None)
+
+object WrappedScalars extends ShapeTag.Companion[WrappedScalars] {
+  val id: ShapeId = ShapeId("smithy4s.example", "WrappedScalars")
+
+  val hints: Hints = Hints(
+    alloy.proto.ProtoEnabled(),
+  ).lazily
+
+  // constructor using the original order from the spec
+  private def make(int: Option[Int], bool: Option[Boolean]): WrappedScalars = WrappedScalars(int, bool)
+
+  implicit val schema: Schema[WrappedScalars] = struct(
+    int.optional[WrappedScalars]("int", _.int).addHints(alloy.proto.ProtoWrapped(), alloy.proto.ProtoIndex(1)),
+    boolean.optional[WrappedScalars]("bool", _.bool).addHints(alloy.proto.ProtoWrapped(), alloy.proto.ProtoIndex(2)),
+  )(make).withId(id).addHints(hints)
+}

--- a/modules/bootstrapped/src/generated/smithy4s/example/WrappedStringList.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/WrappedStringList.scala
@@ -1,0 +1,18 @@
+package smithy4s.example
+
+import smithy4s.Hints
+import smithy4s.Newtype
+import smithy4s.Schema
+import smithy4s.ShapeId
+import smithy4s.schema.Schema.bijection
+import smithy4s.schema.Schema.list
+import smithy4s.schema.Schema.string
+
+object WrappedStringList extends Newtype[List[String]] {
+  val id: ShapeId = ShapeId("smithy4s.example", "WrappedStringList")
+  val hints: Hints = Hints(
+    alloy.proto.ProtoWrapped(),
+  ).lazily
+  val underlyingSchema: Schema[List[String]] = list(string).withId(id).addHints(hints)
+  implicit val schema: Schema[WrappedStringList] = bijection(underlyingSchema, asBijection)
+}

--- a/modules/bootstrapped/src/generated/smithy4s/example/package.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/package.scala
@@ -41,12 +41,14 @@ package object example {
   type Weather[F[_]] = smithy4s.kinds.FunctorAlgebra[WeatherGen, F]
   val Weather = WeatherGen
 
+  type MyIntList = smithy4s.example.MyIntList.Type
   type PublishersList = smithy4s.example.PublishersList.Type
   type TestString = smithy4s.example.TestString.Type
   type ArbitraryData = smithy4s.example.ArbitraryData.Type
   type PersonPhoneNumber = smithy4s.example.PersonPhoneNumber.Type
   type CSV = smithy4s.example.CSV.Type
   type CityId = smithy4s.example.CityId.Type
+  type WrappedStringList = smithy4s.example.WrappedStringList.Type
   type PersonAge = smithy4s.example.PersonAge.Type
   @deprecated(message = "N/A", since = "N/A")
   type DeprecatedString = smithy4s.example.DeprecatedString.Type
@@ -101,6 +103,7 @@ package object example {
   type StreamedBlob = smithy4s.example.StreamedBlob.Type
   type TestIdRefValueMap = smithy4s.example.TestIdRefValueMap.Type
   type PNG = smithy4s.example.PNG.Type
+  type MyInt = smithy4s.example.MyInt.Type
   type StringWithEnumTraits = smithy4s.example.StringWithEnumTraits.Type
   type Name = smithy4s.example.Name.Type
   type ObjectKey = smithy4s.example.ObjectKey.Type

--- a/modules/codegen/src/smithy4s/codegen/internals/CodegenImpl.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/CodegenImpl.scala
@@ -120,6 +120,7 @@ private[codegen] object CodegenImpl { self =>
       Set(
         "alloy",
         "alloy.common",
+        "alloy.proto",
         "smithy4s.api",
         "smithy4s.meta"
       )
@@ -169,6 +170,7 @@ private[codegen] object CodegenImpl { self =>
           os.RelPath(result.namespace.split('.').toIndexedSeq, ups = 0)
         (relPath, result)
       }
+
   }
 
   def dumpModel(args: DumpModelArgs): String = {

--- a/sampleSpecs/metadata.smithy
+++ b/sampleSpecs/metadata.smithy
@@ -11,7 +11,7 @@ service DummyService {
   operations: [Dummy, DummyHostPrefix, DummyPath]
 }
 
-@http(method: "GET", uri: "/dummy")
+@http(method: "POST", uri: "/dummy")
 @endpoint(hostPrefix: "foo.{label1}--abc{label2}.{label3}.secure.")
 operation DummyHostPrefix {
     input: HostLabelInput

--- a/sampleSpecs/protoTest.smithy
+++ b/sampleSpecs/protoTest.smithy
@@ -1,0 +1,211 @@
+$version: "2"
+
+namespace smithy4s.example
+
+use alloy#UUID
+use alloy#openEnum
+use alloy.openapi#openapiExtensions
+use alloy.proto#protoEnabled
+use alloy.proto#protoIndex
+use alloy.proto#protoInlinedOneOf
+use alloy.proto#protoNumType
+use alloy.proto#protoWrapped
+
+@protoEnabled
+structure Integers {
+    @protoIndex(1)
+    @required
+    int: Integer
+    @protoIndex(2)
+    @protoNumType("SIGNED")
+    @required
+    sint: Integer
+    @protoIndex(3)
+    @protoNumType("UNSIGNED")
+    @required
+    uint: Integer
+    @protoIndex(4)
+    @protoNumType("FIXED")
+    @required
+    fixedUint: Integer
+    @protoIndex(5)
+    @protoNumType("FIXED_SIGNED")
+    @required
+    fixedSint: Integer
+}
+
+@protoEnabled
+structure Longs {
+    @protoIndex(1)
+    @required
+    long: Long
+    @protoIndex(2)
+    @protoNumType("SIGNED")
+    @required
+    slong: Long
+    @protoIndex(3)
+    @protoNumType("UNSIGNED")
+    @required
+    ulong: Long
+    @protoIndex(4)
+    @protoNumType("FIXED")
+    @required
+    fixedLong: Long
+    @protoIndex(5)
+    @protoNumType("FIXED_SIGNED")
+    @required
+    fixedSlong: Long
+}
+
+@protoEnabled
+structure OtherScalars {
+    @protoIndex(1)
+    @required
+    boolean: Boolean
+    @required
+    @protoIndex(2)
+    byte: Byte
+    @required
+    @protoIndex(3)
+    float: Float
+    @required
+    @protoIndex(4)
+    double: Double
+    @required
+    @protoIndex(5)
+    short: Short
+}
+
+@protoEnabled
+structure WrappedScalars {
+    @protoIndex(1)
+    @protoWrapped
+    int: Integer
+    @protoIndex(2)
+    @protoWrapped
+    bool: Boolean
+}
+
+@protoEnabled
+structure StringWrapper {
+    @protoIndex(1)
+    @required
+    string: String
+}
+
+@protoEnabled
+structure OptionalStringWrapper {
+    @protoIndex(1)
+    string: String
+}
+
+@protoEnabled
+structure BigDecimalWrapper {
+    @protoIndex(1)
+    @required
+    bigDecimal: BigDecimal
+}
+
+@protoEnabled
+structure Other {
+    @protoIndex(3)
+    @required
+    bigDecimal: BigDecimal
+    @required
+    @protoIndex(4)
+    bigInteger: BigInteger
+    @protoIndex(5)
+    @required
+    uuid: UUID
+}
+
+@protoEnabled
+structure MessageWrapper {
+    @protoIndex(1)
+    @required
+    message: Integers
+}
+
+@protoEnabled
+structure OptionalMessageWrapper {
+    @protoIndex(1)
+    message: Integers
+}
+
+@protoEnabled
+structure IntListWrapper {
+    @protoIndex(1)
+    @required
+    ints: IntList
+}
+
+list StringList {
+    member: String
+}
+
+@protoWrapped
+list WrappedStringList {
+    member: String
+}
+
+@protoEnabled
+structure StringListWrapper {
+    @protoIndex(1)
+    @required
+    strings: StringList
+    @protoIndex(2)
+    @required
+    wrappedStrings: WrappedStringList
+}
+
+integer MyInt
+
+list MyIntList {
+    member: MyInt
+}
+
+@protoEnabled
+structure MyIntListWrapper {
+    @protoIndex(1)
+    @required
+    ints: MyIntList
+}
+
+@protoEnabled
+structure Recursive {
+    @protoIndex(1)
+    recursive: Recursive
+}
+
+@protoEnabled
+structure UnionWrapper {
+    @protoIndex(1)
+    myUnion: MyUnion
+}
+
+union MyUnion {
+    @protoIndex(1)
+    int: Integer
+    @protoIndex(2)
+    bool: Boolean
+}
+
+@protoEnabled
+structure InlinedUnionWrapper {
+    myInlinedUnion: MyInlinedUnion
+}
+
+@protoInlinedOneOf
+union MyInlinedUnion {
+    @protoIndex(1)
+    int: Integer
+    @protoIndex(2)
+    bool: Boolean
+}
+
+@protoEnabled
+structure StringMapWrapper {
+    @protoIndex(1)
+    @required
+    values: StringMap
+}

--- a/smithy-build.json
+++ b/smithy-build.json
@@ -3,8 +3,8 @@
   "imports": ["./sampleSpecs", "./modules/protocol/resources"],
   "maven": {
     "dependencies": [
-      "software.amazon.smithy:smithy-protocol-test-traits:1.31.0",
-      "com.disneystreaming.alloy:alloy-core:0.2.5"
+      "software.amazon.smithy:smithy-protocol-test-traits:1.45.0",
+      "com.disneystreaming.alloy:alloy-core:0.3.2"
     ]
   }
 }


### PR DESCRIPTION
Also adds a bunch of shapes leveraging the proto traits in order to verify that the code is indeed accessible

## PR Checklist (not all items are relevant to all PRs)

- [x] Updated changelog
