### PR TITLE
Respect enum values ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.18.13
+
+* modify rendering logic to guarantee that enum values are rendered in the same order as the spec.
+
 # 0.18.12
 
 * fix issue where schemas for fields of generated big structs (over 22 fields in size) would not be ordered correctly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 0.18.13
 
-* modify rendering logic to guarantee that enum values are rendered in the same order as the spec.
+* modify logic to guarantee that rendered and dynamic enum values respect the ordering from the specification.
 
 # 0.18.12
 

--- a/modules/codegen/src/smithy4s/codegen/internals/SmithyToIR.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/SmithyToIR.scala
@@ -342,13 +342,14 @@ private[codegen] class SmithyToIR(model: Model, namespace: String) {
         })
 
       override def enumShape(shape: EnumShape): Option[Decl] = {
+        val enumValues = shape.getEnumValues()
         val values = shape
-          .getEnumValues()
+          .members()
           .asScala
           .zipWithIndex
-          .map { case ((name, value), index) =>
-            val member = shape.getMember(name).get()
-
+          .map { case (member, index) =>
+            val name = member.getMemberName()
+            val value = enumValues.get(name)
             EnumValue(
               value = value,
               intValue = index,
@@ -372,12 +373,13 @@ private[codegen] class SmithyToIR(model: Model, namespace: String) {
       }
 
       override def intEnumShape(shape: IntEnumShape): Option[Decl] = {
+        val enumValues = shape.getEnumValues()
         val values = shape
-          .getEnumValues()
+          .members()
           .asScala
-          .map { case (name, value) =>
-            val member = shape.getMember(name).get()
-
+          .map { member =>
+            val name = member.getMemberName()
+            val value = enumValues.get(name)
             EnumValue(
               value = name,
               intValue = value,

--- a/modules/dynamic/test/src-jvm/smithy4s/dynamic/EnumSpec.scala
+++ b/modules/dynamic/test/src-jvm/smithy4s/dynamic/EnumSpec.scala
@@ -320,12 +320,12 @@ class EnumSpec extends DummyIO.Suite {
       val stringEnumSchemaNames = index
         .getSchema(ShapeId("input", "MyStringEnum"))
         .toList
-        .flatMap(_.compile(EnumNamesSchemaVisitor))
+        .flatMap(EnumNamesSchemaVisitor(_))
 
       val intEnumSchemaNames = index
         .getSchema(ShapeId("input", "MyIntEnum"))
         .toList
-        .flatMap(_.compile(EnumNamesSchemaVisitor))
+        .flatMap(EnumNamesSchemaVisitor(_))
       assertEquals(stringEnumSchemaNames, identifiers)
       assertEquals(intEnumSchemaNames, identifiers)
     }

--- a/modules/dynamic/test/src/smithy4s/dynamic/DummyIO.scala
+++ b/modules/dynamic/test/src/smithy4s/dynamic/DummyIO.scala
@@ -27,7 +27,7 @@ object DummyIO {
     def raiseError[A](e: Throwable): IO[A] = Left(e)
   }
 
-  trait Suite extends munit.FunSuite {
+  trait Suite extends munit.ScalaCheckSuite {
     override def munitValueTransforms: List[ValueTransform] =
       ioValueTransform :: super.munitValueTransforms
 


### PR DESCRIPTION
* Amend rendering logic to respect the ordering of enum values in rendered enumeration.
* Amend dynamic enum schema compilation to respect the ordering of enum values. 

## PR Checklist (not all items are relevant to all PRs)

- [x] Added unit-tests (for runtime code)
- [x] Updated dynamic module to match generated-code behaviour
- [x] Updated changelog
