### PR TITLE
aws json client max arity to Int.MaxValue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.18.14
+
+* Update aws-http4s clients using json to have a maxArity of Int.MaxValue
+
 # 0.18.13
 
 * Enable generation of protobuf specifications from smithy specifications.

--- a/modules/aws-http4s/src/smithy4s/aws/internals/AwsJsonCodecs.scala
+++ b/modules/aws-http4s/src/smithy4s/aws/internals/AwsJsonCodecs.scala
@@ -37,6 +37,7 @@ private[aws] object AwsJsonCodecs {
         .withInfinitySupport(true)
         .withFlexibleCollectionsSupport(true)
         .withHintMask(hintMask)
+        .withMaxArity(Int.MaxValue)
     )
 
   private[aws] val jsonDecoders = jsonPayloadCodecs.decoders

--- a/modules/aws-http4s/src/smithy4s/aws/internals/AwsRestJsonCodecs.scala
+++ b/modules/aws-http4s/src/smithy4s/aws/internals/AwsRestJsonCodecs.scala
@@ -37,6 +37,7 @@ private[aws] object AwsRestJsonCodecs {
           .withInfinitySupport(true)
           .withFlexibleCollectionsSupport(true)
           .withHintMask(hintMask)
+          .withMaxArity(Int.MaxValue)
       )
 
     def nullToEmptyObject(blob: Blob): Blob =


### PR DESCRIPTION
Update aws-http4s clients using json to have a maxArity of Int.MaxValue

## PR Checklist (not all items are relevant to all PRs)

- [ ] Added unit-tests (for runtime code)
- [ ] Added bootstrapped code + smoke tests (when the rendering logic is modified)
- [ ] Added build-plugins integration tests (when reflection loading is required at codegen-time)
- [ ] Added alloy compliance tests (when simpleRestJson protocol behaviour is expanded/updated)
- [ ] Updated dynamic module to match generated-code behaviour
- [ ] Added documentation
- [x] Updated changelog
