### PR TITLE
support for untagged in DocumentDecoderSchemaVisitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.18.14
+
+* Add support for decoding Document representations of untagged unions
+
 # 0.18.13
 
 * Enable generation of protobuf specifications from smithy specifications.

--- a/modules/bootstrapped/test/src/smithy4s/DocumentSpec.scala
+++ b/modules/bootstrapped/test/src/smithy4s/DocumentSpec.scala
@@ -22,6 +22,7 @@ import smithy4s.example.IntList
 import alloy.Discriminated
 import munit._
 import smithy4s.example.OperationOutput
+import alloy.Untagged
 
 class DocumentSpec() extends FunSuite {
 
@@ -136,6 +137,30 @@ class DocumentSpec() extends FunSuite {
 
     expect.same(document, expectedDocument)
     expect.same(roundTripped, Right(fooOrBar))
+  }
+
+  test("untagged unions encoding") {
+    implicit val eitherSchema: Schema[Either[Long, String]] = {
+      val left = Schema.long
+      val right = Schema.string
+
+      Schema
+        .either(left, right)
+        .addHints(
+          Untagged()
+        )
+    }
+    val longOrString: Either[Long, String] = Right("hello")
+
+    val document = Document.encode(longOrString)
+    import Document._
+    val expectedDocument =
+      Document.fromString("hello")
+
+    val roundTripped = Document.decode[Either[Long, String]](document)
+
+    expect.same(document, expectedDocument)
+    expect.same(roundTripped, Right(longOrString))
   }
 
   test("discriminated unions encoding - empty structure alternative") {


### PR DESCRIPTION
There may be a reason why we didn't have this before, but we came across a case that seems to indicate this was overlooked. We already had support for encoding untagged unions from documents, but not decoding them. Feel free to close this if I missed something and there actually is a good reason to omit them.

## PR Checklist (not all items are relevant to all PRs)

- [x] Added unit-tests (for runtime code)
- [ ] Added bootstrapped code + smoke tests (when the rendering logic is modified)
- [ ] Added build-plugins integration tests (when reflection loading is required at codegen-time)
- [ ] Added alloy compliance tests (when simpleRestJson protocol behaviour is expanded/updated)
- [ ] Updated dynamic module to match generated-code behaviour
- [ ] Added documentation
- [x] Updated changelog
