### PR TITLE
Prevent documentation for streaming members

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,7 @@
 # 0.19.0
 
-<<<<<<< HEAD
-* Reworked enumerations / the EnumerationSchema to eliminate a OOM pitfall and improve ergonomics of SchemaVisitor
-=======
+## Reworked enumerations / the EnumerationSchema to eliminate a OOM pitfall and improve ergonomics of SchemaVisitor
+
 ## Remove localhost from default URI in [#1341](https://github.com/disneystreaming/smithy4s/pull/1341)
 
 Previously, URIs constructed with a base URI of `/` would have `localhost` as the host. In some cases, that may not be desirable, such as in the case of frontend clients that want to reuse the window's origin. This is now fixed: hostnames are optional in the smithy4s URI model, and default to `None`.
@@ -21,7 +20,6 @@ These are now fixed in [#1344](https://github.com/disneystreaming/smithy4s/pull/
 * In some concurrent scenarios, especially those of concurrent initialization of objects (e.g. tests), your application would previously be at risk of deadlocking due to [#537](https://github.com/disneystreaming/smithy4s/issues/537). This is now fixed by suspending evaluation of hints in companion objects using the `.lazily` construct: see [#1326](https://github.com/disneystreaming/smithy4s/pull/1326).
 
 * Allow to configure how the default values (and nulls for optional fields) are rendered. Fixed in [#1315](https://github.com/disneystreaming/smithy4s/pull/1315)
->>>>>>> origin/series/0.19
 
 # 0.18.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # 0.19.0
 
+## Documentation fix
+
+Prevent documentation from being generated for case class when the field are not generated because they're annotated with `@streaming`
+
 ## Reworked enumerations / the EnumerationSchema to eliminate a OOM pitfall and improve ergonomics of SchemaVisitor
 
 ## Remove localhost from default URI in [#1341](https://github.com/disneystreaming/smithy4s/pull/1341)

--- a/modules/bootstrapped/src/generated/smithy4s/example/PackedInputsService.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/PackedInputsService.scala
@@ -77,7 +77,6 @@ object PackedInputsServiceOperation {
     val schema: OperationSchema[PackedInput, Nothing, Unit, Nothing, Nothing] = Schema.operation(ShapeId("smithy4s.example", "PackedInputOperation"))
       .withInput(PackedInput.schema)
       .withOutput(unit)
-      .withHints()
     def wrap(input: PackedInput): PackedInputOperation = PackedInputOperation(input)
   }
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/PutStreamedObjectInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/PutStreamedObjectInput.scala
@@ -7,9 +7,6 @@ import smithy4s.ShapeTag
 import smithy4s.schema.Schema.string
 import smithy4s.schema.Schema.struct
 
-/** @param data
-  *   data docs
-  */
 final case class PutStreamedObjectInput(key: String)
 
 object PutStreamedObjectInput extends ShapeTag.Companion[PutStreamedObjectInput] {

--- a/modules/bootstrapped/src/generated/smithy4s/example/PutStreamedObjectInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/PutStreamedObjectInput.scala
@@ -7,6 +7,9 @@ import smithy4s.ShapeTag
 import smithy4s.schema.Schema.string
 import smithy4s.schema.Schema.struct
 
+/** @param data
+  *   data docs
+  */
 final case class PutStreamedObjectInput(key: String)
 
 object PutStreamedObjectInput extends ShapeTag.Companion[PutStreamedObjectInput] {

--- a/modules/bootstrapped/src/generated/smithy4s/example/StreamedObjects.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/StreamedObjects.scala
@@ -15,9 +15,6 @@ import smithy4s.schema.StreamingSchema
 trait StreamedObjectsGen[F[_, _, _, _, _]] {
   self =>
 
-  /** @param data
-    *   data docs
-    */
   def putStreamedObject(key: String): F[PutStreamedObjectInput, Nothing, Unit, StreamedBlob, Nothing]
   def getStreamedObject(key: String): F[GetStreamedObjectInput, Nothing, GetStreamedObjectOutput, Nothing, StreamedBlob]
 
@@ -86,7 +83,6 @@ object StreamedObjectsOperation {
       .withInput(PutStreamedObjectInput.schema)
       .withOutput(unit)
       .withStreamedInput(StreamingSchema("PutStreamedObjectInput", StreamedBlob.schema.addHints(smithy.api.Documentation("data docs"), smithy.api.Default(smithy4s.Document.fromString("")))))
-      .withHints()
     def wrap(input: PutStreamedObjectInput): PutStreamedObject = PutStreamedObject(input)
   }
   final case class GetStreamedObject(input: GetStreamedObjectInput) extends StreamedObjectsOperation[GetStreamedObjectInput, Nothing, GetStreamedObjectOutput, Nothing, StreamedBlob] {

--- a/modules/bootstrapped/src/generated/smithy4s/example/StreamedObjects.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/StreamedObjects.scala
@@ -15,7 +15,9 @@ import smithy4s.schema.StreamingSchema
 trait StreamedObjectsGen[F[_, _, _, _, _]] {
   self =>
 
+  /** This operation uses {@literal @}streaming on the input (data). */
   def putStreamedObject(key: String): F[PutStreamedObjectInput, Nothing, Unit, StreamedBlob, Nothing]
+  /** This operation uses {@literal @}streaming on the output (data). */
   def getStreamedObject(key: String): F[GetStreamedObjectInput, Nothing, GetStreamedObjectOutput, Nothing, StreamedBlob]
 
   def transform: Transformation.PartiallyApplied[StreamedObjectsGen[F]] = Transformation.of[StreamedObjectsGen[F]](this)

--- a/modules/bootstrapped/src/generated/smithy4s/example/StreamedObjects.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/StreamedObjects.scala
@@ -19,6 +19,8 @@ trait StreamedObjectsGen[F[_, _, _, _, _]] {
   def putStreamedObject(key: String): F[PutStreamedObjectInput, Nothing, Unit, StreamedBlob, Nothing]
   /** This operation uses {@literal @}streaming on the output (data). */
   def getStreamedObject(key: String): F[GetStreamedObjectInput, Nothing, GetStreamedObjectOutput, Nothing, StreamedBlob]
+  /** This operation uses {@literal @}streaming on both the input (data) and the output (data) */
+  def putAndGetStreamedObject(key: String): F[PutStreamedObjectInput, Nothing, GetStreamedObjectOutput, StreamedBlob, StreamedBlob]
 
   def transform: Transformation.PartiallyApplied[StreamedObjectsGen[F]] = Transformation.of[StreamedObjectsGen[F]](this)
 }
@@ -40,6 +42,7 @@ object StreamedObjectsGen extends Service.Mixin[StreamedObjectsGen, StreamedObje
   val endpoints: Vector[smithy4s.Endpoint[StreamedObjectsOperation, _, _, _, _, _]] = Vector(
     StreamedObjectsOperation.PutStreamedObject,
     StreamedObjectsOperation.GetStreamedObject,
+    StreamedObjectsOperation.PutAndGetStreamedObject,
   )
 
   def input[I, E, O, SI, SO](op: StreamedObjectsOperation[I, E, O, SI, SO]): I = op.input
@@ -66,10 +69,12 @@ object StreamedObjectsOperation {
   object reified extends StreamedObjectsGen[StreamedObjectsOperation] {
     def putStreamedObject(key: String): PutStreamedObject = PutStreamedObject(PutStreamedObjectInput(key))
     def getStreamedObject(key: String): GetStreamedObject = GetStreamedObject(GetStreamedObjectInput(key))
+    def putAndGetStreamedObject(key: String): PutAndGetStreamedObject = PutAndGetStreamedObject(PutStreamedObjectInput(key))
   }
   class Transformed[P[_, _, _, _, _], P1[_ ,_ ,_ ,_ ,_]](alg: StreamedObjectsGen[P], f: PolyFunction5[P, P1]) extends StreamedObjectsGen[P1] {
     def putStreamedObject(key: String): P1[PutStreamedObjectInput, Nothing, Unit, StreamedBlob, Nothing] = f[PutStreamedObjectInput, Nothing, Unit, StreamedBlob, Nothing](alg.putStreamedObject(key))
     def getStreamedObject(key: String): P1[GetStreamedObjectInput, Nothing, GetStreamedObjectOutput, Nothing, StreamedBlob] = f[GetStreamedObjectInput, Nothing, GetStreamedObjectOutput, Nothing, StreamedBlob](alg.getStreamedObject(key))
+    def putAndGetStreamedObject(key: String): P1[PutStreamedObjectInput, Nothing, GetStreamedObjectOutput, StreamedBlob, StreamedBlob] = f[PutStreamedObjectInput, Nothing, GetStreamedObjectOutput, StreamedBlob, StreamedBlob](alg.putAndGetStreamedObject(key))
   }
 
   def toPolyFunction[P[_, _, _, _, _]](impl: StreamedObjectsGen[P]): PolyFunction5[StreamedObjectsOperation, P] = new PolyFunction5[StreamedObjectsOperation, P] {
@@ -98,6 +103,19 @@ object StreamedObjectsOperation {
       .withOutput(GetStreamedObjectOutput.schema)
       .withStreamedOutput(StreamingSchema("GetStreamedObjectOutput", StreamedBlob.schema.addHints(smithy.api.Default(smithy4s.Document.fromString("")))))
     def wrap(input: GetStreamedObjectInput): GetStreamedObject = GetStreamedObject(input)
+  }
+  final case class PutAndGetStreamedObject(input: PutStreamedObjectInput) extends StreamedObjectsOperation[PutStreamedObjectInput, Nothing, GetStreamedObjectOutput, StreamedBlob, StreamedBlob] {
+    def run[F[_, _, _, _, _]](impl: StreamedObjectsGen[F]): F[PutStreamedObjectInput, Nothing, GetStreamedObjectOutput, StreamedBlob, StreamedBlob] = impl.putAndGetStreamedObject(input.key)
+    def ordinal: Int = 2
+    def endpoint: smithy4s.Endpoint[StreamedObjectsOperation,PutStreamedObjectInput, Nothing, GetStreamedObjectOutput, StreamedBlob, StreamedBlob] = PutAndGetStreamedObject
+  }
+  object PutAndGetStreamedObject extends smithy4s.Endpoint[StreamedObjectsOperation,PutStreamedObjectInput, Nothing, GetStreamedObjectOutput, StreamedBlob, StreamedBlob] {
+    val schema: OperationSchema[PutStreamedObjectInput, Nothing, GetStreamedObjectOutput, StreamedBlob, StreamedBlob] = Schema.operation(ShapeId("smithy4s.example", "PutAndGetStreamedObject"))
+      .withInput(PutStreamedObjectInput.schema)
+      .withOutput(GetStreamedObjectOutput.schema)
+      .withStreamedInput(StreamingSchema("PutStreamedObjectInput", StreamedBlob.schema.addHints(smithy.api.Documentation("data docs"), smithy.api.Default(smithy4s.Document.fromString("")))))
+      .withStreamedOutput(StreamingSchema("GetStreamedObjectOutput", StreamedBlob.schema.addHints(smithy.api.Default(smithy4s.Document.fromString("")))))
+    def wrap(input: PutStreamedObjectInput): PutAndGetStreamedObject = PutAndGetStreamedObject(input)
   }
 }
 

--- a/modules/bootstrapped/src/generated/smithy4s/example/StreamedObjects.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/StreamedObjects.scala
@@ -15,6 +15,9 @@ import smithy4s.schema.StreamingSchema
 trait StreamedObjectsGen[F[_, _, _, _, _]] {
   self =>
 
+  /** @param data
+    *   data docs
+    */
   def putStreamedObject(key: String): F[PutStreamedObjectInput, Nothing, Unit, StreamedBlob, Nothing]
   def getStreamedObject(key: String): F[GetStreamedObjectInput, Nothing, GetStreamedObjectOutput, Nothing, StreamedBlob]
 
@@ -82,7 +85,8 @@ object StreamedObjectsOperation {
     val schema: OperationSchema[PutStreamedObjectInput, Nothing, Unit, StreamedBlob, Nothing] = Schema.operation(ShapeId("smithy4s.example", "PutStreamedObject"))
       .withInput(PutStreamedObjectInput.schema)
       .withOutput(unit)
-      .withStreamedInput(StreamingSchema("PutStreamedObjectInput", StreamedBlob.schema.addHints(smithy.api.Default(smithy4s.Document.fromString("")))))
+      .withStreamedInput(StreamingSchema("PutStreamedObjectInput", StreamedBlob.schema.addHints(smithy.api.Documentation("data docs"), smithy.api.Default(smithy4s.Document.fromString("")))))
+      .withHints()
     def wrap(input: PutStreamedObjectInput): PutStreamedObject = PutStreamedObject(input)
   }
   final case class GetStreamedObject(input: GetStreamedObjectInput) extends StreamedObjectsOperation[GetStreamedObjectInput, Nothing, GetStreamedObjectOutput, Nothing, StreamedBlob] {

--- a/modules/codegen/src/smithy4s/codegen/internals/Renderer.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/Renderer.scala
@@ -576,7 +576,7 @@ private[internals] class Renderer(compilationUnit: CompilationUnit) { self =>
           line".withOutput(${op.output.schemaRef})",
           op.streamedInput.map(si => line".withStreamedInput(${renderStreamingSchema(si)})"),
           op.streamedOutput.map(si => line".withStreamedOutput(${renderStreamingSchema(si)})"),
-          Option(op.hints).filter(_.nonEmpty).map(h => line".withHints(${memberHints(h)})")
+          memberHints(op.hints).surroundIfNotEmpty(line".withHints(", line")")
         ),
         line"def wrap(input: ${op.input}): $opNameRef = ${opNameRef}($input)"
       ),

--- a/modules/codegen/src/smithy4s/codegen/internals/Renderer.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/Renderer.scala
@@ -590,7 +590,7 @@ private[internals] class Renderer(compilationUnit: CompilationUnit) { self =>
     import sField._
     val mh =
       if (hints.isEmpty) Line.empty
-      else line".addHints(${memberHints(hints)})"
+      else memberHints(hints).surroundIfNotEmpty(line".addHints(", line")")
     line"""$StreamingSchema_("$name", ${tpe.schemaRef}$mh)"""
   }
 
@@ -711,10 +711,8 @@ private[internals] class Renderer(compilationUnit: CompilationUnit) { self =>
               if (hints.isEmpty) {
                 line"""${tpe.schemaRef}.$fieldBuilder[${product.nameRef}]("$realName", _.$fieldName)"""
               } else {
-                val memHints = memberHints(hints)
                 val addMemHints =
-                  if (memHints.nonEmpty) line".addHints($memHints)"
-                  else Line.empty
+                  memberHints(hints).surroundIfNotEmpty(line".addHints(", line")")
                 // format: off
                 line"""${tpe.schemaRef}${renderConstraintValidation(hints)}.$fieldBuilder[${product.nameRef}]("$realName", _.$fieldName)$addMemHints"""
                 // format: on
@@ -1369,16 +1367,13 @@ private[internals] class Renderer(compilationUnit: CompilationUnit) { self =>
           case CollectionType.IndexedSeq => s"$schemaPkg_.indexedSeq"
         }
         val hintsLine =
-          if (hints.isEmpty) Line.empty
-          else line".addMemberHints(${memberHints(hints)})"
+          memberHints(hints).surroundIfNotEmpty(line".addMemberHints(", line")")
         line"${NameRef(col)}(${member.schemaRef}$hintsLine)"
       case Type.Map(key, keyHints, value, valueHints) =>
         val keyHintsLine =
-          if (keyHints.isEmpty) Line.empty
-          else line".addMemberHints(${memberHints(keyHints)})"
+          memberHints(keyHints).surroundIfNotEmpty(line".addMemberHints(", line")")
         val valueHintsLine =
-          if (valueHints.isEmpty) Line.empty
-          else line".addMemberHints(${memberHints(valueHints)})"
+          memberHints(valueHints).surroundIfNotEmpty(line".addMemberHints(", line")")
         line"${NameRef(s"$schemaPkg_.map")}(${key.schemaRef}$keyHintsLine, ${value.schemaRef}$valueHintsLine)"
       case Type.Alias(
             ns,

--- a/modules/codegen/src/smithy4s/codegen/internals/SmithyToIR.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/SmithyToIR.scala
@@ -951,6 +951,7 @@ private[codegen] class SmithyToIR(model: Model, namespace: String) {
           shape
             .members()
             .asScala
+            .filterNot(isStreaming)
             .map { member =>
               val memberDocs =
                 member.getTrait(classOf[DocumentationTrait]).asScala

--- a/modules/codegen/src/smithy4s/codegen/internals/ToLine.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/ToLine.scala
@@ -131,6 +131,13 @@ private[internals] case class Line(segments: Chain[LineSegment]) {
     }
   }
 
+  def surroundIfNotEmpty(before: Line, after: Line): Line = {
+    if (segments.isEmpty) this
+    else {
+      new Line(before.segments ++ self.segments ++ after.segments)
+    }
+  }
+
   def appendIf(condition: this.type => Boolean)(other: Line): Line =
     if (condition(this)) this + other else this
 

--- a/sampleSpecs/streaming.smithy
+++ b/sampleSpecs/streaming.smithy
@@ -5,7 +5,7 @@ use alloy#UUID
 
 service StreamedObjects {
   version: "1.0.0",
-  operations: [PutStreamedObject, GetStreamedObject]
+  operations: [PutStreamedObject, GetStreamedObject, PutAndGetStreamedObject]
 }
 
 operation PutStreamedObject {
@@ -32,6 +32,11 @@ structure GetStreamedObjectInput {
 
 structure GetStreamedObjectOutput {
   data: StreamedBlob
+}
+
+operation PutAndGetStreamedObject {
+  input: PutStreamedObjectInput,
+  output: GetStreamedObjectOutput
 }
 
 @streaming

--- a/sampleSpecs/streaming.smithy
+++ b/sampleSpecs/streaming.smithy
@@ -20,6 +20,7 @@ operation GetStreamedObject {
 structure PutStreamedObjectInput {
     @required
     key: String,
+    @documentation("data docs")
     data: StreamedBlob
 }
 


### PR DESCRIPTION
## PR Checklist (not all items are relevant to all PRs)

- [x] Added bootstrapped code + smoke tests (when the rendering logic is modified)
- [x] Updated changelog

You can see from the [first commit](https://github.com/disneystreaming/smithy4s/commit/5d6e486a38dd8292c90b6d817cc53eb6845f81ea) that originally, codegen would write scaladocs in irrelevant places