### PR TITLE
perf: Optimize isRecursive check in DynamicModelCompiler

### DIFF
--- a/modules/dynamic/src/smithy4s/dynamic/internals/DynamicModelCompiler.scala
+++ b/modules/dynamic/src/smithy4s/dynamic/internals/DynamicModelCompiler.scala
@@ -125,25 +125,11 @@ private[dynamic] object Compiler {
         shapeId -> ClosureVisitor(shapeId, shape)
     }
 
+    private val recursiveShapesSet = recursiveVertices(closureMap)
+
     private def isRecursive(
-        id: ShapeId,
-        visited: Set[ShapeId] = Set.empty
-    ): Boolean = {
-      def transitiveClosure(
-          _id: ShapeId,
-          visited: Set[ShapeId]
-      ): Set[ShapeId] = {
-        val newVisited = visited + _id
-        val neighbours = closureMap.getOrElse(_id, Set.empty)
-        val nonVisitedNeighbours = neighbours.filterNot(newVisited)
-        val neighbourClosures =
-          nonVisitedNeighbours.flatMap(transitiveClosure(_, newVisited))
-        neighbours ++ neighbourClosures
-      }
-      val closure = transitiveClosure(id, Set.empty)
-      // A type is recursive if it's referenced in its own closure
-      closure.contains(id)
-    }
+        id: ShapeId
+    ): Boolean = recursiveShapesSet.contains(id)
 
     private def schema(idRef: IdRef): Eval[Schema[DynData]] = Eval.defer {
       schemaMap(

--- a/modules/dynamic/test/src/smithy4s/dynamic/internals/IsRecursiveSpec.scala
+++ b/modules/dynamic/test/src/smithy4s/dynamic/internals/IsRecursiveSpec.scala
@@ -1,0 +1,44 @@
+package smithy4s.dynamic.internals
+
+import smithy4s.dynamic.internals.recursiveVertices
+
+class IsRecursiveSpec() extends munit.FunSuite {
+
+  test("detect recursive vertices - example 1") {
+    val map = Map[Int, Set[Int]](
+      1 -> Set(2),
+      2 -> Set(3, 4, 5),
+      3 -> Set(4),
+      5 -> Set(6, 7),
+      6 -> Set(2),
+      7 -> Set(2)
+    )
+    val result = recursiveVertices(map)
+    assertEquals(result, Set(2, 5, 6, 7))
+  }
+
+  test("detect recursive vertices - example 2") {
+    val map = Map(
+      2 -> Set(1, 3),
+      1 -> Set(3),
+      3 -> Set(4, 5),
+      4 -> Set(2),
+      5 -> Set(2)
+    )
+    val result = recursiveVertices(map)
+    assertEquals(result, Set(1, 2, 3, 4, 5))
+  }
+
+  test("detect recursive vertices - example 3") {
+    val map = Map(
+      2 -> Set(1),
+      1 -> Set(3),
+      3 -> Set(1, 2, 3, 4, 5),
+      4 -> Set(3, 5),
+      5 -> Set(3, 4)
+    )
+    val result = recursiveVertices(map)
+    assertEquals(result, Set(1, 2, 3, 4, 5))
+  }
+
+}

--- a/modules/dynamic/test/src/smithy4s/dynamic/internals/IsRecursiveSpec.scala
+++ b/modules/dynamic/test/src/smithy4s/dynamic/internals/IsRecursiveSpec.scala
@@ -1,7 +1,5 @@
 package smithy4s.dynamic.internals
 
-import smithy4s.dynamic.internals.recursiveVertices
-
 class IsRecursiveSpec() extends munit.FunSuite {
 
   test("detect recursive vertices - example 1") {


### PR DESCRIPTION
This fixes #1258 

`DynamicSchemaIndex.load` times before and after this change for some models tested on Intel® Core™ i7-10875H × 16 64GB RAM. Testing script was mostly based on the one from the [issue](https://github.com/disneystreaming/smithy4s/issues/1258#issue-1938852215).

A model that consists of "aws-quicksight-spec" and "aws-sagemaker-spec".
- before: 17 675ms
- after: 2 659ms
- flamegraph after:![flamegraph3](https://github.com/disneystreaming/smithy4s/assets/5662622/4d16d99d-d625-488b-a391-3ca9d9ab0473)

A confidential model:
- before: 12 821ms
- after: 2 472ms
- flamegraph after: ![flamegraph2](https://github.com/disneystreaming/smithy4s/assets/5662622/2532d1b7-8d50-4277-bb27-e8933e6960e7)

The new implementation has been tested manually with mentioned models against the old one and they both return the same results; however, it should be noted that the first model contains only a single recursive shape, while the confidential model contains only a few more.

The implementation is fully based on @Baccata's [idea](https://github.com/disneystreaming/smithy4s/issues/1258#issuecomment-1759187608). My plan was to check that approach and then move to implementing mentioned Tarjan algorithm, but this implementation turned out to be quite fast. I don't mind implementing Tarjan but I propose to stop here, as at the moment the current solution is fast enough. Implementing Tarjan would probably yield better results but I think that the increase in complexity outweighs potential gains in speed. This decision can always be revisited in the future if needed.

## PR Checklist (not all items are relevant to all PRs)

- [x] Added unit-tests (for runtime code)
- [ ] Added bootstrapped code + smoke tests (when the rendering logic is modified)
- [ ] Added build-plugins integration tests (when reflection loading is required at codegen-time)
- [ ] Added alloy compliance tests (when simpleRestJson protocol behaviour is expanded/updated)
- [ ] Updated dynamic module to match generated-code behaviour
- [ ] Added documentation
- [ ] Updated changelog
