### PR TITLE
Changes to AWS construct to support streaming

### DIFF
--- a/modules/aws-http4s/src/smithy4s/aws/internals/AwsPayloadSignature.scala
+++ b/modules/aws-http4s/src/smithy4s/aws/internals/AwsPayloadSignature.scala
@@ -1,0 +1,76 @@
+/*
+ *  Copyright 2021-2024 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package smithy4s.aws
+package internals
+
+import cats.effect.Concurrent
+import cats.effect.Resource
+import cats.syntax.all._
+import fs2.Chunk
+import org.http4s._
+import org.http4s.client.Client
+import org.typelevel.ci.CIString
+import smithy4s._
+import smithy4s.aws.kernel.AwsCrypto._
+
+private[aws] sealed trait AwsPayloadSignature {
+  import AwsPayloadSignature._
+  val headerValue: String = this match {
+    case Sha256(v) => v
+    case UnsignedPayload => "UNSIGNED-PAYLOAD"
+    // case StreamingUnsignedPayload => "STREAMING-UNSIGNED-PAYLOAD-TRAILER"
+  }
+}
+
+/**
+ * This is a draft API. There are many other ways to include the payload in the signature.
+ * Some of which are complex: using trailers and/or multiple chunks
+ */
+private[aws] object AwsPayloadSignature {
+  case class Sha256(value: String) extends AwsPayloadSignature
+  case object UnsignedPayload extends AwsPayloadSignature
+  // case object StreamingUnsignedPayload extends AwsPayloadSignature
+
+  val `X-Amz-Content-SHA256` = CIString("X-Amz-Content-SHA256")
+
+  def makeHeader(value: AwsPayloadSignature): Header.Raw =
+    Header.Raw(`X-Amz-Content-SHA256`, value.headerValue)
+
+
+  def signSingleChunk[F[_]: Concurrent]: Endpoint.Middleware[Client[F]] =
+    new Endpoint.Middleware[Client[F]] {
+      def prepare[Alg[_[_, _, _, _, _]]](service: Service[Alg])(
+          endpoint: service.Endpoint[_, _, _, _, _]
+      ): Client[F] => Client[F] = { client =>
+        Client { request =>
+          Resource.eval(hashSingleChunk(request)).flatMap { request =>
+            client.run(request)
+          }
+        }
+      }
+    }
+
+  private def hashSingleChunk[F[_]: Concurrent](
+      request: Request[F]
+  ): F[Request[F]] = {
+    request.body.chunks.compile.to(Chunk).map(_.flatten).map { body =>
+      val payloadHash = sha256HexDigest(body.toArray)
+      val signature = AwsPayloadSignature.Sha256(payloadHash)
+      request.putHeaders(AwsPayloadSignature.makeHeader(signature))
+    }
+  }
+}

--- a/modules/aws-http4s/src/smithy4s/aws/internals/AwsSigning.scala
+++ b/modules/aws-http4s/src/smithy4s/aws/internals/AwsSigning.scala
@@ -20,20 +20,18 @@ package internals
 import cats.effect.Concurrent
 import cats.effect.Resource
 import cats.syntax.all._
-import fs2.Chunk
 import org.http4s._
 import org.http4s.client.Client
 import org.typelevel.ci.CIString
 import smithy4s._
 import smithy4s.aws.kernel.AwsCrypto._
+import smithy4s.aws.internals.AwsPayloadSignature.`X-Amz-Content-SHA256`
 
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
 
 /**
   * A Client middleware that signs http requests before they are sent to AWS.
-  * This works by compiling the body of the request in memory in a chunk before sending
-  * it back, which means it is not proper to use it in the context of streaming.
   */
 private[aws] object AwsSigning {
 
@@ -108,8 +106,7 @@ private[aws] object AwsSigning {
     // scalafmt: { align.preset = most, danglingParentheses.preset = false, maxColumn = 240, align.tokens = [{code = ":"}]}
     (request: Request[F]) => {
 
-      val bodyF = request.body.chunks.compile.to(Chunk).map(_.flatten)
-      val awsHeadersF = (bodyF, timestamp, credentials, region).mapN { case (body, timestamp, credentials, region) =>
+      val awsHeadersF = (timestamp, credentials, region).mapN { case (timestamp, credentials, region) =>
         val credentialsScope = s"${timestamp.conciseDate}/$region/$endpointPrefix/aws4_request"
         val queryParams: Vector[(String, String)] =
           request.uri.query.toVector.sorted.map { case (k, v) => k -> v.getOrElse("") }
@@ -122,8 +119,15 @@ private[aws] object AwsSigning {
               }
               .mkString("&")
 
-        // // !\ Important: these must remain in the same order
-        val baseHeadersList = List(
+        val amzHeaders: List[(CIString, String)] = request.headers.headers
+          .map(h => (h.name, h.value))
+          .filterNot(_._2 == null)
+
+        // It is assumed that the hash value is computed before this middleware run
+        // via another middleware. If it is not, we use a default unsigned value
+        val payloadHash = amzHeaders.find(_._1 == `X-Amz-Content-SHA256`).map(_._2).getOrElse(AwsPayloadSignature.UnsignedPayload.headerValue)
+
+        val addedHeaders: List[(CIString, String)] = List(
           `Content-Type` -> request.contentType.map(contentType.value(_)).orNull,
           `Host` -> request.uri.host.map(_.renderString).orNull,
           `X-Amz-Date` -> timestamp.conciseDateTime,
@@ -131,14 +135,16 @@ private[aws] object AwsSigning {
           `X-Amz-Target` -> (serviceName + "." + operationName)
         ).filterNot(_._2 == null)
 
-        val canonicalHeadersString = baseHeadersList
+        // Headers included in the signature needs to be sorted alphabetically
+        val allHeaders = (addedHeaders ++ amzHeaders).sortBy(_._1)
+
+        val canonicalHeadersString = allHeaders
           .map { case (key, value) =>
             key.toString.toLowerCase + ":" + value.trim
           }
           .mkString(newline)
-        lazy val signedHeadersString = baseHeadersList.map(_._1).map(_.toString.toLowerCase()).mkString(";")
+        lazy val signedHeadersString = allHeaders.map(_._1).map(_.toString.toLowerCase()).mkString(";")
 
-        val payloadHash = sha256HexDigest(body.toArray)
         val pathString = request.uri.path.toAbsolute.renderString
         val canonicalRequest = new StringBuilder()
           .append(request.method.name.toUpperCase())
@@ -171,7 +177,7 @@ private[aws] object AwsSigning {
         val signature = toHexString(hmacSha256(stringToSign, signatureKey))
         val authHeaderValue = s"${algorithm} Credential=${credentials.accessKeyId}/$credentialsScope, SignedHeaders=$signedHeadersString, Signature=$signature"
         val authHeader = Headers("Authorization" -> authHeaderValue)
-        val baseHeaders = Headers(baseHeadersList.map { case (k, v) => Header.Raw(k, v) })
+        val baseHeaders = Headers(addedHeaders.map { case (k, v) => Header.Raw(k, v) })
         authHeader ++ baseHeaders
       }
 

--- a/modules/aws-http4s/src/smithy4s/aws/internals/AwsSigning.scala
+++ b/modules/aws-http4s/src/smithy4s/aws/internals/AwsSigning.scala
@@ -120,6 +120,7 @@ private[aws] object AwsSigning {
               .mkString("&")
 
         val amzHeaders: List[(CIString, String)] = request.headers.headers
+          .filter(_.name.toString.toLowerCase.startsWith("x-amz"))
           .map(h => (h.name, h.value))
           .filterNot(_._2 == null)
 


### PR DESCRIPTION
TLDR: the design you originally proposed mostly works. the only thing that I needed to fix was to carry along a function to convert from bytes to the StreamingInput or StreamingOutput types. This PR only contains a few changes I'd make to improve things when we want to support streaming payload signature, trailers, etc.

I've opened this PR because theses are changes I made to make [s3-restart-wip](https://github.com/disneystreaming/smithy4s/compare/dfrancoeur/s3-restart...dfrancoeur/s3-restart-wip) work.

It does the following:

1. reorder headers so that they are alphabetically sorted for the signature
2. include any headers starting with x-amz in the signature
3. extract payload signing in a middleware of it's own and default to unsigned-payload

Regarding 2), I did that because if we introduce middleware like CRC/SHA checksum, they'll include additional headers that need to be in the signature.

Regarding 3), I did that because generating a sha256 hash and including it in the signature works but is only one way, of several ways, to do payload signature. It does not work well when the payload is large (load everything in memory, it does not support sending the payload in chunks), and it does not work for sigv4a.

For example, signing the payload on a request where the payload is uploaded in chunks is [described in the docs](https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-streaming.html). One of the input of the first chunk is the signature computed for the Authorization header, so we'd probably have to rework how we do ( in AWSSigning) to expose it.

In the list of changes in [s3-restart-wip](https://github.com/disneystreaming/smithy4s/compare/dfrancoeur/s3-restart...dfrancoeur/s3-restart-wip), you'll see that I also include the java-sdk. This is for testing and inspecting what the java SDK does when we enable certain things. But **I'M UNABLE TO ENABLE THE SIGNATURE OF THE PAYLOAD**. The only thing that comes close is setting the CRC32 checksum algorithm which will affect the request (change the body to include trailers, and so it changes the `X-Amz-Content-SHA256` header to `STREAMING-UNSIGNED-PAYLOAD-TRAILER`, add a bunch of headers).

Example:

```
PUT /david/bytes-todelete.txt HTTP/1.1
Host: som-bucket.s3.amazonaws.com
amz-sdk-invocation-id: 1f70431f-b110-74b5-0962-c64b0f8b4b69
amz-sdk-request: attempt=1; max=4
Authorization: AWS4-HMAC-SHA256 Credential=****************/20240419/us-east-1/s3/aws4_request, SignedHeaders=amz-sdk-invocation-id;amz-sdk-request;content-encoding;content-length;content-type;host;x-amz-content-sha256;x-amz-date;x-amz-decoded-content-length;x-amz-sdk-checksum-algorithm;x-amz-security-token;x-amz-trailer, Signature=ddc0712d2d703eebe2f7dfd90e10addd18d130be24635bf6a779d943cdff8cc9
Content-Type: application/octet-stream
User-Agent: aws-sdk-java/2.25.11 Mac_OS_X....
x-amz-content-sha256: STREAMING-UNSIGNED-PAYLOAD-TRAILER
X-Amz-Date: 20240419T142913Z
x-amz-decoded-content-length: 16
x-amz-sdk-checksum-algorithm: CRC32
X-Amz-Security-Token: *****
x-amz-trailer: x-amz-checksum-crc32
Content-Length: 58
Connection: Keep-Alive

10
my data is in s3
0
x-amz-checksum-crc32:N7SBfA==
```
To view this request, I've also used [mitm](https://mitmproxy.org/) and target my AWS java sdk client to it. It makes it easy to see what the SDK does when playing with settings.


## PR Checklist (not all items are relevant to all PRs)

- [ ] Added unit-tests (for runtime code)
- [ ] Added bootstrapped code + smoke tests (when the rendering logic is modified)
- [ ] Added build-plugins integration tests (when reflection loading is required at codegen-time)
- [ ] Added alloy compliance tests (when simpleRestJson protocol behaviour is expanded/updated)
- [ ] Updated dynamic module to match generated-code behaviour
- [ ] Added documentation
- [ ] Updated changelog
