### PR TITLE
Use ListSet for repos, imports and dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 0.18.17
 
 * Constraints applied to list or map members are now correctly rendered in the generated code.
+* Fix an issue with duplicated entries in generated smithy-build.json file (#1491)
 
 # 0.18.16
 

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/update-lsp-config/build.sbt
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/update-lsp-config/build.sbt
@@ -1,0 +1,24 @@
+import sbt.io.IO
+val subproj = project
+
+val subproj2 = project.enablePlugins(Smithy4sCodegenPlugin)
+
+val root = project
+  .in(file("."))
+  .aggregate(subproj, subproj2)
+  .settings(
+    TaskKey[Unit]("checkSmithyBuild") := {
+      val generated = IO.readLines(file(".") / "smithy-build.json")
+      val expected = IO.readLines(file(".") / "expected.json")
+      val compare = s"""|generated:
+                        |${generated.mkString("\n")}
+                        |===================================
+                        |expected:
+                        |${expected.mkString("\n")}
+                        |===================================
+                        |""".stripMargin
+
+      assert(generated == expected, s"content are not the same:\n $compare")
+      ()
+    }
+  )

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/update-lsp-config/expected.json
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/update-lsp-config/expected.json
@@ -1,0 +1,20 @@
+{
+    "version" : "1.0",
+    "imports" : [
+        "subproj2/src/main/smithy",
+        "subproj2/target/scala-2.12/src_managed/main/smithy"
+    ],
+    "maven" : {
+        "dependencies" : [
+            "com.disneystreaming.alloy:alloy-core:0.3.6"
+        ],
+        "repositories" : [
+            {
+                "url" : "https://oss.sonatype.org/content/repositories/snapshots"
+            },
+            {
+                "url" : "https://s01.oss.sonatype.org/content/repositories/snapshots"
+            }
+        ]
+    }
+}

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/update-lsp-config/project/build.properties
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/update-lsp-config/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.8.3

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/update-lsp-config/project/custom.scala
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/update-lsp-config/project/custom.scala
@@ -1,0 +1,16 @@
+package demo
+
+import sbt.plugins.JvmPlugin
+
+import _root_.sbt.Keys._
+import _root_.sbt._
+
+object MyPlugin extends AutoPlugin {
+  override def trigger = allRequirements
+  override def requires = JvmPlugin
+
+  override def buildSettings: Seq[Def.Setting[_]] = Seq(
+    resolvers ++= Resolver.sonatypeOssRepos("snapshots")
+  )
+
+}

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/update-lsp-config/project/custom.scala
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/update-lsp-config/project/custom.scala
@@ -1,3 +1,19 @@
+/*
+ *  Copyright 2021-2024 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 package demo
 
 import sbt.plugins.JvmPlugin

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/update-lsp-config/project/plugins.sbt
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/update-lsp-config/project/plugins.sbt
@@ -1,0 +1,9 @@
+sys.props.get("plugin.version") match {
+  case Some(x) =>
+    addSbtPlugin("com.disneystreaming.smithy4s" % "smithy4s-sbt-codegen" % x)
+  case _ =>
+    sys.error(
+      """|The system property 'plugin.version' is not defined.
+         |Specify this property using the scriptedLaunchOpts -D.""".stripMargin
+    )
+}

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/update-lsp-config/src/main/scala/Main.scala
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/update-lsp-config/src/main/scala/Main.scala
@@ -1,0 +1,36 @@
+/*
+ *  Copyright 2021-2024 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package demo
+
+import smithy4s.dynamic.DynamicSchemaIndex
+import software.amazon.smithy.model.Model
+
+object Main extends App {
+  try {
+    println(smithy4s.example.Foo.IntCase(42))
+    println(smithy.api.NonEmptyString("nope").value)
+  } catch {
+    case _: java.lang.ExceptionInInitializerError =>
+      println("failed")
+      sys.exit(1)
+  }
+
+  def buildSchemaIndex() = Model.assembler().assemble().unwrap()
+
+  val model = buildSchemaIndex()
+  DynamicSchemaIndex.loadModel(model)
+}

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/update-lsp-config/src/main/smithy/example.smithy
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/update-lsp-config/src/main/smithy/example.smithy
@@ -1,0 +1,83 @@
+namespace smithy4s.example
+
+use alloy#simpleRestJson
+
+@simpleRestJson
+service ObjectService {
+  version: "1.0.0",
+  operations: [PutObject, GetObject]
+}
+
+
+@idempotent
+@http(method: "PUT", uri: "/{bucketName}/{key}", code: 200)
+operation PutObject {
+  input: PutObjectInput,
+  errors: [NoMoreSpace]
+}
+
+@readonly
+@http(method: "GET", uri: "/{bucketName}/{key}", code: 200)
+operation GetObject {
+  input: GetObjectInput,
+  output: GetObjectOutput
+}
+
+structure PutObjectInput {
+    // Sent in the URI label named "key".
+    @required
+    @httpLabel
+    key: String,
+
+    // Sent in the URI label named "bucketName".
+    @required
+    @httpLabel
+    bucketName: String,
+
+    // Sent in the X-Foo header
+    @httpHeader("X-Foo")
+    foo: String,
+
+    // Sent in the query string as paramName
+    @httpQuery("paramName")
+    someValue: String,
+
+    // Sent in the body
+    @httpPayload
+    @required
+    data: String
+}
+
+structure GetObjectInput {
+    // Sent in the URI label named "key".
+    @required
+    @httpLabel
+    key: String,
+
+    // Sent in the URI label named "bucketName".
+    @required
+    @httpLabel
+    bucketName: String,
+}
+
+structure GetObjectOutput {
+  @httpHeader("X-Size")
+  @required
+  size: Integer,
+  @httpPayload
+  data: String
+}
+
+union Foo {
+  int: Integer,
+  str: String
+}
+
+@error("server")
+@httpError(507)
+structure NoMoreSpace {
+  @required
+  message: String,
+  foo: Foo
+}
+

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/update-lsp-config/test
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/update-lsp-config/test
@@ -1,0 +1,3 @@
+> smithy4sUpdateLSPConfig
+
+> checkSmithyBuild

--- a/modules/codegen-plugin/src/smithy4s/codegen/GenerateSmithyBuild.scala
+++ b/modules/codegen-plugin/src/smithy4s/codegen/GenerateSmithyBuild.scala
@@ -19,16 +19,17 @@ package smithy4s.codegen
 import sbt._
 import sbt.Keys._
 import Smithy4sCodegenPlugin.autoImport._
+import scala.collection.immutable.ListSet
 
 private final case class SmithyBuildData(
-    imports: Set[String],
-    deps: Set[String],
-    repos: Set[String]
+    imports: ListSet[String],
+    deps: ListSet[String],
+    repos: ListSet[String]
 ) {
   def addAll(
-      imports: Set[String],
-      deps: Set[String],
-      repos: Set[String]
+      imports: ListSet[String],
+      deps: ListSet[String],
+      repos: ListSet[String]
   ): SmithyBuildData = {
     SmithyBuildData(
       this.imports ++ imports,
@@ -71,7 +72,7 @@ private[codegen] object GenerateSmithyBuild {
       rootDir: File
   ): SmithyBuildData =
     extracted.structure.allProjectRefs
-      .foldLeft(SmithyBuildData(Set.empty, Set.empty, Set.empty)) {
+      .foldLeft(SmithyBuildData(ListSet.empty, ListSet.empty, ListSet.empty)) {
         case (gsb, pr) =>
           gsb.addAll(
             extractImports(pr, extracted.structure.data, rootDir),
@@ -83,7 +84,7 @@ private[codegen] object GenerateSmithyBuild {
   private def extractDeps(
       pr: ProjectRef,
       settings: Settings[Scope]
-  ): Set[String] = {
+  ): ListSet[String] = {
     val scalaBin = (pr / scalaBinaryVersion).get(settings)
 
     (pr / libraryDependencies)
@@ -92,33 +93,33 @@ private[codegen] object GenerateSmithyBuild {
       .flatten
       .filter(_.configurations.exists(_.contains(Smithy4s.name)))
       .flatMap(Smithy4sCodegenPlugin.moduleIdEncode(_, scalaBin))
-      .toSet
+      .to[ListSet]
   }
 
   private def extractRepos(
       pr: ProjectRef,
       settings: Settings[Scope]
-  ): Set[String] = {
+  ): ListSet[String] = {
     println("extract Repos")
     (pr / resolvers)
       .get(settings)
       .toList
       .flatten
       .collect(prepareResolvers)
-      .toSet
+      .to[ListSet]
   }
 
   private def extractImports(
       pr: ProjectRef,
       settings: Settings[Scope],
       rootDir: File
-  ): Set[String] =
+  ): ListSet[String] =
     (pr / Compile / smithy4sInputDirs)
       .get(settings)
       .toList
       .flatten
       .collect(prepareInputDirs(rootDir))
-      .toSet
+      .to[ListSet]
 
   private val prepareResolvers: PartialFunction[Resolver, String] = {
     case mr: MavenRepository if !mr.root.contains("repo1.maven.org") => mr.root

--- a/modules/codegen/src/smithy4s/codegen/SmithyBuildJson.scala
+++ b/modules/codegen/src/smithy4s/codegen/SmithyBuildJson.scala
@@ -23,9 +23,9 @@ import io.circe.{Json, parser}
 
 private[codegen] object SmithyBuildJson {
   def toJson(
-      imports: Seq[String],
-      dependencies: Seq[String],
-      repositories: Seq[String]
+      imports: Set[String],
+      dependencies: Set[String],
+      repositories: Set[String]
   ): String = {
     SmithyBuild.writeJson(
       SmithyBuild(

--- a/modules/codegen/src/smithy4s/codegen/SmithyBuildJson.scala
+++ b/modules/codegen/src/smithy4s/codegen/SmithyBuildJson.scala
@@ -21,11 +21,13 @@ import smithy4s.codegen.internals.SmithyBuildMaven
 import smithy4s.codegen.internals.SmithyBuildMavenRepository
 import io.circe.{Json, parser}
 
+import scala.collection.immutable.ListSet
+
 private[codegen] object SmithyBuildJson {
   def toJson(
-      imports: Set[String],
-      dependencies: Set[String],
-      repositories: Set[String]
+      imports: ListSet[String],
+      dependencies: ListSet[String],
+      repositories: ListSet[String]
   ): String = {
     SmithyBuild.writeJson(
       SmithyBuild(

--- a/modules/codegen/src/smithy4s/codegen/internals/SmithyBuild.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/SmithyBuild.scala
@@ -23,7 +23,7 @@ import io.circe.syntax._
 
 private[internals] final case class SmithyBuild(
     version: String,
-    imports: Seq[String],
+    imports: Set[String],
     maven: SmithyBuildMaven
 )
 private[codegen] object SmithyBuild {
@@ -32,8 +32,8 @@ private[codegen] object SmithyBuild {
 }
 
 private[internals] final case class SmithyBuildMaven(
-    dependencies: Seq[String],
-    repositories: Seq[SmithyBuildMavenRepository]
+    dependencies: Set[String],
+    repositories: Set[SmithyBuildMavenRepository]
 )
 private[codegen] object SmithyBuildMaven {
   implicit val codecs: Codec[SmithyBuildMaven] = deriveCodec

--- a/modules/codegen/test/src/smithy4s/codegen/internals/SmithyBuildSpec.scala
+++ b/modules/codegen/test/src/smithy4s/codegen/internals/SmithyBuildSpec.scala
@@ -17,14 +17,18 @@
 package smithy4s.codegen.internals
 
 import smithy4s.codegen.SmithyBuildJson
+import scala.collection.immutable.ListSet
 
 final class SmithyBuildSpec extends munit.FunSuite {
   test("generate json") {
     val actual = SmithyBuild.writeJson(
       SmithyBuild(
         "1.0",
-        List("src/"),
-        SmithyBuildMaven(List("dep"), List(SmithyBuildMavenRepository("repo")))
+        ListSet("src/"),
+        SmithyBuildMaven(
+          ListSet("dep"),
+          ListSet(SmithyBuildMavenRepository("repo"))
+        )
       )
     )
     assertEquals(

--- a/modules/mill-codegen-plugin/src/smithy4s/codegen/LSP.scala
+++ b/modules/mill-codegen-plugin/src/smithy4s/codegen/LSP.scala
@@ -36,7 +36,7 @@ object LSP extends ExternalModule {
 
     val depsTask = Target
       .traverse(s4sModules)(_.smithy4sAllDeps)
-      .map(_.flatten.flatMap(Smithy4sModule.depIdEncode(_)).distinct)
+      .map(_.flatten.flatMap(Smithy4sModule.depIdEncode(_)).toSet)
 
     val reposTask = Target
       .traverse(s4sModules)(_.repositoriesTask)
@@ -44,7 +44,7 @@ object LSP extends ExternalModule {
         _.flatten.collect {
           case r: MavenRepository if !r.root.contains("repo1.maven.org") =>
             r.root
-        }.distinct
+        }.toSet
       }
 
     val importsTask = Target
@@ -53,7 +53,7 @@ object LSP extends ExternalModule {
         _.flatten
           .map(p => p.path.relativeTo(rootPath))
           .map(rp => "./" + rp.toString)
-          .distinct
+          .toSet
       )
 
     Target.command {


### PR DESCRIPTION
The reason we saw duplicates is because we have multiple modules and they all inherit from the project plugin that is enabled. Because we use `Seq`, we just keep on adding new elements. Using a `Set` ensure we only have uniques in the end.

When running the command twice, the duplicates are cleared. This happens because the deep merge algorithm calls `distinct` when it merge arrays.

## PR Checklist (not all items are relevant to all PRs)

- [ ] Added unit-tests (for runtime code)
- [ ] Added bootstrapped code + smoke tests (when the rendering logic is modified)
- [x] Added build-plugins integration tests (when reflection loading is required at codegen-time)
- [ ] Added alloy compliance tests (when simpleRestJson protocol behaviour is expanded/updated)
- [ ] Updated dynamic module to match generated-code behaviour
- [ ] Added documentation
- [x] Updated changelog
