### PR TITLE
Filter mixins that have different types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 0.18.17
 
 * Constraints applied to list or map members are now correctly rendered in the generated code.
+* Fix a bug when using `adt` with mixins, see #1457
 
 # 0.18.16
 

--- a/modules/bootstrapped/src/generated/smithy4s/example/HasName.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/HasName.scala
@@ -1,0 +1,6 @@
+package smithy4s.example
+
+
+trait HasName {
+  def name: Option[String]
+}

--- a/modules/bootstrapped/src/generated/smithy4s/example/PersonUnion.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/PersonUnion.scala
@@ -1,0 +1,67 @@
+package smithy4s.example
+
+import smithy4s.Hints
+import smithy4s.Schema
+import smithy4s.ShapeId
+import smithy4s.ShapeTag
+import smithy4s.schema.Schema.string
+import smithy4s.schema.Schema.struct
+import smithy4s.schema.Schema.union
+
+sealed trait PersonUnion extends scala.Product with scala.Serializable { self =>
+  @inline final def widen: PersonUnion = this
+  def $ordinal: Int
+
+  object project {
+    def p: Option[PersonUnion.OtherPerson] = PersonUnion.OtherPerson.alt.project.lift(self)
+  }
+
+  def accept[A](visitor: PersonUnion.Visitor[A]): A = this match {
+    case value: PersonUnion.OtherPerson => visitor.p(value)
+  }
+}
+object PersonUnion extends ShapeTag.Companion[PersonUnion] {
+
+  def otherPerson(name: String):OtherPerson = OtherPerson(name)
+
+  val id: ShapeId = ShapeId("smithy4s.example", "PersonUnion")
+
+  val hints: Hints = Hints.empty
+
+  final case class OtherPerson(name: String) extends PersonUnion {
+    def $ordinal: Int = 0
+  }
+
+  object OtherPerson extends ShapeTag.Companion[OtherPerson] {
+    val id: ShapeId = ShapeId("smithy4s.example", "OtherPerson")
+
+    val hints: Hints = Hints.empty
+
+    // constructor using the original order from the spec
+    private def make(name: String): OtherPerson = OtherPerson(name)
+
+    val schema: Schema[OtherPerson] = struct(
+      string.required[OtherPerson]("name", _.name),
+    )(make).withId(id).addHints(hints)
+
+    val alt = schema.oneOf[PersonUnion]("p")
+  }
+
+
+  trait Visitor[A] {
+    def p(value: PersonUnion.OtherPerson): A
+  }
+
+  object Visitor {
+    trait Default[A] extends Visitor[A] {
+      def default: A
+      def p(value: PersonUnion.OtherPerson): A = default
+    }
+  }
+
+  implicit val schema: Schema[PersonUnion] = union(
+    PersonUnion.OtherPerson.alt,
+  ){
+    _.$ordinal
+  }.withId(id).addHints(hints)
+}

--- a/modules/codegen/src/smithy4s/codegen/internals/SmithyToIR.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/SmithyToIR.scala
@@ -237,8 +237,11 @@ private[codegen] class SmithyToIR(model: Model, namespace: String) {
           .asScala
           .toList
           .map(mem => model.expectShape(mem.getTarget))
-        val mixins = memberTargets
-          .map(_.getMixins.asScala.toSet)
+        val mixins: List[Set[ShapeId]] = memberTargets
+          .map(targetShape =>
+            targetShape.getMixins.asScala.toSet
+              .filter(mixinId => doFieldsMatch(mixinId, targetShape.fields))
+          )
 
         val union = mixins.foldLeft(Set.empty[ShapeId])(_ union _)
 

--- a/sampleSpecs/adtMember.smithy
+++ b/sampleSpecs/adtMember.smithy
@@ -84,3 +84,19 @@ structure PodcastCommon {
 structure Video with [PodcastCommon] {}
 @generateOptics
 structure Audio with [PodcastCommon] {}
+
+
+@mixin
+structure HasName {
+    name: String
+}
+
+structure OtherPerson with [HasName] {
+    @required
+    $name
+}
+
+@adt
+union PersonUnion {
+    p: OtherPerson
+}


### PR DESCRIPTION
Similar to what was done in https://github.com/disneystreaming/smithy4s/pull/425, I've filtered out the
mixins that have different type than the final shape they're
applied to.

As such, in the example above, `HasName` has a optional name
member where as `Person` inherits the mixin but makes the member
required. The filtering catches that and as a result the mixin is
removed from the list of mixins to add on `Person`.

This behaviour aligns with the behaviour that happens when no `@adt`
trait is added and `Person` is code generated on it's own. In both
cases, now, the trait `HasName` is not extended because the types of
`name` don't align.

## PR Checklist (not all items are relevant to all PRs)

- [ ] Added unit-tests (for runtime code)
- [x] Added bootstrapped code + smoke tests (when the rendering logic is modified)
- [ ] Added build-plugins integration tests (when reflection loading is required at codegen-time)
- [ ] Added alloy compliance tests (when simpleRestJson protocol behaviour is expanded/updated)
- [ ] Updated dynamic module to match generated-code behaviour
- [ ] Added documentation
- [x] Updated changelog
