### PR TITLE
Fix shape equality in ADT validator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.18.18
+
+* Fix an issue in the ADT trait validators that would sometimes fail validation while it shouldn't.
+
 # 0.18.17
 
 * Constraints applied to list or map members are now correctly rendered in the generated code.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 0.18.18
 
-* Fix an issue in the ADT trait validators that would sometimes fail validation while it shouldn't.
+* Fix an issue in the ADT trait validators that would sometimes fail validation while they shouldn't.
 
 # 0.18.17
 

--- a/modules/protocol/src/smithy4s/meta/validation/AdtValidatorCommon.java
+++ b/modules/protocol/src/smithy4s/meta/validation/AdtValidatorCommon.java
@@ -51,7 +51,7 @@ final class AdtValidatorCommon {
 
 	private static List<Reference> getReferences(Model model, Shape adtMemberShape, Shape adtParent) {
 		return model.getMemberShapes().stream().flatMap(memberShape -> {
-			boolean doesMemberTargetAdtShape = memberShape.getTarget() .equals( adtMemberShape.getId());
+			boolean doesMemberTargetAdtShape = memberShape.getTarget().equals(adtMemberShape.getId());
 			boolean isMemberShapeInDesiredTarget = memberShape.getContainer().equals(adtParent.toShapeId());
 			if (doesMemberTargetAdtShape) {
 				return Stream.of(new Reference(isMemberShapeInDesiredTarget, memberShape.getContainer()));

--- a/modules/protocol/src/smithy4s/meta/validation/AdtValidatorCommon.java
+++ b/modules/protocol/src/smithy4s/meta/validation/AdtValidatorCommon.java
@@ -51,7 +51,7 @@ final class AdtValidatorCommon {
 
 	private static List<Reference> getReferences(Model model, Shape adtMemberShape, Shape adtParent) {
 		return model.getMemberShapes().stream().flatMap(memberShape -> {
-			boolean doesMemberTargetAdtShape = memberShape.getTarget() == adtMemberShape.getId();
+			boolean doesMemberTargetAdtShape = memberShape.getTarget() .equals( adtMemberShape.getId());
 			boolean isMemberShapeInDesiredTarget = memberShape.getContainer().equals(adtParent.toShapeId());
 			if (doesMemberTargetAdtShape) {
 				return Stream.of(new Reference(isMemberShapeInDesiredTarget, memberShape.getContainer()));


### PR DESCRIPTION
It was causing false negatives (`doesMemberTargetAdtShape` being false when it should be `true`) for some shapes, when a lot of shapes were added in an unrelated namespace.

Some `ShapeId` constructors use a cache internally, which explains why it'd sometimes still match instance equality, but it's not a mechanism that should be relied upon, and [it will never be one](https://github.com/smithy-lang/smithy/issues/2242).

I've also checked for any other usages of `==` in our Java sources and they are all about primitives/enums, so it's fine.

Not adding tests due to the unpredictable nature of the issue.

## PR Checklist (not all items are relevant to all PRs)

- :x: Added unit-tests (for runtime code)
- :x: Added bootstrapped code + smoke tests (when the rendering logic is modified)
- :x: Added build-plugins integration tests (when reflection loading is required at codegen-time)
- :x: Added alloy compliance tests (when simpleRestJson protocol behaviour is expanded/updated)
- :x: Updated dynamic module to match generated-code behaviour
- :x: Added documentation
- [x] Updated changelog
