### PR TITLE
EncoderK: use type member for `Result`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Previously, URIs constructed with a base URI of `/` would have `localhost` as th
 
 Previously they'd be named after the **member target**, now they will use the name of the member itself (same as in the case of non-ADT unions).
 
+## Made `EncoderK`'s second type parameter a type member in [#1519](https://github.com/disneystreaming/smithy4s/pull/1519)
+
+There's usually only one instance of `EncoderK[F, A]` for a particular `F[_]`, and interpreters don't need to know what `A` is. For convenience, the type parameter has been moved to a type member.
+
 # 0.18.18
 
 * Fix an issue in the ADT trait validators that would sometimes fail validation while they shouldn't.

--- a/modules/cats/src/smithy4s/interopcats/SchemaVisitorHash.scala
+++ b/modules/cats/src/smithy4s/interopcats/SchemaVisitorHash.scala
@@ -123,7 +123,8 @@ final class SchemaVisitorHash(
     }
 
     // The encoded form that Hash works against for the eqV method, is a partially-applied curried function.
-    implicit val encoderKInstance = new EncoderK[AltHash, (U => Boolean, Int)] {
+    implicit val encoderKInstance: EncoderK[AltHash] = new EncoderK[AltHash] {
+      type Result = (U => Boolean, Int)
       def apply[A](fa: AltHash[A], a: A): (U => Boolean, Int) = {
         ((u: U) => fa.eqv(a, u), fa.hash(a))
       }

--- a/modules/cats/src/smithy4s/interopcats/SchemaVisitorShow.scala
+++ b/modules/cats/src/smithy4s/interopcats/SchemaVisitorShow.scala
@@ -79,7 +79,8 @@ final class SchemaVisitorShow(
         (t: A) => s"${shapeId.name}($label = ${showUnion.show(t)})"
       }
     }
-    implicit val encoderKShow: EncoderK.Aux[Show, String] =
+
+    implicit val encoderKShow: EncoderK[Show] =
       new EncoderK[Show] {
         type Result = String
 

--- a/modules/cats/src/smithy4s/interopcats/SchemaVisitorShow.scala
+++ b/modules/cats/src/smithy4s/interopcats/SchemaVisitorShow.scala
@@ -79,8 +79,10 @@ final class SchemaVisitorShow(
         (t: A) => s"${shapeId.name}($label = ${showUnion.show(t)})"
       }
     }
-    implicit val encoderKShow: EncoderK[Show, String] =
-      new EncoderK[Show, String] {
+    implicit val encoderKShow: EncoderK.Aux[Show, String] =
+      new EncoderK[Show] {
+        type Result = String
+
         override def apply[A](fa: Show[A], a: A): String = fa.show(a)
 
         override def absorb[A](f: A => String): Show[A] = Show.show(f)

--- a/modules/compliance-tests/src/smithy4s/compliancetests/internals/eq/EqSchemaVisitor.scala
+++ b/modules/compliance-tests/src/smithy4s/compliancetests/internals/eq/EqSchemaVisitor.scala
@@ -93,7 +93,8 @@ object EqSchemaVisitor extends SchemaVisitor[Eq] { self =>
     }
 
     // The encoded form that Eq works against is a partially-applied curried function.
-    implicit val encoderKInstance = new EncoderK[AltEq, U => Boolean] {
+    implicit val encoderKInstance: EncoderK[AltEq] = new EncoderK[AltEq] {
+      type Result = U => Boolean
       def apply[A](fa: AltEq[A], a: A): U => Boolean = { (u: U) =>
         fa.eqv(a, u)
       }

--- a/modules/core/src/smithy4s/capability/EncoderK.scala
+++ b/modules/core/src/smithy4s/capability/EncoderK.scala
@@ -24,7 +24,8 @@ package smithy4s.capability
   * to pre-compile codecs for each union member, and dispatch union instances
   * to a specific codec.
   */
-trait EncoderK[F[_], Result] extends Contravariant[F] {
+trait EncoderK[F[_]] extends Contravariant[F] {
+  type Result
   def apply[A](fa: F[A], a: A): Result
   def absorb[A](f: A => Result): F[A]
   def contramap[A, B](fa: F[A])(f: B => A): F[B] =
@@ -32,8 +33,12 @@ trait EncoderK[F[_], Result] extends Contravariant[F] {
 }
 
 object EncoderK {
-  implicit def encoderKForFunction[B]: EncoderK[* => B, B] =
-    new EncoderK[* => B, B] {
+  // todo: do we even need this? Arguably you're only going to have one instance per F, and the Result is an implementation detail
+  type Aux[F[_], B] = EncoderK[F] { type Result = B }
+
+  implicit def encoderKForFunction[B]: EncoderK.Aux[* => B, B] =
+    new EncoderK[* => B] {
+      type Result = B
       def apply[A](fa: A => B, a: A): B = fa(a)
       def absorb[A](f: A => B): A => B = f
     }

--- a/modules/core/src/smithy4s/capability/EncoderK.scala
+++ b/modules/core/src/smithy4s/capability/EncoderK.scala
@@ -33,10 +33,7 @@ trait EncoderK[F[_]] extends Contravariant[F] {
 }
 
 object EncoderK {
-  // todo: do we even need this? Arguably you're only going to have one instance per F, and the Result is an implementation detail
-  type Aux[F[_], B] = EncoderK[F] { type Result = B }
-
-  implicit def encoderKForFunction[B]: EncoderK.Aux[* => B, B] =
+  implicit def encoderKForFunction[B]: EncoderK[* => B] =
     new EncoderK[* => B] {
       type Result = B
       def apply[A](fa: A => B, a: A): B = fa(a)

--- a/modules/core/src/smithy4s/codecs/Encoder.scala
+++ b/modules/core/src/smithy4s/codecs/Encoder.scala
@@ -101,8 +101,9 @@ object Encoder {
     */
   def static[Out](out: Out): Encoder[Out, Any] = _ => out
 
-  implicit def encoderEncoderK[In, Out]: EncoderK[Encoder[Out, *], Out] =
-    new EncoderK[Encoder[Out, *], Out] {
+  implicit def encoderEncoderK[In, Out]: EncoderK.Aux[Encoder[Out, *], Out] =
+    new EncoderK[Encoder[Out, *]] {
+      type Result = Out
       def apply[A](fa: Encoder[Out, A], a: A): Out = fa.encode(a)
       def absorb[A](f: A => Out): Encoder[Out, A] = f(_)
     }

--- a/modules/core/src/smithy4s/codecs/Encoder.scala
+++ b/modules/core/src/smithy4s/codecs/Encoder.scala
@@ -101,7 +101,7 @@ object Encoder {
     */
   def static[Out](out: Out): Encoder[Out, Any] = _ => out
 
-  implicit def encoderEncoderK[In, Out]: EncoderK.Aux[Encoder[Out, *], Out] =
+  implicit def encoderEncoderK[In, Out]: EncoderK[Encoder[Out, *]] =
     new EncoderK[Encoder[Out, *]] {
       type Result = Out
       def apply[A](fa: Encoder[Out, A], a: A): Out = fa.encode(a)

--- a/modules/core/src/smithy4s/codecs/Writer.scala
+++ b/modules/core/src/smithy4s/codecs/Writer.scala
@@ -110,7 +110,7 @@ object Writer {
   def noop[Message]: Writer[Message, Any] = (message, _) => message
 
   // format: off
-  implicit def writerEncoderK[Message]: EncoderK.Aux[Writer[Message, *], Message => Message] =
+  implicit def writerEncoderK[Message]: EncoderK[Writer[Message, *]] =
     new EncoderK[Writer[Message, *]] {
       type Result = Message => Message
       def apply[A](fa: Writer[Message, A], a: A): Message => Message = fa.write(_, a)

--- a/modules/core/src/smithy4s/codecs/Writer.scala
+++ b/modules/core/src/smithy4s/codecs/Writer.scala
@@ -110,8 +110,9 @@ object Writer {
   def noop[Message]: Writer[Message, Any] = (message, _) => message
 
   // format: off
-  implicit def writerEncoderK[Message]: EncoderK[Writer[Message, *], Message => Message] =
-    new EncoderK[Writer[Message, *], Message => Message] {
+  implicit def writerEncoderK[Message]: EncoderK.Aux[Writer[Message, *], Message => Message] =
+    new EncoderK[Writer[Message, *]] {
+      type Result = Message => Message
       def apply[A](fa: Writer[Message, A], a: A): Message => Message = fa.write(_, a)
       def absorb[A](f: A => (Message => Message)): Writer[Message, A] = new Writer[Message, A]{
         def write(message: Message, a: A): Message = f(a)(message)

--- a/modules/core/src/smithy4s/http/internals/UrlFormDataEncoder.scala
+++ b/modules/core/src/smithy4s/http/internals/UrlFormDataEncoder.scala
@@ -37,8 +37,9 @@ private[http] trait UrlFormDataEncoder[-A] { self =>
 private[internals] object UrlFormDataEncoder {
 
   implicit val urlFormDataEncoderK
-      : EncoderK[UrlFormDataEncoder, List[UrlForm.FormData]] =
-    new EncoderK[UrlFormDataEncoder, List[UrlForm.FormData]] {
+      : EncoderK.Aux[UrlFormDataEncoder, List[UrlForm.FormData]] =
+    new EncoderK[UrlFormDataEncoder] {
+      type Result = List[UrlForm.FormData]
 
       override def absorb[A](
           f: A => List[UrlForm.FormData]

--- a/modules/core/src/smithy4s/http/internals/UrlFormDataEncoder.scala
+++ b/modules/core/src/smithy4s/http/internals/UrlFormDataEncoder.scala
@@ -36,8 +36,7 @@ private[http] trait UrlFormDataEncoder[-A] { self =>
 
 private[internals] object UrlFormDataEncoder {
 
-  implicit val urlFormDataEncoderK
-      : EncoderK.Aux[UrlFormDataEncoder, List[UrlForm.FormData]] =
+  implicit val urlFormDataEncoderK: EncoderK[UrlFormDataEncoder] =
     new EncoderK[UrlFormDataEncoder] {
       type Result = List[UrlForm.FormData]
 

--- a/modules/core/src/smithy4s/internals/DocumentEncoderSchemaVisitor.scala
+++ b/modules/core/src/smithy4s/internals/DocumentEncoderSchemaVisitor.scala
@@ -62,8 +62,9 @@ trait DocumentEncoder[A] { self =>
 
 object DocumentEncoder {
 
-  implicit val encoderKInstance: EncoderK[DocumentEncoder, Document] =
-    new EncoderK[DocumentEncoder, Document] {
+  implicit val encoderKInstance: EncoderK.Aux[DocumentEncoder, Document] =
+    new EncoderK[DocumentEncoder] {
+      type Result = Document
       def apply[A](fa: DocumentEncoder[A], a: A): Document = fa.apply(a)
       def absorb[A](f: A => Document): DocumentEncoder[A] =
         new DocumentEncoder[A] {

--- a/modules/core/src/smithy4s/internals/DocumentEncoderSchemaVisitor.scala
+++ b/modules/core/src/smithy4s/internals/DocumentEncoderSchemaVisitor.scala
@@ -62,7 +62,7 @@ trait DocumentEncoder[A] { self =>
 
 object DocumentEncoder {
 
-  implicit val encoderKInstance: EncoderK.Aux[DocumentEncoder, Document] =
+  implicit val encoderKInstance: EncoderK[DocumentEncoder] =
     new EncoderK[DocumentEncoder] {
       type Result = Document
       def apply[A](fa: DocumentEncoder[A], a: A): Document = fa.apply(a)

--- a/modules/core/src/smithy4s/schema/Alt.scala
+++ b/modules/core/src/smithy4s/schema/Alt.scala
@@ -76,8 +76,8 @@ object Alt {
     */
   trait Dispatcher[U] {
 
-    def compile[G[_], Result](precompile: Precompiler[G])(implicit
-        encoderK: EncoderK[G, Result]
+    def compile[G[_]](precompile: Precompiler[G])(implicit
+        encoderK: EncoderK[G]
     ): G[U]
 
     def ordinal(u: U): Int
@@ -101,8 +101,8 @@ object Alt {
         alts: Vector[Alt[U, _]],
         ord: U => Int
     ) extends Dispatcher[U] {
-      def compile[F[_], Result](precompile: Precompiler[F])(implicit
-          encoderK: EncoderK[F, Result]
+      def compile[F[_]](precompile: Precompiler[F])(implicit
+          encoderK: EncoderK[F]
       ): F[U] = {
         val compiler = precompile.toPolyFunction[U]
         val builder = scala.collection.mutable.ArrayBuffer[Any]()

--- a/modules/xml/src/smithy4s/xml/internals/XmlEncoder.scala
+++ b/modules/xml/src/smithy4s/xml/internals/XmlEncoder.scala
@@ -101,8 +101,9 @@ private[smithy4s] trait XmlEncoder[-A] { self =>
 }
 
 object XmlEncoder {
-  implicit val xmlEncoderK: EncoderK[XmlEncoder, List[XmlContent]] =
-    new EncoderK[XmlEncoder, List[XmlContent]] {
+  implicit val xmlEncoderK: EncoderK.Aux[XmlEncoder, List[XmlContent]] =
+    new EncoderK[XmlEncoder] {
+      type Result = List[XmlContent]
       def apply[A](fa: XmlEncoder[A], a: A): List[XmlContent] = fa.encode(a)
 
       def absorb[A](f: A => List[XmlContent]): XmlEncoder[A] =

--- a/modules/xml/src/smithy4s/xml/internals/XmlEncoder.scala
+++ b/modules/xml/src/smithy4s/xml/internals/XmlEncoder.scala
@@ -101,7 +101,7 @@ private[smithy4s] trait XmlEncoder[-A] { self =>
 }
 
 object XmlEncoder {
-  implicit val xmlEncoderK: EncoderK.Aux[XmlEncoder, List[XmlContent]] =
+  implicit val xmlEncoderK: EncoderK[XmlEncoder] =
     new EncoderK[XmlEncoder] {
       type Result = List[XmlContent]
       def apply[A](fa: XmlEncoder[A], a: A): List[XmlContent] = fa.encode(a)


### PR DESCRIPTION
~~Targetting 0.18 as it's only source-breaking (like `cats.Parallel` if you're old enough to remember that).~~

## PR Checklist (not all items are relevant to all PRs)

- [ ] Added unit-tests (for runtime code)
- [ ] Added bootstrapped code + smoke tests (when the rendering logic is modified)
- [ ] Added build-plugins integration tests (when reflection loading is required at codegen-time)
- [ ] Added alloy compliance tests (when simpleRestJson protocol behaviour is expanded/updated)
- [ ] Updated dynamic module to match generated-code behaviour
- [ ] Added documentation
- [x] Updated changelog
