### PR TITLE
Add a small note in refinement docs for scala 3 users

### DIFF
--- a/modules/docs/markdown/04-codegen/01-customisation/04-refinements.md
+++ b/modules/docs/markdown/04-codegen/01-customisation/04-refinements.md
@@ -105,7 +105,7 @@ use smithy4s.meta#refinement
 
 apply test#emailFormat @refinement(
   targetType: "myapp.types.Email",
-  providerImport: "myapp.types.providers._"
+  providerImport: "myapp.types.providers._" // or `providerImport: "myapp.types.providers.given"` if you use scala 3
 )
 ```
 


### PR DESCRIPTION
Because otherwise We'll have this error:
```
[error]    |No given instance of type smithy4s.RefinementProvider[fide.spec.PageFormat, String, fide.types.Natural] was found for parameter refinementProvider of method apply in class PartiallyAppliedRefinement.
[error]    |I found:
[error]    |
[error]    |    smithy4s.RefinementProvider.isomorphismConstraint[C, A, A0]
[error]    |
[error]    |But method isomorphismConstraint in trait LowPriorityImplicits does not match type smithy4s.RefinementProvider[fide.spec.PageFormat, String, fide.types.Natural].
[error]    |
[error]    |Note: given instance given_RefinementProvider_PageFormat_String_Natural in
[error]    |  object providers was not considered because it was not imported with `import given`.
```

## PR Checklist (not all items are relevant to all PRs)

- [ ] Added unit-tests (for runtime code)
- [ ] Added bootstrapped code + smoke tests (when the rendering logic is modified)
- [ ] Added build-plugins integration tests (when reflection loading is required at codegen-time)
- [ ] Added alloy compliance tests (when simpleRestJson protocol behaviour is expanded/updated)
- [ ] Updated dynamic module to match generated-code behaviour
- [ ] Added documentation
- [ ] Updated changelog
