### PR TITLE
Change the smithy4sOutputDir SBT setting default value

### DIFF
--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/aws-newtype-flatten/test
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/aws-newtype-flatten/test
@@ -2,7 +2,7 @@
 > run
 
 # This new type was not flattened because it has range constraints
-$ exists  smithy_output/smithy4s/com/amazonaws/dynamodb/ListTablesInputLimit.scala
+$ exists  smithy_output/com/amazonaws/dynamodb/ListTablesInputLimit.scala
 
 # Flattened and removed by the projection transformer
--$ exists smithy_output/smithy4s/com/amazonaws/dynamodb/Long.scala
+-$ exists smithy_output/com/amazonaws/dynamodb/Long.scala

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/aws-specs/test
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/aws-specs/test
@@ -1,3 +1,3 @@
 # check if smithy4sCodegen works
 > smithy4sCodegen
-$ exists target/scala-2.13/src_managed/main/scala/smithy4s/com/amazonaws/dynamodb/AttributeValue.scala
+$ exists target/scala-2.13/src_managed/main/smithy4s/com/amazonaws/dynamodb/AttributeValue.scala

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/custom-settings/test
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/custom-settings/test
@@ -1,10 +1,10 @@
 # check if smithy4sCodegen works
 > show p1/smithy4sAllExternalDependencies
 > p1/compile
-$ exists p1/smithy_output/smithy4s/aws/iam/ActionPermissionDescription.scala
-$ exists p1/smithy_output/smithy4s/smithy4s/example/ObjectService.scala
+$ exists p1/smithy_output/aws/iam/ActionPermissionDescription.scala
+$ exists p1/smithy_output/smithy4s/example/ObjectService.scala
 
 > p2/compile
-$ exists p2/smithy_output/smithy4s/aws/iam/ActionPermissionDescription.scala
-$ exists p2/smithy_output/smithy4s/smithy4s/example/ObjectService.scala
--$ exists p2/smithy_output/smithy4s/smithy4s/toexclude/StructureToExclude.scala
+$ exists p2/smithy_output/aws/iam/ActionPermissionDescription.scala
+$ exists p2/smithy_output/smithy4s/example/ObjectService.scala
+-$ exists p2/smithy_output/smithy4s/toexclude/StructureToExclude.scala

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/defaults/test
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/defaults/test
@@ -1,6 +1,6 @@
 # check if smithy4sCodegen works
 > compile
-$ exists target/scala-2.13/src_managed/main/scala/smithy4s/smithy4s/example/ObjectService.scala
+$ exists target/scala-2.13/src_managed/main/smithy4s/smithy4s/example/ObjectService.scala
 $ exists target/scala-2.13/resource_managed/main/smithy4s.example.ObjectService.json
 
 # check if code can run, this can reveal runtime issues
@@ -8,7 +8,7 @@ $ exists target/scala-2.13/resource_managed/main/smithy4s.example.ObjectService.
 > run
 $ copy-file example-added.smithy src/main/smithy/example-added.smithy
 > compile
-$ exists target/scala-2.13/src_managed/main/scala/smithy4s/smithy4s/example/Added.scala
+$ exists target/scala-2.13/src_managed/main/smithy4s/smithy4s/example/Added.scala
 
 # ensuring that removing existing files removes their outputs
 $ delete src/main/smithy/example.smithy

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/dependencies-only/test
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/dependencies-only/test
@@ -1,3 +1,3 @@
 # check if smithy4sCodegen works
 > p1/compile
-$ exists p1/smithy_output/smithy4s/aws/iam/ActionPermissionDescription.scala
+$ exists p1/smithy_output/aws/iam/ActionPermissionDescription.scala

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/extra-configs/test
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/extra-configs/test
@@ -1,7 +1,7 @@
 # check if main sources are generated
 > compile
-$ exists target/scala-2.13/src_managed/main/scala/smithy4s/example/ExampleStruct.scala
+$ exists target/scala-2.13/src_managed/main/smithy4s/example/ExampleStruct.scala
 
 # check if test sources are generated
 > Test/compile
-$ exists target/scala-2.13/src_managed/test/scala/smithy4s/testexample/TestStruct.scala
+$ exists target/scala-2.13/src_managed/test/smithy4s/testexample/TestStruct.scala

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/multimodule-aws/test
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/multimodule-aws/test
@@ -1,5 +1,5 @@
 # check if smithy4sCodegen works with libraries that were built with Smithy4s
 > show bar/smithy4sAllExternalDependencies
 > compile
-$ exists foo/target/scala-2.13/src_managed/main/scala/smithy4s/foo/Lambda.scala
-$ absent bar/target/scala-2.13/src_managed/main/scala/smithy4s/foo/Lambda.scala
+$ exists foo/target/scala-2.13/src_managed/main/smithy4s/foo/Lambda.scala
+$ absent bar/target/scala-2.13/src_managed/main/smithy4s/foo/Lambda.scala

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/multimodule-staged/test
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/multimodule-staged/test
@@ -2,8 +2,8 @@
 > foo/publishLocal
 > upstream/publishLocal
 > bar/compile
-$ exists bar/target/scala-2.13/src_managed/main/scala/smithy4s/bar/Bar.scala
-$ absent bar/target/scala-2.13/src_managed/main/scala/smithy4s/foo/Foo.scala
+$ exists bar/target/scala-2.13/src_managed/main/smithy4s/bar/Bar.scala
+$ absent bar/target/scala-2.13/src_managed/main/smithy4s/foo/Foo.scala
 
 # check if code can run, this can reveal runtime issues# such as initialization errors
 > bar/run

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/multimodule/test
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/multimodule/test
@@ -1,10 +1,10 @@
 # check if smithy4sCodegen works in multimodule contexts
 > compile
-$ exists bar/target/scala-2.13/src_managed/main/scala/smithy4s/bar/Bar.scala
-$ absent bar/target/scala-2.13/src_managed/main/scala/smithy4s/foo/Foo.scala
-$ absent bar/target/scala-2.13/src_managed/main/scala/smithy4s/foodir/FooDir.scala
-$ exists foo/target/scala-2.13/src_managed/main/scala/smithy4s/foo/Foo.scala
-$ exists foo/target/scala-2.13/src_managed/main/scala/smithy4s/foodir/FooDir.scala
+$ exists bar/target/scala-2.13/src_managed/main/smithy4s/bar/Bar.scala
+$ absent bar/target/scala-2.13/src_managed/main/smithy4s/foo/Foo.scala
+$ absent bar/target/scala-2.13/src_managed/main/smithy4s/foodir/FooDir.scala
+$ exists foo/target/scala-2.13/src_managed/main/smithy4s/foo/Foo.scala
+$ exists foo/target/scala-2.13/src_managed/main/smithy4s/foodir/FooDir.scala
 # check if code can run, this can reveal runtime issues# such as initialization errors
 > bar/run
 

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/scala3/test
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/scala3/test
@@ -1,10 +1,10 @@
 # check if smithy4sCodegen works
 > compile
 
-$ exists target/scala-3.3.0/src_managed/main/scala/smithy4s/smithy4s/errors/BadRequest.scala
-$ exists target/scala-3.3.0/src_managed/main/scala/smithy4s/smithy4s/errors/InternalServerError.scala
-$ exists target/scala-3.3.0/src_managed/main/scala/smithy4s/smithy4s/errors/ErrorService.scala
-$ exists target/scala-3.3.0/src_managed/main/scala/smithy4s/smithy4s/errors/package.scala
+$ exists target/scala-3.3.0/src_managed/main/smithy4s/smithy4s/errors/BadRequest.scala
+$ exists target/scala-3.3.0/src_managed/main/smithy4s/smithy4s/errors/InternalServerError.scala
+$ exists target/scala-3.3.0/src_managed/main/smithy4s/smithy4s/errors/ErrorService.scala
+$ exists target/scala-3.3.0/src_managed/main/smithy4s/smithy4s/errors/package.scala
 
 # check if code can run
 > run

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/smithy-build/test
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/smithy-build/test
@@ -1,5 +1,5 @@
 # check if smithy4sCodegen works
 > compile
-$ exists target/scala-2.13/src_managed/main/scala/smithy4s/smithy4s/example/ObjectService.scala
+$ exists target/scala-2.13/src_managed/main/smithy4s/smithy4s/example/ObjectService.scala
 $ exists target/scala-2.13/resource_managed/main/smithy4s.example.ObjectService.json
 > checkOpenApi

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/smithy-rules/test
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/smithy-rules/test
@@ -1,3 +1,3 @@
 # check if smithy4sCodegen works
 > compile
-$ exists target/scala-2.13/src_managed/main/scala/smithy4s/smithy/rules
+$ exists target/scala-2.13/src_managed/main/smithy4s/smithy/rules

--- a/modules/codegen-plugin/src/smithy4s/codegen/Smithy4sCodegenPlugin.scala
+++ b/modules/codegen-plugin/src/smithy4s/codegen/Smithy4sCodegenPlugin.scala
@@ -188,7 +188,7 @@ object Smithy4sCodegenPlugin extends AutoPlugin {
       (config / sourceManaged).value / "smithy"
     ),
     config / unmanagedSourceDirectories ++= (config / smithy4sInputDirs).value,
-    config / smithy4sOutputDir := (config / sourceManaged).value / "scala",
+    config / smithy4sOutputDir := (config / sourceManaged).value / "smithy4s",
     config / smithy4sResourceDir := (config / resourceManaged).value,
     config / smithy4sCodegen := cachedSmithyCodegen(config).value,
     config / smithy4sSmithyLibrary := true,
@@ -408,7 +408,7 @@ object Smithy4sCodegenPlugin extends AutoPlugin {
       (inputDirs ++ generatedFiles)
         .filter(_.exists())
         .toList
-    val outputPath = (conf / smithy4sOutputDir).value / "smithy4s"
+    val outputPath = (conf / smithy4sOutputDir).value
     val resourceOutputPath = (conf / smithy4sResourceDir).value
     val allowedNamespaces =
       (conf / smithy4sAllowedNamespaces).?.value.map(_.toSet)

--- a/modules/docs/markdown/06-guides/endpoint-middleware.md
+++ b/modules/docs/markdown/06-guides/endpoint-middleware.md
@@ -108,7 +108,6 @@ We will create a server-side middleware that implements the authentication as de
 import smithy4s.example.guides.auth._
 import cats.effect._
 import cats.implicits._
-import org.http4s.implicits._
 import org.http4s._
 import smithy4s.http4s.SimpleRestJsonBuilder
 import smithy4s._

--- a/modules/xml/src/smithy4s/xml/Xml.scala
+++ b/modules/xml/src/smithy4s/xml/Xml.scala
@@ -115,7 +115,7 @@ object Xml {
 
     XmlDocument.documentEventifier
       .eventify(xmlDocument)
-      .through(render(collapseEmpty = false))
+      .through(render.raw(collapseEmpty = false))
   }
 
   private def writeToBytes[A: Schema](a: A): Stream[fs2.Pure, Byte] =

--- a/modules/xml/src/smithy4s/xml/internals/XmlPayloadEncoderCompilerImpl.scala
+++ b/modules/xml/src/smithy4s/xml/internals/XmlPayloadEncoderCompilerImpl.scala
@@ -33,7 +33,7 @@ private[xml] class XmlPayloadEncoderCompilerImpl(escapeAttributes: Boolean)
       Blob {
         eventifier
           .eventify(xmlDocumentEncoder.encode(a))
-          .through(fs2.data.xml.render(collapseEmpty = false))
+          .through(fs2.data.xml.render.raw(collapseEmpty = false))
           .through(fs2.text.utf8.encode[fs2.Pure])
           .compile
           .to(Collector.supportsArray(Array))

--- a/modules/xml/test/src/smithy4s/xml/XmlCodecSpec.scala
+++ b/modules/xml/test/src/smithy4s/xml/XmlCodecSpec.scala
@@ -585,7 +585,7 @@ object XmlCodecSpec extends SimpleIOSuite {
         def show(xmlDocument: XmlDocument): String =
           XmlDocument.documentEventifier
             .eventify(xmlDocument)
-            .through(render())
+            .through(render.raw())
             .compile
             .string
       }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -80,7 +80,7 @@ object Dependencies {
 
   object Fs2Data {
     val xml: Def.Initialize[ModuleID] =
-      Def.setting("org.gnieh" %%% "fs2-data-xml" % "1.10.0")
+      Def.setting("org.gnieh" %%% "fs2-data-xml" % "1.11.0")
   }
 
   object Mill {

--- a/project/Smithy4sBuildPlugin.scala
+++ b/project/Smithy4sBuildPlugin.scala
@@ -30,7 +30,7 @@ case class CatsEffectAxis(idSuffix: String, directorySuffix: String)
 object Smithy4sBuildPlugin extends AutoPlugin {
 
   val Scala212 = "2.12.19"
-  val Scala213 = "2.13.12"
+  val Scala213 = "2.13.13"
   val Scala3 = "3.3.3"
 
   object autoImport {

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 // format: off
 addSbtPlugin("ch.epfl.scala"        % "sbt-scalafix"                  % "0.12.0")
-addSbtPlugin("org.scala-js"         % "sbt-scalajs"                   % "1.15.0")
+addSbtPlugin("org.scala-js"         % "sbt-scalajs"                   % "1.16.0")
 addSbtPlugin("com.github.sbt"       % "sbt-pgp"                       % "2.2.1")
 addSbtPlugin("com.github.sbt"       % "sbt-dynver"                    % "5.0.1")
 addSbtPlugin("org.xerial.sbt"       % "sbt-sonatype"                  % "3.10.0")


### PR DESCRIPTION
* Avoid hardcoding the `/smithy4s` segment by making it part of the default value of a configurable setting
* Remove the `/scala` segment to align with ScalaPB
* Bumps a few versions (ScalaJS/Scala 2.13/fs2-data)