### PR TITLE
Implement `scalaImports` trait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ When adding entries, please treat them as if they could end up in a release any 
 
 Thank you!
 
-# 0.18.20 
+# 0.18.21
+
+* Addition of an new `@scalaImport` trait to provide a mechanism to add additional imports to the generated code. Read the new [docs](https://disneystreaming.github.io/smithy4s/docs/codegen/customisation/scala-imports) for more info (see https://github.com/disneystreaming/smithy4s/pull/1550).
+
+# 0.18.20
 
 * Change semantics of `Blob.equals` - Blobs do not take underlying type into consideration, just bytes in https://github.com/disneystreaming/smithy4s/pull/1526
 

--- a/modules/bootstrapped/src/generated/smithy4s/example/StructureWithScalaImports.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/StructureWithScalaImports.scala
@@ -1,0 +1,24 @@
+package smithy4s.example
+
+import smithy4s.Hints
+import smithy4s.Schema
+import smithy4s.ShapeId
+import smithy4s.ShapeTag
+import smithy4s.refined.Age.provider._
+import smithy4s.schema.Schema.struct
+
+
+final case class StructureWithScalaImports(teenage: Option[Age] = None)
+
+object StructureWithScalaImports extends ShapeTag.Companion[StructureWithScalaImports] {
+  val id: ShapeId = ShapeId("smithy4s.example", "StructureWithScalaImports")
+
+  val hints: Hints = Hints.empty
+
+  // constructor using the original order from the spec
+  private def make(teenage: Option[Age]): StructureWithScalaImports = StructureWithScalaImports(teenage)
+
+  implicit val schema: Schema[StructureWithScalaImports] = struct(
+    Age.schema.validated(smithy.api.Range(min = Some(scala.math.BigDecimal(13.0)), max = Some(scala.math.BigDecimal(19.0)))).optional[StructureWithScalaImports]("teenage", _.teenage),
+  )(make).withId(id).addHints(hints)
+}

--- a/modules/bootstrapped/src/main/smithy4s/refined/Age.scala
+++ b/modules/bootstrapped/src/main/smithy4s/refined/Age.scala
@@ -20,5 +20,10 @@ object Age {
         Age.apply,
         (b: Age) => b.value
       )
+
+    implicit val rangeProvider
+        : RefinementProvider.Simple[smithy.api.Range, Age] =
+      RefinementProvider.rangeConstraint(x => x.value)
+
   }
 }

--- a/modules/codegen/src/smithy4s/codegen/internals/IR.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/IR.scala
@@ -357,6 +357,7 @@ private[internals] object Hint {
       extends Hint
   case object GenerateServiceProduct extends Hint
   case object GenerateOptics extends Hint
+  case class ScalaImports(providerImport: String) extends Hint
 
   implicit val eq: Eq[Hint] = Eq.fromUniversalEquals
 }

--- a/modules/codegen/src/smithy4s/codegen/internals/IR.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/IR.scala
@@ -357,7 +357,7 @@ private[internals] object Hint {
       extends Hint
   case object GenerateServiceProduct extends Hint
   case object GenerateOptics extends Hint
-  case class ScalaImports(providerImport: String) extends Hint
+  case class ScalaImports(imports: List[String]) extends Hint
 
   implicit val eq: Eq[Hint] = Eq.fromUniversalEquals
 }

--- a/modules/codegen/src/smithy4s/codegen/internals/Renderer.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/Renderer.scala
@@ -1040,7 +1040,6 @@ private[internals] class Renderer(compilationUnit: CompilationUnit) { self =>
       lines(
         documentationAnnotation(alt.hints),
         deprecationAnnotation(alt.hints),
-        renderScalaImports(alt.hints),
         constructor
       )
     }
@@ -1100,6 +1099,7 @@ private[internals] class Renderer(compilationUnit: CompilationUnit) { self =>
     lines(
       documentationAnnotation(hints),
       deprecationAnnotation(hints),
+      renderScalaImports(hints),
       block(
         line"sealed trait ${NameDef(name.name)} extends ${mixinExtendsStatement}scala.Product with scala.Serializable"
       ).withSameLineValue(line" self =>")(

--- a/modules/codegen/src/smithy4s/codegen/internals/Renderer.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/Renderer.scala
@@ -334,6 +334,7 @@ private[internals] class Renderer(compilationUnit: CompilationUnit) { self =>
     lines(
       documentationAnnotation(hints),
       deprecationAnnotation(hints),
+      renderScalaImports(hints),
       block(line"trait $genName[F[_, _, _, _, _]]")(
         line"self =>",
         newline,
@@ -1039,6 +1040,7 @@ private[internals] class Renderer(compilationUnit: CompilationUnit) { self =>
       lines(
         documentationAnnotation(alt.hints),
         deprecationAnnotation(alt.hints),
+        renderScalaImports(alt.hints),
         constructor
       )
     }
@@ -1257,6 +1259,7 @@ private[internals] class Renderer(compilationUnit: CompilationUnit) { self =>
     lines(
       documentationAnnotation(hints),
       deprecationAnnotation(hints),
+      renderScalaImports(hints),
       block(
         line"sealed abstract class ${name.name}(_value: $string_, _name: $string_, _intValue: $int_, _hints: $Hints_) extends $Enumeration_.Value"
       )(
@@ -1328,6 +1331,7 @@ private[internals] class Renderer(compilationUnit: CompilationUnit) { self =>
     lines(
       documentationAnnotation(hints),
       deprecationAnnotation(hints),
+      renderScalaImports(hints),
       obj(name, line"$Newtype_[$tpe]")(
         renderId(shapeId),
         renderHintsVal(hints),

--- a/modules/codegen/src/smithy4s/codegen/internals/Renderer.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/Renderer.scala
@@ -211,8 +211,10 @@ private[internals] class Renderer(compilationUnit: CompilationUnit) { self =>
 
   private def renderScalaImports(hints: List[Hint]): Lines = {
     lines(
-      hints.collect { case Hint.ScalaImports(value) =>
-        LineSegment.Import(value).toLine
+      hints.flatMap {
+        case Hint.ScalaImports(imports) =>
+          imports.map(LineSegment.Import(_).toLine)
+        case _ => Nil
       }
     )
   }

--- a/modules/codegen/src/smithy4s/codegen/internals/Renderer.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/Renderer.scala
@@ -209,6 +209,14 @@ private[internals] class Renderer(compilationUnit: CompilationUnit) { self =>
       }
   }
 
+  private def renderScalaImports(hints: List[Hint]): Lines = {
+    lines(
+      hints.collect { case Hint.ScalaImports(value) =>
+        LineSegment.Import(value).toLine
+      }
+    )
+  }
+
   /**
    * Returns the given list of Smithy documentation strings formatted as Scaladoc comments.
    *
@@ -816,6 +824,7 @@ private[internals] class Renderer(compilationUnit: CompilationUnit) { self =>
     lines(
       documentationAnnotation(product.hints),
       deprecationAnnotation(product.hints),
+      renderScalaImports(product.hints),
       base
     )
   }

--- a/modules/codegen/src/smithy4s/codegen/internals/SmithyToIR.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/SmithyToIR.scala
@@ -932,7 +932,7 @@ private[codegen] class SmithyToIR(model: Model, namespace: String) {
     case _: GenerateOpticsTrait =>
       Hint.GenerateOptics
     case s: ScalaImportsTrait =>
-      Hint.ScalaImports(s.getProviderImport())
+      Hint.ScalaImports(s.getImports().asScala.toList)
     case t if t.toShapeId() == ShapeId.fromParts("smithy.api", "trait") =>
       Hint.Trait
     case ConstraintTrait(tr) => Hint.Constraint(toTypeRef(tr), unfoldTrait(tr))

--- a/modules/codegen/src/smithy4s/codegen/internals/SmithyToIR.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/SmithyToIR.scala
@@ -28,6 +28,7 @@ import smithy4s.meta.IndexedSeqTrait
 import smithy4s.meta.NoStackTraceTrait
 import smithy4s.meta.PackedInputsTrait
 import smithy4s.meta.RefinementTrait
+import smithy4s.meta.ScalaImportsTrait
 import smithy4s.meta.TypeclassTrait
 import smithy4s.meta.VectorTrait
 import software.amazon.smithy.aws.traits.ServiceTrait
@@ -930,6 +931,8 @@ private[codegen] class SmithyToIR(model: Model, namespace: String) {
       Hint.GenerateServiceProduct
     case _: GenerateOpticsTrait =>
       Hint.GenerateOptics
+    case s: ScalaImportsTrait =>
+      Hint.ScalaImports(s.getProviderImport())
     case t if t.toShapeId() == ShapeId.fromParts("smithy.api", "trait") =>
       Hint.Trait
     case ConstraintTrait(tr) => Hint.Constraint(toTypeRef(tr), unfoldTrait(tr))

--- a/modules/codegen/test/src/smithy4s/codegen/internals/RendererSpec.scala
+++ b/modules/codegen/test/src/smithy4s/codegen/internals/RendererSpec.scala
@@ -491,6 +491,34 @@ final class RendererSpec extends munit.ScalaCheckSuite {
     )
   }
 
+  test(
+    "generated code of a structure that is applied @scalaImports should contain imports"
+  ) {
+    val smithy =
+      """
+        |$version: "2.0"
+        |
+        |namespace smithy4s
+        |
+        |use smithy4s.meta#scalaImports
+        |
+        |apply smithy4s#MyStruct @scalaImports(
+        |  ["smithy4s.providers._"]
+        |)
+        |
+        |structure MyStruct {
+        | str: String
+        |}
+        |""".stripMargin
+
+    val contents = generateScalaCode(smithy).values
+
+    assert(
+      contents.exists(_.contains("import smithy4s.providers._")),
+      "generated code should contain imports"
+    )
+  }
+
   property("enumeration order is preserved") {
 
     // custom input to avoid scalacheck shrinking

--- a/modules/codegen/test/src/smithy4s/codegen/internals/RendererSpec.scala
+++ b/modules/codegen/test/src/smithy4s/codegen/internals/RendererSpec.scala
@@ -492,9 +492,10 @@ final class RendererSpec extends munit.ScalaCheckSuite {
   }
 
   test(
-    "generated code of a structure that is applied @scalaImports should contain imports"
+    "generated code of a shape that is applied @scalaImports should contain imports"
   ) {
-    val smithy =
+
+    val structure =
       """
         |$version: "2.0"
         |
@@ -511,12 +512,69 @@ final class RendererSpec extends munit.ScalaCheckSuite {
         |}
         |""".stripMargin
 
-    val contents = generateScalaCode(smithy).values
+    val service =
+      """
+        |$version: "2.0"
+        |
+        |namespace smithy4s
+        |
+        |use smithy4s.meta#scalaImports
+        |
+        |apply smithy4s#MyService @scalaImports(
+        |  ["smithy4s.providers._"]
+        |)
+        |
+        |
+        |service MyService {
+        |  version: "1.0.0"
+        |}
+        |""".stripMargin
 
-    assert(
-      contents.exists(_.contains("import smithy4s.providers._")),
-      "generated code should contain imports"
-    )
+    val union =
+      """
+        |$version: "2.0"
+        |
+        |namespace smithy4s
+        |
+        |use smithy4s.meta#scalaImports
+        |
+        |apply smithy4s#MyUnion @scalaImports(
+        |  ["smithy4s.providers._"]
+        |)
+        |
+        |union MyUnion {
+        | int: Integer,
+        | str: String
+        |}
+        |""".stripMargin
+
+    val myEnum =
+      """
+        |$version: "2.0"
+        |
+        |namespace smithy4s
+        |
+        |use smithy4s.meta#scalaImports
+        |
+        |apply smithy4s#MyEnum @scalaImports(
+        |  ["smithy4s.providers._"]
+        |)
+        |
+        |enum MyEnum {
+        | Right = "right"
+        | Left = "left"
+        |}
+        |""".stripMargin
+
+    List(structure, service, union, myEnum).foreach { smithy =>
+      val contents = generateScalaCode(smithy).values
+
+      assert(
+        contents.exists(_.contains("import smithy4s.providers._")),
+        "generated code should contain imports"
+      )
+    }
+
   }
 
   property("enumeration order is preserved") {

--- a/modules/docs/markdown/04-codegen/01-customisation/15-scala-imports.md
+++ b/modules/docs/markdown/04-codegen/01-customisation/15-scala-imports.md
@@ -1,0 +1,149 @@
+---
+sidebar_label: ScalaImports
+title: Add Scala imports to generated code
+---
+
+`scalaImports` trait provides a mechanism for adding additional imports to smithy4s's generated code. This can be particularly useful when you want to combine type refinements (especially when the type refinements come a third party or in other module) and validators.
+
+Lets say We have a smithy specification and it's accommodated Scala code as below:
+
+```kotlin
+$version: "2.0"
+namespace test
+
+use smithy4s.meta#refinement
+
+@trait(selector: "integer")
+@refinement(
+    targetType: "myapp.types.PositiveInt"
+    providerImport: "myapp.types.providers._"
+)
+structure PageSizeFormat { }
+
+@PageSizeFormat
+integer PageSize
+
+structure Input {
+  pageSize: PageSize
+}
+
+```
+
+And
+
+```scala mdoc:reset:invisible
+// this is just here so the lower blocks will compile
+import smithy4s._
+import smithy4s.schema.Schema._
+case class PageSizeFormat()
+
+object PageSizeFormat extends ShapeTag.Companion[PageSizeFormat] {
+  val id: ShapeId = ShapeId("smithy4s", "PageSizeFormat")
+
+  val hints: Hints = Hints(
+    smithy.api.Trait(selector = Some("integer"), structurallyExclusive = None, conflicts = None, breakingChanges = None),
+  ).lazily
+
+
+  implicit val schema: Schema[PageSizeFormat] = constant(PageSizeFormat()).withId(id).addHints(hints)
+}
+```
+
+```scala mdoc:silent
+// package myapp.types
+// The recommendations from Type refinements docs are also applied here
+import smithy4s._
+
+case class PositiveInt(value: Int)
+object PositiveInt {
+
+  private def isPositiveInt(value: Int): Boolean = value > 0
+
+  def apply(value: Int): Either[String, PositiveInt] =
+    if (isPositiveInt(value)) Right(new PositiveInt(value))
+    else Left(s"$value is not a positive int")
+}
+
+object providers {
+
+  implicit val provider: RefinementProvider[PageSizeFormat, Int, PositiveInt] = Refinement.drivenBy[PageSizeFormat](
+    PositiveInt.apply,
+    (i: PositiveInt) => i.value
+  )
+}
+```
+
+:::info
+
+Note that the implicit `RefinementProvider` is not in the companion object of `PositiveInt`, so that We need to add an `providerImport` to the `refinement` trait.
+
+:::
+
+What We have here is `PageSize` will be generated as a `PositiveInt`. Which is really nice, but what if you need another validator like `@range` to limit how big a `pageSize` can be? So, just let try:
+
+```kotlin
+structure Input {
+  // highlight-start
+  @range(max: 100)
+  // highlight-end
+  pageSize: PageSize
+}
+```
+
+And compile to see what happen:
+
+```
+[error] 20 |    PageSize.schema.validated(smithy.api.Range(min = None, max = Some(scala.math.BigDecimal(100.0)))).field[Input]("pageSize", _.pageSize).addHints(smithy.api.Default(smithy4s.Document.fromDouble(0.0d))),
+[error]    |                                                                                                     ^
+[error]    |No implicit value of type smithy4s.RefinementProvider.Simple[smithy.api.Range, test.PageSize] was found for parameter constraint of method validated in trait Schema.
+[error]    |I found:
+[error]    |
+[error]    |    smithy4s.RefinementProvider.isomorphismConstraint[smithy.api.Range, A,
+[error]    |      test.PageSize.Type](smithy4s.RefinementProvider.enumRangeConstraint[A],
+[error]    |      /* missing */summon[smithy4s.Bijection[A, test.PageSize.Type]])
+[error]    |
+[error]    |But no implicit values were found that match type smithy4s.Bijection[A, test.PageSize.Type].
+[error] one error found
+```
+
+This looks scary, but it basically says that We need to create an implicit value of `RefinementProvider.Simple[Range, PageSize.Type]` and provide it to the file that contains `Input` structure. We can do the first step by adding this to `providers` object:
+
+```scala
+   implicit val rangeProvider: RefinementProvider.Simple[smithy.api.Range, PositiveInt] =
+     RefinementProvider.rangeConstraint(x => x.value)
+```
+:::info
+
+Note that the `PageSize.Type` is `PositiveInt`
+
+:::
+
+And for the second step, We need to apply `scalaImports` trait with an appropriate import to `Input` structure:
+
+```kotlin
+namespace test
+// highlight-start
+use smithy4s.meta#scalaImports
+// highlight-end
+use smithy4s.meta#refinement
+
+@trait(selector: "integer")
+@refinement(
+   targetType: "myapp.types.Natural"
+   providerImport: "myapp.types.providers._"
+)
+structure PageSizeFormat {}
+
+@PageSizeFormat
+integer PageSize
+
+// highlight-start
+@scalaImports(["myapp.types.providers._"])
+// highlight-end
+structure Input {
+  @range(max: 100)
+  pageSize: PageSize
+}
+```
+
+Now, Smithy4s will validate any `PageSize` value against range and then refine it into `PositiveInt`. We have the best of both worlds.

--- a/modules/protocol/resources/META-INF/services/software.amazon.smithy.model.traits.TraitService
+++ b/modules/protocol/resources/META-INF/services/software.amazon.smithy.model.traits.TraitService
@@ -11,3 +11,4 @@ smithy4s.meta.TypeclassTrait$Provider
 smithy4s.meta.GenerateServiceProductTrait$Provider
 smithy4s.meta.GenerateOpticsTrait$Provider
 smithy4s.meta.OnlyTrait$Provider
+smithy4s.meta.ScalaImportsTrait$Provider

--- a/modules/protocol/resources/META-INF/smithy/smithy4s.meta.smithy
+++ b/modules/protocol/resources/META-INF/smithy/smithy4s.meta.smithy
@@ -165,12 +165,10 @@ structure generateOptics {}
 structure noStackTrace {}
 
 /// Allows users to manually add imports to files of generated shapes.
-/// This would be helpful when some shape needs a specific import in order
-/// to compile. espically in the case you want to compose refinement types
-/// and other validators. `providerImport` should be an import that the
-/// target shape is required to compile.
+/// This would be helpful when some shape needs specific import(s) in order
+/// to compile. Espically in the case you want to compose refinement types
+/// and other validators.
 @trait(selector: "structure :not([trait|error])") // todo remove trait
-structure scalaImports {
-    @required
-    providerImport: Import
+list scalaImports {
+    member: Import
 }

--- a/modules/protocol/resources/META-INF/smithy/smithy4s.meta.smithy
+++ b/modules/protocol/resources/META-INF/smithy/smithy4s.meta.smithy
@@ -163,3 +163,14 @@ structure generateOptics {}
 ///  via extending scala.util.control.NoStackTrace instead of Throwable.
 @trait(selector: "structure :is([trait|error])")
 structure noStackTrace {}
+
+/// Allows users to manually add imports to files of generated shapes.
+/// This would be helpful when some shape needs a specific import in order
+/// to compile. espically in the case you want to compose refinement types
+/// and other validators. `providerImport` should be an import that the
+/// target shape is required to compile.
+@trait(selector: "* [trait|trait]")
+structure scalaImports {
+    @required
+    providerImport: Import
+}

--- a/modules/protocol/resources/META-INF/smithy/smithy4s.meta.smithy
+++ b/modules/protocol/resources/META-INF/smithy/smithy4s.meta.smithy
@@ -169,7 +169,7 @@ structure noStackTrace {}
 /// to compile. espically in the case you want to compose refinement types
 /// and other validators. `providerImport` should be an import that the
 /// target shape is required to compile.
-@trait(selector: "* [trait|trait]")
+@trait(selector: "structure :not([trait|error])") // todo remove trait
 structure scalaImports {
     @required
     providerImport: Import

--- a/modules/protocol/resources/META-INF/smithy/smithy4s.meta.smithy
+++ b/modules/protocol/resources/META-INF/smithy/smithy4s.meta.smithy
@@ -168,7 +168,7 @@ structure noStackTrace {}
 /// This would be helpful when some shape needs specific import(s) in order
 /// to compile. Espically in the case you want to compose refinement types
 /// and other validators.
-@trait(selector: "structure :not([trait|error])") // todo remove trait
+@trait
 list scalaImports {
     member: Import
 }

--- a/modules/protocol/src/smithy4s/meta/ScalaImportsTrait.java
+++ b/modules/protocol/src/smithy4s/meta/ScalaImportsTrait.java
@@ -1,0 +1,97 @@
+/*
+ *  Copyright 2021-2024 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package smithy4s.meta;
+
+import software.amazon.smithy.model.SourceException;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ObjectNode;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.traits.AbstractTrait;
+import software.amazon.smithy.model.traits.AbstractTraitBuilder;
+import software.amazon.smithy.model.traits.TraitService;
+import software.amazon.smithy.utils.SmithyBuilder;
+import software.amazon.smithy.utils.ToSmithyBuilder;
+
+public final class ScalaImportsTrait extends AbstractTrait implements ToSmithyBuilder<ScalaImportsTrait> {
+
+
+	public static final ShapeId ID = ShapeId.from("smithy4s.meta#scalaImports");
+
+	private final String providerImport;
+
+	private ScalaImportsTrait(ScalaImportsTrait.Builder builder) {
+		super(ID, builder.getSourceLocation());
+		this.providerImport = builder.providerImport;
+
+		if (providerImport == null) {
+			throw new SourceException("An providerImport must be provided.", getSourceLocation());
+		}
+	}
+
+	public String getProviderImport() {
+		return this.providerImport;
+	}
+
+	@Override
+	protected Node createNode() {
+		ObjectNode.Builder builder = Node.objectNodeBuilder();
+		builder.withMember("providerImport", getProviderImport());
+		return builder.build();
+	}
+
+	@Override
+	public SmithyBuilder<ScalaImportsTrait> toBuilder() {
+		return builder().providerImport(providerImport).sourceLocation(getSourceLocation());
+	}
+
+	/**
+	 * @return Returns a new RefinedTrait builder.
+	 */
+	public static ScalaImportsTrait.Builder builder() {
+		return new Builder();
+	}
+
+	public static final class Builder extends AbstractTraitBuilder<ScalaImportsTrait, ScalaImportsTrait.Builder> {
+
+		private String providerImport;
+
+		public ScalaImportsTrait.Builder providerImport(String providerImport) {
+			this.providerImport = providerImport;
+			return this;
+		}
+
+		@Override
+		public ScalaImportsTrait build() {
+			return new ScalaImportsTrait(this);
+		}
+	}
+
+	public static final class Provider implements TraitService {
+
+		@Override
+		public ShapeId getShapeId() {
+			return ID;
+		}
+
+		@Override
+		public ScalaImportsTrait createTrait(ShapeId target, Node value) {
+			ObjectNode objectNode = value.expectObjectNode();
+			String providerImport = objectNode.getMember("providerImport").map(node -> node.expectStringNode().getValue()).orElse(null);
+			return builder().sourceLocation(value).providerImport(providerImport).build();
+		}
+	}
+}

--- a/sampleSpecs/scalaImports.smithy
+++ b/sampleSpecs/scalaImports.smithy
@@ -1,0 +1,11 @@
+$version: "2.0"
+
+namespace smithy4s.example
+
+use smithy4s.meta#scalaImports
+
+@scalaImports(["smithy4s.refined.Age.provider._"])
+structure StructureWithScalaImports {
+  @range(min: 13, max: 19)
+  teenage: Age
+}


### PR DESCRIPTION
This is to implement `scalaImports` trait, which provides mechanism to add an import to a specific generated `structure` from smithy. The rationale behind is on this [discussion](https://github.com/disneystreaming/smithy4s/discussions/1525).

I still need to check all the items below but want to make a draft PR first to gather some early feedback.

ps: You can see this pr in action here: https://github.com/lenguyenthanh/fide/pull/100

## PR Checklist (not all items are relevant to all PRs)

- [x] Added unit-tests (for runtime code)
- [x] Added bootstrapped code + smoke tests (when the rendering logic is modified)
- ~~[ ] Added build-plugins integration tests (when reflection loading is required at codegen-time)~~
- ~~[ ] Added alloy compliance tests (when simpleRestJson protocol behaviour is expanded/updated)~~
- ~~[ ] Updated dynamic module to match generated-code behaviour~~
- [x] Added documentation
- [x] Updated changelog
