### PR TITLE
Log the args diff when re-running the smithy4s codegen

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -148,8 +148,8 @@ lazy val docs =
 val munitDeps = Def.setting {
   if (virtualAxes.value.contains(VirtualAxis.native)) {
     Seq(
-      Dependencies.MunitMilestone.core.value % Test,
-      Dependencies.MunitMilestone.scalacheck.value % Test
+      Dependencies.MunitV1.core.value % Test,
+      Dependencies.MunitV1.scalacheck.value % Test
     )
   } else {
     Seq(
@@ -471,6 +471,7 @@ lazy val codegenPlugin = (projectMatrix in file("modules/codegen-plugin"))
     Compile / unmanagedSources / excludeFilter := { f =>
       Glob("**/sbt-test/**").matches(f.toPath)
     },
+    libraryDependencies += Dependencies.MunitV1.diff.value,
     publishLocal := {
       // make sure that core and codegen are published before the
       // plugin is published

--- a/build.sbt
+++ b/build.sbt
@@ -148,8 +148,8 @@ lazy val docs =
 val munitDeps = Def.setting {
   if (virtualAxes.value.contains(VirtualAxis.native)) {
     Seq(
-      Dependencies.MunitV1.core.value % Test,
-      Dependencies.MunitV1.scalacheck.value % Test
+      Dependencies.MunitMilestone.core.value % Test,
+      Dependencies.MunitMilestone.scalacheck.value % Test
     )
   } else {
     Seq(

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/defaults/test
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/defaults/test
@@ -1,4 +1,5 @@
 # check if smithy4sCodegen works
+> set logLevel := Level.Debug
 > compile
 $ exists target/scala-2.13/src_managed/main/smithy4s/smithy4s/example/ObjectService.scala
 $ exists target/scala-2.13/resource_managed/main/smithy4s.example.ObjectService.json

--- a/modules/codegen-plugin/src/smithy4s/codegen/CachedTask.scala
+++ b/modules/codegen-plugin/src/smithy4s/codegen/CachedTask.scala
@@ -1,3 +1,19 @@
+/*
+ *  Copyright 2021-2024 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 package smithy4s.codegen
 
 import sbt._

--- a/modules/codegen-plugin/src/smithy4s/codegen/CachedTask.scala
+++ b/modules/codegen-plugin/src/smithy4s/codegen/CachedTask.scala
@@ -1,0 +1,56 @@
+package smithy4s.codegen
+
+import sbt._
+import sbt.util.CacheStore
+import sbt.util.Logger
+import sjsonnew._
+import sjsonnew.support.scalajson.unsafe.Converter
+import sjsonnew.support.scalajson.unsafe.PrettyPrinter
+
+import scala.util.Try
+
+private[codegen] object CachedTask {
+
+  // This implementation is inspired by sbt.util.Tracked.inputChanged
+  // The main difference is that when the values don't match, the difference is calculated
+  // using munit-diff and recorded to debug log
+  def inputChanged[I: JsonFormat, O](store: CacheStore, logger: Logger)(
+      f: (Boolean, I) => O
+  ): I => O = { in =>
+    def debug(str: String): Unit = logger.debug(s"[smithy4s]$str")
+
+    val previousValue = Try(store.read[I]()).toOption
+
+    previousValue match {
+      case None =>
+        debug(
+          "Could not read previous value from inputs, smithy4s codegen needs to be executed."
+        )
+        store.write[I](in)
+        f(true, in)
+
+      case Some(oldValue) =>
+        (serializeCodegenArgs(oldValue), serializeCodegenArgs(in)) match {
+          case (Some(oldArgs), Some(newArgs)) if (oldArgs != newArgs) =>
+            val diff = new munit.diff.Diff(oldArgs, newArgs)
+            val report = diff.createReport(
+              "Arguments changed between smithy4s codegen invocations, diff:",
+              printObtainedAsStripMargin = false
+            )
+            debug(report)
+            store.write[I](in)
+            f(true, in)
+          case (_, _) =>
+            debug("Input didn't change between codegen invocations")
+            f(false, in)
+        }
+    }
+
+  }
+
+  private def serializeCodegenArgs[I: JsonFormat](args: I): Option[String] =
+    Converter
+      .toJson(args)
+      .map(v => PrettyPrinter(v))
+      .toOption
+}

--- a/modules/codegen-plugin/src/smithy4s/codegen/Smithy4sCodegenPlugin.scala
+++ b/modules/codegen-plugin/src/smithy4s/codegen/Smithy4sCodegenPlugin.scala
@@ -460,9 +460,9 @@ object Smithy4sCodegenPlugin extends AutoPlugin {
             s.cacheStoreFactory.make("output")
           ) { case ((inputChanged, args), outputs) =>
             if (inputChanged || outputs.isEmpty) {
-              s.log.debug("[smithy4s] Sources will be regenerated")
               s.log.debug(s"[smithy4s] Input changed: $inputChanged")
               s.log.debug(s"[smithy4s] Outputs empty: ${outputs.isEmpty}")
+              s.log.debug("[smithy4s] Sources will be regenerated")
               val resPaths = smithy4s.codegen.Codegen
                 .generateToDisk(args)
                 .toList

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -139,14 +139,17 @@ object Dependencies {
       )
   }
 
-  class MunitCross(munitVersion: String) {
+  class MunitCross(val munitVersion: String) {
     val core: Def.Initialize[ModuleID] =
       Def.setting("org.scalameta" %%% "munit" % munitVersion)
     val scalacheck: Def.Initialize[ModuleID] =
       Def.setting("org.scalameta" %%% "munit-scalacheck" % munitVersion)
   }
   object Munit extends MunitCross("0.7.29")
-  object MunitMilestone extends MunitCross("1.0.0-M6")
+  object MunitV1 extends MunitCross("1.0.0") {
+    val diff: Def.Initialize[ModuleID] =
+      Def.setting("org.scalameta" %%% "munit-diff" % munitVersion)
+  }
 
   val Scalacheck = new {
     val scalacheckVersion = "1.16.0"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -146,6 +146,7 @@ object Dependencies {
       Def.setting("org.scalameta" %%% "munit-scalacheck" % munitVersion)
   }
   object Munit extends MunitCross("0.7.29")
+  object MunitMilestone extends MunitCross("1.0.0-M6")
   object MunitV1 extends MunitCross("1.0.0") {
     val diff: Def.Initialize[ModuleID] =
       Def.setting("org.scalameta" %%% "munit-diff" % munitVersion)


### PR DESCRIPTION
This PR introduces a change in Smithy4s sbt codegen plugin that would allow users to see what caused the codegen to re-execute. It is done by replacing `sbt.util.Tracked.inputChanged` with a similar implementation that keeps the entire codegen args serialized in cache, and when codegen needs to be rerun, plugin will print the diff of the values to debug log. The diff is calculated using [munit-diff](https://scalameta.org/munit/blog/2024/05/22/release-1.0.0.html#diff-module-extracted-to-a-separate-module).

When running `sbt` with `set logLevel := Level.Debug`, user will notice a diff like this when codegen needs to rerun:

![obraz](https://github.com/disneystreaming/smithy4s/assets/7260594/5b40c2a6-afba-4ce4-9827-9d9674b943d8)


## PR Checklist (not all items are relevant to all PRs)

- [ ] Added unit-tests (for runtime code)
- [ ] Added bootstrapped code + smoke tests (when the rendering logic is modified)
- [ ] Added build-plugins integration tests (when reflection loading is required at codegen-time)
- [ ] Added alloy compliance tests (when simpleRestJson protocol behaviour is expanded/updated)
- [ ] Updated dynamic module to match generated-code behaviour
- [ ] Added documentation
- [ ] Updated changelog
