### PR TITLE
Add info about failing discrimintator to UnknownErrorResponse

### DIFF
--- a/modules/core/src/smithy4s/http/HttpErrorSelector.scala
+++ b/modules/core/src/smithy4s/http/HttpErrorSelector.scala
@@ -41,8 +41,8 @@ object HttpErrorSelector {
   def apply[F[_]: Covariant, E](
       maybeErrorSchema: Option[ErrorSchema[E]],
       compiler: CachedSchemaCompiler[F]
-  ): HttpDiscriminator => Option[F[E]] = maybeErrorSchema match {
-    case None => _ => None
+  ): HttpDiscriminator => Either[String, F[E]] = maybeErrorSchema match {
+    case None => _ => Left("error schema not found")
     case Some(errorschema) =>
       new HttpErrorSelector[F, E](
         errorschema.alternatives,
@@ -61,8 +61,13 @@ object HttpErrorSelector {
   def asThrowable[F[_]: Covariant, E](
       maybeErrorSchema: Option[ErrorSchema[E]],
       compiler: CachedSchemaCompiler[F]
-  ): HttpDiscriminator => Option[F[Throwable]] = maybeErrorSchema match {
-    case None => _ => None
+  ): HttpDiscriminator => Option[F[Throwable]] = asThrowableWithError(maybeErrorSchema, compiler).andThen(_.toOption)
+
+  def asThrowableWithError[F[_]: Covariant, E](
+      maybeErrorSchema: Option[ErrorSchema[E]],
+      compiler: CachedSchemaCompiler[F]
+  ): HttpDiscriminator => Either[String, F[Throwable]] = maybeErrorSchema match {
+    case None => _ => Left("error schema not found")
     case Some(errorschema) =>
       new HttpErrorSelector[F, E](
         errorschema.alternatives,
@@ -75,7 +80,7 @@ object HttpErrorSelector {
 private[http] final class HttpErrorSelector[F[_]: Covariant, E](
     alts: Vector[Alt[E, _]],
     compiler: CachedSchemaCompiler[F]
-) extends (HttpDiscriminator => Option[F[E]]) {
+) extends (HttpDiscriminator => Either[String, F[E]]) {
 
   type ConstF[A] = F[E]
   val cachedDecoders: PolyFunction[Alt[E, *], ConstF] =
@@ -101,7 +106,7 @@ private[http] final class HttpErrorSelector[F[_]: Covariant, E](
 
   def apply(
       discriminator: HttpDiscriminator
-  ): Option[F[E]] = {
+  ): Either[String, F[E]] = {
     val alt = getPreciseAlternative(discriminator)
     alt.map(cachedDecoders(_))
   }
@@ -170,13 +175,24 @@ private[http] final class HttpErrorSelector[F[_]: Covariant, E](
 
   private[http] def getPreciseAlternative(
       discriminator: HttpDiscriminator
-  ): Option[Alt[E, _]] = {
+  ): Either[String, Alt[E, _]] = {
     import HttpDiscriminator._
     discriminator match {
-      case FullId(shapeId) => byShapeId.get(shapeId)
-      case NameOnly(name)  => byName.get(name)
-      case StatusCode(int) => byStatusCode(int)
-      case Undetermined    => None
+      case FullId(shapeId) =>
+        byShapeId
+          .get(shapeId)
+          .map(Right(_))
+          .getOrElse(Left(s"Couldn't match by fullId: $shapeId"))
+      case NameOnly(name) =>
+        byName
+          .get(name)
+          .map(Right(_))
+          .getOrElse(Left(s"Couldn't match by name: $name"))
+      case StatusCode(int) =>
+        byStatusCode(int)
+          .map(Right(_))
+          .getOrElse(Left(s"Couldn't match by statucCode: $int"))
+      case Undetermined => Left("The error shape could not be determined")
     }
   }
 }

--- a/modules/core/src/smithy4s/http/HttpResponse.scala
+++ b/modules/core/src/smithy4s/http/HttpResponse.scala
@@ -203,7 +203,7 @@ object HttpResponse {
     ): Decoder[F, Body, E] =
       discriminating(
         discriminate,
-        HttpErrorSelector(maybeErrorSchema, decoderCompiler),
+        HttpErrorSelector.makeWithReason(maybeErrorSchema, decoderCompiler),
         toStrict
       )
 
@@ -220,7 +220,8 @@ object HttpResponse {
     ): Decoder[F, Body, Throwable] =
       discriminating(
         discriminate,
-        HttpErrorSelector.asThrowableWithError(maybeErrorSchema, decoderCompiler),
+        HttpErrorSelector
+          .asThrowableWithReason(maybeErrorSchema, decoderCompiler),
         toStrict
       )
 

--- a/modules/core/src/smithy4s/http/HttpResponse.scala
+++ b/modules/core/src/smithy4s/http/HttpResponse.scala
@@ -220,7 +220,7 @@ object HttpResponse {
     ): Decoder[F, Body, Throwable] =
       discriminating(
         discriminate,
-        HttpErrorSelector.asThrowable(maybeErrorSchema, decoderCompiler),
+        HttpErrorSelector.asThrowableWithError(maybeErrorSchema, decoderCompiler),
         toStrict
       )
 
@@ -230,7 +230,7 @@ object HttpResponse {
     */
     private def discriminating[F[_], Body, Discriminator, E](
         discriminate: HttpResponse[Body] => F[Discriminator],
-        select: Discriminator => Option[Decoder[F, Body, E]],
+        select: Discriminator => Either[String, Decoder[F, Body, E]],
         toStrict: Body => F[(Body, Blob)]
     )(implicit F: MonadThrowLike[F]): Decoder[F, Body, E] =
       new Decoder[F, Body, E] {
@@ -239,13 +239,14 @@ object HttpResponse {
             val strictResponse = response.copy(body = strictBody)
             F.flatMap(discriminate(strictResponse)) { discriminator =>
               select(discriminator) match {
-                case Some(decoder) => decoder.decode(strictResponse)
-                case None =>
+                case Right(decoder) => decoder.decode(strictResponse)
+                case Left(errors) =>
                   F.raiseError(
                     smithy4s.http.UnknownErrorResponse(
                       response.statusCode,
                       response.headers,
-                      bodyBlob.toUTF8String
+                      bodyBlob.toUTF8String,
+                      errors
                     )
                   )
               }

--- a/modules/core/src/smithy4s/http/UnknownErrorResponse.scala
+++ b/modules/core/src/smithy4s/http/UnknownErrorResponse.scala
@@ -19,7 +19,8 @@ package smithy4s.http
 case class UnknownErrorResponse(
     code: Int,
     headers: Map[CaseInsensitive, Seq[String]],
-    body: String
+    body: String,
+    error: String
 ) extends Throwable {
   override def getMessage(): String =
     s"status $code, headers: $headers, body:\n$body"


### PR DESCRIPTION
## PR Checklist (not all items are relevant to all PRs)

- [ ] Added unit-tests (for runtime code)
- [ ] Added bootstrapped code + smoke tests (when the rendering logic is modified)
- [ ] Added build-plugins integration tests (when reflection loading is required at codegen-time)
- [ ] Added alloy compliance tests (when simpleRestJson protocol behaviour is expanded/updated)
- [ ] Updated dynamic module to match generated-code behaviour
- [ ] Added documentation
- [ ] Updated changelog
