### PR TITLE
fix: Add missing nano part when encoding timestamp to document

### DIFF
--- a/modules/bootstrapped/test/src/smithy4s/DocumentSpec.scala
+++ b/modules/bootstrapped/test/src/smithy4s/DocumentSpec.scala
@@ -583,7 +583,7 @@ class DocumentSpec() extends FunSuite {
 
   test("Document encoder - timestamp epoch seconds with nanos") {
     val timestampWithNanos =
-      Timestamp(1716459630L, 500_000_000 /* half a second */ )
+      Timestamp(1716459630L, 500 * 1000 * 1000 /* half a second */ )
     val result = Document.Encoder
       .withExplicitDefaultsEncoding(false)
       .fromSchema(TimestampOperationInput.schema)

--- a/modules/bootstrapped/test/src/smithy4s/DocumentSpec.scala
+++ b/modules/bootstrapped/test/src/smithy4s/DocumentSpec.scala
@@ -581,6 +581,30 @@ class DocumentSpec() extends FunSuite {
     )
   }
 
+  test("Document encoder - timestamp epoch seconds with nanos") {
+    val timestampWithNanos = Timestamp(1716459630L, 5000000)
+    val result = Document.Encoder
+      .withExplicitDefaultsEncoding(false)
+      .fromSchema(TimestampOperationInput.schema)
+      .encode(
+        TimestampOperationInput(
+          timestampWithNanos,
+          timestampWithNanos,
+          timestampWithNanos
+        )
+      )
+    expect.same(
+      Document.obj(
+        "httpDate" -> Document.fromString("Thu, 23 May 2024 10:20:30.005 GMT"),
+        "dateTime" -> Document.fromString("2024-05-23T10:20:30.005Z"),
+        "epochSeconds" -> Document.fromBigDecimal(
+          BigDecimal("1716459630.500000")
+        )
+      ),
+      result
+    )
+  }
+
   test("Document decoder - timestamp defaults") {
     val doc = Document.obj()
     val result = Document.Decoder

--- a/modules/bootstrapped/test/src/smithy4s/DocumentSpec.scala
+++ b/modules/bootstrapped/test/src/smithy4s/DocumentSpec.scala
@@ -582,7 +582,8 @@ class DocumentSpec() extends FunSuite {
   }
 
   test("Document encoder - timestamp epoch seconds with nanos") {
-    val timestampWithNanos = Timestamp(1716459630L, 5000000)
+    val timestampWithNanos =
+      Timestamp(1716459630L, 500_000_000 /* half a second */ )
     val result = Document.Encoder
       .withExplicitDefaultsEncoding(false)
       .fromSchema(TimestampOperationInput.schema)
@@ -595,8 +596,8 @@ class DocumentSpec() extends FunSuite {
       )
     expect.same(
       Document.obj(
-        "httpDate" -> Document.fromString("Thu, 23 May 2024 10:20:30.005 GMT"),
-        "dateTime" -> Document.fromString("2024-05-23T10:20:30.005Z"),
+        "httpDate" -> Document.fromString("Thu, 23 May 2024 10:20:30.500 GMT"),
+        "dateTime" -> Document.fromString("2024-05-23T10:20:30.500Z"),
         "epochSeconds" -> Document.fromBigDecimal(
           BigDecimal("1716459630.500000")
         )

--- a/modules/core/src/smithy4s/internals/DocumentEncoderSchemaVisitor.scala
+++ b/modules/core/src/smithy4s/internals/DocumentEncoderSchemaVisitor.scala
@@ -99,9 +99,10 @@ class DocumentEncoderSchemaVisitor(
       hints
         .get(TimestampFormat)
         .getOrElse(TimestampFormat.EPOCH_SECONDS) match {
-        case DATE_TIME     => ts => DString(ts.format(DATE_TIME))
-        case HTTP_DATE     => ts => DString(ts.format(HTTP_DATE))
-        case EPOCH_SECONDS => ts => DNumber(BigDecimal(ts.epochSecond))
+        case DATE_TIME => ts => DString(ts.format(DATE_TIME))
+        case HTTP_DATE => ts => DString(ts.format(HTTP_DATE))
+        case EPOCH_SECONDS =>
+          ts => DNumber(BigDecimal(s"${ts.epochSecond}.${ts.nano}"))
       }
     case PDocument => from(identity)
     case PFloat    => from(float => DNumber(BigDecimal(float.toDouble)))

--- a/modules/core/src/smithy4s/internals/DocumentEncoderSchemaVisitor.scala
+++ b/modules/core/src/smithy4s/internals/DocumentEncoderSchemaVisitor.scala
@@ -102,7 +102,11 @@ class DocumentEncoderSchemaVisitor(
         case DATE_TIME => ts => DString(ts.format(DATE_TIME))
         case HTTP_DATE => ts => DString(ts.format(HTTP_DATE))
         case EPOCH_SECONDS =>
-          ts => DNumber(BigDecimal(s"${ts.epochSecond}.${ts.nano}"))
+          ts =>
+            val epochSecondsWithNanos =
+              BigDecimal(ts.epochSecond) + (BigDecimal(ts.nano) * BigDecimal(10)
+                .pow(-9))
+            DNumber(epochSecondsWithNanos)
       }
     case PDocument => from(identity)
     case PFloat    => from(float => DNumber(BigDecimal(float.toDouble)))


### PR DESCRIPTION
## PR Checklist (not all items are relevant to all PRs)

- [x] Added unit-tests (for runtime code)
- [ ] Added bootstrapped code + smoke tests (when the rendering logic is modified)
- [ ] Added build-plugins integration tests (when reflection loading is required at codegen-time)
- [ ] Added alloy compliance tests (when simpleRestJson protocol behaviour is expanded/updated)
- [ ] Updated dynamic module to match generated-code behaviour
- [ ] Added documentation
- [ ] Updated changelog
