### PR TITLE
Generate `transform` as a final def for cats-tagless friendliness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,14 @@ When adding entries, please treat them as if they could end up in a release any 
 
 Thank you!
 
+# 0.18.25
+
+* Make the `transform` method in generated `*Gen` algebras final. This should make it possible to derive e.g. `FunctorK` instances in cats-tagless automatically (see [#1588](https://github.com/disneystreaming/smithy4s/pull/1588)).
+
 # 0.18.24
 
 * Adds missing nanoseconds in Document encoding of EPOCH_SECOND timestamps
-* Add support for `alloy#jsonUnknown`, allowing structures to capture unknown JSON fields in one of their members. 
+* Add support for `alloy#jsonUnknown`, allowing structures to capture unknown JSON fields in one of their members.
 * Add `getMessage` implementation in `Smithy4sThrowable` which will be overridden in cases where the error structure contains a message field, but otherwise will be used to prevent a useless `null` result when `getMessage` is called.
 
 # 0.18.23

--- a/modules/bootstrapped/src/generated/com/amazonaws/dynamodb/DynamoDB.scala
+++ b/modules/bootstrapped/src/generated/com/amazonaws/dynamodb/DynamoDB.scala
@@ -49,7 +49,7 @@ trait DynamoDBGen[F[_, _, _, _, _]] {
     */
   def listTables(exclusiveStartTableName: Option[TableName] = None, limit: Option[ListTablesInputLimit] = None): F[ListTablesInput, DynamoDBOperation.ListTablesError, ListTablesOutput, Nothing, Nothing]
 
-  def transform: Transformation.PartiallyApplied[DynamoDBGen[F]] = Transformation.of[DynamoDBGen[F]](this)
+  final def transform: Transformation.PartiallyApplied[DynamoDBGen[F]] = Transformation.of[DynamoDBGen[F]](this)
 }
 
 object DynamoDBGen extends Service.Mixin[DynamoDBGen, DynamoDBOperation] {

--- a/modules/bootstrapped/src/generated/smithy4s/benchmark/BenchmarkService.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/benchmark/BenchmarkService.scala
@@ -17,7 +17,7 @@ trait BenchmarkServiceGen[F[_, _, _, _, _]] {
   def createObject(key: String, bucketName: String, payload: S3Object): F[CreateObjectInput, Nothing, Unit, Nothing, Nothing]
   def sendString(key: String, bucketName: String, body: String): F[SendStringInput, Nothing, Unit, Nothing, Nothing]
 
-  def transform: Transformation.PartiallyApplied[BenchmarkServiceGen[F]] = Transformation.of[BenchmarkServiceGen[F]](this)
+  final def transform: Transformation.PartiallyApplied[BenchmarkServiceGen[F]] = Transformation.of[BenchmarkServiceGen[F]](this)
 }
 
 object BenchmarkServiceGen extends Service.Mixin[BenchmarkServiceGen, BenchmarkServiceOperation] {

--- a/modules/bootstrapped/src/generated/smithy4s/example/BrandService.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/BrandService.scala
@@ -16,7 +16,7 @@ trait BrandServiceGen[F[_, _, _, _, _]] {
 
   def addBrands(brands: Option[List[String]] = None): F[AddBrandsInput, Nothing, Unit, Nothing, Nothing]
 
-  def transform: Transformation.PartiallyApplied[BrandServiceGen[F]] = Transformation.of[BrandServiceGen[F]](this)
+  final def transform: Transformation.PartiallyApplied[BrandServiceGen[F]] = Transformation.of[BrandServiceGen[F]](this)
 }
 
 object BrandServiceGen extends Service.Mixin[BrandServiceGen, BrandServiceOperation] {

--- a/modules/bootstrapped/src/generated/smithy4s/example/DeprecatedService.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/DeprecatedService.scala
@@ -18,7 +18,7 @@ trait DeprecatedServiceGen[F[_, _, _, _, _]] {
   @deprecated(message = "N/A", since = "N/A")
   def deprecatedOperation(): F[Unit, Nothing, Unit, Nothing, Nothing]
 
-  def transform: Transformation.PartiallyApplied[DeprecatedServiceGen[F]] = Transformation.of[DeprecatedServiceGen[F]](this)
+  final def transform: Transformation.PartiallyApplied[DeprecatedServiceGen[F]] = Transformation.of[DeprecatedServiceGen[F]](this)
 }
 
 object DeprecatedServiceGen extends Service.Mixin[DeprecatedServiceGen, DeprecatedServiceOperation] {

--- a/modules/bootstrapped/src/generated/smithy4s/example/DiscriminatedService.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/DiscriminatedService.scala
@@ -15,7 +15,7 @@ trait DiscriminatedServiceGen[F[_, _, _, _, _]] {
 
   def testDiscriminated(key: String): F[TestDiscriminatedInput, Nothing, TestDiscriminatedOutput, Nothing, Nothing]
 
-  def transform: Transformation.PartiallyApplied[DiscriminatedServiceGen[F]] = Transformation.of[DiscriminatedServiceGen[F]](this)
+  final def transform: Transformation.PartiallyApplied[DiscriminatedServiceGen[F]] = Transformation.of[DiscriminatedServiceGen[F]](this)
 }
 
 object DiscriminatedServiceGen extends Service.Mixin[DiscriminatedServiceGen, DiscriminatedServiceOperation] {

--- a/modules/bootstrapped/src/generated/smithy4s/example/DummyService.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/DummyService.scala
@@ -22,7 +22,7 @@ trait DummyServiceGen[F[_, _, _, _, _]] {
   def dummyHostPrefix(label1: String, label2: String, label3: HostLabelEnum): F[HostLabelInput, Nothing, Unit, Nothing, Nothing]
   def dummyPath(str: String, int: Int, ts1: Timestamp, ts2: Timestamp, ts3: Timestamp, ts4: Timestamp, b: Boolean, ie: Numbers): F[PathParams, Nothing, Unit, Nothing, Nothing]
 
-  def transform: Transformation.PartiallyApplied[DummyServiceGen[F]] = Transformation.of[DummyServiceGen[F]](this)
+  final def transform: Transformation.PartiallyApplied[DummyServiceGen[F]] = Transformation.of[DummyServiceGen[F]](this)
 }
 
 object DummyServiceGen extends Service.Mixin[DummyServiceGen, DummyServiceOperation] {

--- a/modules/bootstrapped/src/generated/smithy4s/example/EmptyService.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/EmptyService.scala
@@ -12,7 +12,7 @@ trait EmptyServiceGen[F[_, _, _, _, _]] {
   self =>
 
 
-  def transform: Transformation.PartiallyApplied[EmptyServiceGen[F]] = Transformation.of[EmptyServiceGen[F]](this)
+  final def transform: Transformation.PartiallyApplied[EmptyServiceGen[F]] = Transformation.of[EmptyServiceGen[F]](this)
 }
 
 object EmptyServiceGen extends Service.Mixin[EmptyServiceGen, EmptyServiceOperation] {

--- a/modules/bootstrapped/src/generated/smithy4s/example/ErrorHandlingService.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/ErrorHandlingService.scala
@@ -18,7 +18,7 @@ trait ErrorHandlingServiceGen[F[_, _, _, _, _]] {
 
   def errorHandlingOperation(in: Option[String] = None): F[ErrorHandlingOperationInput, ErrorHandlingServiceOperation.ErrorHandlingOperationError, ErrorHandlingOperationOutput, Nothing, Nothing]
 
-  def transform: Transformation.PartiallyApplied[ErrorHandlingServiceGen[F]] = Transformation.of[ErrorHandlingServiceGen[F]](this)
+  final def transform: Transformation.PartiallyApplied[ErrorHandlingServiceGen[F]] = Transformation.of[ErrorHandlingServiceGen[F]](this)
 }
 
 object ErrorHandlingServiceGen extends Service.Mixin[ErrorHandlingServiceGen, ErrorHandlingServiceOperation] {

--- a/modules/bootstrapped/src/generated/smithy4s/example/ErrorHandlingServiceExtraErrors.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/ErrorHandlingServiceExtraErrors.scala
@@ -19,7 +19,7 @@ trait ErrorHandlingServiceExtraErrorsGen[F[_, _, _, _, _]] {
 
   def extraErrorOperation(in: Option[String] = None): F[ExtraErrorOperationInput, ErrorHandlingServiceExtraErrorsOperation.ExtraErrorOperationError, Unit, Nothing, Nothing]
 
-  def transform: Transformation.PartiallyApplied[ErrorHandlingServiceExtraErrorsGen[F]] = Transformation.of[ErrorHandlingServiceExtraErrorsGen[F]](this)
+  final def transform: Transformation.PartiallyApplied[ErrorHandlingServiceExtraErrorsGen[F]] = Transformation.of[ErrorHandlingServiceExtraErrorsGen[F]](this)
 }
 
 object ErrorHandlingServiceExtraErrorsGen extends Service.Mixin[ErrorHandlingServiceExtraErrorsGen, ErrorHandlingServiceExtraErrorsOperation] {

--- a/modules/bootstrapped/src/generated/smithy4s/example/FooService.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/FooService.scala
@@ -23,7 +23,7 @@ trait FooServiceGen[F[_, _, _, _, _]] {
     */
   def getFoo(): F[Unit, Nothing, GetFooOutput, Nothing, Nothing]
 
-  def transform: Transformation.PartiallyApplied[FooServiceGen[F]] = Transformation.of[FooServiceGen[F]](this)
+  final def transform: Transformation.PartiallyApplied[FooServiceGen[F]] = Transformation.of[FooServiceGen[F]](this)
 }
 
 object FooServiceGen extends Service.Mixin[FooServiceGen, FooServiceOperation] {

--- a/modules/bootstrapped/src/generated/smithy4s/example/KVStore.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/KVStore.scala
@@ -21,7 +21,7 @@ trait KVStoreGen[F[_, _, _, _, _]] {
   def put(key: String, value: String): F[KeyValue, KVStoreOperation.PutError, Unit, Nothing, Nothing]
   def delete(key: String): F[Key, KVStoreOperation.DeleteError, Unit, Nothing, Nothing]
 
-  def transform: Transformation.PartiallyApplied[KVStoreGen[F]] = Transformation.of[KVStoreGen[F]](this)
+  final def transform: Transformation.PartiallyApplied[KVStoreGen[F]] = Transformation.of[KVStoreGen[F]](this)
 }
 
 object KVStoreGen extends Service.Mixin[KVStoreGen, KVStoreOperation] {

--- a/modules/bootstrapped/src/generated/smithy4s/example/Library.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/Library.scala
@@ -18,7 +18,7 @@ trait LibraryGen[F[_, _, _, _, _]] {
   def getBook(): F[Unit, Nothing, Unit, Nothing, Nothing]
   def buyBook(): F[Unit, Nothing, Unit, Nothing, Nothing]
 
-  def transform: Transformation.PartiallyApplied[LibraryGen[F]] = Transformation.of[LibraryGen[F]](this)
+  final def transform: Transformation.PartiallyApplied[LibraryGen[F]] = Transformation.of[LibraryGen[F]](this)
 }
 
 object LibraryGen extends Service.Mixin[LibraryGen, LibraryOperation] {

--- a/modules/bootstrapped/src/generated/smithy4s/example/NameCollision.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/NameCollision.scala
@@ -19,7 +19,7 @@ trait NameCollisionGen[F[_, _, _, _, _]] {
   def myOp(): F[Unit, NameCollisionOperation.MyOpError, Unit, Nothing, Nothing]
   def endpoint(): F[Unit, Nothing, Unit, Nothing, Nothing]
 
-  def transform: Transformation.PartiallyApplied[NameCollisionGen[F]] = Transformation.of[NameCollisionGen[F]](this)
+  final def transform: Transformation.PartiallyApplied[NameCollisionGen[F]] = Transformation.of[NameCollisionGen[F]](this)
 }
 
 object NameCollisionGen extends Service.Mixin[NameCollisionGen, NameCollisionOperation] {

--- a/modules/bootstrapped/src/generated/smithy4s/example/ObjectCollision.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/ObjectCollision.scala
@@ -24,7 +24,7 @@ trait ObjectCollisionGen[F[_, _, _, _, _]] {
   def _toString(): F[Unit, Nothing, Unit, Nothing, Nothing]
   def _wait(): F[Unit, Nothing, Unit, Nothing, Nothing]
 
-  def transform: Transformation.PartiallyApplied[ObjectCollisionGen[F]] = Transformation.of[ObjectCollisionGen[F]](this)
+  final def transform: Transformation.PartiallyApplied[ObjectCollisionGen[F]] = Transformation.of[ObjectCollisionGen[F]](this)
 }
 
 object ObjectCollisionGen extends Service.Mixin[ObjectCollisionGen, ObjectCollisionOperation] {

--- a/modules/bootstrapped/src/generated/smithy4s/example/ObjectService.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/ObjectService.scala
@@ -27,7 +27,7 @@ trait ObjectServiceGen[F[_, _, _, _, _]] {
     */
   def getObject(key: ObjectKey, bucketName: BucketName): F[GetObjectInput, ObjectServiceOperation.GetObjectError, GetObjectOutput, Nothing, Nothing]
 
-  def transform: Transformation.PartiallyApplied[ObjectServiceGen[F]] = Transformation.of[ObjectServiceGen[F]](this)
+  final def transform: Transformation.PartiallyApplied[ObjectServiceGen[F]] = Transformation.of[ObjectServiceGen[F]](this)
 }
 
 object ObjectServiceGen extends Service.Mixin[ObjectServiceGen, ObjectServiceOperation] {

--- a/modules/bootstrapped/src/generated/smithy4s/example/PackedInputsService.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/PackedInputsService.scala
@@ -16,7 +16,7 @@ trait PackedInputsServiceGen[F[_, _, _, _, _]] {
 
   def packedInputOperation(input: PackedInput): F[PackedInput, Nothing, Unit, Nothing, Nothing]
 
-  def transform: Transformation.PartiallyApplied[PackedInputsServiceGen[F]] = Transformation.of[PackedInputsServiceGen[F]](this)
+  final def transform: Transformation.PartiallyApplied[PackedInputsServiceGen[F]] = Transformation.of[PackedInputsServiceGen[F]](this)
 }
 
 object PackedInputsServiceGen extends Service.Mixin[PackedInputsServiceGen, PackedInputsServiceOperation] {

--- a/modules/bootstrapped/src/generated/smithy4s/example/PizzaAdminService.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/PizzaAdminService.scala
@@ -32,7 +32,7 @@ trait PizzaAdminServiceGen[F[_, _, _, _, _]] {
   def headRequest(): F[Unit, Nothing, HeadRequestOutput, Nothing, Nothing]
   def noContentRequest(): F[Unit, Nothing, Unit, Nothing, Nothing]
 
-  def transform: Transformation.PartiallyApplied[PizzaAdminServiceGen[F]] = Transformation.of[PizzaAdminServiceGen[F]](this)
+  final def transform: Transformation.PartiallyApplied[PizzaAdminServiceGen[F]] = Transformation.of[PizzaAdminServiceGen[F]](this)
 }
 
 object PizzaAdminServiceGen extends Service.Mixin[PizzaAdminServiceGen, PizzaAdminServiceOperation] {

--- a/modules/bootstrapped/src/generated/smithy4s/example/RecursiveInputService.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/RecursiveInputService.scala
@@ -16,7 +16,7 @@ trait RecursiveInputServiceGen[F[_, _, _, _, _]] {
 
   def recursiveInputOperation(hello: Option[RecursiveInput] = None): F[RecursiveInput, Nothing, Unit, Nothing, Nothing]
 
-  def transform: Transformation.PartiallyApplied[RecursiveInputServiceGen[F]] = Transformation.of[RecursiveInputServiceGen[F]](this)
+  final def transform: Transformation.PartiallyApplied[RecursiveInputServiceGen[F]] = Transformation.of[RecursiveInputServiceGen[F]](this)
 }
 
 object RecursiveInputServiceGen extends Service.Mixin[RecursiveInputServiceGen, RecursiveInputServiceOperation] {

--- a/modules/bootstrapped/src/generated/smithy4s/example/ServiceWithNullsAndDefaults.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/ServiceWithNullsAndDefaults.scala
@@ -17,7 +17,7 @@ trait ServiceWithNullsAndDefaultsGen[F[_, _, _, _, _]] {
   def defaultNullsOperation(input: DefaultNullsOperationInput): F[DefaultNullsOperationInput, Nothing, DefaultNullsOperationOutput, Nothing, Nothing]
   def timestampOperation(input: TimestampOperationInput): F[TimestampOperationInput, Nothing, Unit, Nothing, Nothing]
 
-  def transform: Transformation.PartiallyApplied[ServiceWithNullsAndDefaultsGen[F]] = Transformation.of[ServiceWithNullsAndDefaultsGen[F]](this)
+  final def transform: Transformation.PartiallyApplied[ServiceWithNullsAndDefaultsGen[F]] = Transformation.of[ServiceWithNullsAndDefaultsGen[F]](this)
 }
 
 object ServiceWithNullsAndDefaultsGen extends Service.Mixin[ServiceWithNullsAndDefaultsGen, ServiceWithNullsAndDefaultsOperation] {

--- a/modules/bootstrapped/src/generated/smithy4s/example/StreamedObjects.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/StreamedObjects.scala
@@ -18,7 +18,7 @@ trait StreamedObjectsGen[F[_, _, _, _, _]] {
   def putStreamedObject(key: String): F[PutStreamedObjectInput, Nothing, Unit, StreamedBlob, Nothing]
   def getStreamedObject(key: String): F[GetStreamedObjectInput, Nothing, GetStreamedObjectOutput, Nothing, StreamedBlob]
 
-  def transform: Transformation.PartiallyApplied[StreamedObjectsGen[F]] = Transformation.of[StreamedObjectsGen[F]](this)
+  final def transform: Transformation.PartiallyApplied[StreamedObjectsGen[F]] = Transformation.of[StreamedObjectsGen[F]](this)
 }
 
 object StreamedObjectsGen extends Service.Mixin[StreamedObjectsGen, StreamedObjectsOperation] {

--- a/modules/bootstrapped/src/generated/smithy4s/example/Weather.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/Weather.scala
@@ -23,7 +23,7 @@ trait WeatherGen[F[_, _, _, _, _]] {
   def getForecast(cityId: CityId): F[GetForecastInput, Nothing, GetForecastOutput, Nothing, Nothing]
   def listCities(nextToken: Option[String] = None, pageSize: Option[Int] = None): F[ListCitiesInput, Nothing, ListCitiesOutput, Nothing, Nothing]
 
-  def transform: Transformation.PartiallyApplied[WeatherGen[F]] = Transformation.of[WeatherGen[F]](this)
+  final def transform: Transformation.PartiallyApplied[WeatherGen[F]] = Transformation.of[WeatherGen[F]](this)
 }
 
 object WeatherGen extends Service.Mixin[WeatherGen, WeatherOperation] {

--- a/modules/bootstrapped/src/generated/smithy4s/example/aws/MyThing.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/aws/MyThing.scala
@@ -12,7 +12,7 @@ trait MyThingGen[F[_, _, _, _, _]] {
   self =>
 
 
-  def transform: Transformation.PartiallyApplied[MyThingGen[F]] = Transformation.of[MyThingGen[F]](this)
+  final def transform: Transformation.PartiallyApplied[MyThingGen[F]] = Transformation.of[MyThingGen[F]](this)
 }
 
 object MyThingGen extends Service.Mixin[MyThingGen, MyThingOperation] {

--- a/modules/bootstrapped/src/generated/smithy4s/example/collision/ReservedNameService.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/collision/ReservedNameService.scala
@@ -19,7 +19,7 @@ trait ReservedNameServiceGen[F[_, _, _, _, _]] {
   def map(value: scala.collection.immutable.Map[smithy4s.example.collision.String, smithy4s.example.collision.String]): F[MapInput, Nothing, Unit, Nothing, Nothing]
   def option(value: scala.Option[smithy4s.example.collision.String] = None): F[OptionInput, Nothing, Unit, Nothing, Nothing]
 
-  def transform: Transformation.PartiallyApplied[ReservedNameServiceGen[F]] = Transformation.of[ReservedNameServiceGen[F]](this)
+  final def transform: Transformation.PartiallyApplied[ReservedNameServiceGen[F]] = Transformation.of[ReservedNameServiceGen[F]](this)
 }
 
 object ReservedNameServiceGen extends Service.Mixin[ReservedNameServiceGen, ReservedNameServiceOperation] {

--- a/modules/bootstrapped/src/generated/smithy4s/example/greet/GreetService.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/greet/GreetService.scala
@@ -15,7 +15,7 @@ trait GreetServiceGen[F[_, _, _, _, _]] {
 
   def greet(name: String): F[GreetInput, Nothing, GreetOutput, Nothing, Nothing]
 
-  def transform: Transformation.PartiallyApplied[GreetServiceGen[F]] = Transformation.of[GreetServiceGen[F]](this)
+  final def transform: Transformation.PartiallyApplied[GreetServiceGen[F]] = Transformation.of[GreetServiceGen[F]](this)
 }
 
 object GreetServiceGen extends Service.Mixin[GreetServiceGen, GreetServiceOperation] {

--- a/modules/bootstrapped/src/generated/smithy4s/example/guides/auth/HelloWorldAuthService.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/guides/auth/HelloWorldAuthService.scala
@@ -20,7 +20,7 @@ trait HelloWorldAuthServiceGen[F[_, _, _, _, _]] {
   def sayWorld(): F[Unit, HelloWorldAuthServiceOperation.SayWorldError, World, Nothing, Nothing]
   def healthCheck(): F[Unit, HelloWorldAuthServiceOperation.HealthCheckError, HealthCheckOutput, Nothing, Nothing]
 
-  def transform: Transformation.PartiallyApplied[HelloWorldAuthServiceGen[F]] = Transformation.of[HelloWorldAuthServiceGen[F]](this)
+  final def transform: Transformation.PartiallyApplied[HelloWorldAuthServiceGen[F]] = Transformation.of[HelloWorldAuthServiceGen[F]](this)
 }
 
 object HelloWorldAuthServiceGen extends Service.Mixin[HelloWorldAuthServiceGen, HelloWorldAuthServiceOperation] {

--- a/modules/bootstrapped/src/generated/smithy4s/example/guides/hello/HelloWorldService.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/guides/hello/HelloWorldService.scala
@@ -16,7 +16,7 @@ trait HelloWorldServiceGen[F[_, _, _, _, _]] {
 
   def sayWorld(): F[Unit, Nothing, World, Nothing, Nothing]
 
-  def transform: Transformation.PartiallyApplied[HelloWorldServiceGen[F]] = Transformation.of[HelloWorldServiceGen[F]](this)
+  final def transform: Transformation.PartiallyApplied[HelloWorldServiceGen[F]] = Transformation.of[HelloWorldServiceGen[F]](this)
 }
 
 object HelloWorldServiceGen extends Service.Mixin[HelloWorldServiceGen, HelloWorldServiceOperation] {

--- a/modules/bootstrapped/src/generated/smithy4s/example/hello/HelloWorldService.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/hello/HelloWorldService.scala
@@ -18,7 +18,7 @@ trait HelloWorldServiceGen[F[_, _, _, _, _]] {
 
   def hello(name: String, town: Option[String] = None): F[Person, HelloWorldServiceOperation.HelloError, Greeting, Nothing, Nothing]
 
-  def transform: Transformation.PartiallyApplied[HelloWorldServiceGen[F]] = Transformation.of[HelloWorldServiceGen[F]](this)
+  final def transform: Transformation.PartiallyApplied[HelloWorldServiceGen[F]] = Transformation.of[HelloWorldServiceGen[F]](this)
 }
 
 object HelloWorldServiceGen extends Service.Mixin[HelloWorldServiceGen, HelloWorldServiceOperation] {

--- a/modules/bootstrapped/src/generated/smithy4s/example/imp/ImportService.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/imp/ImportService.scala
@@ -21,7 +21,7 @@ trait ImportServiceGen[F[_, _, _, _, _]] {
 
   def importOperation(): F[Unit, ImportServiceOperation.ImportOperationError, OpOutput, Nothing, Nothing]
 
-  def transform: Transformation.PartiallyApplied[ImportServiceGen[F]] = Transformation.of[ImportServiceGen[F]](this)
+  final def transform: Transformation.PartiallyApplied[ImportServiceGen[F]] = Transformation.of[ImportServiceGen[F]](this)
 }
 
 object ImportServiceGen extends Service.Mixin[ImportServiceGen, ImportServiceOperation] {

--- a/modules/bootstrapped/src/generated/smithy4s/example/product/ExampleService.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/product/ExampleService.scala
@@ -16,7 +16,7 @@ trait ExampleServiceGen[F[_, _, _, _, _]] {
 
   def exampleOperation(a: String): F[ExampleOperationInput, Nothing, ExampleOperationOutput, Nothing, Nothing]
 
-  def transform: Transformation.PartiallyApplied[ExampleServiceGen[F]] = Transformation.of[ExampleServiceGen[F]](this)
+  final def transform: Transformation.PartiallyApplied[ExampleServiceGen[F]] = Transformation.of[ExampleServiceGen[F]](this)
 }
 
 trait ExampleServiceProductGen[F[_, _, _, _, _]] {

--- a/modules/bootstrapped/src/generated/smithy4s/example/reservedNameOverride/ReservedNameOverrideService.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/reservedNameOverride/ReservedNameOverrideService.scala
@@ -16,7 +16,7 @@ trait ReservedNameOverrideServiceGen[F[_, _, _, _, _]] {
 
   def setOp(set: Set): F[SetOpInput, Nothing, Unit, Nothing, Nothing]
 
-  def transform: Transformation.PartiallyApplied[ReservedNameOverrideServiceGen[F]] = Transformation.of[ReservedNameOverrideServiceGen[F]](this)
+  final def transform: Transformation.PartiallyApplied[ReservedNameOverrideServiceGen[F]] = Transformation.of[ReservedNameOverrideServiceGen[F]](this)
 }
 
 object ReservedNameOverrideServiceGen extends Service.Mixin[ReservedNameOverrideServiceGen, ReservedNameOverrideServiceOperation] {

--- a/modules/bootstrapped/src/generated/smithy4s/example/test/HelloService.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/test/HelloService.scala
@@ -21,7 +21,7 @@ trait HelloServiceGen[F[_, _, _, _, _]] {
   def listen(): F[Unit, Nothing, Unit, Nothing, Nothing]
   def testPath(path: String): F[TestPathInput, Nothing, Unit, Nothing, Nothing]
 
-  def transform: Transformation.PartiallyApplied[HelloServiceGen[F]] = Transformation.of[HelloServiceGen[F]](this)
+  final def transform: Transformation.PartiallyApplied[HelloServiceGen[F]] = Transformation.of[HelloServiceGen[F]](this)
 }
 
 object HelloServiceGen extends Service.Mixin[HelloServiceGen, HelloServiceOperation] {

--- a/modules/bootstrapped/src/generated/smithy4s/example/test/HelloWorldService.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/test/HelloWorldService.scala
@@ -15,7 +15,7 @@ trait HelloWorldServiceGen[F[_, _, _, _, _]] {
 
   def hello(name: String): F[HelloInput, Nothing, HelloOutput, Nothing, Nothing]
 
-  def transform: Transformation.PartiallyApplied[HelloWorldServiceGen[F]] = Transformation.of[HelloWorldServiceGen[F]](this)
+  final def transform: Transformation.PartiallyApplied[HelloWorldServiceGen[F]] = Transformation.of[HelloWorldServiceGen[F]](this)
 }
 
 object HelloWorldServiceGen extends Service.Mixin[HelloWorldServiceGen, HelloWorldServiceOperation] {

--- a/modules/bootstrapped/src/generated/weather/WeatherService.scala
+++ b/modules/bootstrapped/src/generated/weather/WeatherService.scala
@@ -15,7 +15,7 @@ trait WeatherServiceGen[F[_, _, _, _, _]] {
 
   def getWeather(city: String): F[GetWeatherInput, Nothing, GetWeatherOutput, Nothing, Nothing]
 
-  def transform: Transformation.PartiallyApplied[WeatherServiceGen[F]] = Transformation.of[WeatherServiceGen[F]](this)
+  final def transform: Transformation.PartiallyApplied[WeatherServiceGen[F]] = Transformation.of[WeatherServiceGen[F]](this)
 }
 
 object WeatherServiceGen extends Service.Mixin[WeatherServiceGen, WeatherServiceOperation] {

--- a/modules/codegen/src/smithy4s/codegen/internals/ModelLoader.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/ModelLoader.scala
@@ -51,7 +51,7 @@ private[codegen] object ModelLoader {
     val modelsInJars = deps.flatMap { file =>
       Using.resource(
         // Note: On JDK13+, the second parameter is redundant.
-        FileSystems.newFileSystem(file.toPath(), null)
+        FileSystems.newFileSystem(file.toPath(), null: ClassLoader)
       ) { jarFS =>
         val p = jarFS.getPath("META-INF", "smithy", "manifest")
 

--- a/modules/codegen/src/smithy4s/codegen/internals/Renderer.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/Renderer.scala
@@ -355,7 +355,7 @@ private[internals] class Renderer(compilationUnit: CompilationUnit) { self =>
           )
         },
         newline,
-        line"def $transform_: $Transformation.PartiallyApplied[$genName[F]] = $Transformation.of[$genName[F]](this)"
+        line"final def $transform_: $Transformation.PartiallyApplied[$genName[F]] = $Transformation.of[$genName[F]](this)"
       ),
       newline,
       lines(


### PR DESCRIPTION
Closes #1587 

## PR Checklist (not all items are relevant to all PRs)

- [ ] Added unit-tests (for runtime code)
- [ ] Added bootstrapped code + smoke tests (when the rendering logic is modified)
- [ ] Added build-plugins integration tests (when reflection loading is required at codegen-time)
- [ ] Added alloy compliance tests (when simpleRestJson protocol behaviour is expanded/updated)
- [ ] Updated dynamic module to match generated-code behaviour
- [ ] Added documentation
- [x] Updated changelog
