### PR TITLE
Include field modifiers in collision avoidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,12 @@ When adding entries, please treat them as if they could end up in a release any 
 
 Thank you!
 
-# 0.18.24
+# 0.18.25
 
 * Fixes a regression from 0.18.4 which incorrectly rendered default values for certain types (see [#1593](https://github.com/disneystreaming/smithy4s/pull/1593))
+
+# 0.18.24
+
 * Adds missing nanoseconds in Document encoding of EPOCH_SECOND timestamps
 * Add support for `alloy#jsonUnknown`, allowing structures to capture unknown JSON fields in one of their members.
 * Add `getMessage` implementation in `Smithy4sThrowable` which will be overridden in cases where the error structure contains a message field, but otherwise will be used to prevent a useless `null` result when `getMessage` is called.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,9 @@ Thank you!
 
 # 0.18.24
 
+* Fixes a regression from 0.18.4 which incorrectly rendered default values for certain types (see [#1593](https://github.com/disneystreaming/smithy4s/pull/1593))
 * Adds missing nanoseconds in Document encoding of EPOCH_SECOND timestamps
-* Add support for `alloy#jsonUnknown`, allowing structures to capture unknown JSON fields in one of their members. 
+* Add support for `alloy#jsonUnknown`, allowing structures to capture unknown JSON fields in one of their members.
 * Add `getMessage` implementation in `Smithy4sThrowable` which will be overridden in cases where the error structure contains a message field, but otherwise will be used to prevent a useless `null` result when `getMessage` is called.
 
 # 0.18.23

--- a/modules/bootstrapped/src/generated/smithy4s/example/DefaultNotCapitalized.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/DefaultNotCapitalized.scala
@@ -6,7 +6,7 @@ import smithy4s.ShapeId
 import smithy4s.ShapeTag
 import smithy4s.schema.Schema.struct
 
-final case class DefaultNotCapitalized(name: Username = smithy4s.example.username("hello"))
+final case class DefaultNotCapitalized(name: Username = smithy4s.example.Username("hello"))
 
 object DefaultNotCapitalized extends ShapeTag.Companion[DefaultNotCapitalized] {
   val id: ShapeId = ShapeId("smithy4s.example", "DefaultNotCapitalized")

--- a/modules/bootstrapped/src/generated/smithy4s/example/DefaultNotCapitalized.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/DefaultNotCapitalized.scala
@@ -1,0 +1,22 @@
+package smithy4s.example
+
+import smithy4s.Hints
+import smithy4s.Schema
+import smithy4s.ShapeId
+import smithy4s.ShapeTag
+import smithy4s.schema.Schema.struct
+
+final case class DefaultNotCapitalized(name: Username = smithy4s.example.username("hello"))
+
+object DefaultNotCapitalized extends ShapeTag.Companion[DefaultNotCapitalized] {
+  val id: ShapeId = ShapeId("smithy4s.example", "DefaultNotCapitalized")
+
+  val hints: Hints = Hints.empty
+
+  // constructor using the original order from the spec
+  private def make(name: Username): DefaultNotCapitalized = DefaultNotCapitalized(name)
+
+  implicit val schema: Schema[DefaultNotCapitalized] = struct(
+    Username.schema.required[DefaultNotCapitalized]("name", _.name).addHints(smithy.api.Default(smithy4s.Document.fromString("hello"))),
+  )(make).withId(id).addHints(hints)
+}

--- a/modules/bootstrapped/src/generated/smithy4s/example/Username.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/Username.scala
@@ -1,0 +1,15 @@
+package smithy4s.example
+
+import smithy4s.Hints
+import smithy4s.Newtype
+import smithy4s.Schema
+import smithy4s.ShapeId
+import smithy4s.schema.Schema.bijection
+import smithy4s.schema.Schema.string
+
+object Username extends Newtype[String] {
+  val id: ShapeId = ShapeId("smithy4s.example", "username")
+  val hints: Hints = Hints.empty
+  val underlyingSchema: Schema[String] = string.withId(id).addHints(hints)
+  implicit val schema: Schema[Username] = bijection(underlyingSchema, asBijection)
+}

--- a/modules/bootstrapped/src/generated/smithy4s/example/package.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/package.scala
@@ -117,6 +117,7 @@ package object example {
   type UVIndex = smithy4s.example.UVIndex.Type
   type UnicodeRegexString = smithy4s.example.UnicodeRegexString.Type
   type UnwrappedFancyList = smithy4s.example.UnwrappedFancyList.Type
+  type Username = smithy4s.example.Username.Type
   type ValidatedString = smithy4s.example.ValidatedString.Type
 
 }

--- a/modules/codegen/src/smithy4s/codegen/internals/CollisionAvoidance.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/CollisionAvoidance.scala
@@ -154,14 +154,27 @@ private[internals] object CollisionAvoidance {
 
   private def modField(field: Field): Field = {
     Field(
-      protectKeyword(uncapitalise(field.name)),
-      field.name,
-      modType(field.tpe),
-      field.modifier,
-      field.originalIndex,
-      field.hints.map(modHint)
+      name = protectKeyword(uncapitalise(field.name)),
+      realName = field.name,
+      tpe = modType(field.tpe),
+      modifier = modModifier(field.modifier),
+      originalIndex = field.originalIndex,
+      hints = field.hints.map(modHint)
     )
   }
+
+  private def modModifier(modifier: Field.Modifier): Field.Modifier =
+    Field.Modifier(
+      required = modifier.required,
+      nullable = modifier.nullable,
+      default = modifier.default.map(modFieldDefault)
+    )
+
+  private def modFieldDefault(default: Field.Default): Field.Default =
+    Field.Default(
+      node = default.node,
+      typedNode = default.typedNode.map(recursion.preprocess(modTypedNode))
+    )
 
   private def modStreamingField(
       streamingField: StreamingField

--- a/modules/codegen/src/smithy4s/codegen/internals/ModelLoader.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/ModelLoader.scala
@@ -51,7 +51,7 @@ private[codegen] object ModelLoader {
     val modelsInJars = deps.flatMap { file =>
       Using.resource(
         // Note: On JDK13+, the second parameter is redundant.
-        FileSystems.newFileSystem(file.toPath(), null)
+        FileSystems.newFileSystem(file.toPath(), null: ClassLoader)
       ) { jarFS =>
         val p = jarFS.getPath("META-INF", "smithy", "manifest")
 

--- a/sampleSpecs/defaults.smithy
+++ b/sampleSpecs/defaults.smithy
@@ -73,6 +73,7 @@ structure DefaultVariants {
 
 structure DefaultInMixinUsageTest with [DefaultInMixinTest] {}
 
+// Regression test for https://github.com/disneystreaming/smithy4s/issues/1592
 structure DefaultNotCapitalized {
     @required
     name: username = "hello"

--- a/sampleSpecs/defaults.smithy
+++ b/sampleSpecs/defaults.smithy
@@ -72,3 +72,10 @@ structure DefaultVariants {
 }
 
 structure DefaultInMixinUsageTest with [DefaultInMixinTest] {}
+
+structure DefaultNotCapitalized {
+    @required
+    name: username = "hello"
+}
+
+string username


### PR DESCRIPTION
In #1301, we forgot to apply collision avoidance on field modifiers (which include the `TypedNode` for the field's default value). This would result in incorrectly rendering an unchanged type name in default values, which could result in e.g. a Scala keyword, or a lowercase reference to a shape that gets rendered as uppercase (as reported in #1592).

Closes #1592

## PR Checklist (not all items are relevant to all PRs)

- [ ] Added unit-tests (for runtime code)
- [x] Added bootstrapped code + smoke tests (when the rendering logic is modified)
- [ ] Added build-plugins integration tests (when reflection loading is required at codegen-time)
- [ ] Added alloy compliance tests (when simpleRestJson protocol behaviour is expanded/updated)
- [ ] Updated dynamic module to match generated-code behaviour
- [ ] Added documentation
- [x] Updated changelog
