### PR TITLE
Lenient numeric decoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Thank you!
 
 # 0.18.25
 
+* Add A flag to allow for numerics to be decoded from JSON strings (in smithy4s-json).
 * Fixes issues in which applications of some Smithy traits would be incorrectly rendered in Scala code (see [#1602](https://github.com/disneystreaming/smithy4s/pull/1602)).
 * Fixes an issue in which refinements wouldn't work on custom simple shapes (newtypes) (see [#1595](https://github.com/disneystreaming/smithy4s/pull/1595))
 * Fixes a regression from 0.18.4 which incorrectly rendered default values for certain types (see [#1593](https://github.com/disneystreaming/smithy4s/pull/1593))

--- a/modules/docs/markdown/03-protocols/04-simple-rest-json/01-overview.md
+++ b/modules/docs/markdown/03-protocols/04-simple-rest-json/01-overview.md
@@ -90,6 +90,14 @@ See the section about [unions](../../04-codegen/02-unions.md) for a detailed des
 
 By default, optional properties (headers, query parameters, structure fields) that are set to `None` and optional properties that are set to default value will be excluded during encoding process. If you wish to change this so that instead they are included and set to `null` explicitly, you can do so by calling `.withExplicitDefaultsEncoding(true)`.
 
+## Other customisations of JSON codec behaviour
+
+The underlying JSON codecs can be configured with a number of options to cater to niche usecases, via the `.transformJsonCodecs` method, which takes a function that takes in and returns a
+`JsonPayloadCodecCompiler`. For instance, by default, the `NaN` and `Infinity` values are not considered valid during parsing `Float` or `Double` values. This can be amended via
+`.transformJsonCodecs(_.configureJsoniterCodecCompiler(_.withInfinitySupport(true)))`.
+
+The customisations are bound to evolve as we uncover new niche cases that warrant adding new pieces of opt-in behaviour. The default behaviour is kept rather strict as it helps keep competitive performance and safety.
+
 ## Supported traits
 
 Here is the list of traits supported by `SimpleRestJson`

--- a/modules/http4s/src/smithy4s/http4s/SimpleRestJsonBuilder.scala
+++ b/modules/http4s/src/smithy4s/http4s/SimpleRestJsonBuilder.scala
@@ -35,7 +35,7 @@ class SimpleRestJsonBuilder private (
       simpleRestJsonCodecs
     ) {
 
-  @deprecated(message = "Use builder methods instead", since = "0.18.25")
+  @deprecated(message = "Use .withXXX methods instead", since = "0.18.25")
   def this(
       maxArity: Int,
       explicitDefaultsEncoding: Boolean,

--- a/modules/http4s/src/smithy4s/http4s/SimpleRestJsonBuilder.scala
+++ b/modules/http4s/src/smithy4s/http4s/SimpleRestJsonBuilder.scala
@@ -17,7 +17,17 @@
 package smithy4s
 package http4s
 
-object SimpleRestJsonBuilder extends SimpleRestJsonBuilder(1024, false, true)
+import smithy4s.json.Json
+import smithy4s.json.JsonPayloadCodecCompiler
+
+object SimpleRestJsonBuilder
+    extends SimpleRestJsonBuilder(
+      new internals.SimpleRestJsonCodecs(
+        jsonCodecs = Json.payloadCodecs,
+        explicitDefaultsEncoding = false,
+        hostPrefixInjection = true
+      )
+    )
 
 class SimpleRestJsonBuilder private (
     simpleRestJsonCodecs: internals.SimpleRestJsonCodecs
@@ -25,6 +35,7 @@ class SimpleRestJsonBuilder private (
       simpleRestJsonCodecs
     ) {
 
+  @deprecated(message = "Use builder methods instead", since = "0.18.25")
   def this(
       maxArity: Int,
       explicitDefaultsEncoding: Boolean,
@@ -32,7 +43,12 @@ class SimpleRestJsonBuilder private (
   ) =
     this(
       new internals.SimpleRestJsonCodecs(
-        maxArity,
+        Json.payloadCodecs
+          .withJsoniterCodecCompiler(
+            Json.jsoniter
+              .withMaxArity(maxArity)
+              .withExplicitDefaultsEncoding(explicitDefaultsEncoding)
+          ),
         explicitDefaultsEncoding,
         hostPrefixInjection
       )
@@ -40,24 +56,28 @@ class SimpleRestJsonBuilder private (
 
   def withMaxArity(maxArity: Int): SimpleRestJsonBuilder =
     new SimpleRestJsonBuilder(
-      maxArity,
-      simpleRestJsonCodecs.explicitDefaultsEncoding,
-      simpleRestJsonCodecs.hostPrefixInjection
+      simpleRestJsonCodecs.transformJsonCodecs(
+        _.configureJsoniterCodecCompiler(_.withMaxArity(maxArity))
+      )
     )
 
   def withExplicitDefaultsEncoding(
       explicitDefaultsEncoding: Boolean
   ): SimpleRestJsonBuilder =
     new SimpleRestJsonBuilder(
-      simpleRestJsonCodecs.maxArity,
-      explicitDefaultsEncoding,
-      simpleRestJsonCodecs.hostPrefixInjection
+      simpleRestJsonCodecs.withExplicitDefaultEncoding(explicitDefaultsEncoding)
     )
 
   def disableHostPrefixInjection(): SimpleRestJsonBuilder =
     new SimpleRestJsonBuilder(
-      simpleRestJsonCodecs.maxArity,
-      simpleRestJsonCodecs.explicitDefaultsEncoding,
-      false
+      simpleRestJsonCodecs.withHostPrefixInjection(false)
     )
+
+  /**
+    * Transforms the underlying JSON codec compiler to change its behaviour.
+    */
+  def transformJsonCodecs(
+      f: JsonPayloadCodecCompiler => JsonPayloadCodecCompiler
+  ): SimpleRestJsonBuilder =
+    new SimpleRestJsonBuilder(simpleRestJsonCodecs.transformJsonCodecs(f))
 }

--- a/modules/json/src/smithy4s/json/JsoniterCodecCompiler.scala
+++ b/modules/json/src/smithy4s/json/JsoniterCodecCompiler.scala
@@ -78,6 +78,12 @@ trait JsoniterCodecCompiler extends CachedSchemaCompiler[JsonCodec] {
     */
   def withLenientTaggedUnionDecoding: JsoniterCodecCompiler
 
+  /**
+    * Enables lenient decoding of numeric values, where numbers may be carried by JSON strings
+    * as well as JSON numbers.
+    */
+  def withLenientNumericDecoding: JsoniterCodecCompiler
+
 }
 
 object JsoniterCodecCompiler {

--- a/modules/json/src/smithy4s/json/internals/JsoniterCodecCompilerImpl.scala
+++ b/modules/json/src/smithy4s/json/internals/JsoniterCodecCompilerImpl.scala
@@ -27,7 +27,8 @@ private[smithy4s] case class JsoniterCodecCompilerImpl(
     infinitySupport: Boolean,
     preserveMapOrder: Boolean,
     hintMask: Option[HintMask],
-    lenientTaggedUnionDecoding: Boolean
+    lenientTaggedUnionDecoding: Boolean,
+    lenientNumericDecoding: Boolean
 ) extends CachedSchemaCompiler.Impl[JCodec]
     with JsoniterCodecCompiler {
 
@@ -59,6 +60,9 @@ private[smithy4s] case class JsoniterCodecCompilerImpl(
   def withLenientTaggedUnionDecoding: JsoniterCodecCompiler =
     copy(lenientTaggedUnionDecoding = true)
 
+  def withLenientNumericDecoding: JsoniterCodecCompiler =
+    copy(lenientNumericDecoding = true)
+
   def fromSchema[A](schema: Schema[A], cache: Cache): JCodec[A] = {
     val visitor = new SchemaVisitorJCodec(
       maxArity,
@@ -67,6 +71,7 @@ private[smithy4s] case class JsoniterCodecCompilerImpl(
       flexibleCollectionsSupport,
       preserveMapOrder,
       lenientTaggedUnionDecoding,
+      lenientNumericDecoding,
       cache
     )
     val amendedSchema =
@@ -88,6 +93,7 @@ private[smithy4s] object JsoniterCodecCompilerImpl {
       flexibleCollectionsSupport = false,
       preserveMapOrder = false,
       lenientTaggedUnionDecoding = false,
+      lenientNumericDecoding = false,
       hintMask = Some(JsoniterCodecCompiler.defaultHintMask)
     )
 

--- a/modules/json/test/src/smithy4s/json/SchemaVisitorJCodecCustomisationTests.scala
+++ b/modules/json/test/src/smithy4s/json/SchemaVisitorJCodecCustomisationTests.scala
@@ -24,6 +24,30 @@ import munit._
 
 class SchemaVisitorJCodecCustomisationTests extends FunSuite {
 
+  case class FooInt(i: Int)
+  object FooInt {
+    implicit val schema: Schema[FooInt] = {
+      val i = int.required[FooInt]("i", _.i)
+      struct(i)(FooInt.apply)
+    }
+  }
+
+  case class FooShort(s: Short)
+  object FooShort {
+    implicit val schema: Schema[FooShort] = {
+      val s = short.required[FooShort]("s", _.s)
+      struct(s)(FooShort.apply)
+    }
+  }
+
+  case class FooLong(l: Long)
+  object FooLong {
+    implicit val schema: Schema[FooLong] = {
+      val s = long.required[FooLong]("l", _.l)
+      struct(s)(FooLong.apply)
+    }
+  }
+
   case class FooDouble(d: Double)
   object FooDouble {
     implicit val schema: Schema[FooDouble] = {
@@ -177,5 +201,40 @@ class SchemaVisitorJCodecCustomisationTests extends FunSuite {
     val result = readFromString[FooFloat](input)
 
     expect(result.f.isNegInfinity)
+  }
+
+  test("decoding JSON string as a Float") {
+    val input = """{"f" : "1.1" }"""
+    val result = readFromString[FooFloat](input)
+
+    expect.eql(result.f, 1.1f)
+  }
+
+  test("decoding JSON string as a Double") {
+    val input = """{"d" : "1.1" }"""
+    val result = readFromString[FooDouble](input)
+
+    expect.eql(result.d, 1.1d)
+  }
+
+  test("decoding JSON string as an Int") {
+    val input = """{"i" : "1" }"""
+    val result = readFromString[FooInt](input)
+
+    expect.eql(result.i, 1)
+  }
+
+  test("decoding JSON string as a Long") {
+    val input = """{"l" : "1" }"""
+    val result = readFromString[FooLong](input)
+
+    expect.eql(result.l, 1L)
+  }
+
+  test("decoding JSON string as a Short") {
+    val input = """{"s" : "1" }"""
+    val result = readFromString[FooShort](input)
+
+    expect.eql(result.s, 1.toShort)
   }
 }


### PR DESCRIPTION
This adds opt-in logic to allow decoding numeric values from JSON strings. 
This also exposes a new method on the SimpleRestJsonBuilder to configure the underlying JSON codecs, without having to duplicate the smart-builder methods every time we add new options. 

## PR Checklist (not all items are relevant to all PRs)

- [x] Added unit-tests (for runtime code)
- [x] Added documentation
- [x] Updated changelog
