### PR TITLE
Add convenience truncate method to Timestamp type

### DIFF
--- a/modules/bootstrapped/test/src-js/smithy4s/TimestampSpec.scala
+++ b/modules/bootstrapped/test/src-js/smithy4s/TimestampSpec.scala
@@ -216,4 +216,30 @@ class TimestampSpec() extends munit.FunSuite with munit.ScalaCheckSuite {
       expect.same(tsFromEpochMilli, ts)
     }
   }
+
+  property("Truncate to milliseconds precision") {
+    forAll { (d: Date) =>
+      val epochMilli = d.valueOf().toLong
+      val ts = Timestamp.fromDate(d).truncateToMillis
+
+      val strippedDate = new Date(0)
+      strippedDate.setUTCMilliseconds(epochMilli)
+      val tsFromStrippedDate = Timestamp.fromDate(strippedDate)
+
+      expect.same(ts, tsFromStrippedDate)
+    }
+  }
+
+  property("Truncate to seconds precision") {
+    forAll { (d: Date) =>
+      val epochSecond = (d.valueOf() / 1000).toLong
+      val ts = Timestamp.fromDate(d).truncateToMillis
+
+      val strippedDate = new Date(0)
+      strippedDate.setUTCSeconds(epochSecond)
+      val tsFromStrippedDate = Timestamp.fromDate(strippedDate)
+
+      expect.same(ts, tsFromStrippedDate)
+    }
+  }
 }

--- a/modules/bootstrapped/test/src-jvm/smithy4s/TimestampSpec.scala
+++ b/modules/bootstrapped/test/src-jvm/smithy4s/TimestampSpec.scala
@@ -224,4 +224,23 @@ class TimestampSpec() extends munit.FunSuite with munit.ScalaCheckSuite {
       expect.same(tsFromEpochMilli, tsFromStrippedInstant)
     }
   }
+
+  property("Truncate nanoseconds") {
+    forAll { (i: Instant) =>
+      val ts = Timestamp.fromInstant(i).truncateNanos
+      val strippedInstant = Instant.ofEpochMilli(i.toEpochMilli)
+      val tsFromStrippedInstant = Timestamp.fromInstant(strippedInstant)
+
+      expect.same(ts, tsFromStrippedInstant)
+    }
+  }
+
+  property("Truncate milliseconds") {
+    forAll { (i: Instant) =>
+      val ts = Timestamp.fromInstant(i).truncateMillis
+      val tsFromStrippedInstant = Timestamp.fromEpochSecond(i.getEpochSecond)
+
+      expect.same(ts, tsFromStrippedInstant)
+    }
+  }
 }

--- a/modules/bootstrapped/test/src-jvm/smithy4s/TimestampSpec.scala
+++ b/modules/bootstrapped/test/src-jvm/smithy4s/TimestampSpec.scala
@@ -225,9 +225,9 @@ class TimestampSpec() extends munit.FunSuite with munit.ScalaCheckSuite {
     }
   }
 
-  property("Truncate nanoseconds") {
+  property("Truncate to milliseconds precision") {
     forAll { (i: Instant) =>
-      val ts = Timestamp.fromInstant(i).truncateNanos
+      val ts = Timestamp.fromInstant(i).truncateToMillis
       val strippedInstant = Instant.ofEpochMilli(i.toEpochMilli)
       val tsFromStrippedInstant = Timestamp.fromInstant(strippedInstant)
 
@@ -235,9 +235,9 @@ class TimestampSpec() extends munit.FunSuite with munit.ScalaCheckSuite {
     }
   }
 
-  property("Truncate milliseconds") {
+  property("Truncate to seconds precision") {
     forAll { (i: Instant) =>
-      val ts = Timestamp.fromInstant(i).truncateMillis
+      val ts = Timestamp.fromInstant(i).truncateToSeconds
       val tsFromStrippedInstant = Timestamp.fromEpochSecond(i.getEpochSecond)
 
       expect.same(ts, tsFromStrippedInstant)

--- a/modules/core/src-js/smithy4s/Timestamp.scala
+++ b/modules/core/src-js/smithy4s/Timestamp.scala
@@ -47,6 +47,16 @@ case class Timestamp private (epochSecond: Long, nano: Int) {
     date
   }
 
+  /**
+    * @return a copy of this timestamp with a milisecond resolution
+    */
+  def truncateNanos: Timestamp = copy(nano = (nano / 1000000) * 1000000)
+
+  /**
+    * @return a copy of this timestamp with a second resolution
+    */
+  def truncateMillis: Timestamp = copy(nano = 0)
+
   override def toString: String = format(TimestampFormat.DATE_TIME)
 
   private[this] def formatToString(internalFormat: Int): String = {

--- a/modules/core/src-js/smithy4s/Timestamp.scala
+++ b/modules/core/src-js/smithy4s/Timestamp.scala
@@ -48,14 +48,14 @@ case class Timestamp private (epochSecond: Long, nano: Int) {
   }
 
   /**
-    * @return a copy of this timestamp with a milisecond resolution
+    * @return a copy of this timestamp truncated to a miliseconds precision
     */
-  def truncateNanos: Timestamp = copy(nano = (nano / 1000000) * 1000000)
+  def truncateToMillis: Timestamp = copy(nano = (nano / 1000000) * 1000000)
 
   /**
-    * @return a copy of this timestamp with a second resolution
+    * @return a copy of this timestamp truncated to a seconds resolution
     */
-  def truncateMillis: Timestamp = copy(nano = 0)
+  def truncateToSeconds: Timestamp = copy(nano = 0)
 
   override def toString: String = format(TimestampFormat.DATE_TIME)
 

--- a/modules/core/src-jvm-native/smithy4s/Timestamp.scala
+++ b/modules/core/src-jvm-native/smithy4s/Timestamp.scala
@@ -39,6 +39,16 @@ case class Timestamp private (epochSecond: Long, nano: Int)
 
   def conciseDate: String = formatToString(2)
 
+  /**
+    * @return a copy of this timestamp with a milisecond resolution
+    */
+  def truncateNanos: Timestamp = copy(nano = (nano / 1000000) * 1000000)
+
+  /**
+    * @return a copy of this timestamp with a second resolution
+    */
+  def truncateMillis: Timestamp = copy(nano = 0)
+
   override def toString: String = format(TimestampFormat.DATE_TIME)
 
   private[this] def formatToString(internalFormat: Int): String = {

--- a/modules/core/src-jvm-native/smithy4s/Timestamp.scala
+++ b/modules/core/src-jvm-native/smithy4s/Timestamp.scala
@@ -40,14 +40,14 @@ case class Timestamp private (epochSecond: Long, nano: Int)
   def conciseDate: String = formatToString(2)
 
   /**
-    * @return a copy of this timestamp with a milisecond resolution
+    * @return a copy of this timestamp truncated to a miliseconds precision
     */
-  def truncateNanos: Timestamp = copy(nano = (nano / 1000000) * 1000000)
+  def truncateToMillis: Timestamp = copy(nano = (nano / 1000000) * 1000000)
 
   /**
-    * @return a copy of this timestamp with a second resolution
+    * @return a copy of this timestamp truncated to a seconds resolution
     */
-  def truncateMillis: Timestamp = copy(nano = 0)
+  def truncateToSeconds: Timestamp = copy(nano = 0)
 
   override def toString: String = format(TimestampFormat.DATE_TIME)
 


### PR DESCRIPTION
This closes #1598 

## PR Checklist (not all items are relevant to all PRs)

- [x] Added unit-tests (for runtime code)
- [ ] Added bootstrapped code + smoke tests (when the rendering logic is modified)
- [ ] Added build-plugins integration tests (when reflection loading is required at codegen-time)
- [ ] Added alloy compliance tests (when simpleRestJson protocol behaviour is expanded/updated)
- [ ] Updated dynamic module to match generated-code behaviour
- [ ] Added documentation
- [ ] Updated changelog
