### PR TITLE
Add utility types for fromHandlers and friends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Thank you!
 # 0.18.26
 
 * Optimises the conversion of empty smithy4s.Blob to fs2.Stream, to avoid performance degradation in Ember (see [#1609](https://github.com/disneystreaming/smithy4s/pull/1609))
+* Adds utility types for working with endpoint handlers (see [#1612](https://github.com/disneystreaming/smithy4s/pull/1612))
 
 # 0.18.25
 

--- a/modules/core/src/smithy4s/Service.scala
+++ b/modules/core/src/smithy4s/Service.scala
@@ -108,6 +108,16 @@ trait Service[Alg[_[_, _, _, _, _]]] extends FunctorK5[Alg] with HasId {
    */
   type ErrorAware[F[_, _]] = BiFunctorAlgebra[Alg, F]
 
+  /* *
+    * A short-hand for the result of a MyService.fromFunctorHandlers call.
+   */
+  type FromFunctorHandlers[F[_]] = EndpointHandler.AsService[Alg, Kind1[F]#toKind5]
+
+  /* *
+    * A short-hand for the result of a MyService.fromHandlers call.
+   */
+  type FromHandlers[F[_, _, _, _, _]] = EndpointHandler.AsService[Alg, F]
+
   val service: Service[Alg] = this
   def endpoints: IndexedSeq[Endpoint[_, _, _, _, _]]
 
@@ -179,19 +189,19 @@ trait Service[Alg[_[_, _, _, _, _]]] extends FunctorK5[Alg] with HasId {
   /**
     * Allows to turn a list of endpoint handlers into an instance of [[Alg]].
     */
-  final def fromHandlers[F[_, _, _, _, _]](handlers: EndpointHandler[Operation, F]*): EndpointHandler.AsService[Alg, F] =
+  final def fromHandlers[F[_, _, _, _, _]](handlers: EndpointHandler[Operation, F]*): FromHandlers[F] =
     EndpointHandler.combineAll(handlers:_*).asService(this)
 
   /**
     * A functor-specialised version of [[fromHandlers]], to help scala 2.12
     */
-  final def fromFunctorHandlers[F[_]](handlers: EndpointHandler[Operation, Kind1[F]#toKind5]*) : EndpointHandler.AsService[Alg, Kind1[F]#toKind5]
+  final def fromFunctorHandlers[F[_]](handlers: EndpointHandler[Operation, Kind1[F]#toKind5]*): FromFunctorHandlers[F]
     = fromHandlers[Kind1[F]#toKind5](handlers:_*)
 
   /**
     * A bifunctor-specialised version of [[fromHandlers]], to help scala 2.12
     */
-  final def fromBifunctorHandlers[F[_, _]](handlers: EndpointHandler[Operation, Kind2[F]#toKind5]*) : EndpointHandler.AsService[Alg, Kind2[F]#toKind5]
+  final def fromBifunctorHandlers[F[_, _]](handlers: EndpointHandler[Operation, Kind2[F]#toKind5]*) : FromHandlers[Kind2[F]#toKind5]
     = fromHandlers[Kind2[F]#toKind5](handlers:_*)
 }
 


### PR DESCRIPTION
Useful when you want to type the intermediate type of a `fromHandlers` call:

```scala
val myApi: MyApi.FromFunctorHandlers[IO] = MyApi.fromFunctorHandlers(
  ...
)

myApi.throwing
```


## PR Checklist (not all items are relevant to all PRs)

- [ ] Added unit-tests (for runtime code)
- [ ] Added bootstrapped code + smoke tests (when the rendering logic is modified)
- [ ] Added build-plugins integration tests (when reflection loading is required at codegen-time)
- [ ] Added alloy compliance tests (when simpleRestJson protocol behaviour is expanded/updated)
- [ ] Updated dynamic module to match generated-code behaviour
- [ ] Added documentation
- [x] Updated changelog
