### PR TITLE
Document timestamp encoder precision fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ When adding entries, please treat them as if they could end up in a release any 
 
 Thank you!
 
+# 0.18.28
+
+* Better support for timestamps before Linux Epoch and trimming the Timestamp nanosecond part (see [#1623](https://github.com/disneystreaming/smithy4s/pull/1623))
+
 # 0.18.27
 
 * Fix for how `NaN` is handled for `Float` and `Double` inside of the `MetadataDecoder` and `Range` constraint `RefinementProvider`

--- a/modules/bootstrapped/test/src/smithy4s/DocumentSpec.scala
+++ b/modules/bootstrapped/test/src/smithy4s/DocumentSpec.scala
@@ -617,7 +617,7 @@ class DocumentSpec() extends FunSuite {
       inside(result) { case Document.DObject(fields) =>
         inside(fields.get("epochSeconds")) {
           case Some(Document.DNumber(bigDecimal)) =>
-            expect.same(expectedScale, bigDecimal.scale)
+            expect.same(bigDecimal.scale, expectedScale)
         }
       }
     }

--- a/modules/bootstrapped/test/src/smithy4s/DocumentSpec.scala
+++ b/modules/bootstrapped/test/src/smithy4s/DocumentSpec.scala
@@ -626,6 +626,19 @@ class DocumentSpec() extends FunSuite {
     check(Timestamp(1L, 123 * 1000 * 1000), 3)
   }
 
+  test("Document decoder - timestamps before linux epoch") {
+    val doc =
+      Document.obj("epochSeconds" -> Document.fromBigDecimal(-0.999999877))
+    val result = Document.Decoder
+      .fromSchema(TimestampOperationInput.schema)
+      .decode(doc)
+    expect.same(
+      result,
+      Right(TimestampOperationInput(epochSeconds = Timestamp(-1, 123)))
+    )
+
+  }
+
   test("Document decoder - timestamp defaults") {
     val doc = Document.obj()
     val result = Document.Decoder

--- a/modules/core/src/smithy4s/internals/DocumentDecoderSchemaVisitor.scala
+++ b/modules/core/src/smithy4s/internals/DocumentDecoderSchemaVisitor.scala
@@ -186,11 +186,9 @@ class DocumentDecoderSchemaVisitor(
       case EPOCH_SECONDS =>
         DocumentDecoder.instance("Timestamp", "Number") {
           case (_, DNumber(value)) =>
-            val epochSeconds = value.toLong
-            Timestamp(
-              epochSeconds,
-              ((value - epochSeconds) * 1000000000).toInt
-            )
+            val epochSeconds =
+              value.setScale(0, BigDecimal.RoundingMode.FLOOR).toLong
+            Timestamp(epochSeconds, ((value - epochSeconds) * 1000000000).toInt)
         }
     }
   }

--- a/modules/core/src/smithy4s/internals/DocumentEncoderSchemaVisitor.scala
+++ b/modules/core/src/smithy4s/internals/DocumentEncoderSchemaVisitor.scala
@@ -105,11 +105,16 @@ class DocumentEncoderSchemaVisitor(
         case EPOCH_SECONDS =>
           ts =>
             DNumber(
-              BigDecimal(ts.epochSecond) + BigDecimal(
-                ts.nano * 1 / 1000000000.0
-              )
-                .underlying()
-                .stripTrailingZeros()
+              BigDecimal({
+                val es = java.math.BigDecimal.valueOf(ts.epochSecond)
+                if (ts.nano == 0) es
+                else
+                  es.add(
+                    java.math.BigDecimal
+                      .valueOf(ts.nano.toLong, 9)
+                      .stripTrailingZeros
+                  )
+              })
             )
       }
     case PDocument => from(identity)

--- a/modules/core/src/smithy4s/internals/DocumentEncoderSchemaVisitor.scala
+++ b/modules/core/src/smithy4s/internals/DocumentEncoderSchemaVisitor.scala
@@ -105,15 +105,11 @@ class DocumentEncoderSchemaVisitor(
         case EPOCH_SECONDS =>
           ts =>
             DNumber(
-              BigDecimal(
-                java.math.BigDecimal
-                  .valueOf(ts.epochSecond)
-                  .add(
-                    java.math.BigDecimal
-                      .valueOf(ts.nano.toLong, 9)
-                      .stripTrailingZeros
-                  )
+              BigDecimal(ts.epochSecond) + BigDecimal(
+                ts.nano * 1 / 1000000000.0
               )
+                .underlying()
+                .stripTrailingZeros()
             )
       }
     case PDocument => from(identity)

--- a/modules/core/src/smithy4s/internals/DocumentEncoderSchemaVisitor.scala
+++ b/modules/core/src/smithy4s/internals/DocumentEncoderSchemaVisitor.scala
@@ -104,10 +104,17 @@ class DocumentEncoderSchemaVisitor(
         case HTTP_DATE => ts => DString(ts.format(HTTP_DATE))
         case EPOCH_SECONDS =>
           ts =>
-            val bd = (BigDecimal(ts.epochSecond) + (BigDecimal(
-              ts.nano
-            ) * BigDecimal(10).pow(-9))).underlying.stripTrailingZeros
-            DNumber(bd)
+            DNumber(
+              BigDecimal(
+                java.math.BigDecimal
+                  .valueOf(ts.epochSecond)
+                  .add(
+                    java.math.BigDecimal
+                      .valueOf(ts.nano.toLong, 9)
+                      .stripTrailingZeros
+                  )
+              )
+            )
       }
     case PDocument => from(identity)
     case PFloat    => from(float => DNumber(BigDecimal(float.toDouble)))

--- a/modules/core/src/smithy4s/internals/DocumentEncoderSchemaVisitor.scala
+++ b/modules/core/src/smithy4s/internals/DocumentEncoderSchemaVisitor.scala
@@ -104,10 +104,10 @@ class DocumentEncoderSchemaVisitor(
         case HTTP_DATE => ts => DString(ts.format(HTTP_DATE))
         case EPOCH_SECONDS =>
           ts =>
-            val epochSecondsWithNanos =
-              BigDecimal(ts.epochSecond) + (BigDecimal(ts.nano) * BigDecimal(10)
-                .pow(-9))
-            DNumber(epochSecondsWithNanos)
+            val bd = (BigDecimal(ts.epochSecond) + (BigDecimal(
+              ts.nano
+            ) * BigDecimal(10).pow(-9))).underlying.stripTrailingZeros
+            DNumber(bd)
       }
     case PDocument => from(identity)
     case PFloat    => from(float => DNumber(BigDecimal(float.toDouble)))

--- a/modules/json/src/smithy4s/json/internals/SchemaVisitorJCodec.scala
+++ b/modules/json/src/smithy4s/json/internals/SchemaVisitorJCodec.scala
@@ -394,8 +394,17 @@ private[smithy4s] class SchemaVisitorJCodec(
       }
 
       def encodeValue(x: Timestamp, out: JsonWriter): Unit = {
-        val bd = BigDecimal(x.epochSecond) + (x.nano * BigDecimal(10).pow(-9))
-        out.writeVal(bd.underlying.stripTrailingZeros)
+        out.writeVal(
+          BigDecimal(
+            java.math.BigDecimal
+              .valueOf(x.epochSecond)
+              .add(
+                java.math.BigDecimal
+                  .valueOf(x.nano.toLong, 9)
+                  .stripTrailingZeros
+              )
+          )
+        )
       }
 
       def decodeKey(in: JsonReader): Timestamp = {

--- a/modules/json/src/smithy4s/json/internals/SchemaVisitorJCodec.scala
+++ b/modules/json/src/smithy4s/json/internals/SchemaVisitorJCodec.scala
@@ -395,7 +395,9 @@ private[smithy4s] class SchemaVisitorJCodec(
 
       def encodeValue(x: Timestamp, out: JsonWriter): Unit = {
         out.writeVal(
-          BigDecimal(x.epochSecond) + BigDecimal(x.nano * 1/ 1000000000.0).underlying().stripTrailingZeros()
+          BigDecimal(x.epochSecond) + BigDecimal(x.nano * 1 / 1000000000.0)
+            .underlying()
+            .stripTrailingZeros()
         )
       }
 

--- a/modules/json/src/smithy4s/json/internals/SchemaVisitorJCodec.scala
+++ b/modules/json/src/smithy4s/json/internals/SchemaVisitorJCodec.scala
@@ -394,11 +394,14 @@ private[smithy4s] class SchemaVisitorJCodec(
       }
 
       def encodeValue(x: Timestamp, out: JsonWriter): Unit = {
-        out.writeVal(
-          BigDecimal(x.epochSecond) + BigDecimal(x.nano * 1 / 1000000000.0)
-            .underlying()
-            .stripTrailingZeros()
-        )
+        out.writeVal(BigDecimal({
+          val es = java.math.BigDecimal.valueOf(x.epochSecond)
+          if (x.nano == 0) es
+          else
+            es.add(
+              java.math.BigDecimal.valueOf(x.nano.toLong, 9).stripTrailingZeros
+            )
+        }))
       }
 
       def decodeKey(in: JsonReader): Timestamp = {

--- a/modules/json/src/smithy4s/json/internals/SchemaVisitorJCodec.scala
+++ b/modules/json/src/smithy4s/json/internals/SchemaVisitorJCodec.scala
@@ -389,11 +389,13 @@ private[smithy4s] class SchemaVisitorJCodec(
 
       def decodeValue(cursor: Cursor, in: JsonReader): Timestamp = {
         val timestamp = in.readBigDecimal(null)
-        val epochSecond = timestamp.toLong
-        Timestamp(epochSecond, ((timestamp - epochSecond) * 1000000000).toInt)
+        val epochSeconds =
+          timestamp.setScale(0, BigDecimal.RoundingMode.FLOOR).toLong
+        Timestamp(epochSeconds, ((timestamp - epochSeconds) * 1000000000).toInt)
       }
 
       def encodeValue(x: Timestamp, out: JsonWriter): Unit = {
+        // TODO: can be improved with out.writeTimestampVal(x.epochSecond, x.nano) when https://github.com/plokhotnyuk/jsoniter-scala/releases/tag/v2.32.0 is used
         out.writeVal(BigDecimal({
           val es = java.math.BigDecimal.valueOf(x.epochSecond)
           if (x.nano == 0) es

--- a/modules/json/src/smithy4s/json/internals/SchemaVisitorJCodec.scala
+++ b/modules/json/src/smithy4s/json/internals/SchemaVisitorJCodec.scala
@@ -395,15 +395,7 @@ private[smithy4s] class SchemaVisitorJCodec(
 
       def encodeValue(x: Timestamp, out: JsonWriter): Unit = {
         out.writeVal(
-          BigDecimal(
-            java.math.BigDecimal
-              .valueOf(x.epochSecond)
-              .add(
-                java.math.BigDecimal
-                  .valueOf(x.nano.toLong, 9)
-                  .stripTrailingZeros
-              )
-          )
+          BigDecimal(x.epochSecond) + BigDecimal(x.nano * 1/ 1000000000.0).underlying().stripTrailingZeros()
         )
       }
 

--- a/modules/json/src/smithy4s/json/internals/SchemaVisitorJCodec.scala
+++ b/modules/json/src/smithy4s/json/internals/SchemaVisitorJCodec.scala
@@ -394,11 +394,8 @@ private[smithy4s] class SchemaVisitorJCodec(
       }
 
       def encodeValue(x: Timestamp, out: JsonWriter): Unit = {
-        if (x.nano == 0) {
-          out.writeVal(x.epochSecond)
-        } else {
-          out.writeVal(BigDecimal(x.epochSecond) + x.nano / 1000000000.0)
-        }
+        val bd = BigDecimal(x.epochSecond) + (x.nano * BigDecimal(10).pow(-9))
+        out.writeVal(bd.underlying.stripTrailingZeros)
       }
 
       def decodeKey(in: JsonReader): Timestamp = {

--- a/modules/json/test/src/smithy4s/json/JsonSpec.scala
+++ b/modules/json/test/src/smithy4s/json/JsonSpec.scala
@@ -60,4 +60,21 @@ class JsonSpec() extends FunSuite {
     assertEquals(roundTripped, Right(foo))
   }
 
+  test("Json document respects BigDecimal resolution on read/write") {
+    val foo =
+      Document.obj(
+        "a" -> Document.fromBigDecimal(BigDecimal(1)),
+        "b" -> Document.fromBigDecimal(BigDecimal(1.1))
+      )
+    val result = Json.writeDocumentAsPrettyString(foo)
+    val roundTripped = Json.readDocument(Blob(result))
+    val expectedJson = """|{
+                          |  "a": 1,
+                          |  "b": 1.1
+                          |}""".stripMargin
+
+    assertEquals(result, expectedJson)
+    assertEquals(roundTripped, Right(foo))
+  }
+
 }


### PR DESCRIPTION
## PR Checklist (not all items are relevant to all PRs)

fixes #1622

- [x] Added unit-tests (for runtime code)
- [ ] Added bootstrapped code + smoke tests (when the rendering logic is modified)
- [ ] Added build-plugins integration tests (when reflection loading is required at codegen-time)
- [ ] Added alloy compliance tests (when simpleRestJson protocol behaviour is expanded/updated)
- [ ] Updated dynamic module to match generated-code behaviour
- [ ] Added documentation
- [x] Updated changelog
