### PR TITLE
Handle edge cases with NaN/Infinity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ When adding entries, please treat them as if they could end up in a release any 
 
 Thank you!
 
+# 0.18.27
+
+* Fix for how `NaN` is handled for `Float` and `Double` inside of the `MetadataDecoder` and `Range` constraint `RefinementProvider`
+
 # 0.18.26
 
 * Optimises the conversion of empty smithy4s.Blob to fs2.Stream, to avoid performance degradation in Ember (see [#1609](https://github.com/disneystreaming/smithy4s/pull/1609))

--- a/modules/bootstrapped/src/generated/smithy4s/example/DummyService.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/DummyService.scala
@@ -18,7 +18,7 @@ import smithy4s.schema.Schema.unit
 trait DummyServiceGen[F[_, _, _, _, _]] {
   self =>
 
-  def dummy(str: Option[String] = None, int: Option[Int] = None, ts1: Option[Timestamp] = None, ts2: Option[Timestamp] = None, ts3: Option[Timestamp] = None, ts4: Option[Timestamp] = None, b: Option[Boolean] = None, sl: Option[List[String]] = None, ie: Option[Numbers] = None, on: Option[OpenNums] = None, ons: Option[OpenNumsStr] = None, slm: Option[Map[String, String]] = None): F[Queries, Nothing, Unit, Nothing, Nothing]
+  def dummy(str: Option[String] = None, int: Option[Int] = None, ts1: Option[Timestamp] = None, ts2: Option[Timestamp] = None, ts3: Option[Timestamp] = None, ts4: Option[Timestamp] = None, b: Option[Boolean] = None, sl: Option[List[String]] = None, ie: Option[Numbers] = None, on: Option[OpenNums] = None, ons: Option[OpenNumsStr] = None, dbl: Option[Double] = None, slm: Option[Map[String, String]] = None): F[Queries, Nothing, Unit, Nothing, Nothing]
   def dummyHostPrefix(label1: String, label2: String, label3: HostLabelEnum): F[HostLabelInput, Nothing, Unit, Nothing, Nothing]
   def dummyPath(str: String, int: Int, ts1: Timestamp, ts2: Timestamp, ts3: Timestamp, ts4: Timestamp, b: Boolean, ie: Numbers): F[PathParams, Nothing, Unit, Nothing, Nothing]
 
@@ -69,12 +69,12 @@ sealed trait DummyServiceOperation[Input, Err, Output, StreamedInput, StreamedOu
 object DummyServiceOperation {
 
   object reified extends DummyServiceGen[DummyServiceOperation] {
-    def dummy(str: Option[String] = None, int: Option[Int] = None, ts1: Option[Timestamp] = None, ts2: Option[Timestamp] = None, ts3: Option[Timestamp] = None, ts4: Option[Timestamp] = None, b: Option[Boolean] = None, sl: Option[List[String]] = None, ie: Option[Numbers] = None, on: Option[OpenNums] = None, ons: Option[OpenNumsStr] = None, slm: Option[Map[String, String]] = None): Dummy = Dummy(Queries(str, int, ts1, ts2, ts3, ts4, b, sl, ie, on, ons, slm))
+    def dummy(str: Option[String] = None, int: Option[Int] = None, ts1: Option[Timestamp] = None, ts2: Option[Timestamp] = None, ts3: Option[Timestamp] = None, ts4: Option[Timestamp] = None, b: Option[Boolean] = None, sl: Option[List[String]] = None, ie: Option[Numbers] = None, on: Option[OpenNums] = None, ons: Option[OpenNumsStr] = None, dbl: Option[Double] = None, slm: Option[Map[String, String]] = None): Dummy = Dummy(Queries(str, int, ts1, ts2, ts3, ts4, b, sl, ie, on, ons, dbl, slm))
     def dummyHostPrefix(label1: String, label2: String, label3: HostLabelEnum): DummyHostPrefix = DummyHostPrefix(HostLabelInput(label1, label2, label3))
     def dummyPath(str: String, int: Int, ts1: Timestamp, ts2: Timestamp, ts3: Timestamp, ts4: Timestamp, b: Boolean, ie: Numbers): DummyPath = DummyPath(PathParams(str, int, ts1, ts2, ts3, ts4, b, ie))
   }
   class Transformed[P[_, _, _, _, _], P1[_ ,_ ,_ ,_ ,_]](alg: DummyServiceGen[P], f: PolyFunction5[P, P1]) extends DummyServiceGen[P1] {
-    def dummy(str: Option[String] = None, int: Option[Int] = None, ts1: Option[Timestamp] = None, ts2: Option[Timestamp] = None, ts3: Option[Timestamp] = None, ts4: Option[Timestamp] = None, b: Option[Boolean] = None, sl: Option[List[String]] = None, ie: Option[Numbers] = None, on: Option[OpenNums] = None, ons: Option[OpenNumsStr] = None, slm: Option[Map[String, String]] = None): P1[Queries, Nothing, Unit, Nothing, Nothing] = f[Queries, Nothing, Unit, Nothing, Nothing](alg.dummy(str, int, ts1, ts2, ts3, ts4, b, sl, ie, on, ons, slm))
+    def dummy(str: Option[String] = None, int: Option[Int] = None, ts1: Option[Timestamp] = None, ts2: Option[Timestamp] = None, ts3: Option[Timestamp] = None, ts4: Option[Timestamp] = None, b: Option[Boolean] = None, sl: Option[List[String]] = None, ie: Option[Numbers] = None, on: Option[OpenNums] = None, ons: Option[OpenNumsStr] = None, dbl: Option[Double] = None, slm: Option[Map[String, String]] = None): P1[Queries, Nothing, Unit, Nothing, Nothing] = f[Queries, Nothing, Unit, Nothing, Nothing](alg.dummy(str, int, ts1, ts2, ts3, ts4, b, sl, ie, on, ons, dbl, slm))
     def dummyHostPrefix(label1: String, label2: String, label3: HostLabelEnum): P1[HostLabelInput, Nothing, Unit, Nothing, Nothing] = f[HostLabelInput, Nothing, Unit, Nothing, Nothing](alg.dummyHostPrefix(label1, label2, label3))
     def dummyPath(str: String, int: Int, ts1: Timestamp, ts2: Timestamp, ts3: Timestamp, ts4: Timestamp, b: Boolean, ie: Numbers): P1[PathParams, Nothing, Unit, Nothing, Nothing] = f[PathParams, Nothing, Unit, Nothing, Nothing](alg.dummyPath(str, int, ts1, ts2, ts3, ts4, b, ie))
   }
@@ -83,7 +83,7 @@ object DummyServiceOperation {
     def apply[I, E, O, SI, SO](op: DummyServiceOperation[I, E, O, SI, SO]): P[I, E, O, SI, SO] = op.run(impl) 
   }
   final case class Dummy(input: Queries) extends DummyServiceOperation[Queries, Nothing, Unit, Nothing, Nothing] {
-    def run[F[_, _, _, _, _]](impl: DummyServiceGen[F]): F[Queries, Nothing, Unit, Nothing, Nothing] = impl.dummy(input.str, input.int, input.ts1, input.ts2, input.ts3, input.ts4, input.b, input.sl, input.ie, input.on, input.ons, input.slm)
+    def run[F[_, _, _, _, _]](impl: DummyServiceGen[F]): F[Queries, Nothing, Unit, Nothing, Nothing] = impl.dummy(input.str, input.int, input.ts1, input.ts2, input.ts3, input.ts4, input.b, input.sl, input.ie, input.on, input.ons, input.dbl, input.slm)
     def ordinal: Int = 0
     def endpoint: smithy4s.Endpoint[DummyServiceOperation,Queries, Nothing, Unit, Nothing, Nothing] = Dummy
   }

--- a/modules/bootstrapped/src/generated/smithy4s/example/Queries.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/Queries.scala
@@ -6,12 +6,13 @@ import smithy4s.ShapeId
 import smithy4s.ShapeTag
 import smithy4s.Timestamp
 import smithy4s.schema.Schema.boolean
+import smithy4s.schema.Schema.double
 import smithy4s.schema.Schema.int
 import smithy4s.schema.Schema.string
 import smithy4s.schema.Schema.struct
 import smithy4s.schema.Schema.timestamp
 
-final case class Queries(str: Option[String] = None, int: Option[Int] = None, ts1: Option[Timestamp] = None, ts2: Option[Timestamp] = None, ts3: Option[Timestamp] = None, ts4: Option[Timestamp] = None, b: Option[Boolean] = None, sl: Option[List[String]] = None, ie: Option[Numbers] = None, on: Option[OpenNums] = None, ons: Option[OpenNumsStr] = None, slm: Option[Map[String, String]] = None)
+final case class Queries(str: Option[String] = None, int: Option[Int] = None, ts1: Option[Timestamp] = None, ts2: Option[Timestamp] = None, ts3: Option[Timestamp] = None, ts4: Option[Timestamp] = None, b: Option[Boolean] = None, sl: Option[List[String]] = None, ie: Option[Numbers] = None, on: Option[OpenNums] = None, ons: Option[OpenNumsStr] = None, dbl: Option[Double] = None, slm: Option[Map[String, String]] = None)
 
 object Queries extends ShapeTag.Companion[Queries] {
   val id: ShapeId = ShapeId("smithy4s.example", "Queries")
@@ -19,7 +20,7 @@ object Queries extends ShapeTag.Companion[Queries] {
   val hints: Hints = Hints.empty
 
   // constructor using the original order from the spec
-  private def make(str: Option[String], int: Option[Int], ts1: Option[Timestamp], ts2: Option[Timestamp], ts3: Option[Timestamp], ts4: Option[Timestamp], b: Option[Boolean], sl: Option[List[String]], ie: Option[Numbers], on: Option[OpenNums], ons: Option[OpenNumsStr], slm: Option[Map[String, String]]): Queries = Queries(str, int, ts1, ts2, ts3, ts4, b, sl, ie, on, ons, slm)
+  private def make(str: Option[String], int: Option[Int], ts1: Option[Timestamp], ts2: Option[Timestamp], ts3: Option[Timestamp], ts4: Option[Timestamp], b: Option[Boolean], sl: Option[List[String]], ie: Option[Numbers], on: Option[OpenNums], ons: Option[OpenNumsStr], dbl: Option[Double], slm: Option[Map[String, String]]): Queries = Queries(str, int, ts1, ts2, ts3, ts4, b, sl, ie, on, ons, dbl, slm)
 
   implicit val schema: Schema[Queries] = struct(
     string.optional[Queries]("str", _.str).addHints(smithy.api.HttpQuery("str")),
@@ -33,6 +34,7 @@ object Queries extends ShapeTag.Companion[Queries] {
     Numbers.schema.optional[Queries]("ie", _.ie).addHints(smithy.api.HttpQuery("nums")),
     OpenNums.schema.optional[Queries]("on", _.on).addHints(smithy.api.HttpQuery("openNums")),
     OpenNumsStr.schema.optional[Queries]("ons", _.ons).addHints(smithy.api.HttpQuery("openNumsStr")),
+    double.validated(smithy.api.Range(min = Some(scala.math.BigDecimal(0.0)), max = Some(scala.math.BigDecimal(100.0)))).optional[Queries]("dbl", _.dbl).addHints(smithy.api.HttpQuery("dbl")),
     StringMap.underlyingSchema.optional[Queries]("slm", _.slm).addHints(smithy.api.HttpQueryParams()),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/test/src/smithy4s/DocumentSpec.scala
+++ b/modules/bootstrapped/test/src/smithy4s/DocumentSpec.scala
@@ -380,10 +380,14 @@ class DocumentSpec() extends FunSuite {
 
     val in = Double.NaN
     val error = Try(Document.encode(in)).failed.get
+    val expectedMessage =
+      if (weaver.Platform.isJS) "For input string: \"NaN\""
+      else
+        "Character N is neither a decimal digit number, decimal point, nor \"e\" notation exponential mark."
 
     expect.same(
       error.getMessage,
-      "Character N is neither a decimal digit number, decimal point, nor \"e\" notation exponential mark."
+      expectedMessage
     )
   }
 

--- a/modules/bootstrapped/test/src/smithy4s/DocumentSpec.scala
+++ b/modules/bootstrapped/test/src/smithy4s/DocumentSpec.scala
@@ -25,6 +25,7 @@ import munit._
 import smithy4s.example.DefaultNullsOperationOutput
 import alloy.Untagged
 import smithy4s.example.TimestampOperationInput
+import scala.util.Try
 
 class DocumentSpec() extends FunSuite {
 
@@ -368,6 +369,22 @@ class DocumentSpec() extends FunSuite {
 
     expect.same(document, expectedDocument)
     expect.same(roundTripped, Right(mapTest))
+  }
+
+  test("encoding NaN") {
+    // The Document type cannot hold a `NaN` value since it uses BigDecimal to hold numeric values
+    // this test exists to show this. For the same reason, a test on decoding from `NaN` is not necessary
+    // or possible.
+    implicit val schema: Schema[Double] =
+      double.validated(smithy.api.Range(None, Some(BigDecimal(3))))
+
+    val in = Double.NaN
+    val error = Try(Document.encode(in)).failed.get
+
+    expect.same(
+      error.getMessage,
+      "Character N is neither a decimal digit number, decimal point, nor \"e\" notation exponential mark."
+    )
   }
 
   test(

--- a/modules/bootstrapped/test/src/smithy4s/DocumentSpec.scala
+++ b/modules/bootstrapped/test/src/smithy4s/DocumentSpec.scala
@@ -381,7 +381,8 @@ class DocumentSpec() extends FunSuite {
     val in = Double.NaN
     val error = Try(Document.encode(in)).failed.get
     val expectedMessage =
-      if (weaver.Platform.isJS) "For input string: \"NaN\""
+      if (weaver.Platform.isJS || weaver.Platform.isNative)
+        "For input string: \"NaN\""
       else
         "Character N is neither a decimal digit number, decimal point, nor \"e\" notation exponential mark."
 

--- a/modules/core/src/smithy4s/RefinementProvider.scala
+++ b/modules/core/src/smithy4s/RefinementProvider.scala
@@ -161,27 +161,34 @@ object RefinementProvider extends LowPriorityImplicits {
       val N = implicitly[Numeric[N]]
 
       (a: A) =>
-        val value = BigDecimal(N.toDouble(getValue(a)))
-        (range.min, range.max) match {
-          case (Some(min), Some(max)) =>
-            if (value >= min && value <= max) Right(())
-            else
-              Left(
-                s"Input must be >= $min and <= $max, but was $value"
-              )
-          case (None, Some(max)) =>
-            if (value <= max) Right(())
-            else
-              Left(
-                s"Input must be <= $max, but was $value"
-              )
-          case (Some(min), None) =>
-            if (value >= min) Right(())
-            else
-              Left(
-                s"Input must be >= $min, but was $value"
-              )
-          case (None, None) => Right(())
+        val doubleValue = N.toDouble(getValue(a))
+        if (doubleValue.isNaN || doubleValue.isInfinite) {
+          Left(
+            s"Numeric values must not be NaN or pos/neg infinity. Found $doubleValue"
+          )
+        } else {
+          val value = BigDecimal.apply(d = doubleValue)
+          (range.min, range.max) match {
+            case (Some(min), Some(max)) =>
+              if (value >= min && value <= max) Right(())
+              else
+                Left(
+                  s"Input must be >= $min and <= $max, but was $value"
+                )
+            case (None, Some(max)) =>
+              if (value <= max) Right(())
+              else
+                Left(
+                  s"Input must be <= $max, but was $value"
+                )
+            case (Some(min), None) =>
+              if (value >= min) Right(())
+              else
+                Left(
+                  s"Input must be >= $min, but was $value"
+                )
+            case (None, None) => Right(())
+          }
         }
     }
   }

--- a/modules/core/src/smithy4s/http/internals/SchemaVisitorMetadataReader.scala
+++ b/modules/core/src/smithy4s/http/internals/SchemaVisitorMetadataReader.scala
@@ -37,10 +37,13 @@ import java.util.Base64
   * contains values such as path-parameters, query-parameters, headers, and status code.
   *
   * @param awsHeaderEncoding defines whether the AWS encoding of headers should be expected.
+  * @param allowNaNAndInfiniteValues defines whether or not Double and Float values of 'NaN'
+  * positive/negative infinity should be accepted.
   */
 private[http] class SchemaVisitorMetadataReader(
     val cache: CompilationCache[MetaDecode],
-    awsHeaderEncoding: Boolean
+    awsHeaderEncoding: Boolean,
+    allowNaNAndInfiniteValues: Boolean
 ) extends SchemaVisitor.Cached[MetaDecode]
     with ScalaCompat { self =>
 
@@ -50,6 +53,38 @@ private[http] class SchemaVisitorMetadataReader(
       tag: Primitive[P]
   ): MetaDecode[P] = {
     val desc = SchemaDescription.primitive(shapeId, hints, tag)
+
+    tag match {
+      case Primitive.PDouble =>
+        val decode: MetaDecode[Double] =
+          primitivePrivate(shapeId, hints, tag, desc)
+        decode.map(d =>
+          if (!allowNaNAndInfiniteValues && (d.isNaN || d.isInfinite))
+            throw MetadataError.ImpossibleDecoding(
+              s"NaN or pos/neg infinity are not allowed for inputs of type $desc"
+            )
+          else d
+        )
+      case Primitive.PFloat =>
+        val decode: MetaDecode[Float] =
+          primitivePrivate(shapeId, hints, tag, desc)
+        decode.map(f =>
+          if (!allowNaNAndInfiniteValues && (f.isNaN || f.isInfinite))
+            throw MetadataError.ImpossibleDecoding(
+              s"NaN or pos/neg infinity are not allowed for inputs of type $desc"
+            )
+          else f
+        )
+      case _ => primitivePrivate(shapeId, hints, tag, desc)
+    }
+  }
+
+  private def primitivePrivate[P](
+      shapeId: ShapeId,
+      hints: Hints,
+      tag: Primitive[P],
+      desc: String
+  ): MetaDecode[P] = {
     val hasMedia = hints.has(smithy.api.MediaType)
     Primitive.stringParser(tag, hints) match {
       case Some(parse) if hasMedia =>

--- a/modules/core/src/smithy4s/http/internals/SchemaVisitorMetadataReader.scala
+++ b/modules/core/src/smithy4s/http/internals/SchemaVisitorMetadataReader.scala
@@ -57,7 +57,7 @@ private[http] class SchemaVisitorMetadataReader(
     tag match {
       case Primitive.PDouble =>
         val decode: MetaDecode[Double] =
-          primitivePrivate(shapeId, hints, tag, desc)
+          primitiveHandler(shapeId, hints, tag, desc)
         decode.map(d =>
           if (!allowNaNAndInfiniteValues && (d.isNaN || d.isInfinite))
             throw MetadataError.ImpossibleDecoding(
@@ -67,7 +67,7 @@ private[http] class SchemaVisitorMetadataReader(
         )
       case Primitive.PFloat =>
         val decode: MetaDecode[Float] =
-          primitivePrivate(shapeId, hints, tag, desc)
+          primitiveHandler(shapeId, hints, tag, desc)
         decode.map(f =>
           if (!allowNaNAndInfiniteValues && (f.isNaN || f.isInfinite))
             throw MetadataError.ImpossibleDecoding(
@@ -75,11 +75,11 @@ private[http] class SchemaVisitorMetadataReader(
             )
           else f
         )
-      case _ => primitivePrivate(shapeId, hints, tag, desc)
+      case _ => primitiveHandler(shapeId, hints, tag, desc)
     }
   }
 
-  private def primitivePrivate[P](
+  private def primitiveHandler[P](
       shapeId: ShapeId,
       hints: Hints,
       tag: Primitive[P],

--- a/modules/json/test/src/smithy4s/json/JsonSpec.scala
+++ b/modules/json/test/src/smithy4s/json/JsonSpec.scala
@@ -46,6 +46,17 @@ class JsonSpec() extends FunSuite {
     assertEquals(roundTripped, Right(foo))
   }
 
+  test("Json read - NaN") {
+    implicit val schemaDouble: Schema[Double] =
+      double.validated(smithy.api.Range(None, Some(BigDecimal(3))))
+    val expectedJson = """"NaN""""
+    val roundTripped = Json.read[Double](Blob(expectedJson))
+
+    assert(
+      roundTripped.left.toOption.get.message.startsWith("illegal number")
+    )
+  }
+
   test("Json document read/write") {
     val foo =
       Document.obj("a" -> Document.fromInt(1), "b" -> Document.fromInt(2))

--- a/sampleSpecs/metadata.smithy
+++ b/sampleSpecs/metadata.smithy
@@ -72,6 +72,9 @@ structure Queries {
   on: OpenNums
   @httpQuery("openNumsStr")
   ons: OpenNumsStr
+  @httpQuery("dbl")
+  @range(min: 0, max: 100)
+  dbl: Double
   @httpQueryParams
   slm: StringMap
 }


### PR DESCRIPTION
When using a Query Parameter of type Double that has a Range constraint, `NaN` values will cause an exception to be thrown that would lead to a 500 error being returned by the service. The reason for this is that the Range `RefinementProvider` uses `BigDecimal` under the hood and `BigDecimal` does not allow `NaN`.

This PR updates the Range `RefinementProvider` to return an error that will map to a `4xx` response. Additionally, the `MetadataDecoder` has been updated to allow configuring whether or not `NaN` should be allowed. AWS protocols allow `NaN`, whereas `alloy#simpleRestJson` does not. 

Tests have been added to show that `NaN` is not currently supported by the `json` module or the `Document` type.

## PR Checklist (not all items are relevant to all PRs)

- [x] Added unit-tests (for runtime code)
- [x] Added bootstrapped code + smoke tests (when the rendering logic is modified)
- [ ] ~~Added build-plugins integration tests (when reflection loading is required at codegen-time)~~
- [ ] ~~Added alloy compliance tests (when simpleRestJson protocol behaviour is expanded/updated)~~
- [ ] ~~Updated dynamic module to match generated-code behaviour~~
- [ ] Added documentation
- [ ] Updated changelog

Will add relevant docs and update changelog once we know this is the direction we want to go.
