### PR TITLE
Fix missing sbt command in CI build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,7 @@ jobs:
         uses: coursier/setup-action@v1
         with:
           jvm: temurin:1.17
+          apps: sbt
 
       - name: Run tests
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,7 @@ jobs:
         uses: coursier/setup-action@v1
         with:
           jvm: temurin:1.17
+          apps: sbt
 
       - name: Cache
         uses: coursier/cache-action@v6
@@ -160,6 +161,7 @@ jobs:
         uses: coursier/setup-action@v1
         with:
           jvm: temurin:1.17
+          apps: sbt
 
       - name: Cache
         uses: coursier/cache-action@v6


### PR DESCRIPTION
My fork of this repo started to fail CI build with a missing command error for "sbt" and this small patch fixes that.
