### PR TITLE
Update jsoniter-scala to 2.32.0

### DIFF
--- a/modules/json/src/smithy4s/json/internals/SchemaVisitorJCodec.scala
+++ b/modules/json/src/smithy4s/json/internals/SchemaVisitorJCodec.scala
@@ -394,8 +394,15 @@ private[smithy4s] class SchemaVisitorJCodec(
         Timestamp(epochSeconds, ((timestamp - epochSeconds) * 1000000000).toInt)
       }
 
-      def encodeValue(x: Timestamp, out: JsonWriter): Unit =
-        out.writeTimestampVal(x.epochSecond, x.nano)
+      def encodeValue(x: Timestamp, out: JsonWriter): Unit = {
+        var epochSecond = x.epochSecond
+        var nano = x.nano
+        if (epochSecond < 0 && nano > 0) {
+          epochSecond += 1
+          nano = 1000000000 - nano
+        }
+        out.writeTimestampVal(epochSecond, nano)
+      }
 
       def decodeKey(in: JsonReader): Timestamp = {
         val timestamp = in.readKeyAsBigDecimal()

--- a/modules/json/src/smithy4s/json/internals/SchemaVisitorJCodec.scala
+++ b/modules/json/src/smithy4s/json/internals/SchemaVisitorJCodec.scala
@@ -394,17 +394,8 @@ private[smithy4s] class SchemaVisitorJCodec(
         Timestamp(epochSeconds, ((timestamp - epochSeconds) * 1000000000).toInt)
       }
 
-      def encodeValue(x: Timestamp, out: JsonWriter): Unit = {
-        // TODO: can be improved with out.writeTimestampVal(x.epochSecond, x.nano) when https://github.com/plokhotnyuk/jsoniter-scala/releases/tag/v2.32.0 is used
-        out.writeVal(BigDecimal({
-          val es = java.math.BigDecimal.valueOf(x.epochSecond)
-          if (x.nano == 0) es
-          else
-            es.add(
-              java.math.BigDecimal.valueOf(x.nano.toLong, 9).stripTrailingZeros
-            )
-        }))
-      }
+      def encodeValue(x: Timestamp, out: JsonWriter): Unit =
+        out.writeTimestampVal(x.epochSecond, x.nano)
 
       def decodeKey(in: JsonReader): Timestamp = {
         val timestamp = in.readKeyAsBigDecimal()

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,7 +10,7 @@ object Dependencies {
 
   val Jsoniter = new {
     val org = "com.github.plokhotnyuk.jsoniter-scala"
-    val jsoniterScalaVersion = "2.27.6"
+    val jsoniterScalaVersion = "2.32.0"
     val core = Def.setting(org %%% "jsoniter-scala-core" % jsoniterScalaVersion)
     val macros = Def.setting(
       org %%% "jsoniter-scala-macros" % jsoniterScalaVersion % "compile-internal"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 // format: off
 addSbtPlugin("ch.epfl.scala"        % "sbt-scalafix"                  % "0.12.1")
-addSbtPlugin("org.scala-js"         % "sbt-scalajs"                   % "1.16.0")
+addSbtPlugin("org.scala-js"         % "sbt-scalajs"                   % "1.17.0")
 addSbtPlugin("com.github.sbt"       % "sbt-pgp"                       % "2.2.1")
 addSbtPlugin("com.github.sbt"       % "sbt-dynver"                    % "5.0.1")
 addSbtPlugin("org.xerial.sbt"       % "sbt-sonatype"                  % "3.10.0")


### PR DESCRIPTION
Updates a year old version mostly for the performance reason, see https://github.com/disneystreaming/smithy4s/blob/7deb6c32d63a644c729f4d52cece0a399191c401/modules/json/src/smithy4s/json/internals/SchemaVisitorJCodec.scala#L398
