### PR TITLE
Update namespace in quickstart example so things compile.

### DIFF
--- a/modules/docs/markdown/01-overview/02-quickstart.md
+++ b/modules/docs/markdown/01-overview/02-quickstart.md
@@ -71,7 +71,7 @@ Now let's define an API in Smithy. Create the following file:
 And add the content below:
 
 ```kotlin
-namespace smithy4s.hello
+namespace smithy4s.example.hello
 
 use alloy#simpleRestJson
 


### PR DESCRIPTION
This supersedes #1621 and is the fix suggested by @Baccata there