### PR TITLE
Use correct cross path for protobuf-runtime-scala

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -715,7 +715,7 @@ lazy val protobuf = projectMatrix
         )
       else
         Seq(
-          "com.thesamet.scalapb" %% "protobuf-runtime-scala" % "0.8.14"
+          "com.thesamet.scalapb" %%% "protobuf-runtime-scala" % "0.8.14"
         )
     },
     Test / fork := virtualAxes.value.contains(VirtualAxis.jvm)


### PR DESCRIPTION
Currently it fails linking on my machine in JS land. Makes me wonder if protobuf is correctly tested on all platforms 🤔 

## PR Checklist (not all items are relevant to all PRs)

- [ ] Added unit-tests (for runtime code)
- [ ] Added bootstrapped code + smoke tests (when the rendering logic is modified)
- [ ] Added build-plugins integration tests (when reflection loading is required at codegen-time)
- [ ] Added alloy compliance tests (when simpleRestJson protocol behaviour is expanded/updated)
- [ ] Updated dynamic module to match generated-code behaviour
- [ ] Added documentation
- [ ] Updated changelog
