### PR TITLE
Fix handling of non-Option optionals in field filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ When adding entries, please treat them as if they could end up in a release any 
 
 Thank you!
 
+# 0.18.31
+
+* Fix an issue with `FieldFilter`'s handling of optional fields that aren't represented by an actual `Option` (e.g. bijections) in [#1662](https://github.com/disneystreaming/smithy4s/pull/1662)
+
 # 0.18.30
 
 * Add utilities for Service.Builder in [#1644](https://github.com/disneystreaming/smithy4s/pull/1644)

--- a/modules/bootstrapped/test/src/smithy4s/FieldFilterSpec.scala
+++ b/modules/bootstrapped/test/src/smithy4s/FieldFilterSpec.scala
@@ -1,0 +1,37 @@
+package smithy4s
+
+import munit.FunSuite
+import smithy4s.schema.FieldFilter
+import smithy4s.schema.Field
+import smithy4s.Schema
+import munit.Location
+
+class FieldFilterSpec extends FunSuite {
+
+  test("SkipUnsetOptions should remove Nones") {
+    check(Schema.string.option, None, false)
+  }
+
+  test("SkipUnsetOptions should remove Nones bijected to something else") {
+    case class OptionalLike[+A](underlying: Option[A])
+
+    check(
+      Schema.string.option.biject(OptionalLike(_))(_.underlying),
+      OptionalLike(None),
+      false
+    )
+  }
+
+  test("SkipUnsetOptions should keep null nullables") {
+    check(Schema.string.nullable, Nullable.Null, true)
+  }
+
+  private def check[A](schema: Schema[A], value: A, expectedToKeep: Boolean)(
+      implicit loc: Location
+  ) = {
+    val filter =
+      FieldFilter.SkipUnsetOptions.compile(Field("label", schema, identity[A]))
+    assertEquals(filter(value), expectedToKeep)
+  }
+
+}

--- a/modules/bootstrapped/test/src/smithy4s/FieldFilterSpec.scala
+++ b/modules/bootstrapped/test/src/smithy4s/FieldFilterSpec.scala
@@ -25,6 +25,14 @@ class FieldFilterSpec extends FunSuite {
     check(Schema.string.nullable, Nullable.Null, true)
   }
 
+  test("SkipUnsetOptions should skip a None if it contains a nullable") {
+    check(Schema.string.nullable.option, None, false)
+  }
+
+  test("SkipUnsetOptions should keep optional null nullables when present") {
+    check(Schema.string.nullable.option, Some(Nullable.Null), true)
+  }
+
   private def check[A](schema: Schema[A], value: A, expectedToKeep: Boolean)(
       implicit loc: Location
   ) = {

--- a/modules/bootstrapped/test/src/smithy4s/FieldFilterSpec.scala
+++ b/modules/bootstrapped/test/src/smithy4s/FieldFilterSpec.scala
@@ -3,7 +3,6 @@ package smithy4s
 import munit.FunSuite
 import smithy4s.schema.FieldFilter
 import smithy4s.schema.Field
-import smithy4s.Schema
 import munit.Location
 
 class FieldFilterSpec extends FunSuite {

--- a/modules/core/src/smithy4s/schema/FieldFilter.scala
+++ b/modules/core/src/smithy4s/schema/FieldFilter.scala
@@ -169,8 +169,11 @@ object FieldFilter {
 
     def apply[A](schema: Schema[A]): Predicate[A] = schema match {
       // nullables are technically never None, so we fall through
-      case OptionSchema(underlying) if !underlying.hints.has(Nullable) =>
-        _ == None
+      case OptionSchema(underlying) =>
+        if (underlying.hints.has(Nullable) && !underlying.isOption)
+          Function.const(false)
+        else
+          _ == None
 
       case BijectionSchema(underlying, bijection) =>
         this(underlying).compose(bijection.from)

--- a/modules/core/src/smithy4s/schema/FieldFilter.scala
+++ b/modules/core/src/smithy4s/schema/FieldFilter.scala
@@ -16,10 +16,12 @@
 
 package smithy4s.schema
 
-import smithy4s.Bijection
-import smithy4s.Lazy
-import smithy4s.Refinement
+import smithy4s.~>
 import alloy.Nullable
+import smithy4s.schema.Schema.OptionSchema
+import smithy4s.schema.Schema.BijectionSchema
+import smithy4s.schema.Schema.RefinementSchema
+import smithy4s.schema.Schema.LazySchema
 
 trait FieldFilter { self =>
   def compile[S, A](
@@ -163,40 +165,24 @@ object FieldFilter {
 
   val SkipNonRequiredDefaultValues: FieldFilter = skipNonRequiredDefaultValues
 
-  private object IsNoneVisitor extends SchemaVisitor.Default[Predicate] {
-    def default[A]: Predicate[A] = Function.const(false)
+  private object IsNoneVisitor extends (Schema ~> Predicate) {
 
-    override def biject[A, B](
-        schema: Schema[A],
-        bijection: Bijection[A, B]
-    ): Predicate[B] = {
-      val inner = this(schema)
-      a => inner(bijection.from(a))
-    }
-
-    override def lazily[A](suspend: Lazy[Schema[A]]): Predicate[A] = {
-      val u = suspend.map(this(_))
-
-      v => u.value(v)
-    }
-
-    override def option[A](
-        schema: Schema[A]
-    ): Predicate[Option[A]] = {
-      if (schema.hints.has(Nullable)) {
-        // nullables are technically never None
-        Function.const(false)
-      } else
+    def apply[A](schema: Schema[A]): Predicate[A] = schema match {
+      // nullables are technically never None, so we fall through
+      case OptionSchema(underlying) if !underlying.hints.has(Nullable) =>
         _ == None
-    }
 
-    override def refine[A, B](
-        schema: Schema[A],
-        refinement: Refinement[A, B]
-    ): Predicate[B] = {
-      val u = this(schema)
+      case BijectionSchema(underlying, bijection) =>
+        this(underlying).compose(bijection.from)
 
-      v => u(refinement.from(v))
+      case RefinementSchema(underlying, refinement) =>
+        this(underlying).compose(refinement.from)
+
+      case LazySchema(suspend) =>
+        val underlying = suspend.map(this(_))
+        v => underlying.value(v)
+
+      case _ => Function.const(false)
     }
   }
 

--- a/modules/core/src/smithy4s/schema/FieldFilter.scala
+++ b/modules/core/src/smithy4s/schema/FieldFilter.scala
@@ -178,6 +178,9 @@ object FieldFilter {
       case RefinementSchema(underlying, refinement) =>
         this(underlying).compose(refinement.from)
 
+      // technically, realistically this case is probably not reachable
+      // because a recursive schema be wrapped in an option first, and wouldn't be traversed by this visitor.
+      // could possibly be reached from a recursive list/map
       case LazySchema(suspend) =>
         val underlying = suspend.map(this(_))
         v => underlying.value(v)

--- a/modules/core/src/smithy4s/schema/FieldFilter.scala
+++ b/modules/core/src/smithy4s/schema/FieldFilter.scala
@@ -19,6 +19,7 @@ package smithy4s.schema
 import smithy4s.Bijection
 import smithy4s.Lazy
 import smithy4s.Refinement
+import alloy.Nullable
 
 trait FieldFilter { self =>
   def compile[S, A](
@@ -169,8 +170,13 @@ object FieldFilter {
         schema: Schema[A],
         bijection: Bijection[A, B]
     ): Predicate[B] = {
-      val inner = this(schema)
-      a => inner(bijection.from(a))
+      if (schema.hints.has(Nullable)) {
+        // nullables are technically never None
+        Function.const(false)
+      } else {
+        val inner = this(schema)
+        a => inner(bijection.from(a))
+      }
     }
 
     override def lazily[A](suspend: Lazy[Schema[A]]): Predicate[A] = {

--- a/modules/core/src/smithy4s/schema/FieldFilter.scala
+++ b/modules/core/src/smithy4s/schema/FieldFilter.scala
@@ -170,13 +170,8 @@ object FieldFilter {
         schema: Schema[A],
         bijection: Bijection[A, B]
     ): Predicate[B] = {
-      if (schema.hints.has(Nullable)) {
-        // nullables are technically never None
-        Function.const(false)
-      } else {
-        val inner = this(schema)
-        a => inner(bijection.from(a))
-      }
+      val inner = this(schema)
+      a => inner(bijection.from(a))
     }
 
     override def lazily[A](suspend: Lazy[Schema[A]]): Predicate[A] = {
@@ -187,7 +182,13 @@ object FieldFilter {
 
     override def option[A](
         schema: Schema[A]
-    ): Predicate[Option[A]] = _ == None
+    ): Predicate[Option[A]] = {
+      if (schema.hints.has(Nullable)) {
+        // nullables are technically never None
+        Function.const(false)
+      } else
+        _ == None
+    }
 
     override def refine[A, B](
         schema: Schema[A],

--- a/modules/core/src/smithy4s/schema/FieldFilter.scala
+++ b/modules/core/src/smithy4s/schema/FieldFilter.scala
@@ -16,6 +16,10 @@
 
 package smithy4s.schema
 
+import smithy4s.Bijection
+import smithy4s.Lazy
+import smithy4s.Refinement
+
 trait FieldFilter { self =>
   def compile[S, A](
       field: Field[S, A]
@@ -158,10 +162,40 @@ object FieldFilter {
 
   val SkipNonRequiredDefaultValues: FieldFilter = skipNonRequiredDefaultValues
 
-  private case object skipUnsetOptions extends FieldFilter.SkipNonRequired {
-    def compileNonRequired[S, A](field: Field[S, A]): Predicate[A] = { a =>
-      a != None
+  private object IsNoneVisitor extends SchemaVisitor.Default[Predicate] {
+    def default[A]: Predicate[A] = Function.const(false)
+
+    override def biject[A, B](
+        schema: Schema[A],
+        bijection: Bijection[A, B]
+    ): Predicate[B] = {
+      val inner = this(schema)
+      a => inner(bijection.from(a))
     }
+
+    override def lazily[A](suspend: Lazy[Schema[A]]): Predicate[A] = {
+      val u = suspend.map(this(_))
+
+      v => u.value(v)
+    }
+
+    override def option[A](
+        schema: Schema[A]
+    ): Predicate[Option[A]] = _ == None
+
+    override def refine[A, B](
+        schema: Schema[A],
+        refinement: Refinement[A, B]
+    ): Predicate[B] = {
+      val u = this(schema)
+
+      v => u(refinement.from(v))
+    }
+  }
+
+  private case object skipUnsetOptions extends FieldFilter.SkipNonRequired {
+    def compileNonRequired[S, A](field: Field[S, A]): Predicate[A] =
+      IsNoneVisitor(field.schema)
   }
 
   val SkipUnsetOptions: FieldFilter = skipUnsetOptions

--- a/modules/core/src/smithy4s/schema/FieldFilter.scala
+++ b/modules/core/src/smithy4s/schema/FieldFilter.scala
@@ -195,7 +195,7 @@ object FieldFilter {
 
   private case object skipUnsetOptions extends FieldFilter.SkipNonRequired {
     def compileNonRequired[S, A](field: Field[S, A]): Predicate[A] =
-      IsNoneVisitor(field.schema)
+      IsNoneVisitor(field.schema).andThen(!_)
   }
 
   val SkipUnsetOptions: FieldFilter = skipUnsetOptions

--- a/modules/json/test/src/smithy4s/json/JsonCodecApiTests.scala
+++ b/modules/json/test/src/smithy4s/json/JsonCodecApiTests.scala
@@ -22,6 +22,8 @@ import smithy4s.Blob
 import smithy4s.schema.Schema
 import smithy4s.HintMask
 import smithy4s.schema.FieldFilter
+import smithy.api.Length
+import smithy4s.RefinementProvider
 
 class JsonCodecApiTests extends FunSuite {
 
@@ -106,36 +108,74 @@ class JsonCodecApiTests extends FunSuite {
   }
 
   test(
-    "schemas bijected to Option should be encoded when options are"
+    "schemas backed by an OptionSchema should be treated same as OptionSchema itself"
   ) {
-    val schemaWithOption = Schema
-      .struct[Option[String]]
-      .apply(
-        Schema.string.option
-          .field[Option[String]]("a", identity)
-      )(identity)
-
     case class OptionalLike[+A](underlying: Option[A])
+    case class Options(
+        justOption: Option[String],
+        bijectedOption: OptionalLike[String],
+        refinedOption: Option[String],
+        recursive: Option[Options]
+    )
 
-    val schemaWithOptionEquivalent = Schema
-      .struct[OptionalLike[String]]
-      .apply(
-        Schema.string.option
-          .biject(OptionalLike(_))(_.underlying)
-          .field[OptionalLike[String]]("a", identity)
-      )(identity)
-
-    def go[A](input: A, schema: Schema[A]) = {
-      val capi = Json.payloadCodecs.withJsoniterCodecCompiler(
-        Json.jsoniter.withFieldFilter(FieldFilter.SkipUnsetOptions)
-      )
-
-      capi.encoders.fromSchema(schema).encode(input)
+    lazy val schema: Schema[Options] = Schema.recursive {
+      Schema
+        .struct[Options]
+        .apply(
+          Schema.string.optional[Options]("justOption", _.justOption),
+          Schema.string.option
+            .biject(OptionalLike(_))(_.underlying)
+            .field[Options]("bijectedOption", _.bijectedOption),
+          Schema.string.option
+            .validated(Length(max = Some(10)))(
+              RefinementProvider.lengthConstraint(_.fold(0)(_.length))
+            )
+            .field[Options]("refinedOption", _.justOption),
+          schema.optional[Options]("recursive", _.recursive)
+        )(Options.apply)
     }
 
+    val capi = Json.payloadCodecs.withJsoniterCodecCompiler(
+      Json.jsoniter.withFieldFilter(FieldFilter.SkipUnsetOptions)
+    )
+
+    val encoder = capi.encoders.fromSchema(schema)
+
     assertEquals(
-      go(None, schemaWithOption),
-      go(OptionalLike(None), schemaWithOptionEquivalent)
+      encoder
+        .encode(
+          Options(
+            justOption = None,
+            bijectedOption = OptionalLike(None),
+            refinedOption = None,
+            recursive = None
+          )
+        )
+        .toUTF8String,
+      Blob("{}").toUTF8String
+    )
+
+    assertEquals(
+      encoder
+        .encode(
+          Options(
+            justOption = Some("a"),
+            bijectedOption = OptionalLike(Some("a")),
+            refinedOption = Some("a"),
+            recursive = Some(
+              Options(
+                justOption = None,
+                bijectedOption = OptionalLike(None),
+                refinedOption = None,
+                recursive = None
+              )
+            )
+          )
+        )
+        .toUTF8String,
+      Blob(
+        """{"justOption":"a","bijectedOption":"a","refinedOption":"a","recursive":{}}"""
+      ).toUTF8String
     )
   }
 

--- a/modules/json/test/src/smithy4s/json/JsonCodecApiTests.scala
+++ b/modules/json/test/src/smithy4s/json/JsonCodecApiTests.scala
@@ -83,26 +83,6 @@ class JsonCodecApiTests extends FunSuite {
   }
 
   test(
-    "explicit nulls should be used when set"
-  ) {
-    val schemaWithJsonName = Schema
-      .struct[Option[String]]
-      .apply(
-        Schema.string
-          .optional[Option[String]]("a", identity)
-      )(identity)
-
-    val capi = Json.payloadCodecs.withJsoniterCodecCompiler(
-      Json.jsoniter.withFieldFilter(FieldFilter.EncodeAll)
-    )
-
-    val codec = capi.encoders.fromSchema(schemaWithJsonName)
-    val encoded = codec.encode(None)
-
-    assertEquals(encoded, Blob("""{"a":null}"""))
-  }
-
-  test(
     "explicit nulls should be parsable regardless of fieldFilter setting"
   ) {
     val withoutNulls = Json.payloadCodecs
@@ -123,6 +103,40 @@ class JsonCodecApiTests extends FunSuite {
 
       assertEquals(decoded, Right(None))
     }
+  }
+
+  test(
+    "schemas bijected to Option should be encoded when options are"
+  ) {
+    val schemaWithOption = Schema
+      .struct[Option[String]]
+      .apply(
+        Schema.string.option
+          .field[Option[String]]("a", identity)
+      )(identity)
+
+    case class OptionalLike[+A](underlying: Option[A])
+
+    val schemaWithOptionEquivalent = Schema
+      .struct[OptionalLike[String]]
+      .apply(
+        Schema.string.option
+          .biject(OptionalLike(_))(_.underlying)
+          .field[OptionalLike[String]]("a", identity)
+      )(identity)
+
+    def go[A](input: A, schema: Schema[A]) = {
+      val capi = Json.payloadCodecs.withJsoniterCodecCompiler(
+        Json.jsoniter.withFieldFilter(FieldFilter.SkipUnsetOptions)
+      )
+
+      capi.encoders.fromSchema(schema).encode(input)
+    }
+
+    assertEquals(
+      go(None, schemaWithOption),
+      go(OptionalLike(None), schemaWithOptionEquivalent)
+    )
   }
 
 }

--- a/modules/json/test/src/smithy4s/json/JsonCodecApiTests.scala
+++ b/modules/json/test/src/smithy4s/json/JsonCodecApiTests.scala
@@ -24,6 +24,7 @@ import smithy4s.HintMask
 import smithy4s.schema.FieldFilter
 import smithy.api.Length
 import smithy4s.RefinementProvider
+import smithy4s.Nullable
 
 class JsonCodecApiTests extends FunSuite {
 
@@ -115,7 +116,8 @@ class JsonCodecApiTests extends FunSuite {
         justOption: Option[String],
         bijectedOption: OptionalLike[String],
         refinedOption: Option[String],
-        recursive: Option[Options]
+        recursive: Option[Options],
+        optionalNullable: Option[Nullable[String]]
     )
 
     lazy val schema: Schema[Options] = Schema.recursive {
@@ -131,7 +133,9 @@ class JsonCodecApiTests extends FunSuite {
               RefinementProvider.lengthConstraint(_.fold(0)(_.length))
             )
             .field[Options]("refinedOption", _.justOption),
-          schema.optional[Options]("recursive", _.recursive)
+          schema.optional[Options]("recursive", _.recursive),
+          Schema.string.nullable
+            .optional[Options]("optionalNullable", _.optionalNullable)
         )(Options.apply)
     }
 
@@ -148,7 +152,8 @@ class JsonCodecApiTests extends FunSuite {
             justOption = None,
             bijectedOption = OptionalLike(None),
             refinedOption = None,
-            recursive = None
+            recursive = None,
+            optionalNullable = None
           )
         )
         .toUTF8String,
@@ -167,14 +172,16 @@ class JsonCodecApiTests extends FunSuite {
                 justOption = None,
                 bijectedOption = OptionalLike(None),
                 refinedOption = None,
-                recursive = None
+                recursive = None,
+                optionalNullable = None
               )
-            )
+            ),
+            optionalNullable = Some(Nullable.Null)
           )
         )
         .toUTF8String,
       Blob(
-        """{"justOption":"a","bijectedOption":"a","refinedOption":"a","recursive":{}}"""
+        """{"justOption":"a","bijectedOption":"a","refinedOption":"a","recursive":{},"optionalNullable":null}"""
       ).toUTF8String
     )
   }


### PR DESCRIPTION
By oversight in #1398, we kept the `_ != None` check, which makes certain usecases non-viable. Allowing bijections to Option seems like the right move.

## PR Checklist (not all items are relevant to all PRs)

- [x] Added unit-tests (for runtime code)
- [ ] Added bootstrapped code + smoke tests (when the rendering logic is modified)
- [ ] Added build-plugins integration tests (when reflection loading is required at codegen-time)
- [ ] Added alloy compliance tests (when simpleRestJson protocol behaviour is expanded/updated)
- [ ] Updated dynamic module to match generated-code behaviour
- [ ] Added documentation
- [x] Updated changelog
