### PR TITLE
Use the inputs when testing URI conversions in Http4sConversionSpec

### DIFF
--- a/modules/http4s-kernel/test/src/smithy4s/http4s/kernel/Http4sConversionSpec.scala
+++ b/modules/http4s-kernel/test/src/smithy4s/http4s/kernel/Http4sConversionSpec.scala
@@ -39,7 +39,7 @@ object Http4sConversionSpec extends SimpleIOSuite {
   )
 
   http4sToSmithyAndBackUriTest(
-    uri"example.com",
+    uri"//example.com",
     uri"http://example.com/"
   )
 
@@ -109,8 +109,8 @@ object Http4sConversionSpec extends SimpleIOSuite {
   private def http4sToSmithyAndBackUriTest(input: Uri, output: Uri) = {
     pureTest(s"URI: http4s to smithy4s and back: $input -> $output") {
       assert.eql(
-        uri"http://localhost/",
-        fromSmithy4sHttpUri(toSmithy4sHttpUri(uri"http://localhost/"))
+        output,
+        fromSmithy4sHttpUri(toSmithy4sHttpUri(input))
       )
     }
   }


### PR DESCRIPTION
Not a huge deal, but I discovered that `Http4sConversionSpec#http4sToSmithyAndBackUriTest` wasn't using its input in its test setup, so most of the tests were redundant. I believe this was the intended test behavior.