### PR TITLE
Correctly URI-encode HTTP Label values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Thank you!
 # 0.18.40
 
 * codegen: Add support for [bincompat-friendly code generation mode](https://disneystreaming.github.io/smithy4s/docs/codegen/customisation/binary-compatibility) in [#1737](https://github.com/disneystreaming/smithy4s/pull/1737/).
+* core: fix [#1663](https://github.com/disneystreaming/smithy4s/issues/1663) by reworking how path segments are encoded to conform with the Smithy spec in [#1668](https://github.com/disneystreaming/smithy4s/issues/1668)
+* aws-http4s: fix AWS request signing for URIs with encoded path segments in [#1668](https://github.com/disneystreaming/smithy4s/issues/1668)
 
 # 0.18.39
 

--- a/build.sbt
+++ b/build.sbt
@@ -294,7 +294,11 @@ lazy val core = projectMatrix
       // https://github.com/disneystreaming/smithy4s/pull/1669
       ProblemFilters.exclude[IncompatibleMethTypeProblem](
         "smithy4s.http.HttpUnaryServerRouter.partialFunction"
-      )
+      ),
+      // originating in an Alloy update that removed ProtoCompactOffsetDateTime
+      ProblemFilters.exclude[MissingClassProblem]("alloy.proto.ProtoCompactOffsetDateTime"),
+      // originating in an Alloy update that removed ProtoCompactOffsetDateTime
+      ProblemFilters.exclude[MissingClassProblem]("alloy.proto.ProtoCompactOffsetDateTime$"),
     )
   )
   .jvmPlatform(allJvmScalaVersions, jvmDimSettings)

--- a/build.sbt
+++ b/build.sbt
@@ -286,6 +286,10 @@ lazy val core = projectMatrix
       ProblemFilters.exclude[DirectMissingMethodProblem](
         "smithy4s.http.HttpUnaryServerRouter#PartialFunctionRouter.this"
       ),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+        // this is a private case class so any problems are spurious
+        "smithy4s.http.HttpUnaryClientCodecs#HttpUnaryClientCodecsBuilderImpl.*"
+      ),
       // Breaking bin-compat to walk back ambiguous methods introduced in
       // https://github.com/disneystreaming/smithy4s/pull/1669
       ProblemFilters.exclude[IncompatibleMethTypeProblem](

--- a/modules/aws-http4s/src/smithy4s/aws/internals/AwsEc2QueryCodecs.scala
+++ b/modules/aws-http4s/src/smithy4s/aws/internals/AwsEc2QueryCodecs.scala
@@ -105,6 +105,7 @@ private[aws] object AwsEcsQueryCodecs {
       .withMetadataDecoders(Metadata.AwsDecoder)
       .withErrorDiscriminator(AwsErrorTypeDecoder.fromResponse(discriminatorDecoders))
       .withWriteEmptyStructs(_ => true)
+      .withRawHttpLabelValues(true)
       .withRequestMediaType("application/x-www-form-urlencoded")
   }
 

--- a/modules/aws-http4s/src/smithy4s/aws/internals/AwsJsonCodecs.scala
+++ b/modules/aws-http4s/src/smithy4s/aws/internals/AwsJsonCodecs.scala
@@ -53,6 +53,7 @@ private[aws] object AwsJsonCodecs {
       .withErrorBodyDecoders(jsonDecoders)
       .withErrorDiscriminator(AwsErrorTypeDecoder.fromResponse(jsonDecoders))
       .withRequestMediaType(contentType)
+      .withRawHttpLabelValues(true)
   }
 
 }

--- a/modules/aws-http4s/src/smithy4s/aws/internals/AwsQueryCodecs.scala
+++ b/modules/aws-http4s/src/smithy4s/aws/internals/AwsQueryCodecs.scala
@@ -108,6 +108,7 @@ private[aws] object AwsQueryCodecs {
       .withErrorDiscriminator(AwsErrorTypeDecoder.fromResponse(discriminatorDecoders))
       .withWriteEmptyStructs(_ => true)
       .withRequestMediaType("application/x-www-form-urlencoded")
+      .withRawHttpLabelValues(true)
 
   }
 

--- a/modules/aws-http4s/src/smithy4s/aws/internals/AwsRestJsonCodecs.scala
+++ b/modules/aws-http4s/src/smithy4s/aws/internals/AwsRestJsonCodecs.scala
@@ -55,6 +55,7 @@ private[aws] object AwsRestJsonCodecs {
       .withMetadataDecoders(Metadata.AwsDecoder)
       .withMetadataEncoders(Metadata.AwsEncoder)
       .withRawStringsAndBlobsPayloads
+      .withRawHttpLabelValues(false)
       .withRequestMediaType(contentType)
   }
 

--- a/modules/aws-http4s/src/smithy4s/aws/internals/AwsRestXmlCodecs.scala
+++ b/modules/aws-http4s/src/smithy4s/aws/internals/AwsRestXmlCodecs.scala
@@ -43,6 +43,7 @@ private[aws] object AwsRestXmlCodecs {
       .withMetadataDecoders(Metadata.AwsDecoder)
       .withMetadataEncoders(Metadata.AwsEncoder)
       .withRawStringsAndBlobsPayloads
+      .withRawHttpLabelValues(false)
       .withRequestMediaType("application/xml")
   }
 

--- a/modules/aws-http4s/src/smithy4s/aws/internals/AwsSigning.scala
+++ b/modules/aws-http4s/src/smithy4s/aws/internals/AwsSigning.scala
@@ -23,10 +23,7 @@ import cats._
 import cats.syntax.all._
 import fs2.Chunk
 import org.http4s._
-import org.http4s.Uri.Path.Segment
-import org.http4s.Uri.encode
 import org.http4s.client.Client
-import org.http4s.internal.CharPredicate.AlphaNum
 import org.typelevel.ci.CIString
 import smithy4s._
 import smithy4s.aws.kernel.AwsCrypto._
@@ -47,7 +44,6 @@ private[aws] object AwsSigning {
   val S3Control = "AWSS3ControlServiceV20180820"
 
   private val disableDoubleEncoding: Set[String] = Set(S3, S3Control)
-  private val dotSegments: Set[String] = Set("..", ".")
 
   def middleware[F[_]: Concurrent](
       awsEnvironment: AwsEnvironment[F]
@@ -134,43 +130,23 @@ private[aws] object AwsSigning {
           else {
             // Other services double encode and normalize
 
-            if (preparedRequest.uri.path.segments.exists(s => dotSegments.contains(s.encoded))) {
-              // if any of the segments are dot segments as described by RFC3986§3.3,
-              // defer to the Java path normalization algorithm, because that's what
-              // AWS expects. `org.http4s.Uri.removeDotSegments` sometimes removes too
-              // much; e.g. AWS expects a path of `foo/../..` to be normalized to `/..`;
-              // `removeDotSegments` returns `/` but `Uri#normalize` does the expected.
-              MonadThrow[F].catchNonFatal {
-                val uri = new URI(preparedRequest.uri.scheme.map(_.value).orNull, preparedRequest.uri.host.map(_.renderString).orNull, preparedRequest.uri.path.toAbsolute.renderString, preparedRequest.uri.fragment.orNull)
-                val almostNormalized = uri.normalize().getRawPath
+            MonadThrow[F].catchNonFatal {
+              val uri = new URI(
+                preparedRequest.uri.scheme.map(_.value).orNull,
+                preparedRequest.uri.host.map(_.renderString).orNull,
+                preparedRequest.uri.path.toAbsolute.renderString,
+                preparedRequest.uri.fragment.orNull
+              )
+              val almostNormalized = uri.normalize().getRawPath
 
-                val removeExtraneousTrailingSlash = almostNormalized.endsWith("/") &&
-                  !preparedRequest.uri.path.endsWithSlash &&
-                  almostNormalized.length > 1
-                if (removeExtraneousTrailingSlash)
-                  // normalization can add a final slash when we didn't have one
-                  // originally, so remove it if that's the case
-                  almostNormalized.substring(0, almostNormalized.length - 1)
-                else almostNormalized
-              }
-            } else {
-              // otherwise, let http4s handle normalization and encoding
-              val almostNormalized =
-                Uri
-                  .Path(
-                    preparedRequest.uri.path.toAbsolute.segments
-                      .map(_.encoded)
-                      .map(encode(_, toSkip = AlphaNum ++ "-_.~"))
-                      .map(Segment.encoded),
-                    absolute = true,
-                    endsWithSlash = preparedRequest.uri.path.toAbsolute.endsWithSlash
-                  )
-                  .normalize
-                  .toAbsolute
-
-              (if (preparedRequest.uri.path.endsWithSlash) almostNormalized.addEndsWithSlash
-               else almostNormalized).renderString
-                .pure[F]
+              val removeExtraneousTrailingSlash = almostNormalized.endsWith("/") &&
+                !preparedRequest.uri.path.endsWithSlash &&
+                almostNormalized.length > 1
+              if (removeExtraneousTrailingSlash)
+                // normalization can add a final slash when we didn't have one
+                // originally, so remove it if that's the case
+                almostNormalized.substring(0, almostNormalized.length - 1)
+              else almostNormalized
             }
           }
         }

--- a/modules/aws-http4s/src/smithy4s/aws/internals/AwsSigning.scala
+++ b/modules/aws-http4s/src/smithy4s/aws/internals/AwsSigning.scala
@@ -19,15 +19,19 @@ package internals
 
 import cats.effect.Concurrent
 import cats.effect.Resource
+import cats._
 import cats.syntax.all._
 import fs2.Chunk
 import org.http4s._
+import org.http4s.Uri.Path.Segment
+import org.http4s.Uri.encode
 import org.http4s.client.Client
+import org.http4s.internal.CharPredicate.AlphaNum
 import org.typelevel.ci.CIString
 import smithy4s._
 import smithy4s.aws.kernel.AwsCrypto._
 
-import java.net.URLEncoder
+import java.net.{URI, URLEncoder}
 import java.nio.charset.StandardCharsets
 
 /**
@@ -39,6 +43,11 @@ private[aws] object AwsSigning {
 
   // see https://raw.githubusercontent.com/awslabs/aws-sdk-kotlin/main/codegen/sdk/aws-models/s3.json
   val S3 = "AmazonS3"
+  // see https://raw.githubusercontent.com/awslabs/aws-sdk-kotlin/main/codegen/sdk/aws-models/s3-control.json
+  val S3Control = "AWSS3ControlServiceV20180820"
+
+  private val disableDoubleEncoding: Set[String] = Set(S3, S3Control)
+  private val dotSegments: Set[String] = Set("..", ".")
 
   def middleware[F[_]: Concurrent](
       awsEnvironment: AwsEnvironment[F]
@@ -94,7 +103,8 @@ private[aws] object AwsSigning {
 
     // S3 has special rules, in that it expects the X-Amz-Content-SHA256 to be set.
     val preSign: PreSigner[F] =
-      if (serviceName == S3) new PreSigner.S3InMemorySigned[F]
+      if (disableDoubleEncoding.contains(serviceName))
+        new PreSigner.S3InMemorySigned[F]
       else new PreSigner.Standard[F]
 
     val contentType = org.http4s.headers.`Content-Type`.headerInstance
@@ -116,77 +126,124 @@ private[aws] object AwsSigning {
 
     // scalafmt: { align.preset = most, danglingParentheses.preset = false, maxColumn = 240, align.tokens = [{code = ":"}]}
     (request: Request[F]) =>
-      preSign(request).flatMap { case (payloadHash, preparedRequest) =>
-        val awsHeadersF = (timestamp, credentials, region).mapN { case (timestamp, credentials, region) =>
-          val credentialsScope = s"${timestamp.conciseDate}/$region/$endpointPrefix/aws4_request"
-          val queryParams: Vector[(String, String)] =
-            request.uri.query.toVector.sorted.map { case (k, v) => k -> v.getOrElse("") }
-          val canonicalQueryString =
-            if (queryParams.isEmpty) ""
-            else
-              queryParams
-                .map { case (k, v) =>
-                  URLEncoder.encode(k, StandardCharsets.UTF_8.name()) + "=" + URLEncoder.encode(v, StandardCharsets.UTF_8.name())
-                }
-                .mkString("&")
+      preSign(request)
+        .mproduct[String] { case (_, preparedRequest) =>
+          if (disableDoubleEncoding.contains(serviceName))
+            // S3 and S3Control both disable double URL encoding and normalization.
+            preparedRequest.uri.path.toAbsolute.renderString.pure[F]
+          else {
+            // Other services double encode and normalize
 
-          // // !\ Important: these must remain in the same order
-          val baseHeadersList = List(
-            `Content-Type` -> preparedRequest.contentType.map(contentType.value(_)).orNull,
-            `Host` -> preparedRequest.uri.host.map(_.renderString).orNull,
-            `X-Amz-Content-SHA256` -> preparedRequest.headers.get(`X-Amz-Content-SHA256`).map(_.head.value).orNull,
-            `X-Amz-Date` -> timestamp.conciseDateTime,
-            `X-Amz-Security-Token` -> credentials.sessionToken.orNull,
-            `X-Amz-Target` -> (serviceName + "." + operationName)
-          ).filterNot(_._2 == null)
+            if (preparedRequest.uri.path.segments.exists(s => dotSegments.contains(s.encoded))) {
+              // if any of the segments are dot segments as described by RFC3986§3.3,
+              // defer to the Java path normalization algorithm, because that's what
+              // AWS expects. `org.http4s.Uri.removeDotSegments` sometimes removes too
+              // much; e.g. AWS expects a path of `foo/../..` to be normalized to `/..`;
+              // `removeDotSegments` returns `/` but `Uri#normalize` does the expected.
+              MonadThrow[F].catchNonFatal {
+                val uri = new URI(preparedRequest.uri.scheme.map(_.value).orNull, preparedRequest.uri.host.map(_.renderString).orNull, preparedRequest.uri.path.toAbsolute.renderString, preparedRequest.uri.fragment.orNull)
+                val almostNormalized = uri.normalize().getRawPath
 
-          val canonicalHeadersString = baseHeadersList
-            .map { case (key, value) =>
-              key.toString.toLowerCase + ":" + value.trim
+                val removeExtraneousTrailingSlash = almostNormalized.endsWith("/") &&
+                  !preparedRequest.uri.path.endsWithSlash &&
+                  almostNormalized.length > 1
+                if (removeExtraneousTrailingSlash)
+                  // normalization can add a final slash when we didn't have one
+                  // originally, so remove it if that's the case
+                  almostNormalized.substring(0, almostNormalized.length - 1)
+                else almostNormalized
+              }
+            } else {
+              // otherwise, let http4s handle normalization and encoding
+              val almostNormalized =
+                Uri
+                  .Path(
+                    preparedRequest.uri.path.toAbsolute.segments
+                      .map(_.encoded)
+                      .map(encode(_, toSkip = AlphaNum ++ "-_.~"))
+                      .map(Segment.encoded),
+                    absolute = true,
+                    endsWithSlash = preparedRequest.uri.path.toAbsolute.endsWithSlash
+                  )
+                  .normalize
+                  .toAbsolute
+
+              (if (preparedRequest.uri.path.endsWithSlash) almostNormalized.addEndsWithSlash
+               else almostNormalized).renderString
+                .pure[F]
             }
-            .mkString(newline)
-          lazy val signedHeadersString = baseHeadersList.map(_._1).map(_.toString.toLowerCase()).mkString(";")
-
-          val pathString = preparedRequest.uri.path.toAbsolute.renderString
-          val canonicalRequest = new StringBuilder()
-            .append(request.method.name.toUpperCase())
-            .append(newline)
-            .append(pathString)
-            .append(newline)
-            .append(canonicalQueryString)
-            .append(newline)
-            .append(canonicalHeadersString)
-            .append(newline)
-            .append(newline)
-            .append(signedHeadersString)
-            .append(newline)
-            .append(payloadHash)
-            .result()
-
-          val canonicalRequestHash = sha256HexDigest(canonicalRequest)
-          val signatureKey = getSignatureKey(
-            credentials.secretAccessKey,
-            timestamp.conciseDate,
-            region.value,
-            endpointPrefix
-          )
-          val stringToSign = List[String](
-            algorithm,
-            timestamp.conciseDateTime,
-            credentialsScope,
-            canonicalRequestHash
-          ).mkString(newline)
-          val signature = toHexString(hmacSha256(stringToSign, signatureKey))
-          val authHeaderValue = s"${algorithm} Credential=${credentials.accessKeyId}/$credentialsScope, SignedHeaders=$signedHeadersString, Signature=$signature"
-          val authHeader = Headers("Authorization" -> authHeaderValue)
-          val baseHeaders = Headers(baseHeadersList.map { case (k, v) => Header.Raw(k, v) })
-          authHeader ++ baseHeaders
+          }
         }
+        .flatMap { case ((payloadHash, preparedRequest), pathString) =>
+          val awsHeadersF = (timestamp, credentials, region).mapN { case (timestamp, credentials, region) =>
+            val credentialsScope = s"${timestamp.conciseDate}/$region/$endpointPrefix/aws4_request"
+            val queryParams: Vector[(String, String)] =
+              request.uri.query.toVector.sorted.map { case (k, v) => k -> v.getOrElse("") }
+            val canonicalQueryString =
+              if (queryParams.isEmpty) ""
+              else
+                queryParams
+                  .map { case (k, v) =>
+                    URLEncoder.encode(k, StandardCharsets.UTF_8.name()) + "=" + URLEncoder.encode(v, StandardCharsets.UTF_8.name())
+                  }
+                  .mkString("&")
 
-        awsHeadersF.map { headers =>
-          preparedRequest.transformHeaders(_ ++ headers)
+            // // !\ Important: these must remain in the same order
+            val baseHeadersList = List(
+              `Content-Type` -> preparedRequest.contentType.map(contentType.value(_)).orNull,
+              `Host` -> preparedRequest.uri.host.map(_.renderString).orNull,
+              `X-Amz-Content-SHA256` -> preparedRequest.headers.get(`X-Amz-Content-SHA256`).map(_.head.value).orNull,
+              `X-Amz-Date` -> timestamp.conciseDateTime,
+              `X-Amz-Security-Token` -> credentials.sessionToken.orNull,
+              `X-Amz-Target` -> (serviceName + "." + operationName)
+            ).filterNot(_._2 == null)
+
+            val canonicalHeadersString = baseHeadersList
+              .map { case (key, value) =>
+                key.toString.toLowerCase + ":" + value.trim
+              }
+              .mkString(newline)
+            lazy val signedHeadersString = baseHeadersList.map(_._1).map(_.toString.toLowerCase()).mkString(";")
+
+            val canonicalRequest = new StringBuilder()
+              .append(request.method.name.toUpperCase())
+              .append(newline)
+              .append(pathString)
+              .append(newline)
+              .append(canonicalQueryString)
+              .append(newline)
+              .append(canonicalHeadersString)
+              .append(newline)
+              .append(newline)
+              .append(signedHeadersString)
+              .append(newline)
+              .append(payloadHash)
+              .result()
+
+            val canonicalRequestHash = sha256HexDigest(canonicalRequest)
+            val signatureKey = getSignatureKey(
+              credentials.secretAccessKey,
+              timestamp.conciseDate,
+              region.value,
+              endpointPrefix
+            )
+            val stringToSign = List[String](
+              algorithm,
+              timestamp.conciseDateTime,
+              credentialsScope,
+              canonicalRequestHash
+            ).mkString(newline)
+            val signature = toHexString(hmacSha256(stringToSign, signatureKey))
+            val authHeaderValue = s"${algorithm} Credential=${credentials.accessKeyId}/$credentialsScope, SignedHeaders=$signedHeadersString, Signature=$signature"
+            val authHeader = Headers("Authorization" -> authHeaderValue)
+            val baseHeaders = Headers(baseHeadersList.map { case (k, v) => Header.Raw(k, v) })
+            authHeader ++ baseHeaders
+          }
+
+          awsHeadersF.map { headers =>
+            preparedRequest.transformHeaders(_ ++ headers)
+          }
         }
-      }
   }
 
   private val newline = System.lineSeparator()

--- a/modules/aws-http4s/test/src-jvm/smithy4s/aws/internals/AwsSignatureTest.scala
+++ b/modules/aws-http4s/test/src-jvm/smithy4s/aws/internals/AwsSignatureTest.scala
@@ -19,7 +19,7 @@ package smithy4s.aws.internals
 import cats.Show
 import cats.effect.IO
 import cats.effect.kernel.Async
-import cats.implicits._
+import cats.syntax.all._
 import org.http4s.Method
 import org.http4s.Request
 import org.http4s.Uri
@@ -89,12 +89,77 @@ object AwsSignatureTest extends SimpleIOSuite with Checkers {
       awsRequest: SdkHttpFullRequest
   )
   object TestInput {
-    implicit val show: Show[TestInput] = Show.fromToString
+    implicit val showContentStreamProvider: Show[ContentStreamProvider] =
+      Show.show { csp =>
+        scala.io.Source.fromInputStream(csp.newStream()).mkString
+      }
 
-    val genAwsRequest = for {
+    implicit val showSdkHttpFullRequest: Show[SdkHttpFullRequest] = Show.show {
+      (req: SdkHttpFullRequest) =>
+        val headers = Option(req.headers().asScala.toList)
+          .filter(_.nonEmpty)
+          .map(_.map { case (k, v) => s"$k: $v" })
+          .map(
+            _.mkString("\n        ", System.lineSeparator() + "        ", "")
+          )
+          .getOrElse(" none")
+
+        s"""(SdkHttpFullRequest)
+           |    - protocol: ${req.protocol()}
+           |    - host: ${req.host()}
+           |    - port: ${req.port()}
+           |    - method: ${req.method()}
+           |    - encodedPath: ${req.encodedPath()}
+           |    - headers:$headers
+           |    - contentStreamProvider: ${req.contentStreamProvider.toScala.show}
+           |""".stripMargin
+    }
+
+    implicit val showTestInput: Show[TestInput] = Show.show { testInput =>
+      import testInput._
+      s"""TestInput:
+         |  - serviceName: $serviceName
+         |  - operationName: $operationName
+         |  - smithy4sTimestamp: $smithy4sTimestamp
+         |  - smithy4sCredentials: $smithy4sCredentials
+         |  - smithy4sRegion: $smithy4sRegion
+         |  - awsRequest: ${awsRequest.show}
+         |""".stripMargin
+    }
+
+    val genPathSegment: Gen[String] =
+      Gen
+        .frequency(
+          1 -> Gen.oneOf("..", "."),
+          9 -> Gen
+            .stringOf(
+              Gen.frequency(
+                9 -> Gen.oneOf(
+                  Gen.alphaNumChar,
+                  // this list from https://github.com/http4s/http4s/blob/ac5c5cc40f732df238ef38c8ef8f571b4e66bfe3/core/shared/src/main/scala/org/http4s/internal/UriCoding.scala#L26
+                  Gen.oneOf("-_.~".toIndexedSeq)
+                ),
+                1 -> Gen.oneOf(
+                  // this list from https://github.com/http4s/http4s/blob/ac5c5cc40f732df238ef38c8ef8f571b4e66bfe3/core/shared/src/main/scala/org/http4s/Uri.scala#L1069
+                  "!$&'()*+,;=:/?@".toIndexedSeq
+                )
+              )
+            )
+        )
+        .map(
+          Uri.encode(
+            _,
+            toSkip = org.http4s.internal.CharPredicate.AlphaNum ++ "-_.~"
+          )
+        )
+
+    val genAwsRequest: Gen[SdkHttpFullRequest] = for {
       httpMethod <- Gen.oneOf(SdkHttpMethod.values().toList)
       host <- Gen.identifier
-      path <- Gen.listOfN(3, Gen.identifier).map(_.mkString("/"))
+      path <- Gen
+        .choose(0, 3)
+        .flatMap(Gen.listOfN(_, genPathSegment))
+        .map(_.mkString("/"))
       content <- Gen.asciiStr
       queryParams <- Gen.listOfN(3, Gen.zip(Gen.identifier, Gen.alphaNumStr))
     } yield {
@@ -114,7 +179,11 @@ object AwsSignatureTest extends SimpleIOSuite with Checkers {
     }
 
     val gen: Gen[TestInput] = for {
-      serviceName <- Gen.oneOf(Gen.const("AmazonS3"), Gen.identifier)
+      serviceName <- Gen.oneOf(
+        Gen.const("AmazonS3"),
+        Gen.const("AWSS3ControlServiceV20180820"),
+        Gen.identifier
+      )
       operationName <- Gen.identifier
       timestamp <- Gen.chooseNum(0L, 4102444800L).map(Timestamp.fromEpochSecond)
       accessKeyId <- Gen.identifier
@@ -156,53 +225,62 @@ object AwsSignatureTest extends SimpleIOSuite with Checkers {
     }
 
     val region = Region.of(smithy4sRegion.value)
-    val signedAwsRequest = if (testInput.serviceName == AwsSigning.S3) {
 
-      val signerParams = AwsS3V4SignerParams
-        .builder()
-        .awsCredentials(creds)
-        .signingRegion(region)
-        .signingClockOverride(fixedClock)
-        .enablePayloadSigning(true)
-        .signingName(serviceName)
-        .build()
+    val isS3Request =
+      Set(AwsSigning.S3, AwsSigning.S3Control).contains(serviceName)
 
-      // yes, this is an S3-specific signer.
-      val awsSigner = AwsS3V4Signer.create()
+    val signedAwsRequest =
+      if (isS3Request) {
+        val signerParams = AwsS3V4SignerParams
+          .builder()
+          .awsCredentials(creds)
+          .signingRegion(region)
+          .signingClockOverride(fixedClock)
+          .enablePayloadSigning(true)
+          .signingName(serviceName)
 
-      // Amending the AWS Request to force the AMZ target as it's added automatically
-      // by our implementation
-      //
-      // The hardcoded "required" header value is understood by the S3 signer as a signal that the `X-Amz-Content-SHA256` header
-      // should be replaced by the hash of the request payload, and that the same hash should be used in the signature.
-      val amendedAwsRequest = awsRequest
-        .toBuilder()
-        .appendHeader("X-Amz-Target", serviceName + "." + operationName)
-        .appendHeader(
-          "X-Amz-Content-SHA256",
-          "required"
-        ) // this is a magic addition that is understood by the S3 signer
-        .build()
+          // see https://github.com/aws/aws-sdk-java-v2/blob/b6b1ad9f25ea9ff89fd61f7639eb1aa74cc9d725/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/handlers/ConfigureSignerInterceptor.java#L33-L34
+          // and https://github.com/aws/aws-sdk-java-v2/blob/b6b1ad9f25ea9ff89fd61f7639eb1aa74cc9d725/services/s3control/src/main/java/software/amazon/awssdk/services/s3control/internal/interceptors/ConfigureSignerInterceptor.java#L33-L34
+          .doubleUrlEncode(false)
+          .normalizePath(false)
+          .build()
 
-      awsSigner.sign(amendedAwsRequest, signerParams)
-    } else {
-      val params = Aws4SignerParams
-        .builder()
-        .awsCredentials(creds)
-        .signingRegion(region)
-        .signingClockOverride(fixedClock)
-        .signingName(serviceName)
-        .build()
+        // yes, this is an S3-specific signer.
+        val awsSigner = AwsS3V4Signer.create()
 
-      val awsSigner = Aws4Signer.create()
-      // Amending the AWS Request to force the AMZ target as it's added automatically
-      // by our implementation
-      val amendedAwsRequest = awsRequest
-        .toBuilder()
-        .appendHeader("X-Amz-Target", serviceName + "." + operationName)
-        .build()
-      awsSigner.sign(amendedAwsRequest, params)
-    }
+        val amendedAwsRequest = awsRequest.toBuilder
+          // Amending the AWS Request to force the AMZ target as it's added automatically
+          // by our implementation
+          //
+          .appendHeader("X-Amz-Target", serviceName + "." + operationName)
+          // The hardcoded "required" header value is understood by the S3 signer as a signal that the `X-Amz-Content-SHA256` header
+          // should be replaced by the hash of the request payload, and that the same hash should be used in the signature.
+          .appendHeader(
+            "X-Amz-Content-SHA256",
+            "required"
+          ) // this is a magic addition that is understood by the S3 signer
+          .build()
+
+        awsSigner.sign(amendedAwsRequest, signerParams)
+      } else {
+        val params = Aws4SignerParams
+          .builder()
+          .awsCredentials(creds)
+          .signingRegion(region)
+          .signingClockOverride(fixedClock)
+          .signingName(serviceName)
+          .doubleUrlEncode(true)
+          .normalizePath(true)
+          .build()
+
+        val awsSigner = Aws4Signer.create()
+        // Amending the AWS Request to force the AMZ target as it's added automatically
+        // by our implementation
+        val amendedAwsRequest = awsRequest.toBuilder
+          .appendHeader("X-Amz-Target", serviceName + "." + operationName)
+          .build()
+        awsSigner.sign(amendedAwsRequest, params)
+      }
 
     val smithy4sSigner = AwsSigning.signingFunction[IO](
       serviceName,
@@ -246,7 +324,7 @@ object AwsSignatureTest extends SimpleIOSuite with Checkers {
         }
       }
       .withHeaders(http4sHeaders(request))
-      .withUri(Uri.unsafeFromString(request.getUri().toString()))
+      .withUri(Uri.unsafeFromString(request.getUri.toASCIIString))
   }
 
   def http4sHeaders(request: SdkHttpFullRequest): Vector[(String, String)] =

--- a/modules/bootstrapped/test/src/smithy4s/http/internals/PathSpec.scala
+++ b/modules/bootstrapped/test/src/smithy4s/http/internals/PathSpec.scala
@@ -138,7 +138,7 @@ class PathSpec() extends munit.FunSuite {
         )
       )
     val result = SchemaVisitorPathEncoder(schema)
-      .map(_.encode(()))
+      .map(_.encode((), true))
 
     expect.eql(
       result,
@@ -160,7 +160,7 @@ class PathSpec() extends munit.FunSuite {
         )
       )
     val result = SchemaVisitorPathEncoder(schema)
-      .map(_.encode(()))
+      .map(_.encode((), true))
 
     expect.eql(
       result,
@@ -170,21 +170,21 @@ class PathSpec() extends munit.FunSuite {
 
   test("Write PathParams for a simple string") {
     expect.eql(
-      util.simpleString.map(_.encode("example")),
+      util.simpleString.map(_.encode("example", true)),
       Some(List("example"))
     )
   }
 
   test("Write PathParams for a byte") {
     expect.eql(
-      util.encodePathAs(byte).map(_.encode(42)),
+      util.encodePathAs(byte).map(_.encode(42, true)),
       Some(List("42"))
     )
   }
 
   test("Write PathParams for an int") {
     expect.eql(
-      util.encodePathAs(int).map(_.encode(42)),
+      util.encodePathAs(int).map(_.encode(42, true)),
       Some(List("42"))
     )
   }
@@ -195,14 +195,14 @@ class PathSpec() extends munit.FunSuite {
     })
 
     expect.eql(
-      util.encodePathAs(double).map(_.encode(42.0)),
+      util.encodePathAs(double).map(_.encode(42.0, true)),
       expected
     )
   }
 
   test("Write PathParams for a boolean") {
     expect.eql(
-      util.encodePathAs(boolean).map(_.encode(true)),
+      util.encodePathAs(boolean).map(_.encode(true, true)),
       Some(List("true"))
     )
   }
@@ -211,7 +211,7 @@ class PathSpec() extends munit.FunSuite {
     val input = "example with all kinds of strange characters / \\ & "
 
     expect.eql(
-      util.simpleString.map(_.encode(input)),
+      util.simpleString.map(_.encode(input, false)),
       Some(List(input))
     )
   }
@@ -222,14 +222,36 @@ class PathSpec() extends munit.FunSuite {
     val input = "example/with/slashes and spaces"
 
     expect.eql(
-      util.simpleString.map(_.encodeGreedy(input)),
+      util.simpleString.map(_.encodeGreedy(input, false)),
       Some(List("example", "with", "slashes and spaces"))
+    )
+  }
+
+  test("Write PathParams for a string with special characters encoded") {
+    val input = "example with all kinds of_strange-characters. / \\ & ~"
+    val expected =
+      "example%20with%20all%20kinds%20of_strange-characters.%20%2F%20%5C%20%26%20~"
+
+    expect.eql(
+      util.simpleString.map(_.encode(input, true)),
+      Some(List(expected))
+    )
+  }
+
+  test(
+    "Write PathParams for a string greedily by splitting it on /, encoded"
+  ) {
+    val input = "example/with/slashes and spaces"
+
+    expect.eql(
+      util.simpleString.map(_.encodeGreedy(input, true)),
+      Some(List("example", "with", "slashes%20and%20spaces"))
     )
   }
 
   test("Write PathParams for unit as None") {
     expect.eql(
-      util.encodePathAs(unit).map(_.encode(())),
+      util.encodePathAs(unit).map(_.encode((), true)),
       None
     )
   }

--- a/modules/bootstrapped/test/src/smithy4s/http/internals/PathSpec.scala
+++ b/modules/bootstrapped/test/src/smithy4s/http/internals/PathSpec.scala
@@ -30,7 +30,10 @@ class PathSpec() extends munit.FunSuite {
   import smithy4s.schema.Schema._
   object util {
 
-    def encodePathAs[A](schema: Schema[A]): Option[PathEncode[A]] = {
+    def encodePathAs[A](
+        schema: Schema[A],
+        urlEncodeHttpLabelValues: Boolean
+    ): Option[PathEncode[A]] = {
       val schemaA = schema
         .addHints(
           Http(
@@ -39,10 +42,10 @@ class PathSpec() extends munit.FunSuite {
             code = 200
           )
         )
-      SchemaVisitorPathEncoder(schemaA)
+      new SchemaVisitorPathEncoder(urlEncodeHttpLabelValues)(schemaA)
     }
 
-    val simpleString = encodePathAs(string)
+    val simpleString = encodePathAs(string, urlEncodeHttpLabelValues = true)
   }
 
   test("Parse path pattern into path segments") {
@@ -137,8 +140,9 @@ class PathSpec() extends munit.FunSuite {
           code = 200
         )
       )
-    val result = SchemaVisitorPathEncoder(schema)
-      .map(_.encode((), true))
+    val result =
+      new SchemaVisitorPathEncoder(urlEncodeHttpLabelValues = true)(schema)
+        .map(_.encode(()))
 
     expect.eql(
       result,
@@ -159,8 +163,9 @@ class PathSpec() extends munit.FunSuite {
           code = 200
         )
       )
-    val result = SchemaVisitorPathEncoder(schema)
-      .map(_.encode((), true))
+    val result =
+      new SchemaVisitorPathEncoder(urlEncodeHttpLabelValues = true)(schema)
+        .map(_.encode(()))
 
     expect.eql(
       result,
@@ -170,21 +175,23 @@ class PathSpec() extends munit.FunSuite {
 
   test("Write PathParams for a simple string") {
     expect.eql(
-      util.simpleString.map(_.encode("example", true)),
+      util.simpleString.map(_.encode("example")),
       Some(List("example"))
     )
   }
 
   test("Write PathParams for a byte") {
     expect.eql(
-      util.encodePathAs(byte).map(_.encode(42, true)),
+      util
+        .encodePathAs(byte, urlEncodeHttpLabelValues = true)
+        .map(_.encode(42)),
       Some(List("42"))
     )
   }
 
   test("Write PathParams for an int") {
     expect.eql(
-      util.encodePathAs(int).map(_.encode(42, true)),
+      util.encodePathAs(int, urlEncodeHttpLabelValues = true).map(_.encode(42)),
       Some(List("42"))
     )
   }
@@ -195,14 +202,18 @@ class PathSpec() extends munit.FunSuite {
     })
 
     expect.eql(
-      util.encodePathAs(double).map(_.encode(42.0, true)),
+      util
+        .encodePathAs(double, urlEncodeHttpLabelValues = true)
+        .map(_.encode(42.0)),
       expected
     )
   }
 
   test("Write PathParams for a boolean") {
     expect.eql(
-      util.encodePathAs(boolean).map(_.encode(true, true)),
+      util
+        .encodePathAs(boolean, urlEncodeHttpLabelValues = true)
+        .map(_.encode(true)),
       Some(List("true"))
     )
   }
@@ -211,7 +222,9 @@ class PathSpec() extends munit.FunSuite {
     val input = "example with all kinds of strange characters / \\ & "
 
     expect.eql(
-      util.simpleString.map(_.encode(input, false)),
+      util
+        .encodePathAs(string, urlEncodeHttpLabelValues = false)
+        .map(_.encode(input)),
       Some(List(input))
     )
   }
@@ -222,7 +235,9 @@ class PathSpec() extends munit.FunSuite {
     val input = "example/with/slashes and spaces"
 
     expect.eql(
-      util.simpleString.map(_.encodeGreedy(input, false)),
+      util
+        .encodePathAs(string, urlEncodeHttpLabelValues = false)
+        .map(_.encodeGreedy(input)),
       Some(List("example", "with", "slashes and spaces"))
     )
   }
@@ -233,7 +248,7 @@ class PathSpec() extends munit.FunSuite {
       "example%20with%20all%20kinds%20of_strange-characters.%20%2F%20%5C%20%26%20~"
 
     expect.eql(
-      util.simpleString.map(_.encode(input, true)),
+      util.simpleString.map(_.encode(input)),
       Some(List(expected))
     )
   }
@@ -244,14 +259,16 @@ class PathSpec() extends munit.FunSuite {
     val input = "example/with/slashes and spaces"
 
     expect.eql(
-      util.simpleString.map(_.encodeGreedy(input, true)),
+      util.simpleString.map(_.encodeGreedy(input)),
       Some(List("example", "with", "slashes%20and%20spaces"))
     )
   }
 
   test("Write PathParams for unit as None") {
     expect.eql(
-      util.encodePathAs(unit).map(_.encode((), true)),
+      util
+        .encodePathAs(unit, urlEncodeHttpLabelValues = true)
+        .map(_.encode(())),
       None
     )
   }

--- a/modules/compliance-tests/src/smithy4s/compliancetests/internals/ClientHttpComplianceTestCase.scala
+++ b/modules/compliance-tests/src/smithy4s/compliancetests/internals/ClientHttpComplianceTestCase.scala
@@ -75,10 +75,8 @@ private[compliancetests] class ClientHttpComplianceTestCase[
         }
         .toList
 
-    val receivedPathSegments =
-      request.uri.path.segments.map(_.decoded())
-    val expectedPathSegments =
-      Uri.Path.unsafeFromString(testCase.uri).segments.map(_.decoded())
+    val receivedPathSegments = request.uri.path.segments
+    val expectedPathSegments = Uri.Path.unsafeFromString(testCase.uri).segments
 
     val expectedUri = baseUri
       .withPath(Uri.Path.unsafeFromString(testCase.uri))

--- a/modules/core/src/smithy4s/http/HttpEndpoint.scala
+++ b/modules/core/src/smithy4s/http/HttpEndpoint.scala
@@ -24,7 +24,10 @@ import scala.annotation.tailrec
 
 trait HttpEndpoint[I] {
   // Returns a list of path segments that should be appended to the base URL. These are not URL-encoded.
-  @deprecated
+  @deprecated(
+    "Path segments should be encoded in a specific way per the Smithy spec, so use encodedPath instead",
+    "0.18.40"
+  )
   def path(input: I): List[String]
 
   def encodedPath(input: I): List[String]
@@ -64,7 +67,16 @@ object HttpEndpoint {
           )
         )
 
-      encoder <- SchemaVisitorPathEncoder(
+      labelEncodingEncoder <- new SchemaVisitorPathEncoder(
+        urlEncodeHttpLabelValues = true
+      )(
+        operation.input.addHints(http)
+      ).toRight(
+        HttpEndpointError("Unable to encode operation input in HTTP path")
+      )
+      nonLabelEncodingEncoder <- new SchemaVisitorPathEncoder(
+        urlEncodeHttpLabelValues = false
+      )(
         operation.input.addHints(http)
       ).toRight(
         HttpEndpointError("Unable to encode operation input in HTTP path")
@@ -72,8 +84,10 @@ object HttpEndpoint {
 
     } yield {
       new HttpEndpoint[I] {
-        def path(input: I): List[String] = encoder.encode(input, false)
-        def encodedPath(input: I): List[String] = encoder.encode(input, true)
+        def path(input: I): List[String] = nonLabelEncodingEncoder.encode(input)
+
+        def encodedPath(input: I): List[String] =
+          labelEncodingEncoder.encode(input)
         val staticQueryParams: Map[String, Seq[String]] = queryParams
         val path: List[PathSegment] = httpPath.toList
         val method: HttpMethod = httpMethod

--- a/modules/core/src/smithy4s/http/HttpEndpoint.scala
+++ b/modules/core/src/smithy4s/http/HttpEndpoint.scala
@@ -24,7 +24,10 @@ import scala.annotation.tailrec
 
 trait HttpEndpoint[I] {
   // Returns a list of path segments that should be appended to the base URL. These are not URL-encoded.
+  @deprecated
   def path(input: I): List[String]
+
+  def encodedPath(input: I): List[String]
 
   // Returns a path template as a list of segments, which can be constant strings or placeholders.
   def path: List[PathSegment]
@@ -69,7 +72,8 @@ object HttpEndpoint {
 
     } yield {
       new HttpEndpoint[I] {
-        def path(input: I): List[String] = encoder.encode(input)
+        def path(input: I): List[String] = encoder.encode(input, false)
+        def encodedPath(input: I): List[String] = encoder.encode(input, true)
         val staticQueryParams: Map[String, Seq[String]] = queryParams
         val path: List[PathSegment] = httpPath.toList
         val method: HttpMethod = httpMethod

--- a/modules/core/src/smithy4s/http/HttpRequest.scala
+++ b/modules/core/src/smithy4s/http/HttpRequest.scala
@@ -75,10 +75,14 @@ object HttpRequest {
     }
 
     def fromHttpEndpoint[Body, I](
-        httpEndpoint: HttpEndpoint[I]
+        httpEndpoint: HttpEndpoint[I],
+        rawHttpLabelValues: Boolean
     ): Writer[Body, I] = new Writer[Body, I] {
+      @annotation.nowarn("cat=deprecation")
       def write(request: HttpRequest[Body], input: I): HttpRequest[Body] = {
-        val path = httpEndpoint.path(input)
+        val path =
+          if (rawHttpLabelValues) httpEndpoint.path(input)
+          else httpEndpoint.encodedPath(input)
         val staticQueries = httpEndpoint.staticQueryParams
         val oldUri = request.uri
         val newUri =

--- a/modules/core/src/smithy4s/http/HttpUnaryClientCodecs.scala
+++ b/modules/core/src/smithy4s/http/HttpUnaryClientCodecs.scala
@@ -45,7 +45,8 @@ object HttpUnaryClientCodecs {
       requestMediaType = "text/plain",
       requestTransformation = F.pure(_),
       responseTransformation = F.pure(_),
-      hostPrefixInjection = true
+      hostPrefixInjection = true,
+      rawHttpLabelValues = false
     )
 
   trait Builder[F[_], Request, Response] {
@@ -63,6 +64,7 @@ object HttpUnaryClientCodecs {
     def withRequestTransformation[Request1](f: Request => F[Request1]): Builder[F, Request1, Response]
     def withResponseTransformation[Response0](f: Response0 => F[Response]): Builder[F, Request, Response0]
     def withHostPrefixInjection(enabled: Boolean): Builder[F, Request, Response]
+    def withRawHttpLabelValues(enabled: Boolean): Builder[F, Request, Response]
     def build(): UnaryClientCodecs.Make[F, Request, Response]
   }
 
@@ -80,7 +82,8 @@ object HttpUnaryClientCodecs {
       requestMediaType: String,
       requestTransformation: HttpRequest[Blob] => F[Request],
       responseTransformation: Response => F[HttpResponse[Blob]],
-      hostPrefixInjection: Boolean
+      hostPrefixInjection: Boolean,
+      rawHttpLabelValues: Boolean
   )(implicit F: MonadThrowLike[F])
       extends Builder[F, Request, Response] {
     def withOperationPreprocessor(fk: PolyFunction5[OperationSchema, OperationSchema]): Builder[F, Request, Response] =
@@ -112,6 +115,8 @@ object HttpUnaryClientCodecs {
       copy(responseTransformation = f.andThen(F.flatMap(_)(responseTransformation)))
 
     def withHostPrefixInjection(enabled: Boolean): Builder[F, Request, Response] = copy(hostPrefixInjection = enabled)
+    override def withRawHttpLabelValues(enabled: Boolean): Builder[F, Request, Response] =
+      copy(rawHttpLabelValues = enabled)
 
     def build(): UnaryClientCodecs.Make[F, Request, Response] = {
       val setBody: HttpRequest.Writer[Blob, Blob] = Writer.lift((req, blob) => req.copy(body = blob))
@@ -189,7 +194,7 @@ object HttpUnaryClientCodecs {
             HttpEndpoint.cast(endpoint).toOption match {
               case Some(httpEndpoint) => {
                 val httpInputEncoder =
-                  HttpRequest.Writer.fromHttpEndpoint[Blob, I](httpEndpoint)
+                  HttpRequest.Writer.fromHttpEndpoint[Blob, I](httpEndpoint, rawHttpLabelValues)
                 val requestEncoder =
                   inputEncoders.fromSchema(endpoint.input, inputEncoderCache)
                 httpInputEncoder.combine(requestEncoder)

--- a/modules/core/src/smithy4s/http/internals/PathEncode.scala
+++ b/modules/core/src/smithy4s/http/internals/PathEncode.scala
@@ -84,37 +84,36 @@ object PathEncode {
   ): String = {
     // Encode the path segment and undo some of the assumption of URLEncoder to make it with unreserved.
     val encoded = java.net.URLEncoder.encode(source, "UTF-8")
+    val sink = new StringBuilder(encoded.length)
+    var i = 0
+    while (i < encoded.length) {
+      val c = encoded.charAt(i)
+      c match {
+        case '+' => sink.append("%20")
+        case '*' => sink.append("%2A")
+        case '%' =>
+          encoded.charAt(i + 1) match {
+            case '7'
+                if (i < encoded.length - 1 && encoded.charAt(i + 2) == 'E') =>
+              sink.append('~')
+              i += 2
 
-    val (output, leftover) =
-      encoded.toCharArray.foldLeft((Vector.empty[Char], Vector.empty[Char])) {
-        case ((acc, Vector()), '+') =>
-          acc ++ Vector('%', '2', '0') -> Vector.empty
+            case '2'
+                if (i < encoded.length - 1 && encoded.charAt(
+                  i + 2
+                ) == 'F' && ignoreSlashes) =>
+              sink.append('/')
+              i += 2
 
-        case ((acc, Vector()), '*') =>
-          acc ++ Vector('%', '2', 'A') -> Vector.empty
+            case _ => sink.append(c)
+          }
 
-        case ((acc, Vector()), '%') =>
-          acc -> Vector('%')
-
-        case ((acc, Vector('%')), '7') =>
-          acc -> Vector('%', '7')
-
-        case ((acc, Vector('%')), '2') =>
-          acc -> Vector('%', '2')
-
-        case ((acc, Vector('%', '7')), 'E') =>
-          (acc :+ '~') -> Vector.empty
-
-        case ((acc, Vector('%', '2')), 'F') if ignoreSlashes =>
-          (acc :+ '/') -> Vector.empty
-
-        case ((acc, Vector('%', '2')), 'F') if !ignoreSlashes =>
-          acc ++ Vector('%', '2', 'F') -> Vector.empty
-
-        case ((acc, lookback), c) =>
-          (acc ++ lookback :+ c) -> Vector.empty
+        case _ => sink.append(c)
       }
 
-    (output ++ leftover).mkString
+      i += 1
+    }
+
+    sink.toString
   }
 }

--- a/modules/core/src/smithy4s/http/internals/PathEncode.scala
+++ b/modules/core/src/smithy4s/http/internals/PathEncode.scala
@@ -19,12 +19,14 @@ package smithy4s.http.internals
 import smithy4s.capability.Contravariant
 
 trait PathEncode[A] { self =>
-  def encode(a: A): List[String]
-  def encodeGreedy(a: A): List[String]
+  def encode(a: A, urlEncode: Boolean): List[String]
+  def encodeGreedy(a: A, urlEncode: Boolean): List[String]
 
   def contramap[B](from: B => A): PathEncode[B] = new PathEncode[B] {
-    def encode(b: B): List[String] = self.encode(from(b))
-    def encodeGreedy(b: B): List[String] = self.encodeGreedy(from(b))
+    override def encode(b: B, urlEncode: Boolean): List[String] =
+      self.encode(from(b), urlEncode)
+    override def encodeGreedy(b: B, urlEncode: Boolean): List[String] =
+      self.encodeGreedy(from(b), urlEncode)
   }
 }
 
@@ -39,12 +41,20 @@ object PathEncode {
     }
   def raw[A](f: A => String): PathEncode[A] = {
     new PathEncode[A] {
-      def encode(a: A): List[String] = {
-        List(f(a))
+      def encode(a: A, urlEncode: Boolean): List[String] = {
+        val initial = f(a)
+        List {
+          if (urlEncode) encodeUnreserved(initial, false)
+          else initial
+        }
       }
 
-      def encodeGreedy(a: A): List[String] = {
-        f(a).split('/').toList
+      def encodeGreedy(a: A, urlEncode: Boolean): List[String] = {
+        val initial = f(a)
+        (if (urlEncode) encodeUnreserved(initial, true)
+         else initial)
+          .split('/')
+          .toList
       }
     }
   }
@@ -55,4 +65,56 @@ object PathEncode {
     }
   }
   def fromToString[A]: MaybePathEncode[A] = from(_.toString)
+
+  /**
+   * Encodes characters that are not unreserved into a string builder.
+   * [[https://github.com/smithy-lang/smithy-java/blob/7cf74ae295480454d00e905053a212a77cbde34b/io/src/main/java/software/amazon/smithy/java/io/uri/URLEncoding.java#L14 Ported from smithy's `software.amazon.smithy.java.io.uri.URLEncoding`]].
+   * <p>
+   * <code>
+   * unreserved  = ALPHA / DIGIT / "-" / "." / "_" / "~"
+   * </code>
+   * Can optionally handle strings which are meant to encode a path (ie include '/' which should NOT be escaped for paths).
+   *
+   * @param source        The raw string to encode. Note that any existing percent-encoding will be encoded again.
+   * @param ignoreSlashes true if the value is intended to represent a path.
+   */
+  private def encodeUnreserved(
+      source: String,
+      ignoreSlashes: Boolean
+  ): String = {
+    // Encode the path segment and undo some of the assumption of URLEncoder to make it with unreserved.
+    val encoded = java.net.URLEncoder.encode(source, "UTF-8")
+
+    val (output, leftover) =
+      encoded.toCharArray.foldLeft((Vector.empty[Char], Vector.empty[Char])) {
+        case ((acc, Vector()), '+') =>
+          acc ++ Vector('%', '2', '0') -> Vector.empty
+
+        case ((acc, Vector()), '*') =>
+          acc ++ Vector('%', '2', 'A') -> Vector.empty
+
+        case ((acc, Vector()), '%') =>
+          acc -> Vector('%')
+
+        case ((acc, Vector('%')), '7') =>
+          acc -> Vector('%', '7')
+
+        case ((acc, Vector('%')), '2') =>
+          acc -> Vector('%', '2')
+
+        case ((acc, Vector('%', '7')), 'E') =>
+          (acc :+ '~') -> Vector.empty
+
+        case ((acc, Vector('%', '2')), 'F') if ignoreSlashes =>
+          (acc :+ '/') -> Vector.empty
+
+        case ((acc, Vector('%', '2')), 'F') if !ignoreSlashes =>
+          acc ++ Vector('%', '2', 'F') -> Vector.empty
+
+        case ((acc, lookback), c) =>
+          (acc ++ lookback :+ c) -> Vector.empty
+      }
+
+    (output ++ leftover).mkString
+  }
 }

--- a/modules/core/src/smithy4s/http/internals/PathEncode.scala
+++ b/modules/core/src/smithy4s/http/internals/PathEncode.scala
@@ -19,14 +19,14 @@ package smithy4s.http.internals
 import smithy4s.capability.Contravariant
 
 trait PathEncode[A] { self =>
-  def encode(a: A, urlEncode: Boolean): List[String]
-  def encodeGreedy(a: A, urlEncode: Boolean): List[String]
+  def encode(a: A): List[String]
+  def encodeGreedy(a: A): List[String]
 
   def contramap[B](from: B => A): PathEncode[B] = new PathEncode[B] {
-    override def encode(b: B, urlEncode: Boolean): List[String] =
-      self.encode(from(b), urlEncode)
-    override def encodeGreedy(b: B, urlEncode: Boolean): List[String] =
-      self.encodeGreedy(from(b), urlEncode)
+    override def encode(b: B): List[String] =
+      self.encode(from(b))
+    override def encodeGreedy(b: B): List[String] =
+      self.encodeGreedy(from(b))
   }
 }
 
@@ -39,9 +39,9 @@ object PathEncode {
       def contramap[A, B](fa: PathEncode[A])(f: B => A): PathEncode[B] =
         fa.contramap(f)
     }
-  def raw[A](f: A => String): PathEncode[A] = {
+  def raw[A](f: A => String, urlEncode: Boolean): PathEncode[A] = {
     new PathEncode[A] {
-      def encode(a: A, urlEncode: Boolean): List[String] = {
+      override def encode(a: A): List[String] = {
         val initial = f(a)
         List {
           if (urlEncode) encodeUnreserved(initial, false)
@@ -49,7 +49,7 @@ object PathEncode {
         }
       }
 
-      def encodeGreedy(a: A, urlEncode: Boolean): List[String] = {
+      override def encodeGreedy(a: A): List[String] = {
         val initial = f(a)
         (if (urlEncode) encodeUnreserved(initial, true)
          else initial)
@@ -59,12 +59,13 @@ object PathEncode {
     }
   }
 
-  def from[A](f: A => String): MaybePathEncode[A] = {
+  def from[A](f: A => String, urlEncode: Boolean): MaybePathEncode[A] = {
     Some {
-      raw(f)
+      raw(f, urlEncode)
     }
   }
-  def fromToString[A]: MaybePathEncode[A] = from(_.toString)
+  def fromToString[A](urlEncode: Boolean): MaybePathEncode[A] =
+    from(_.toString, urlEncode)
 
   /**
    * Encodes characters that are not unreserved into a string builder.

--- a/modules/core/src/smithy4s/http/internals/SchemaVisitorPathEncoder.scala
+++ b/modules/core/src/smithy4s/http/internals/SchemaVisitorPathEncoder.scala
@@ -25,7 +25,7 @@ import smithy4s.http.PathSegment.{GreedySegment, LabelSegment, StaticSegment}
 import smithy4s.{Hints, Lazy, Refinement, ShapeId}
 import smithy.api.Http
 
-object SchemaVisitorPathEncoder
+class SchemaVisitorPathEncoder(urlEncodeHttpLabelValues: Boolean)
     extends SchemaVisitor[MaybePathEncode]
     with SchemaVisitor.Default[MaybePathEncode] {
   self =>
@@ -38,23 +38,39 @@ object SchemaVisitorPathEncoder
       tag: Primitive[P]
   ): MaybePathEncode[P] = {
     tag match {
-      case Primitive.PShort      => PathEncode.fromToString
-      case Primitive.PInt        => PathEncode.fromToString
-      case Primitive.PFloat      => PathEncode.fromToString
-      case Primitive.PLong       => PathEncode.fromToString
-      case Primitive.PDouble     => PathEncode.fromToString
-      case Primitive.PBigInt     => PathEncode.fromToString
-      case Primitive.PBigDecimal => PathEncode.fromToString
-      case Primitive.PBoolean    => PathEncode.fromToString
-      case Primitive.PString     => PathEncode.fromToString
-      case Primitive.PUUID       => PathEncode.fromToString
-      case Primitive.PByte       => PathEncode.fromToString
-      case Primitive.PBlob       => default
-      case Primitive.PDocument   => default
+      case Primitive.PShort =>
+        PathEncode.fromToString(urlEncode = this.urlEncodeHttpLabelValues)
+      case Primitive.PInt =>
+        PathEncode.fromToString(urlEncode = this.urlEncodeHttpLabelValues)
+      case Primitive.PFloat =>
+        PathEncode.fromToString(urlEncode = this.urlEncodeHttpLabelValues)
+      case Primitive.PLong =>
+        PathEncode.fromToString(urlEncode = this.urlEncodeHttpLabelValues)
+      case Primitive.PDouble =>
+        PathEncode.fromToString(urlEncode = this.urlEncodeHttpLabelValues)
+      case Primitive.PBigInt =>
+        PathEncode.fromToString(urlEncode = this.urlEncodeHttpLabelValues)
+      case Primitive.PBigDecimal =>
+        PathEncode.fromToString(urlEncode = this.urlEncodeHttpLabelValues)
+      case Primitive.PBoolean =>
+        PathEncode.fromToString(urlEncode = this.urlEncodeHttpLabelValues)
+      case Primitive.PString =>
+        PathEncode.fromToString(urlEncode = this.urlEncodeHttpLabelValues)
+      case Primitive.PUUID =>
+        PathEncode.fromToString(urlEncode = this.urlEncodeHttpLabelValues)
+      case Primitive.PByte =>
+        PathEncode.fromToString(urlEncode = this.urlEncodeHttpLabelValues)
+      case Primitive.PBlob     => default
+      case Primitive.PDocument => default
       case Primitive.PTimestamp =>
         val fmt =
           hints.get(TimestampFormat).getOrElse(TimestampFormat.DATE_TIME)
-        Some(PathEncode.raw(_.format(fmt)))
+        Some(
+          PathEncode.raw(
+            _.format(fmt),
+            urlEncode = this.urlEncodeHttpLabelValues
+          )
+        )
     }
   }
 
@@ -67,9 +83,15 @@ object SchemaVisitorPathEncoder
   ): MaybePathEncode[E] =
     tag match {
       case EnumTag.IntEnum() =>
-        PathEncode.from(e => total(e).intValue.toString)
+        PathEncode.from(
+          e => total(e).intValue.toString,
+          urlEncode = this.urlEncodeHttpLabelValues
+        )
       case _ =>
-        PathEncode.from(e => total(e).stringValue)
+        PathEncode.from(
+          e => total(e).stringValue,
+          urlEncode = this.urlEncodeHttpLabelValues
+        )
     }
 
   override def struct[S](
@@ -78,7 +100,7 @@ object SchemaVisitorPathEncoder
       fields: Vector[Field[S, _]],
       make: IndexedSeq[Any] => S
   ): MaybePathEncode[S] = {
-    type Writer = (S, Boolean) => List[String]
+    type Writer = S => List[String]
 
     def toPathEncoder[A](
         field: Field[S, A],
@@ -91,7 +113,7 @@ object SchemaVisitorPathEncoder
     }
 
     def compile1(path: PathSegment): Option[Writer] = path match {
-      case StaticSegment(value) => Some((_: S, _: Boolean) => List(value))
+      case StaticSegment(value) => Some(Function.const(List(value)))
       case LabelSegment(value) =>
         fields
           .find(_.label == value)
@@ -110,9 +132,9 @@ object SchemaVisitorPathEncoder
       path <- pathSegments(httpHint.uri.value)
       writers <- compilePath(path)
     } yield new PathEncode[S] {
-      def encode(s: S, urlEncode: Boolean): List[String] =
-        writers.flatMap(_.apply(s, urlEncode)).toList
-      def encodeGreedy(s: S, urlEncode: Boolean): List[String] = Nil
+      override def encode(s: S): List[String] =
+        writers.flatMap(_.apply(s)).toList
+      override def encodeGreedy(s: S): List[String] = Nil
     }
   }
 

--- a/modules/core/src/smithy4s/http/internals/SchemaVisitorPathEncoder.scala
+++ b/modules/core/src/smithy4s/http/internals/SchemaVisitorPathEncoder.scala
@@ -78,7 +78,7 @@ object SchemaVisitorPathEncoder
       fields: Vector[Field[S, _]],
       make: IndexedSeq[Any] => S
   ): MaybePathEncode[S] = {
-    type Writer = S => List[String]
+    type Writer = (S, Boolean) => List[String]
 
     def toPathEncoder[A](
         field: Field[S, A],
@@ -89,8 +89,9 @@ object SchemaVisitorPathEncoder
       if (greedy) writer.map(_.encodeGreedy)
       else writer.map(_.encode)
     }
+
     def compile1(path: PathSegment): Option[Writer] = path match {
-      case StaticSegment(value) => Some(Function.const(List(value)))
+      case StaticSegment(value) => Some((_: S, _: Boolean) => List(value))
       case LabelSegment(value) =>
         fields
           .find(_.label == value)
@@ -103,13 +104,15 @@ object SchemaVisitorPathEncoder
 
     def compilePath(path: Vector[PathSegment]): Option[Vector[Writer]] =
       path.traverse(compile1(_))
+
     for {
       httpHint <- hints.get[Http]
       path <- pathSegments(httpHint.uri.value)
       writers <- compilePath(path)
     } yield new PathEncode[S] {
-      def encode(s: S): List[String] = writers.flatMap(_.apply(s)).toList
-      def encodeGreedy(s: S): List[String] = Nil
+      def encode(s: S, urlEncode: Boolean): List[String] =
+        writers.flatMap(_.apply(s, urlEncode)).toList
+      def encodeGreedy(s: S, urlEncode: Boolean): List[String] = Nil
     }
   }
 

--- a/modules/core/src/smithy4s/internals/SchemaVisitorPatternEncoder.scala
+++ b/modules/core/src/smithy4s/internals/SchemaVisitorPatternEncoder.scala
@@ -36,7 +36,7 @@ private[internals] final class SchemaVisitorPatternEncoder(
       tag: Primitive[P]
   ): MaybePathEncode[P] = {
     Primitive.stringWriter(tag, hints) match {
-      case Some(writer) => PathEncode.from(e => writer(e))
+      case Some(writer) => PathEncode.from(e => writer(e), urlEncode = false)
       case None         => None
     }
   }
@@ -50,9 +50,9 @@ private[internals] final class SchemaVisitorPatternEncoder(
   ): MaybePathEncode[E] =
     tag match {
       case EnumTag.IntEnum() =>
-        PathEncode.from(e => total(e).intValue.toString)
+        PathEncode.from(e => total(e).intValue.toString, urlEncode = false)
       case _ =>
-        PathEncode.from(e => total(e).stringValue)
+        PathEncode.from(e => total(e).stringValue, urlEncode = false)
     }
 
   override def struct[S](
@@ -61,7 +61,7 @@ private[internals] final class SchemaVisitorPatternEncoder(
       fields: Vector[Field[S, _]],
       make: IndexedSeq[Any] => S
   ): MaybePathEncode[S] = {
-    type Writer = (S, Boolean) => List[String]
+    type Writer = S => List[String]
 
     def toPathEncoder[A](
         field: Field[S, A]
@@ -71,7 +71,7 @@ private[internals] final class SchemaVisitorPatternEncoder(
 
     def compile1(path: PatternSegment): Option[Writer] = path match {
       case PatternSegment.StaticSegment(value) =>
-        Some((_: S, _: Boolean) => List(value))
+        Some(Function.const(List(value)))
       case PatternSegment.ParameterSegment(value, _) =>
         fields
           .find(_.label == value)
@@ -84,9 +84,9 @@ private[internals] final class SchemaVisitorPatternEncoder(
     for {
       writers <- compilePath(segments.toVector)
     } yield new PathEncode[S] {
-      def encode(s: S, urlEncode: Boolean): List[String] =
-        writers.flatMap(_.apply(s, urlEncode)).toList
-      def encodeGreedy(s: S, urlEncode: Boolean): List[String] = Nil
+      override def encode(s: S): List[String] =
+        writers.flatMap(_.apply(s)).toList
+      override def encodeGreedy(s: S): List[String] = Nil
     }
   }
 

--- a/modules/core/src/smithy4s/internals/SchemaVisitorPatternEncoder.scala
+++ b/modules/core/src/smithy4s/internals/SchemaVisitorPatternEncoder.scala
@@ -61,7 +61,7 @@ private[internals] final class SchemaVisitorPatternEncoder(
       fields: Vector[Field[S, _]],
       make: IndexedSeq[Any] => S
   ): MaybePathEncode[S] = {
-    type Writer = S => List[String]
+    type Writer = (S, Boolean) => List[String]
 
     def toPathEncoder[A](
         field: Field[S, A]
@@ -71,7 +71,7 @@ private[internals] final class SchemaVisitorPatternEncoder(
 
     def compile1(path: PatternSegment): Option[Writer] = path match {
       case PatternSegment.StaticSegment(value) =>
-        Some(Function.const(List(value)))
+        Some((_: S, _: Boolean) => List(value))
       case PatternSegment.ParameterSegment(value, _) =>
         fields
           .find(_.label == value)
@@ -80,11 +80,13 @@ private[internals] final class SchemaVisitorPatternEncoder(
 
     def compilePath(path: Vector[PatternSegment]): Option[Vector[Writer]] =
       path.traverse(compile1(_))
+
     for {
       writers <- compilePath(segments.toVector)
     } yield new PathEncode[S] {
-      def encode(s: S): List[String] = writers.flatMap(_.apply(s)).toList
-      def encodeGreedy(s: S): List[String] = Nil
+      def encode(s: S, urlEncode: Boolean): List[String] =
+        writers.flatMap(_.apply(s, urlEncode)).toList
+      def encodeGreedy(s: S, urlEncode: Boolean): List[String] = Nil
     }
   }
 

--- a/modules/core/src/smithy4s/internals/StructurePatternRefinementProvider.scala
+++ b/modules/core/src/smithy4s/internals/StructurePatternRefinementProvider.scala
@@ -60,10 +60,12 @@ object StructurePatternRefinementProvider {
     val encoder =
       new SchemaVisitorPatternEncoder(segments)(sch)
         .getOrElse(
-          PathEncode.raw[A](_ =>
-            throw StructurePatternError(
-              s"Unable to create encoder for ${sch.shapeId}"
-            )
+          PathEncode.raw[A](
+            _ =>
+              throw StructurePatternError(
+                s"Unable to create encoder for ${sch.shapeId}"
+              ),
+            urlEncode = false
           )
         )
     (input: A) => {

--- a/modules/core/src/smithy4s/internals/StructurePatternRefinementProvider.scala
+++ b/modules/core/src/smithy4s/internals/StructurePatternRefinementProvider.scala
@@ -67,7 +67,7 @@ object StructurePatternRefinementProvider {
           )
         )
     (input: A) => {
-      val result = encoder.encode(input)
+      val result = encoder.encode(input, false) // TODO should this encode?
       result.mkString
     }
   }

--- a/modules/core/src/smithy4s/internals/StructurePatternRefinementProvider.scala
+++ b/modules/core/src/smithy4s/internals/StructurePatternRefinementProvider.scala
@@ -67,7 +67,7 @@ object StructurePatternRefinementProvider {
           )
         )
     (input: A) => {
-      val result = encoder.encode(input, false) // TODO should this encode?
+      val result = encoder.encode(input)
       result.mkString
     }
   }

--- a/modules/core/test/src/smithy4s/http/HttpEndpointSpec.scala
+++ b/modules/core/test/src/smithy4s/http/HttpEndpointSpec.scala
@@ -16,8 +16,16 @@
 
 package smithy4s.http
 
+import cats.effect._
+import cats.syntax.all._
+import org.scalacheck.Gen
+import smithy.api.{Http, NonEmptyString}
+import smithy4s._
+import smithy4s.http.HttpEndpoint._
 import weaver._
-import scala.util.Random
+import weaver.scalacheck._
+
+import scala.util._
 
 /**
  * The following algorithm is used to compare two paths
@@ -32,51 +40,68 @@ import scala.util.Random
   * If n > m then A is more specific than B
   * If p > q then A is more specific than B
   */
-object HttpEndpointSpec extends SimpleIOSuite {
+object HttpEndpointSpec extends SimpleIOSuite with Checkers {
 
-  final case class HttpEndpointDummy(
+  def httpEndpointDummy(
       path: List[PathSegment],
       staticQueryParams: Map[String, Seq[String]] = Map.empty
-  ) extends HttpEndpoint[Unit] {
-    override def path(input: Unit): List[String] =
-      throw new NotImplementedError(
-        "HttpEndpointOrderingSpec.HttpEndpointDummy.path"
-      )
-    override def encodedPath(input: Unit): List[String] =
-      throw new NotImplementedError(
-        "HttpEndpointOrderingSpec.HttpEndpointDummy.encodedPath"
-      )
-    override def method: HttpMethod = throw new NotImplementedError(
-      "HttpEndpointOrderingSpec.HttpEndpointDummy.method"
-    )
-    override def code: Int = throw new NotImplementedError(
-      "HttpEndpointOrderingSpec.HttpEndpointDummy.code"
-    )
-  }
+  ): Either[HttpEndpointError, HttpEndpoint[_]] =
+    HttpEndpoint.cast(
+      Schema
+        .operation(ShapeId("smithy4s.dummy", "a"))
+        .withHints(
+          Http(
+            NonEmptyString("GET"), {
+              val base = path
+                .map {
+                  case PathSegment.StaticSegment(value) => value
+                  case PathSegment.LabelSegment(value)  => s"{$value}"
+                  case PathSegment.GreedySegment(value) => value
+                }
+                .mkString("/")
 
-  pureTest("static > label > greedy") {
-    val a = HttpEndpointDummy(path =
+              val uri =
+                if (staticQueryParams.isEmpty) base
+                else {
+                  val qp = staticQueryParams
+                    .map { case (k, v) =>
+                      s"$k=${v.mkString(",")}"
+                    }
+                    .mkString("&")
+
+                  s"$base?$qp"
+                }
+
+              NonEmptyString(uri)
+            }
+          )
+        )
+        .withInput(Schema.string)
+    )
+
+  test("static > label > greedy") {
+    val a = httpEndpointDummy(
       List(
         PathSegment.static("abc"),
         PathSegment.static("bcd"),
         PathSegment.label("xyz")
       )
     )
-    val b = HttpEndpointDummy(path =
+    val b = httpEndpointDummy(path =
       List(
         PathSegment.static("abc"),
         PathSegment.label("xyz"),
         PathSegment.static("cde")
       )
     )
-    val c = HttpEndpointDummy(path =
+    val c = httpEndpointDummy(path =
       List(
         PathSegment.greedy("xyz"),
         PathSegment.static("bcd"),
         PathSegment.static("cde")
       )
     )
-    val d = HttpEndpointDummy(path =
+    val d = httpEndpointDummy(path =
       List(
         PathSegment.greedy("xyz"),
         PathSegment.label("bcd"),
@@ -84,64 +109,82 @@ object HttpEndpointSpec extends SimpleIOSuite {
       )
     )
 
-    val expectedOrder = List[HttpEndpoint[_]](a, b, c, d)
-    val shuffleOrder = Random.shuffle(expectedOrder)
+    List(a, b, c, d).sequence
+      .map { (expectedOrder: List[HttpEndpoint[_]]) =>
+        forall(Gen.long) { seed =>
+          val shuffleOrder = new Random(seed).shuffle(expectedOrder)
 
-    expect(shuffleOrder.sortWith(HttpEndpoint.moreSpecific) == expectedOrder)
+          expect(
+            shuffleOrder.sortWith(HttpEndpoint.moreSpecific) == expectedOrder
+          )
+        }
+      }
+      .getOrElse(IO(failure("could not initialize dummy segments")))
+
   }
 
   pureTest("A[x] and B[x] are both literals then continue") {
-    val a = HttpEndpointDummy(path = List(PathSegment.static("abc")))
-    val b = HttpEndpointDummy(path = List(PathSegment.static("bcd")))
+    val a = httpEndpointDummy(path = List(PathSegment.static("abc")))
+    val b = httpEndpointDummy(path = List(PathSegment.static("bcd")))
 
-    expect(HttpEndpoint.moreSpecific(a, b))
+    expectFirstIsMoreSpecificThanSecond(a, b)
   }
 
   pureTest(
     "A[x] is a literal and B[x] is a label then A is more specific than B"
   ) {
-    val a = HttpEndpointDummy(path =
+    val a = httpEndpointDummy(path =
       List(PathSegment.static("abc"), PathSegment.static("abc"))
     )
-    val b = HttpEndpointDummy(path =
+    val b = httpEndpointDummy(path =
       List(PathSegment.static("bcd"), PathSegment.label("xyz"))
     )
 
-    expect(HttpEndpoint.moreSpecific(a, b))
+    expectFirstIsMoreSpecificThanSecond(a, b)
   }
 
   pureTest(
     "A[x] is a non-greedy label and B[x] is a greedy label then A is more specific than B"
   ) {
-    val a = HttpEndpointDummy(path =
+    val a = httpEndpointDummy(path =
       List(PathSegment.static("abc"), PathSegment.label("abc"))
     )
-    val b = HttpEndpointDummy(path =
+    val b = httpEndpointDummy(path =
       List(PathSegment.static("bcd"), PathSegment.greedy("xyz"))
     )
 
-    expect(HttpEndpoint.moreSpecific(a, b))
+    expectFirstIsMoreSpecificThanSecond(a, b)
   }
 
   pureTest("n > m then A is more specific than B") {
-    val a = HttpEndpointDummy(path =
+    val a = httpEndpointDummy(path =
       List(PathSegment.static("abc"), PathSegment.static("bcd"))
     )
-    val b = HttpEndpointDummy(path = List(PathSegment.static("efg")))
+    val b = httpEndpointDummy(path = List(PathSegment.static("efg")))
 
-    expect(HttpEndpoint.moreSpecific(a, b))
+    expectFirstIsMoreSpecificThanSecond(a, b)
   }
 
   pureTest("p > q then A is more specific than B") {
-    val a = HttpEndpointDummy(
+    val a = httpEndpointDummy(
       path = List(PathSegment.static("abc")),
       staticQueryParams = Map("a" -> Seq.empty, "b" -> Seq.empty)
     )
-    val b = HttpEndpointDummy(
+    val b = httpEndpointDummy(
       path = List(PathSegment.static("abc")),
       staticQueryParams = Map("a" -> Seq.empty)
     )
 
-    expect(HttpEndpoint.moreSpecific(a, b))
+    expectFirstIsMoreSpecificThanSecond(a, b)
   }
+
+  private def expectFirstIsMoreSpecificThanSecond(
+      a: Either[HttpEndpointError, HttpEndpoint[_]],
+      b: Either[HttpEndpointError, HttpEndpoint[_]]
+  ): Expectations =
+    (a, b)
+      .mapN(HttpEndpoint.moreSpecific)
+      .map(expect(_))
+      .getOrElse(failure("could not initialize dummy segments"))
+
 }

--- a/modules/core/test/src/smithy4s/http/HttpEndpointSpec.scala
+++ b/modules/core/test/src/smithy4s/http/HttpEndpointSpec.scala
@@ -42,6 +42,10 @@ object HttpEndpointSpec extends SimpleIOSuite {
       throw new NotImplementedError(
         "HttpEndpointOrderingSpec.HttpEndpointDummy.path"
       )
+    override def encodedPath(input: Unit): List[String] =
+      throw new NotImplementedError(
+        "HttpEndpointOrderingSpec.HttpEndpointDummy.encodedPath"
+      )
     override def method: HttpMethod = throw new NotImplementedError(
       "HttpEndpointOrderingSpec.HttpEndpointDummy.method"
     )

--- a/modules/http4s-kernel/src/smithy4s/http4s/kernel/package.scala
+++ b/modules/http4s-kernel/src/smithy4s/http4s/kernel/package.scala
@@ -54,7 +54,12 @@ package object kernel {
       case 0             => headers
       case contentLength => headers.put("Content-Length" -> contentLength.toString)
     }
-    Request(method, fromSmithy4sHttpUri(req.uri), headers = updatedHeaders, body = toStream(req.body))
+    Request(
+      method,
+      fromSmithy4sHttpUri(req.uri),
+      headers = updatedHeaders,
+      body = toStream(req.body)
+    )
   }
 
   def toSmithy4sHttpUri(uri: Uri, pathParams: Option[PathParams] = None): Smithy4sHttpUri = {
@@ -97,7 +102,7 @@ package object kernel {
     }
 
   def fromSmithy4sHttpUri(uri: Smithy4sHttpUri): Uri = {
-    val path = Uri.Path.Root.addSegments(uri.path.map(Uri.Path.Segment(_)).toVector)
+    val path = Uri.Path.Root.addSegments(uri.path.map(Uri.Path.Segment.encoded))
 
     Uri(
       path = path,

--- a/modules/http4s-kernel/test/src/smithy4s/http4s/kernel/Http4sConversionSpec.scala
+++ b/modules/http4s-kernel/test/src/smithy4s/http4s/kernel/Http4sConversionSpec.scala
@@ -17,8 +17,9 @@
 package smithy4s.http4s.kernel
 
 import weaver._
-import org.http4s.implicits._
-import org.http4s.Uri
+import org.http4s.syntax.all._
+import org.http4s._
+import org.http4s.Uri._
 import smithy4s.http.HttpUriScheme
 
 object Http4sConversionSpec extends SimpleIOSuite {
@@ -106,7 +107,10 @@ object Http4sConversionSpec extends SimpleIOSuite {
     )
   }
 
-  private def http4sToSmithyAndBackUriTest(input: Uri, output: Uri) = {
+  private def http4sToSmithyAndBackUriTest(
+      input: Uri,
+      output: Uri
+  ): Unit = {
     pureTest(s"URI: http4s to smithy4s and back: $input -> $output") {
       expect.eql(
         output,

--- a/modules/http4s/src/smithy4s/http4s/SimpleRestJsonBuilder.scala
+++ b/modules/http4s/src/smithy4s/http4s/SimpleRestJsonBuilder.scala
@@ -26,7 +26,8 @@ object SimpleRestJsonBuilder
       new internals.SimpleRestJsonCodecs(
         jsonCodecs = Json.payloadCodecs,
         fieldFilter = FieldFilter.Default,
-        hostPrefixInjection = true
+        hostPrefixInjection = true,
+        rawHttpLabelValues = false
       )
     )
 
@@ -54,7 +55,8 @@ class SimpleRestJsonBuilder private (
               .withFieldFilter(fieldFilter)
           ),
         fieldFilter,
-        hostPrefixInjection
+        hostPrefixInjection,
+        rawHttpLabelValues = false
       )
     }
   }
@@ -88,6 +90,13 @@ class SimpleRestJsonBuilder private (
   ): SimpleRestJsonBuilder =
     new SimpleRestJsonBuilder(
       simpleRestJsonCodecs.withFieldFilter(fieldFilter)
+    )
+
+  def withRawHttpLabelValues(
+      enabled: Boolean
+  ): SimpleRestJsonBuilder =
+    new SimpleRestJsonBuilder(
+      simpleRestJsonCodecs.withRawHttpLabelValues(enabled)
     )
 
   def disableHostPrefixInjection(): SimpleRestJsonBuilder =

--- a/modules/http4s/src/smithy4s/http4s/internals/SimpleRestJsonCodecs.scala
+++ b/modules/http4s/src/smithy4s/http4s/internals/SimpleRestJsonCodecs.scala
@@ -38,13 +38,14 @@ import smithy4s.schema.FieldFilter
 private[http4s] class SimpleRestJsonCodecs(
     val jsonCodecs: JsonPayloadCodecCompiler,
     val fieldFilter: FieldFilter,
-    val hostPrefixInjection: Boolean
+    val hostPrefixInjection: Boolean,
+    val rawHttpLabelValues: Boolean
 ) extends SimpleProtocolCodecs {
   private val hintMask =
     alloy.SimpleRestJson.protocol.hintMask
 
   def transformJsonCodecs(f: JsonPayloadCodecCompiler => JsonPayloadCodecCompiler): SimpleRestJsonCodecs =
-    new SimpleRestJsonCodecs(f(jsonCodecs), fieldFilter, hostPrefixInjection)
+    new SimpleRestJsonCodecs(f(jsonCodecs), fieldFilter, hostPrefixInjection, rawHttpLabelValues)
 
   @deprecated(
     message = """Use withFieldFilter instead.
@@ -68,11 +69,20 @@ private[http4s] class SimpleRestJsonCodecs(
   ): SimpleRestJsonCodecs = new SimpleRestJsonCodecs(
     jsonCodecs.configureJsoniterCodecCompiler(_.withFieldFilter(fieldFilter)),
     fieldFilter,
-    hostPrefixInjection
+    hostPrefixInjection,
+    rawHttpLabelValues
   )
 
+  def withRawHttpLabelValues(enabled: Boolean): SimpleRestJsonCodecs =
+    new SimpleRestJsonCodecs(
+      jsonCodecs = jsonCodecs,
+      fieldFilter = fieldFilter,
+      hostPrefixInjection = hostPrefixInjection,
+      rawHttpLabelValues = enabled
+    )
+
   def withHostPrefixInjection(newHostPrefixInjection: Boolean): SimpleRestJsonCodecs =
-    new SimpleRestJsonCodecs(jsonCodecs, fieldFilter, newHostPrefixInjection)
+    new SimpleRestJsonCodecs(jsonCodecs, fieldFilter, newHostPrefixInjection, rawHttpLabelValues)
 
   // val mediaType = HttpMediaType("application/json")
   private val payloadEncoders: BlobEncoder.Compiler =
@@ -127,6 +137,7 @@ private[http4s] class SimpleRestJsonCodecs(
       .withRequestTransformation(fromSmithy4sHttpRequest[F](_).pure[F])
       .withResponseTransformation[Response[F]](toSmithy4sHttpResponse[F](_))
       .withHostPrefixInjection(hostPrefixInjection)
+      .withRawHttpLabelValues(rawHttpLabelValues)
       .build()
 
   }

--- a/modules/http4s/test/src/smithy4s/http4s/SimpleRestJsonComplianceSuite.scala
+++ b/modules/http4s/test/src/smithy4s/http4s/SimpleRestJsonComplianceSuite.scala
@@ -95,8 +95,7 @@ object SimpleRestJsonComplianceSuite extends ProtocolComplianceSuite {
       val baseUri = uri"http://localhost"
       val suppliedHost =
         testHost.map(host => Uri.unsafeFromString(s"http://$host"))
-      SimpleRestJsonBuilder
-        .apply(service)
+      SimpleRestJsonBuilder(service)
         .client(Client.fromHttpApp(app))
         .uri(suppliedHost.getOrElse(baseUri))
         .resource

--- a/modules/http4s/test/src/smithy4s/http4s/SimpleRestJsonComplianceSuite.scala
+++ b/modules/http4s/test/src/smithy4s/http4s/SimpleRestJsonComplianceSuite.scala
@@ -95,7 +95,8 @@ object SimpleRestJsonComplianceSuite extends ProtocolComplianceSuite {
       val baseUri = uri"http://localhost"
       val suppliedHost =
         testHost.map(host => Uri.unsafeFromString(s"http://$host"))
-      SimpleRestJsonBuilder(service)
+      SimpleRestJsonBuilder
+        .apply(service)
         .client(Client.fromHttpApp(app))
         .uri(suppliedHost.getOrElse(baseUri))
         .resource

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -40,7 +40,7 @@ object Dependencies {
 
   val Smithytranslate = new {
     val org = "com.disneystreaming.smithy"
-    val smithyTranslateVersion = "0.5.9"
+    val smithyTranslateVersion = "0.5.10"
     val proto = org %% "smithytranslate-proto" % smithyTranslateVersion
   }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -31,7 +31,7 @@ object Dependencies {
 
   val Alloy = new {
     val org = "com.disneystreaming.alloy"
-    val alloyVersion = "0.3.26"
+    val alloyVersion = "0.3.29"
     val core = org % "alloy-core" % alloyVersion
     val openapi = org %% "alloy-openapi" % alloyVersion
     val protobuf = org % "alloy-protobuf" % alloyVersion


### PR DESCRIPTION
I was a little surprised to find that I didn't need to modify `toSmithy4sHttpUri` to make this test pass, so I wanted to get some feedback before I get too much further into modifying `AwsClient` and `SimpleRestJson` as laid out in #1663.

Needs https://github.com/disneystreaming/alloy/pull/210