### PR TITLE
#837, option A

### DIFF
--- a/modules/codegen/src/smithy4s/codegen/internals/ModelLoader.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/ModelLoader.scala
@@ -46,12 +46,18 @@ private[codegen] object ModelLoader {
       localJars: List[os.Path]
   ): (ClassLoader, Model) = {
     val currentClassLoader = this.getClass().getClassLoader()
-    val deps = resolveDependencies(dependencies, localJars, repositories)
+
+    val resolvedDepsAndFiles = resolveDependencies(dependencies, repositories)
+    val resolvedDeps = resolvedDepsAndFiles.map(_._1)
+
+    val deps =
+      resolvedDepsAndFiles.map(_._2) ++
+        localJars
 
     val modelsInJars = deps.flatMap { file =>
       Using.resource(
         // Note: On JDK13+, the second parameter is redundant.
-        FileSystems.newFileSystem(file.toPath(), null: ClassLoader)
+        FileSystems.newFileSystem(file.toNIO, null: ClassLoader)
       ) { jarFS =>
         val p = jarFS.getPath("META-INF", "smithy", "manifest")
 
@@ -75,7 +81,7 @@ private[codegen] object ModelLoader {
       .assembler()
       // disabling cache to support snapshot-driven experimentation
       .putProperty(ModelAssembler.DISABLE_JAR_CACHE, true)
-      .addClasspathModels(currentClassLoader, discoverModels)
+      .addClasspathModels(currentClassLoader, discoverModels, resolvedDeps)
       .addImports(modelsInJars)
       .assemble()
       .unwrap()
@@ -92,7 +98,7 @@ private[codegen] object ModelLoader {
     }
 
     val validatorClassLoader = locally {
-      val jarUrls = deps.map(_.toURI().toURL()).toArray
+      val jarUrls = deps.map(_.toIO.toURI().toURL()).toArray
       new URLClassLoader(jarUrls, currentClassLoader)
     }
 
@@ -127,9 +133,8 @@ private[codegen] object ModelLoader {
 
   private def resolveDependencies(
       dependencies: List[String],
-      localJars: List[os.Path],
       repositories: List[String]
-  ): Seq[File] = {
+  ): Seq[(Dependency, os.Path)] = {
     val maybeRepos = RepositoryParser.repositories(repositories).either
     val maybeDeps = DependencyParser
       .dependencies(
@@ -151,16 +156,17 @@ private[codegen] object ModelLoader {
         )
       case Right(d) => d
     }
-    val resolvedDeps: Seq[java.io.File] =
-      if (deps.nonEmpty) {
-        val fetch = Fetch(FileCache())
-          .addRepositories(repos: _*)
-          .addDependencies(deps: _*)
-        fetch.run()
-      } else {
-        Seq.empty
+
+    if (deps.nonEmpty) {
+      val fetch = Fetch(FileCache())
+        .addRepositories(repos: _*)
+        .addDependencies(deps: _*)
+      fetch.runResult().detailedArtifacts.map { case (dep, _, _, f) =>
+        (dep, os.Path(f))
       }
-    resolvedDeps ++ localJars.map(_.toIO)
+    } else {
+      Nil
+    }
   }
 
   implicit class ModelAssemblerOps(assembler: ModelAssembler) {
@@ -176,15 +182,29 @@ private[codegen] object ModelLoader {
 
     def addClasspathModels(
         classLoader: ClassLoader,
-        discoverModels: Boolean
+        discoverModels: Boolean,
+        resolvedDeps: Seq[Dependency]
     ): ModelAssembler = {
+
+      val isProtocolAlreadyIncluded = resolvedDeps
+        .map(_.module)
+        .contains(
+          Module(
+            Organization(BuildInfo.smithy4sOrg),
+            ModuleName("smithy4s-protocol")
+          )
+        )
+
       val smithy4sResources = List(
         "META-INF/smithy/smithy4s.meta.smithy"
       ).map(classLoader.getResource)
 
       if (discoverModels) {
         assembler.discoverModels(classLoader)
-      } else addImports(smithy4sResources)
+      } else if (!isProtocolAlreadyIncluded)
+        assembler.addImports(smithy4sResources)
+      else
+        assembler
     }
   }
 

--- a/modules/codegen/test/src/smithy4s/codegen/internals/ModelLoaderSpec.scala
+++ b/modules/codegen/test/src/smithy4s/codegen/internals/ModelLoaderSpec.scala
@@ -60,6 +60,17 @@ class ModelLoaderSpec extends FunSuite {
     model.expectShape(ShapeId.from("testlibrary#MyString"))
   }
 
+  test(
+    "ModelLoader can load a version of the smithy4s protocol conflicting against the current"
+  ) {
+    doLoad(
+      dependencies =
+        List("com.disneystreaming.smithy4s:smithy4s-protocol:0.18.29"),
+      repositories = Nil
+    )
+    // nothing failed
+  }
+
   test("ModelLoader can load a dependency from s01 if it has a + in the name") {
     val model = doLoad(
       dependencies =


### PR DESCRIPTION
Closes #837.

- check if the protocol is already included (any version of it), before attempting to add our own from the local classpath.

Main problem: in case a lower version is included in the dependencies, the lower version will be picked for model loading - smithy4s's own fixes won't be taken into account, this could pose problems.

---

## PR Checklist (not all items are relevant to all PRs)

- [ ] Added unit-tests (for runtime code)
- [ ] Added bootstrapped code + smoke tests (when the rendering logic is modified)
- [ ] Added build-plugins integration tests (when reflection loading is required at codegen-time)
- [ ] Added alloy compliance tests (when simpleRestJson protocol behaviour is expanded/updated)
- [ ] Updated dynamic module to match generated-code behaviour
- [ ] Added documentation
- [ ] Updated changelog
