### PR TITLE
Prevent conflicts in the protocol jar (#837), option B

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Thank you!
 
 # 0.18.32
 
-* Fixes an issue in which smithy4s-protocol would conflict with its previous versions during codegen ([#837](https://github.com/disneystreaming/smithy4s/issues/837)) in [#1672](https://github.com/disneystreaming/smithy4s/pull/1672)
+* codegen: Fix an issue in which smithy4s-protocol would conflict with its previous versions if they're in the dependencies ([#837](https://github.com/disneystreaming/smithy4s/issues/837)) in [#1672](https://github.com/disneystreaming/smithy4s/pull/1672)
 * Adds a missing space in the type annotations of smart constructors in [#1674](https://github.com/disneystreaming/smithy4s/pull/1674)
 * More expressive namespace patterns for the codegen in [#1649](https://github.com/disneystreaming/smithy4s/pull/1649)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Thank you!
 
 # 0.18.32
 
+* Fixes an issue in which smithy4s-protocol would conflict with its previous versions during codegen ([#837](https://github.com/disneystreaming/smithy4s/issues/837)) in [#1672](https://github.com/disneystreaming/smithy4s/pull/1672)
 * Adds a missing space in the type annotations of smart constructors in [#1674](https://github.com/disneystreaming/smithy4s/pull/1674)
 * More expressive namespace patterns for the codegen in [#1649](https://github.com/disneystreaming/smithy4s/pull/1649)
 

--- a/build.sbt
+++ b/build.sbt
@@ -495,7 +495,7 @@ lazy val codegenPlugin = (projectMatrix in file("modules/codegen-plugin"))
 
         // for sbt
         (codegen.jvm(Scala212) / publishLocal).value,
-        (protocol.jvm(autoScalaLibrary = false) / publishLocal).value
+        (protocolJvm / publishLocal).value
       )
       publishLocal.value
     },
@@ -536,7 +536,7 @@ lazy val millCodegenPlugin = projectMatrix
         (codegen.jvm(Scala213) / publishLocal).value,
 
         // for mill
-        (protocol.jvm(autoScalaLibrary = false) / publishLocal).value
+        (protocolJvm / publishLocal).value
       )
       publishLocal.value
     },
@@ -589,6 +589,8 @@ lazy val protocol = projectMatrix
     libraryDependencies += Dependencies.Smithy.model,
     javacOptions ++= Seq("--release", "8")
   )
+
+lazy val protocolJvm = protocol.jvm(autoScalaLibrary = false)
 
 lazy val protocolTests = projectMatrix
   .in(file("modules/protocol-tests"))

--- a/build.sbt
+++ b/build.sbt
@@ -409,7 +409,7 @@ lazy val codegen = projectMatrix
       "alloyOrg" -> Dependencies.Alloy.org,
       "alloyVersion" -> Dependencies.Alloy.alloyVersion,
       "smithy4sOrg" -> organization.value,
-      "protocolArtifactName" -> "smithy4s-protocol",
+      "protocolArtifactName" -> "smithy4s-protocol"
     ),
     buildInfoPackage := "smithy4s.codegen",
     libraryDependencies ++= Seq(
@@ -435,7 +435,10 @@ lazy val codegen = projectMatrix
       sourceManaged
         .map(AwsBoilerplate.generate(_))
         .taskValue,
-    }
+    },
+    (Compile / compile) := (Compile / compile)
+      .dependsOn((protocol.jvm(autoScalaLibrary = false) / publishLocal))
+      .value
   )
 
 /**

--- a/modules/codegen/src/smithy4s/codegen/SmithyBuildJson.scala
+++ b/modules/codegen/src/smithy4s/codegen/SmithyBuildJson.scala
@@ -26,9 +26,6 @@ import scala.collection.immutable.ListSet
 
 private[codegen] object SmithyBuildJson {
 
-  val protocolDependency =
-    s"${BuildInfo.smithy4sOrg}:${BuildInfo.protocolArtifactName}:${BuildInfo.version}"
-
   def toJson(
       sources: ListSet[String],
       dependencies: ListSet[String],

--- a/modules/codegen/src/smithy4s/codegen/internals/ModelLoader.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/ModelLoader.scala
@@ -47,7 +47,7 @@ private[codegen] object ModelLoader {
   ): (ClassLoader, Model) = {
     val currentClassLoader = this.getClass().getClassLoader()
     val deps = resolveDependencies(
-      dependencies :+ s"${BuildInfo.smithy4sOrg}:${BuildInfo.protocolArtifactName}:${BuildInfo.version}",
+      dependencies :+ protocolDependency,
       localJars,
       repositories
     )

--- a/modules/codegen/src/smithy4s/codegen/internals/ModelLoader.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/ModelLoader.scala
@@ -46,7 +46,11 @@ private[codegen] object ModelLoader {
       localJars: List[os.Path]
   ): (ClassLoader, Model) = {
     val currentClassLoader = this.getClass().getClassLoader()
-    val deps = resolveDependencies(dependencies, localJars, repositories)
+    val deps = resolveDependencies(
+      dependencies :+ s"${BuildInfo.smithy4sOrg}:${BuildInfo.protocolArtifactName}:${BuildInfo.version}",
+      localJars,
+      repositories
+    )
 
     val modelsInJars = deps.flatMap { file =>
       Using.resource(
@@ -178,13 +182,9 @@ private[codegen] object ModelLoader {
         classLoader: ClassLoader,
         discoverModels: Boolean
     ): ModelAssembler = {
-      val smithy4sResources = List(
-        "META-INF/smithy/smithy4s.meta.smithy"
-      ).map(classLoader.getResource)
-
       if (discoverModels) {
         assembler.discoverModels(classLoader)
-      } else addImports(smithy4sResources)
+      } else assembler
     }
   }
 

--- a/modules/codegen/src/smithy4s/codegen/package.scala
+++ b/modules/codegen/src/smithy4s/codegen/package.scala
@@ -17,5 +17,9 @@
 package smithy4s
 
 package object codegen {
-  val SMITHY4S_DEPENDENCIES = "smithy4sDependencies"
+  val SMITHY4S_DEPENDENCIES: String = "smithy4sDependencies"
+
+  val protocolDependency: String =
+    s"${BuildInfo.smithy4sOrg}:${BuildInfo.protocolArtifactName}:${BuildInfo.version}"
+
 }

--- a/modules/codegen/test/src/smithy4s/codegen/internals/ModelLoaderSpec.scala
+++ b/modules/codegen/test/src/smithy4s/codegen/internals/ModelLoaderSpec.scala
@@ -71,6 +71,16 @@ class ModelLoaderSpec extends FunSuite {
     // nothing failed
   }
 
+  test(
+    "ModelLoader can load a version of Alloy conflicting against the current"
+  ) {
+    doLoad(
+      dependencies = List("com.disneystreaming.alloy:alloy-core:0.1.18"),
+      repositories = Nil
+    )
+    // nothing failed
+  }
+
   test("ModelLoader can load a dependency from s01 if it has a + in the name") {
     val model = doLoad(
       dependencies =

--- a/modules/codegen/test/src/smithy4s/codegen/internals/ModelLoaderSpec.scala
+++ b/modules/codegen/test/src/smithy4s/codegen/internals/ModelLoaderSpec.scala
@@ -60,6 +60,17 @@ class ModelLoaderSpec extends FunSuite {
     model.expectShape(ShapeId.from("testlibrary#MyString"))
   }
 
+  test(
+    "ModelLoader can load a version of the smithy4s protocol conflicting against the current"
+  ) {
+    doLoad(
+      dependencies =
+        List("com.disneystreaming.smithy4s:smithy4s-protocol:0.18.29"),
+      repositories = Nil
+    )
+    // nothing failed
+  }
+
   test("ModelLoader can load a dependency from s01 if it has a + in the name") {
     val model = doLoad(
       dependencies =


### PR DESCRIPTION
Closes #837.

- Hardcode the artifactId of `smithy4s-protocol` based on BuildInfo, always pass it to the coursier resolution - that would apply deconflicting on Coursier's side, allowing the user to still use a newer protocol version than the one they (maybe transitively) provide. This would replace the manual import of `smithy4s.meta.smithy`
- Make sure `protocol/publishLocal` runs before the codegen runs. The easiest way to ensure this in both local codegen, its publishing AND its tests - was to add `protocol/publishLocal` to `codegen/compile`. There's already a dependency between the two, so the extra overhead of publishing to ivy2 local is low. We can also add caching around it.

Main problem: sketchy `compile->publishLocal` dependency, although I'm not sure I see anything bad about that.

Note: I already tried to do something like this in #1520, but for a whole other reason (just thought the explicit import was weird).

## PR Checklist (not all items are relevant to all PRs)

- [x] Added unit-tests (for runtime code)
- [ ] Added bootstrapped code + smoke tests (when the rendering logic is modified)
- [ ] Added build-plugins integration tests (when reflection loading is required at codegen-time)
- [ ] Added alloy compliance tests (when simpleRestJson protocol behaviour is expanded/updated)
- [ ] Updated dynamic module to match generated-code behaviour
- [ ] Added documentation
- [x] Updated changelog
