### PR TITLE
fix ambiguous methods in HttpUnaryServerRouter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ When adding entries, please treat them as if they could end up in a release any 
 
 Thank you!
 
+# 0.18.34
+
+* Update `HttpUnaryServerRouter#partialFunction` to remove ambiguity between the two methods
+
 # 0.18.33
 
 * codegen: Fix an issue in which using UUIDs as trait or default values would prevent code generation in [#1685](https://github.com/disneystreaming/smithy4s/pull/1685)

--- a/build.sbt
+++ b/build.sbt
@@ -263,6 +263,11 @@ lazy val core = projectMatrix
       ),
       ProblemFilters.exclude[DirectMissingMethodProblem](
         "smithy4s.http.HttpUnaryServerRouter#PartialFunctionRouter.this"
+      ),
+      // Breaking bin-compat to walk back ambiguous methods introduced in
+      // https://github.com/disneystreaming/smithy4s/pull/1669
+      ProblemFilters.exclude[IncompatibleMethTypeProblem](
+        "smithy4s.http.HttpUnaryServerRouter.partialFunction"
       )
     )
   )

--- a/modules/core/src/smithy4s/http/HttpUnaryServerRouter.scala
+++ b/modules/core/src/smithy4s/http/HttpUnaryServerRouter.scala
@@ -77,15 +77,15 @@ object HttpUnaryServerRouter {
     * such as Play.
     */
   def partialFunction[Alg[_[_, _, _, _, _]], F[_], RequestHead, Request, Response](
-      service: smithy4s.Service[Alg]
+      service: smithy4s.Service[Alg],
+      encodeErrorsBeforeMiddleware: Boolean
   )(
       impl: service.Impl[F],
       makeServerCodecs: UnaryServerCodecs.Make[F, Request, Response],
       endpointMiddleware: Endpoint.Middleware[Request => F[Response]],
       getMethod: RequestHead => HttpMethod,
       getUri: RequestHead => HttpUri,
-      addDecodedPathParams: (Request, PathParams) => Request,
-      encodeErrorsBeforeMiddleware: Boolean
+      addDecodedPathParams: (Request, PathParams) => Request
   )(implicit F: MonadThrowLike[F]): PartialFunction[RequestHead, Request => F[Response]] = {
     new PartialFunctionRouter[Alg, service.Operation, F, RequestHead, Request, Response](
       service,


### PR DESCRIPTION
## PR Checklist (not all items are relevant to all PRs)

- [ ] Added unit-tests (for runtime code)
- [ ] Added bootstrapped code + smoke tests (when the rendering logic is modified)
- [ ] Added build-plugins integration tests (when reflection loading is required at codegen-time)
- [ ] Added alloy compliance tests (when simpleRestJson protocol behaviour is expanded/updated)
- [ ] Updated dynamic module to match generated-code behaviour
- [ ] Added documentation
- [x] Updated changelog
