### PR TITLE
Don't use -release flag

### DIFF
--- a/project/Smithy4sBuildPlugin.scala
+++ b/project/Smithy4sBuildPlugin.scala
@@ -245,9 +245,9 @@ object Smithy4sBuildPlugin extends AutoPlugin {
   }
 
   def targetScalacOptions(scalaVersion: String) =
-    if (scalaVersion.startsWith("2.12")) Seq("-target:jvm-1.8", "-release", "8")
-    else if (scalaVersion.startsWith("2.13")) Seq("-release", "8")
-    else if (scalaVersion.startsWith("3.")) Seq("-release", "8")
+    if (scalaVersion.startsWith("2.12")) Seq.empty // Scala 2.12 can't emit classfiles that require more than Java 8.
+    else if (scalaVersion.startsWith("2.13")) Seq("-java-output-version:8")
+    else if (scalaVersion.startsWith("3.")) Seq("-java-output-version:8")
     else Seq.empty // when we get Scala 4...
 
   def filterScala3Options(opts: Seq[String]) =


### PR DESCRIPTION
Workaround/solution for https://github.com/scalameta/metals/issues/7359

Also, `-release` was deprecated in Scala 2.12 because:

> `-target is deprecated: Scala 2.12 cannot emit valid class files for targets newer than 8 (this is possible with Scala 2.13). Use -release to compile against a specific platform API version.`

The `-java-output-version` flags work on both 2.13 and 3.x:

<img width="1856" alt="image" src="https://github.com/user-attachments/assets/eb0120cc-193c-405f-a33c-03892b250711" />

## PR Checklist (not all items are relevant to all PRs)

- [ ] Added unit-tests (for runtime code)
- [ ] Added bootstrapped code + smoke tests (when the rendering logic is modified)
- [ ] Added build-plugins integration tests (when reflection loading is required at codegen-time)
- [ ] Added alloy compliance tests (when simpleRestJson protocol behaviour is expanded/updated)
- [ ] Updated dynamic module to match generated-code behaviour
- [ ] Added documentation
- [ ] Updated changelog
