### PR TITLE
Update Coursier (allows using local Alloy snapshots)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -448,7 +448,7 @@ lazy val codegen = projectMatrix
       Dependencies.Circe.generic.value,
       Dependencies.collectionsCompat.value,
       "org.scala-lang" % "scala-reflect" % scalaVersion.value,
-      "io.get-coursier" %% "coursier" % "2.1.9"
+      "io.get-coursier" %% "coursier" % "2.1.24"
     ),
     libraryDependencies ++= munitDeps.value,
     scalacOptions := scalacOptions.value


### PR DESCRIPTION
Closes #1692.

The reason we need this is probably https://github.com/com-lihaoyi/mill/pull/4077 (or another change in Mill 0.12.4)

## PR Checklist (not all items are relevant to all PRs)

- [ ] Added unit-tests (for runtime code)
- [ ] Added bootstrapped code + smoke tests (when the rendering logic is modified)
- [ ] Added build-plugins integration tests (when reflection loading is required at codegen-time)
- [ ] Added alloy compliance tests (when simpleRestJson protocol behaviour is expanded/updated)
- [ ] Updated dynamic module to match generated-code behaviour
- [ ] Added documentation
- [ ] Updated changelog
