### PR TITLE
Fix: Lazy native hints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ When adding entries, please treat them as if they could end up in a release any 
 
 Thank you!
 
+# 0.18.35
+
+* codegen: Prevent `StackOverflowError` in dealing with recursive collection traits in [#1708](https://github.com/disneystreaming/smithy4s/pull/1708)
+
 # 0.18.34
 
 * codegen-cli: Ensure the command returns a failing exit code if command line arguments aren't valid in [#1694](https://github.com/disneystreaming/smithy4s/pull/1694).

--- a/modules/bootstrapped/src/generated/smithy4s/example/RecursiveListTrait.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/RecursiveListTrait.scala
@@ -1,0 +1,19 @@
+package smithy4s.example
+
+import smithy4s.Hints
+import smithy4s.Newtype
+import smithy4s.Schema
+import smithy4s.ShapeId
+import smithy4s.schema.Schema.bijection
+import smithy4s.schema.Schema.list
+import smithy4s.schema.Schema.recursive
+import smithy4s.schema.Schema.string
+
+object RecursiveListTrait extends Newtype[List[String]] {
+  val id: ShapeId = ShapeId("smithy4s.example", "RecursiveListTrait")
+  val hints: Hints = Hints(
+    smithy.api.Trait(selector = None, structurallyExclusive = None, conflicts = None, breakingChanges = None),
+  ).lazily
+  val underlyingSchema: Schema[List[String]] = list(string.addMemberHints(smithy4s.example.RecursiveListTrait(List()))).withId(id).addHints(hints)
+  implicit val schema: Schema[RecursiveListTrait] = recursive(bijection(underlyingSchema, asBijection))
+}

--- a/modules/bootstrapped/src/generated/smithy4s/example/RecursiveMapTrait.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/RecursiveMapTrait.scala
@@ -1,0 +1,19 @@
+package smithy4s.example
+
+import smithy4s.Hints
+import smithy4s.Newtype
+import smithy4s.Schema
+import smithy4s.ShapeId
+import smithy4s.schema.Schema.bijection
+import smithy4s.schema.Schema.map
+import smithy4s.schema.Schema.recursive
+import smithy4s.schema.Schema.string
+
+object RecursiveMapTrait extends Newtype[Map[String, String]] {
+  val id: ShapeId = ShapeId("smithy4s.example", "RecursiveMapTrait")
+  val hints: Hints = Hints(
+    smithy.api.Trait(selector = None, structurallyExclusive = None, conflicts = None, breakingChanges = None),
+  ).lazily
+  val underlyingSchema: Schema[Map[String, String]] = map(string.addMemberHints(smithy4s.example.RecursiveMapTrait(Map())), string).withId(id).addHints(hints)
+  implicit val schema: Schema[RecursiveMapTrait] = recursive(bijection(underlyingSchema, asBijection))
+}

--- a/modules/bootstrapped/src/generated/smithy4s/example/package.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/package.scala
@@ -95,6 +95,8 @@ package object example {
   type PublisherId = smithy4s.example.PublisherId.Type
   type PublishersList = smithy4s.example.PublishersList.Type
   type RecursiveList = smithy4s.example.RecursiveList.Type
+  type RecursiveListTrait = smithy4s.example.RecursiveListTrait.Type
+  type RecursiveMapTrait = smithy4s.example.RecursiveMapTrait.Type
   type SomeIndexSeq = smithy4s.example.SomeIndexSeq.Type
   type SomeInt = smithy4s.example.SomeInt.Type
   type SomeValue = smithy4s.example.SomeValue.Type

--- a/modules/codegen/src/smithy4s/codegen/internals/CollisionAvoidance.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/CollisionAvoidance.scala
@@ -198,11 +198,12 @@ private[internals] object CollisionAvoidance {
   private def modRef(ref: Type.Ref): Type.Ref =
     Type.Ref(ref.namespace, protectKeyword(ref.name.capitalize))
 
-  private def modNativeHint(hint: Hint.Native): Hint.Native =
+  private def modNativeHint(hint: Hint.Native): Hint.Native = {
     Hint.Native(
       hint.shapeId,
-      recursion.preprocess(modTypedNode)(hint.typedNode)
+      hint.typedNode.map(recursion.preprocess(modTypedNode))
     )
+  }
 
   private def modDefaultHint(hint: Hint.Default): Hint.Default =
     Hint.Default(recursion.preprocess(modTypedNode)(hint.typedNode))

--- a/modules/codegen/src/smithy4s/codegen/internals/IR.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/IR.scala
@@ -338,7 +338,13 @@ private[internals] object CollectionType {
   case object IndexedSeq extends CollectionType(NameRef("scala.IndexedSeq"))
 }
 
-private[internals] sealed trait Hint
+private[internals] sealed trait Hint {
+  def sameNativeTrait(native: Hint.Native): Boolean =
+    this match {
+      case Hint.Native(shapeId, _) => shapeId == native.shapeId
+      case _                       => false
+    }
+}
 
 private[internals] object Hint {
   case object Trait extends Hint
@@ -356,8 +362,13 @@ private[internals] object Hint {
   ) extends Hint
   case class Deprecated(message: Option[String], since: Option[String])
       extends Hint
-  // traits that get rendered generically
-  case class Native(shapeId: ShapeId, typedNode: Fix[TypedNode]) extends Hint
+
+  // Traits that get rendered generically.
+  // The typed node is potentially lazy, to simplify the handling of recursive traits:
+  // https://github.com/disneystreaming/smithy4s/issues/1308
+  // https://github.com/disneystreaming/smithy4s/issues/1296
+  case class Native(shapeId: ShapeId, typedNode: Eval[Fix[TypedNode]])
+      extends Hint
   case object IntEnum extends Hint
   case object OpenEnum extends Hint
 

--- a/modules/codegen/src/smithy4s/codegen/internals/Renderer.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/Renderer.scala
@@ -1500,7 +1500,7 @@ private[internals] class Renderer(compilationUnit: CompilationUnit) { self =>
 
   private def renderHint(hint: Hint.Native): Line =
     recursion
-      .cata(renderTypedNode)(hint.typedNode)
+      .cata(renderTypedNode)(hint.typedNode.value)
       .run(true)
       ._2
 

--- a/modules/codegen/src/smithy4s/codegen/internals/SmithyToIR.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/SmithyToIR.scala
@@ -1069,7 +1069,7 @@ private[codegen] class SmithyToIR(
 
     def tpe: Option[Type] = shape.accept(toType)
 
-    private def fieldsInternal(hintsExtractor: Shape => List[Hint]) = {
+    def fields: List[Field] = {
       val noDefault =
         if (defaultRenderMode == DefaultRenderMode.NoDefaults)
           List(Hint.NoDefault)
@@ -1088,7 +1088,7 @@ private[codegen] class SmithyToIR(
             member.getMemberName(),
             member.tpe,
             modifier,
-            hintsExtractor(member) ++ default ++ noDefault
+            hints(member) ++ default ++ noDefault
           )
         }
         .zipWithIndex
@@ -1111,20 +1111,6 @@ private[codegen] class SmithyToIR(
         case DefaultRenderMode.NoDefaults => result
       }
     }
-
-    /**
-      * Should be used when calculating schema for a structure.
-      *
-      * See https://github.com/disneystreaming/smithy4s/issues/1296 for details.
-      */
-    def fields: List[Field] = fieldsInternal(hintsExtractor = hints)
-
-    /**
-      * Should be used only on the call site
-      * of the trait application where there is no need to call `unfoldTrait` for every hint of the trait.
-      */
-    def getFieldsPlain: List[Field] =
-      fieldsInternal(hintsExtractor = _ => List.empty)
 
     def alts = {
       shape
@@ -1287,8 +1273,8 @@ private[codegen] class SmithyToIR(
       case (N.ObjectNode(map), UnRef(S.Structure(struct))) =>
         val shapeId = struct.getId()
         val ref = Type.Ref(shapeId.getNamespace(), shapeId.getName())
-        val structFields = struct.getFieldsPlain
-        val fieldNames = struct.getFieldsPlain.map(_.name)
+        val structFields = struct.fields
+        val fieldNames = struct.fields.map(_.name)
         val fields: List[TypedNode.FieldTN[NodeAndType]] = structFields.map {
           case Field(_, realName, tpe, mod, _, _)
               if mod.typeMod == Field.TypeModification.None =>

--- a/modules/codegen/src/smithy4s/codegen/internals/SmithyToIR.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/SmithyToIR.scala
@@ -157,7 +157,7 @@ private[codegen] class SmithyToIR(
 
         shape.tpe.flatMap {
           case Type.Alias(_, name, tpe: Type.ExternalType, isUnwrapped) =>
-            val newHints = hints.filterNot(_ == tpe.refinementHint)
+            val newHints = hints.filterNot(_ sameNativeTrait tpe.refinementHint)
             TypeAlias(
               shape.getId(),
               name,
@@ -686,8 +686,9 @@ private[codegen] class SmithyToIR(
       def getHints(tpe: Type, shape: Shape): List[Hint] = {
         val h = hints(shape)
         tpe match {
-          case e: Type.ExternalType => h.filterNot(_ == e.refinementHint)
-          case _                    => h
+          case e: Type.ExternalType =>
+            h.filterNot(_ sameNativeTrait e.refinementHint)
+          case _ => h
         }
       }
 
@@ -701,13 +702,7 @@ private[codegen] class SmithyToIR(
           }
           .map { tpe =>
             val _hints = hints(x)
-            val memberHints = {
-              val h = hints(x.getMember())
-              tpe match {
-                case e: Type.ExternalType => h.filterNot(_ == e.refinementHint)
-                case _                    => h
-              }
-            }
+            val memberHints = getHints(tpe, x.getMember)
             if (_hints.contains(Hint.UniqueItems)) {
               Type.Collection(CollectionType.Set, tpe, memberHints)
             } else if (_hints.contains(Hint.SpecializedList.Vector)) {
@@ -1099,7 +1094,7 @@ private[codegen] class SmithyToIR(
         .zipWithIndex
         .collect {
           case ((name, Some(tpe: Type.ExternalType), modifier, hints), index) =>
-            val newHints = hints.filterNot(_ == tpe.refinementHint)
+            val newHints = hints.filterNot(_ sameNativeTrait tpe.refinementHint)
             Field(name, tpe, modifier, index, newHints)
           case ((name, Some(tpe), modifier, hints), index) =>
             Field(name, tpe, modifier, index, hints)
@@ -1154,7 +1149,7 @@ private[codegen] class SmithyToIR(
             Alt(
               name,
               UnionMember.TypeCase(tpe),
-              h.filterNot(_ == tpe.refinementHint)
+              h.filterNot(_ sameNativeTrait tpe.refinementHint)
             )
           case (name, Some(Right(tpe)), h) =>
             Alt(name, UnionMember.TypeCase(tpe), h)
@@ -1280,7 +1275,10 @@ private[codegen] class SmithyToIR(
   }
 
   private def unfoldTrait(tr: Trait): Hint.Native = {
-    Hint.Native(tr.toShapeId, unfoldNode(tr.toNode(), tr.toShapeId()))
+    Hint.Native(
+      tr.toShapeId,
+      cats.Eval.later(unfoldNode(tr.toNode(), tr.toShapeId()))
+    )
   }
 
   private def unfoldNodeAndType(layer: NodeAndType): TypedNode[NodeAndType] =

--- a/sampleSpecs/recursive.smithy
+++ b/sampleSpecs/recursive.smithy
@@ -3,6 +3,7 @@ namespace smithy4s.example
 structure IntList {
     @required
     head: Integer
+
     tail: IntList
 }
 

--- a/sampleSpecs/recursiveTraitStructure.smithy
+++ b/sampleSpecs/recursiveTraitStructure.smithy
@@ -2,8 +2,25 @@ $version: "2"
 
 namespace smithy4s.example
 
+// https://github.com/disneystreaming/smithy4s/issues/1296
 @trait
 structure RecursiveTraitStructure {
     @RecursiveTraitStructure
     name: String
+}
+
+// https://github.com/disneystreaming/smithy4s/issues/1308
+@trait
+list RecursiveListTrait {
+    @RecursiveListTrait
+    member: String
+}
+
+// https://github.com/disneystreaming/smithy4s/issues/1308
+@trait
+map RecursiveMapTrait {
+    @RecursiveMapTrait
+    key: String
+
+    value: String
 }


### PR DESCRIPTION
Closes #1308, maybe some other undiscovered bugs too.

Supersedes the fix from #1305.

Update: this also halved the time codegen took for our model of ~100k shapes.

## PR Checklist (not all items are relevant to all PRs)

- [ ] Added unit-tests (for runtime code)
- [x] Added bootstrapped code + smoke tests (when the rendering logic is modified)
- [ ] Added build-plugins integration tests (when reflection loading is required at codegen-time)
- [ ] Added alloy compliance tests (when simpleRestJson protocol behaviour is expanded/updated)
- [ ] Updated dynamic module to match generated-code behaviour
- [ ] Added documentation
- [x] Updated changelog
