### PR TITLE
Increase CodeHeap for non-profiled nmethods in .sbtopts.example

### DIFF
--- a/.sbtopts.example
+++ b/.sbtopts.example
@@ -3,4 +3,5 @@
 -J-Xss2m
 -J-Xms512M
 -J-Xmx6G
--J-XX:ReservedCodeCacheSize=256M
+-J-XX:ReservedCodeCacheSize=512M
+-J-XX:NonProfiledCodeHeapSize=256m


### PR DESCRIPTION
Noticed following warning when running mill-plugin integration tests:

```
OpenJDK 64-Bit Server VM warning: CodeHeap 'non-profiled nmethods' is full. Compiler has been disabled.
OpenJDK 64-Bit Server VM warning: Try increasing the code heap size using -XX:NonProfiledCodeHeapSize=
[100.383s][warning][codecache] CodeHeap 'non-profiled nmethods' is full. Compiler has been disabled.
[100.383s][warning][codecache] Try increasing the code heap size using -XX:NonProfiledCodeHeapSize=
CodeHeap 'non-profiled nmethods': size=119168Kb used=119167Kb max_used=119167Kb free=0Kb
 bounds [0x00007fa9f4fe9000, 0x00007fa9fc449000, 0x00007fa9fc449000]
CodeHeap 'profiled nmethods': size=119164Kb used=117598Kb max_used=119080Kb free=1566Kb
 bounds [0x00007fa9ed449000, 0x00007fa9f48a8000, 0x00007fa9f48a8000]
CodeHeap 'non-nmethods': size=7428Kb used=3329Kb max_used=3444Kb free=4098Kb
 bounds [0x00007fa9f48a8000, 0x00007fa9f4c18000, 0x00007fa9f4fe9000]
 total_blobs=78515 nmethods=77563 adapters=852
 compilation: disabled (not enough contiguous free space left)
              stopped_count=1, restarted_count=0
 full_count=0
[info] done compiling
```

## PR Checklist (not all items are relevant to all PRs)

- [ ] Added unit-tests (for runtime code)
- [ ] Added bootstrapped code + smoke tests (when the rendering logic is modified)
- [ ] Added build-plugins integration tests (when reflection loading is required at codegen-time)
- [ ] Added alloy compliance tests (when simpleRestJson protocol behaviour is expanded/updated)
- [ ] Updated dynamic module to match generated-code behaviour
- [ ] Added documentation
- [ ] Updated changelog
