### PR TITLE
Fix a test that passes for the wrong reason

### DIFF
--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/multiple-artifacts-same-namespace/build.sbt
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/multiple-artifacts-same-namespace/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / scalaVersion := "2.13.10"
+ThisBuild / scalaVersion := "2.13.16"
 
 lazy val a = project
   .enablePlugins(Smithy4sCodegenPlugin)

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/multiple-artifacts-same-namespace/test
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/multiple-artifacts-same-namespace/test
@@ -1,2 +1,4 @@
-# smithy4s codegen should fail to compile; both a and b define the same namespace
--> compile
+> a/compile
+> b/compile
+# smithy4s codegen in `usage` should fail to compile; both a and b define the same namespace
+-> usage/compile


### PR DESCRIPTION
I noticed errors in the scripted test output that weren't causing a failure.

Turns out, the test was passing because the codegen task failed completely (due to the Scala version being too low for the current sbt).

This PR changes the test to only expect codegen failure in the module that tries to use both of the other generated modules. The other two should still compile.

After that change to the test script, the Scala version problem correctly makes it fail, hence the bump.

## PR Checklist (not all items are relevant to all PRs)

- [ ] Added unit-tests (for runtime code)
- [ ] Added bootstrapped code + smoke tests (when the rendering logic is modified)
- [ ] Added build-plugins integration tests (when reflection loading is required at codegen-time)
- [ ] Added alloy compliance tests (when simpleRestJson protocol behaviour is expanded/updated)
- [ ] Updated dynamic module to match generated-code behaviour
- [ ] Added documentation
- [ ] Updated changelog
