### PR TITLE
add mapping between HttpUri and java.net.URI

### DIFF
--- a/modules/bootstrapped/test/src/smithy4s/http/HttpUriSpec.scala
+++ b/modules/bootstrapped/test/src/smithy4s/http/HttpUriSpec.scala
@@ -1,0 +1,42 @@
+/*
+ *  Copyright 2021-2025 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package smithy4s.http
+
+import munit._
+import java.net.URI
+
+final class HttpUriSpec extends FunSuite {
+
+  test("Roundtrip from java.net.URI and back ") {
+    val uri = URI.create("http://example.com/foo?bar=2")
+    val httpUri = HttpUri.fromURI(uri)
+    assertEquals(uri, httpUri.toURI)
+  }
+
+  test("Roundtrip from HttpUri and back") {
+    val httpUri = HttpUri(
+      HttpUriScheme.Http,
+      "example.com",
+      None,
+      IndexedSeq("foo"),
+      Map("bar" -> List("2")),
+      Option.empty
+    )
+    val uri = httpUri.toURI
+    assertEquals(httpUri, HttpUri.fromURI(uri))
+  }
+}

--- a/modules/core/src/smithy4s/http/HttpUri.scala
+++ b/modules/core/src/smithy4s/http/HttpUri.scala
@@ -69,7 +69,7 @@ object HttpUri
       path: IndexedSeq[String],
       queryParams: Map[String, Seq[String]],
       pathParams: Option[Map[String, String]]
-  ): HttpUri = HttpUri(scheme, host, port, path, queryParams, pathParams)
+  ): HttpUri = new HttpUri(scheme, host, port, path, queryParams, pathParams)
 
   def fromURI(uri: URI): HttpUri = {
     val scheme = uri.getScheme() match {

--- a/modules/core/src/smithy4s/http/HttpUri.scala
+++ b/modules/core/src/smithy4s/http/HttpUri.scala
@@ -15,6 +15,8 @@
  */
 
 package smithy4s.http
+import java.net.URI
+import scala.runtime.AbstractFunction6
 
 final case class HttpUri(
     scheme: HttpUriScheme,
@@ -30,4 +32,69 @@ final case class HttpUri(
       * once the routing logic has come in effect.
       */
     pathParams: Option[Map[String, String]]
-)
+) {
+  def toURI: URI = {
+    val schemeStr = scheme match {
+      case HttpUriScheme.Http  => "http"
+      case HttpUriScheme.Https => "https"
+    }
+    val portStr = port.map(":" + _).getOrElse("")
+    val pathStr = path.mkString("/", "/", "")
+    val queryStr =
+      if (queryParams.isEmpty) ""
+      else
+        "?" + queryParams
+          .map { case (k, v) =>
+            v.map(vv => s"$k=$vv").mkString("&")
+          }
+          .mkString("&")
+    new URI(s"$schemeStr://$host$portStr$pathStr$queryStr")
+  }
+}
+
+object HttpUri
+    extends AbstractFunction6[
+      HttpUriScheme,
+      String,
+      Option[Int],
+      IndexedSeq[String],
+      Map[String, Seq[String]],
+      Option[Map[String, String]],
+      HttpUri
+    ] {
+  def apply(
+      scheme: HttpUriScheme,
+      host: String,
+      port: Option[Int],
+      path: IndexedSeq[String],
+      queryParams: Map[String, Seq[String]],
+      pathParams: Option[Map[String, String]]
+  ): HttpUri = HttpUri(scheme, host, port, path, queryParams, pathParams)
+
+  def fromURI(uri: URI): HttpUri = {
+    val scheme = uri.getScheme() match {
+      case "https" => HttpUriScheme.Https
+      case _       => HttpUriScheme.Http
+    }
+    val host = uri.getHost()
+    val port = Option(uri.getPort()).filter(_ >= 0)
+    val path = uri.getPath.split('/').filter(_.nonEmpty).toIndexedSeq
+    val queryParams: Map[String, Seq[String]] = Option(uri.getQuery())
+      .map { query =>
+        query
+          .split("&")
+          .map { pair =>
+            pair.split("=") match {
+              case Array(k: String, v: String) => k -> Seq(v)
+              case Array(k: String)            => k -> Seq.empty[String]
+              // cases where you have q1=v1=v2 => q1 -> "v1=v2"
+              case v @ Array(k: String, _*) => k -> Seq(v.tail.mkString("="))
+            }
+          }
+          .groupBy(_._1)
+          .map { case (k, vs) => k -> vs.map(_._2).flatten.toSeq }
+      }
+      .getOrElse(Map.empty)
+    HttpUri(scheme, host, port, path, queryParams, None)
+  }
+}


### PR DESCRIPTION
Goal is to simply to have this logic in one place, given the many http libs on the JVM do have some interop or direct dependency on the URI data type. 

Binary compatibility breaks though due to adding the companion object for HttpUri which results in the companion object not extending AbstractFunctionN. To remedy this , I've added it in manually.