### PR TITLE
refactor httpuri to be rfc compliant

### DIFF
--- a/modules/aws-http4s/src/smithy4s/aws/AwsClient.scala
+++ b/modules/aws-http4s/src/smithy4s/aws/AwsClient.scala
@@ -72,9 +72,9 @@ object AwsClient {
       def baseRequest(endpoint: OperationSchema[_, _, _, _, _]): F[HttpRequest[Blob]] = {
         awsEnv.region.map { region =>
           val endpointPrefix = awsService.endpointPrefix.getOrElse(endpoint.id.name)
-          val baseUri = HttpUri(
+          val baseUri = HttpUri.absolute(
             scheme = HttpUriScheme.Https,
-            host = Some(s"$endpointPrefix.$region.amazonaws.com"),
+            host = s"$endpointPrefix.$region.amazonaws.com",
             port = None,
             path = IndexedSeq.empty,
             queryParams = Map.empty,

--- a/modules/bootstrapped/test/src/smithy4s/http/HttpRequestSpec.scala
+++ b/modules/bootstrapped/test/src/smithy4s/http/HttpRequestSpec.scala
@@ -42,9 +42,9 @@ final class HttpRequestSpec extends FunSuite {
 
     val writer = HttpRequest.Writer.hostPrefix[String, Foo](opSchema)
 
-    val uri = HttpUri(
+    val uri = HttpUri.absolute(
       HttpUriScheme.Https,
-      Some("example.com"),
+      "example.com",
       None,
       IndexedSeq.empty,
       Map.empty,
@@ -54,7 +54,7 @@ final class HttpRequestSpec extends FunSuite {
     val resultUri = writer.write(request, Foo("hello")).uri
     assertEquals(
       resultUri,
-      uri.copy(host = Some("test.hello-other.example.com"))
+      uri.withHost("test.hello-other.example.com")
     )
   }
 

--- a/modules/core/src/smithy4s/http/HttpRequest.scala
+++ b/modules/core/src/smithy4s/http/HttpRequest.scala
@@ -108,8 +108,9 @@ object HttpRequest {
             ): HttpRequest[Body] = {
               val hostPrefix = prefixEncoder.write(List.empty, input).mkString
               val oldUri = request.uri
-              val prefixedHost = oldUri.host.map(host => s"$hostPrefix$host")
-              val newUri = oldUri.copy(host = prefixedHost)
+              val prefixedOrigin =
+                oldUri.origin.map(origin => origin.hostPrefix(hostPrefix))
+              val newUri = oldUri.copy(origin = prefixedOrigin)
               request.copy(uri = newUri)
             }
           }

--- a/modules/core/src/smithy4s/http/HttpRequest.scala
+++ b/modules/core/src/smithy4s/http/HttpRequest.scala
@@ -81,8 +81,11 @@ object HttpRequest {
         val path = httpEndpoint.path(input)
         val staticQueries = httpEndpoint.staticQueryParams
         val oldUri = request.uri
-        val newUri =
-          oldUri.copy(path = oldUri.path ++ path, queryParams = staticQueries)
+        val newUri = oldUri
+          .withQueryParams(staticQueries)
+          .transformPath(
+            _ ++ path
+          )
         val method = httpEndpoint.method
         request.copy(method = method, uri = newUri)
       }
@@ -92,7 +95,7 @@ object HttpRequest {
       (req: HttpRequest[Body], meta: Metadata) =>
         val oldUri = req.uri
         val newUri =
-          oldUri.copy(queryParams = oldUri.queryParams ++ meta.query)
+          oldUri.transformQueryParams(_ ++ meta.query)
         req.addHeaders(meta.headers).copy(uri = newUri)
     }
 
@@ -108,9 +111,9 @@ object HttpRequest {
             ): HttpRequest[Body] = {
               val hostPrefix = prefixEncoder.write(List.empty, input).mkString
               val oldUri = request.uri
-              val prefixedOrigin =
-                oldUri.origin.map(origin => origin.withHostPrefix(hostPrefix))
-              val newUri = oldUri.copy(origin = prefixedOrigin)
+              val newUri = oldUri.transformOrigin(origin =>
+                origin.withHostPrefix(hostPrefix)
+              )
               request.copy(uri = newUri)
             }
           }

--- a/modules/core/src/smithy4s/http/HttpRequest.scala
+++ b/modules/core/src/smithy4s/http/HttpRequest.scala
@@ -109,7 +109,7 @@ object HttpRequest {
               val hostPrefix = prefixEncoder.write(List.empty, input).mkString
               val oldUri = request.uri
               val prefixedOrigin =
-                oldUri.origin.map(origin => origin.hostPrefix(hostPrefix))
+                oldUri.origin.map(origin => origin.withHostPrefix(hostPrefix))
               val newUri = oldUri.copy(origin = prefixedOrigin)
               request.copy(uri = newUri)
             }

--- a/modules/core/src/smithy4s/http/HttpUri.scala
+++ b/modules/core/src/smithy4s/http/HttpUri.scala
@@ -16,10 +16,17 @@
 
 package smithy4s.http
 
+import scala.runtime.AbstractFunction4
+
+/**
+ * RFC 3986 compliant URI implementation.
+ * @param origin The origin component of the URI.
+ * @param path A sequence of URL-decoded URI path segments
+ * @param queryParams A map of query parameters where keys and values are URL-decoded
+ * @param pathParams Optional map of path parameters extracted during routing
+ */
 final case class HttpUri(
-    scheme: HttpUriScheme,
-    host: Option[String],
-    port: Option[Int],
+    origin: Option[HttpUriOrigin],
     /**
       * A sequence of URL-decoded URI segment.
       */
@@ -30,4 +37,112 @@ final case class HttpUri(
       * once the routing logic has come in effect.
       */
     pathParams: Option[Map[String, String]]
-)
+) {
+
+  def host: Option[String] = origin.map(_.authority.host)
+
+  def port: Option[Int] = origin.flatMap(_.authority.port)
+
+  def scheme: Option[HttpUriScheme] = origin.flatMap(_.scheme)
+
+  def authority: Option[HttpUriAuthority] = origin.map(_.authority)
+
+  /**
+   * Returns true if this is a relative URI (no scheme or authority)
+   */
+  def isRelative: Boolean = origin.isEmpty
+
+  /**
+   * Returns true if this is an absolute URI (has scheme)
+   */
+  def isAbsolute: Boolean = origin.exists(_.scheme.isDefined)
+
+  /**
+   * Returns true if this is a scheme-relative URI (starts with //)
+   */
+  def isSchemeRelative: Boolean = origin.exists(_.scheme.isEmpty)
+
+  def withHost(host: String): HttpUri = {
+    origin match {
+      case Some(o) =>
+        copy(origin = Some(o.copy(authority = o.authority.withHost(host))))
+      case None =>
+        copy(origin = Some(HttpUriOrigin.schemeRelative(host)))
+    }
+
+  }
+
+}
+
+object HttpUri
+    extends AbstractFunction4[
+      Option[HttpUriOrigin],
+      IndexedSeq[String],
+      Map[String, Seq[String]],
+      Option[Map[String, String]],
+      HttpUri
+    ] {
+
+  def apply(
+      origin: Option[HttpUriOrigin],
+      path: IndexedSeq[String],
+      queryParams: Map[String, Seq[String]],
+      pathParams: Option[Map[String, String]]
+  ): HttpUri = {
+    new HttpUri(origin, path, queryParams, pathParams)
+  }
+
+  /**
+   * Creates a relative URI with path and query parameters
+   */
+  def relative(
+      path: IndexedSeq[String],
+      queryParams: Map[String, Seq[String]],
+      pathParams: Option[Map[String, String]] = None
+  ): HttpUri = {
+    HttpUri(
+      origin = None,
+      path = path,
+      queryParams = queryParams,
+      pathParams = pathParams
+    )
+  }
+
+  /**
+   * Creates a scheme-relative URI (starts with //)
+   */
+  def schemeRelative(
+      host: String,
+      port: Option[Int],
+      path: IndexedSeq[String],
+      queryParams: Map[String, Seq[String]] = Map.empty,
+      pathParams: Option[Map[String, String]] = None
+  ): HttpUri = {
+    HttpUri(
+      origin = Some(HttpUriOrigin.schemeRelative(host, port)),
+      path = path,
+      queryParams = queryParams,
+      pathParams = pathParams
+    )
+  }
+
+  /**
+   * Creates an absolute URI
+   */
+  def absolute(
+      scheme: HttpUriScheme,
+      host: String,
+      port: Option[Int],
+      path: IndexedSeq[String],
+      queryParams: Map[String, Seq[String]] = Map.empty,
+      pathParams: Option[Map[String, String]] = None
+  ): HttpUri = {
+
+    HttpUri(
+      origin = Some(HttpUriOrigin.absolute(scheme, host, port)),
+      path = path,
+      queryParams = queryParams,
+      pathParams = pathParams
+    )
+  }
+}

--- a/modules/core/src/smithy4s/http/HttpUri.scala
+++ b/modules/core/src/smithy4s/http/HttpUri.scala
@@ -39,16 +39,18 @@ final case class HttpUri(
     pathParams: Option[Map[String, String]]
 ) {
 
-  def host: Option[String] = origin.map(_.authority.host)
-
-  def port: Option[Int] = origin.flatMap(_.authority.port)
-
   def scheme: Option[HttpUriScheme] = origin.flatMap(_.scheme)
 
   def authority: Option[HttpUriAuthority] = origin.map(_.authority)
 
+  def host: Option[String] = origin.map(_.authority.host)
+
+  def port: Option[Int] = origin.flatMap(_.authority.port)
+
+  def userInfo: Option[String] = origin.flatMap(_.authority.userInfo)
+
   /**
-   * Returns true if this is a relative URI (no scheme or authority)
+   * Returns true if this is a relative URI (no authority)
    */
   def isRelative: Boolean = origin.isEmpty
 

--- a/modules/core/src/smithy4s/http/HttpUri.scala
+++ b/modules/core/src/smithy4s/http/HttpUri.scala
@@ -16,8 +16,6 @@
 
 package smithy4s.http
 
-import scala.runtime.AbstractFunction4
-
 /**
  * RFC 3986 compliant URI implementation.
  * @param origin The origin component of the URI.
@@ -140,14 +138,7 @@ final case class HttpUri private (
   }
 }
 
-object HttpUri
-    extends AbstractFunction4[
-      Option[HttpUriOrigin],
-      IndexedSeq[String],
-      Map[String, Seq[String]],
-      Option[Map[String, String]],
-      HttpUri
-    ] {
+object HttpUri {
 
   @scala.annotation.nowarn(
     "msg=private method unapply in object HttpUri is never used"

--- a/modules/core/src/smithy4s/http/HttpUri.scala
+++ b/modules/core/src/smithy4s/http/HttpUri.scala
@@ -71,7 +71,21 @@ final case class HttpUri(
       case None =>
         copy(origin = Some(HttpUriOrigin.schemeRelative(host)))
     }
+  }
 
+  def withHostPrefix(prefix: String): HttpUri = {
+    origin match {
+      case Some(o) =>
+        copy(origin = Some(o.withHostPrefix(prefix)))
+      case None => this
+    }
+  }
+  def withPort(port: Int): HttpUri = {
+    origin match {
+      case Some(o) =>
+        copy(origin = Some(o.copy(authority = o.authority.withPort(port))))
+      case None => this
+    }
   }
 
 }

--- a/modules/core/src/smithy4s/http/HttpUri.scala
+++ b/modules/core/src/smithy4s/http/HttpUri.scala
@@ -25,7 +25,7 @@ import scala.runtime.AbstractFunction4
  * @param queryParams A map of query parameters where keys and values are URL-decoded
  * @param pathParams Optional map of path parameters extracted during routing
  */
-final case class HttpUri(
+final case class HttpUri private (
     origin: Option[HttpUriOrigin],
     /**
       * A sequence of URL-decoded URI segment.
@@ -64,10 +64,23 @@ final case class HttpUri(
    */
   def isSchemeRelative: Boolean = origin.exists(_.scheme.isEmpty)
 
+  def withOrigin(origin: HttpUriOrigin): HttpUri = {
+    copy(origin = Some(origin))
+  }
+
+  def transformOrigin(
+      f: HttpUriOrigin => HttpUriOrigin
+  ): HttpUri = {
+    origin match {
+      case Some(o) => copy(origin = Some(f(o)))
+      case None    => this
+    }
+  }
+
   def withHost(host: String): HttpUri = {
     origin match {
       case Some(o) =>
-        copy(origin = Some(o.copy(authority = o.authority.withHost(host))))
+        copy(origin = Some(o.withAuthority(o.authority.withHost(host))))
       case None =>
         copy(origin = Some(HttpUriOrigin.schemeRelative(host)))
     }
@@ -83,11 +96,48 @@ final case class HttpUri(
   def withPort(port: Int): HttpUri = {
     origin match {
       case Some(o) =>
-        copy(origin = Some(o.copy(authority = o.authority.withPort(port))))
+        copy(origin = Some(o.withAuthority(o.authority.withPort(port))))
       case None => this
     }
   }
 
+  def transformPath(
+      f: IndexedSeq[String] => IndexedSeq[String]
+  ): HttpUri = {
+    copy(path = f(path))
+  }
+  def withPath(path: IndexedSeq[String]): HttpUri = {
+    copy(path = path)
+  }
+  def withQueryParams(
+      queryParams: Map[String, Seq[String]]
+  ): HttpUri = {
+    copy(queryParams = queryParams)
+  }
+  def withoutQueryParams: HttpUri = {
+    copy(queryParams = Map.empty)
+  }
+  def transformQueryParams(
+      f: Map[String, Seq[String]] => Map[String, Seq[String]]
+  ): HttpUri = {
+    copy(queryParams = f(queryParams))
+  }
+  def withPathParams(
+      pathParams: Map[String, String]
+  ): HttpUri = {
+    copy(pathParams = Some(pathParams))
+  }
+  def withoutPathParams: HttpUri = {
+    copy(pathParams = None)
+  }
+  def transformPathParams(
+      f: Map[String, String] => Map[String, String]
+  ): HttpUri = {
+    pathParams match {
+      case Some(params) => copy(pathParams = Some(f(params)))
+      case None         => this
+    }
+  }
 }
 
 object HttpUri
@@ -98,6 +148,22 @@ object HttpUri
       Option[Map[String, String]],
       HttpUri
     ] {
+
+  @scala.annotation.nowarn(
+    "msg=private method unapply in object HttpUri is never used"
+  )
+  private def unapply(
+      uri: HttpUri
+  ): Option[
+    (
+        Option[HttpUriOrigin],
+        IndexedSeq[String],
+        Map[String, Seq[String]],
+        Option[Map[String, String]]
+    )
+  ] = {
+    Some((uri.origin, uri.path, uri.queryParams, uri.pathParams))
+  }
 
   def apply(
       origin: Option[HttpUriOrigin],

--- a/modules/core/src/smithy4s/http/HttpUriAuthority.scala
+++ b/modules/core/src/smithy4s/http/HttpUriAuthority.scala
@@ -1,3 +1,19 @@
+/*
+ *  Copyright 2021-2025 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 package smithy4s.http
 
 final case class HttpUriAuthority(

--- a/modules/core/src/smithy4s/http/HttpUriAuthority.scala
+++ b/modules/core/src/smithy4s/http/HttpUriAuthority.scala
@@ -1,0 +1,24 @@
+package smithy4s.http
+
+final case class HttpUriAuthority(
+    host: String,
+    port: Option[Int] = None,
+    userInfo: Option[String] = None
+) {
+  def render: String = {
+    val userInfoStr = userInfo.map(ui => s"$ui@").getOrElse("")
+    val portStr = port.map(p => s":$p").getOrElse("")
+    s"$userInfoStr$host$portStr"
+  }
+
+  def hostPrefix(prefix: String): HttpUriAuthority =
+    copy(host = s"$prefix$host")
+
+  def withHost(host: String): HttpUriAuthority = copy(host = host)
+  def withPort(port: Int): HttpUriAuthority = copy(port = Some(port))
+  def withUserInfo(userInfo: String): HttpUriAuthority =
+    copy(userInfo = Some(userInfo))
+  def withoutUserInfo: HttpUriAuthority = copy(userInfo = None)
+  def withoutPort: HttpUriAuthority = copy(port = None)
+
+}

--- a/modules/core/src/smithy4s/http/HttpUriAuthority.scala
+++ b/modules/core/src/smithy4s/http/HttpUriAuthority.scala
@@ -16,10 +16,10 @@
 
 package smithy4s.http
 
-final case class HttpUriAuthority(
+final case class HttpUriAuthority private (
     host: String,
-    port: Option[Int] = None,
-    userInfo: Option[String] = None
+    port: Option[Int],
+    userInfo: Option[String]
 ) {
   def render: String = {
     val userInfoStr = userInfo.map(ui => s"$ui@").getOrElse("")
@@ -37,4 +37,20 @@ final case class HttpUriAuthority(
   def withoutUserInfo: HttpUriAuthority = copy(userInfo = None)
   def withoutPort: HttpUriAuthority = copy(port = None)
 
+}
+object HttpUriAuthority {
+  @scala.annotation.nowarn(
+    "msg=private method unapply in object HttpUriAuthority is never used"
+  )
+  private def unapply(
+      authority: HttpUriAuthority
+  ): Option[(String, Option[Int], Option[String])] = {
+    Some((authority.host, authority.port, authority.userInfo))
+
+  }
+  def apply(
+      host: String,
+      port: Option[Int] = None,
+      userInfo: Option[String] = None
+  ): HttpUriAuthority = new HttpUriAuthority(host, port, userInfo)
 }

--- a/modules/core/src/smithy4s/http/HttpUriOrigin.scala
+++ b/modules/core/src/smithy4s/http/HttpUriOrigin.scala
@@ -41,7 +41,7 @@ final case class HttpUriOrigin(
     s"$schemeStr${authority.render}"
   }
 
-  def hostPrefix(prefix: String): HttpUriOrigin =
+  def withHostPrefix(prefix: String): HttpUriOrigin =
     copy(authority = authority.hostPrefix(prefix))
 
   /**

--- a/modules/core/src/smithy4s/http/HttpUriOrigin.scala
+++ b/modules/core/src/smithy4s/http/HttpUriOrigin.scala
@@ -1,0 +1,113 @@
+/*
+ *  Copyright 2021-2025 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package smithy4s.http
+
+/**
+ * Represents a complete network location including scheme and authority components.
+ * This enforces that a scheme can only be present when there is a host.
+ * Based off of RFC 3986 and 6454 (UriOrigin).
+ * @param scheme The URI scheme (e.g. http, https). Optional for relative URIs.
+ * @param authority The authority component of the URI. Required if scheme is present.
+ */
+final case class HttpUriOrigin(
+    scheme: Option[HttpUriScheme],
+    authority: HttpUriAuthority
+) {
+
+  /**
+   * Renders the location according to RFC 3986
+   */
+  def render: String = {
+    val schemeStr = scheme
+      .map {
+        case HttpUriScheme.Http  => "http://"
+        case HttpUriScheme.Https => "https://"
+      }
+      .getOrElse("//")
+    s"$schemeStr${authority.render}"
+  }
+
+  def hostPrefix(prefix: String): HttpUriOrigin =
+    copy(authority = authority.hostPrefix(prefix))
+
+  /**
+   * Creates a new HttpLocation with the given scheme
+   */
+  def withScheme(scheme: HttpUriScheme): HttpUriOrigin =
+    copy(scheme = Some(scheme))
+
+  /**
+   * Creates a new HttpLocation with the given port
+   */
+  def withPort(port: Int): HttpUriOrigin =
+    copy(authority = authority.withPort(port))
+
+  /**
+   * Creates a new HttpLocation with the given user info
+   */
+  def withUserInfo(userInfo: String): HttpUriOrigin =
+    copy(authority = authority.withUserInfo(userInfo))
+
+  /**
+   * Creates a new HttpLocation without scheme
+   */
+  def withoutScheme: HttpUriOrigin = copy(scheme = None)
+
+  /**
+   * Creates a new HttpLocation without port
+   */
+  def withoutPort: HttpUriOrigin = copy(authority = authority.withoutPort)
+
+  /**
+   * Creates a new HttpLocation without user info
+   */
+  def withoutUserInfo: HttpUriOrigin =
+    copy(authority = authority.withoutUserInfo)
+}
+
+object HttpUriOrigin {
+
+  /**
+   * Creates a scheme-relative location (starts with //)
+   */
+  def schemeRelative(host: String, port: Option[Int] = None): HttpUriOrigin =
+    new HttpUriOrigin(None, HttpUriAuthority(host, port))
+
+  /**
+   * Creates an absolute location with scheme
+   */
+  def absolute(
+      scheme: HttpUriScheme,
+      host: String,
+      port: Option[Int] = None
+  ): HttpUriOrigin =
+    new HttpUriOrigin(Some(scheme), HttpUriAuthority(host, port))
+
+  /**
+   * Creates an absolute location with scheme, host, and port
+   */
+  def absolute(
+      scheme: HttpUriScheme,
+      host: String,
+      port: Int,
+      userInfo: String
+  ): HttpUriOrigin =
+    new HttpUriOrigin(
+      Some(scheme),
+      HttpUriAuthority(host, Some(port), Some(userInfo))
+    )
+}

--- a/modules/core/src/smithy4s/http/HttpUriOrigin.scala
+++ b/modules/core/src/smithy4s/http/HttpUriOrigin.scala
@@ -29,7 +29,7 @@ final case class HttpUriOrigin(
 ) {
 
   /**
-   * Renders the location according to RFC 3986
+   * Renders the origin according to RFC 3986
    */
   def render: String = {
     val schemeStr = scheme
@@ -45,35 +45,35 @@ final case class HttpUriOrigin(
     copy(authority = authority.hostPrefix(prefix))
 
   /**
-   * Creates a new HttpLocation with the given scheme
+   * Creates a new HttpUriOrigin with the given scheme
    */
   def withScheme(scheme: HttpUriScheme): HttpUriOrigin =
     copy(scheme = Some(scheme))
 
   /**
-   * Creates a new HttpLocation with the given port
+   * Creates a new HttpUriOrigin with the given port
    */
   def withPort(port: Int): HttpUriOrigin =
     copy(authority = authority.withPort(port))
 
   /**
-   * Creates a new HttpLocation with the given user info
+   * Creates a new HttpUriOrigin with the given user info
    */
   def withUserInfo(userInfo: String): HttpUriOrigin =
     copy(authority = authority.withUserInfo(userInfo))
 
   /**
-   * Creates a new HttpLocation without scheme
+   * Creates a new HttpUriOrigin without scheme
    */
   def withoutScheme: HttpUriOrigin = copy(scheme = None)
 
   /**
-   * Creates a new HttpLocation without port
+   * Creates a new HttpUriOrigin without port
    */
   def withoutPort: HttpUriOrigin = copy(authority = authority.withoutPort)
 
   /**
-   * Creates a new HttpLocation without user info
+   * Creates a new HttpUriOrigin without user info
    */
   def withoutUserInfo: HttpUriOrigin =
     copy(authority = authority.withoutUserInfo)
@@ -82,13 +82,13 @@ final case class HttpUriOrigin(
 object HttpUriOrigin {
 
   /**
-   * Creates a scheme-relative location (starts with //)
+   * Creates a scheme-relative origin (starts with //)
    */
   def schemeRelative(host: String, port: Option[Int] = None): HttpUriOrigin =
     new HttpUriOrigin(None, HttpUriAuthority(host, port))
 
   /**
-   * Creates an absolute location with scheme
+   * Creates an absolute origin with scheme
    */
   def absolute(
       scheme: HttpUriScheme,
@@ -98,7 +98,7 @@ object HttpUriOrigin {
     new HttpUriOrigin(Some(scheme), HttpUriAuthority(host, port))
 
   /**
-   * Creates an absolute location with scheme, host, and port
+   * Creates an absolute origin with scheme, host, and port
    */
   def absolute(
       scheme: HttpUriScheme,

--- a/modules/core/src/smithy4s/http/HttpUriOrigin.scala
+++ b/modules/core/src/smithy4s/http/HttpUriOrigin.scala
@@ -23,7 +23,7 @@ package smithy4s.http
  * @param scheme The URI scheme (e.g. http, https). Optional for relative URIs.
  * @param authority The authority component of the URI. Required if scheme is present.
  */
-final case class HttpUriOrigin(
+final case class HttpUriOrigin private (
     scheme: Option[HttpUriScheme],
     authority: HttpUriAuthority
 ) {
@@ -43,6 +43,9 @@ final case class HttpUriOrigin(
 
   def withHostPrefix(prefix: String): HttpUriOrigin =
     copy(authority = authority.hostPrefix(prefix))
+
+  def withAuthority(authority: HttpUriAuthority): HttpUriOrigin =
+    copy(authority = authority)
 
   /**
    * Creates a new HttpUriOrigin with the given scheme
@@ -81,6 +84,20 @@ final case class HttpUriOrigin(
 
 object HttpUriOrigin {
 
+  @scala.annotation.nowarn(
+    "msg=private method unapply in object HttpUriOrigin is never used"
+  )
+  private def unapply(
+      origin: HttpUriOrigin
+  ): Option[(Option[HttpUriScheme], HttpUriAuthority)] = {
+    Some((origin.scheme, origin.authority))
+  }
+
+  def apply(
+      scheme: Option[HttpUriScheme],
+      authority: HttpUriAuthority
+  ): HttpUriOrigin = new HttpUriOrigin(scheme, authority)
+
   /**
    * Creates a scheme-relative origin (starts with //)
    */
@@ -110,4 +127,5 @@ object HttpUriOrigin {
       Some(scheme),
       HttpUriAuthority(host, Some(port), Some(userInfo))
     )
+
 }

--- a/modules/http4s-kernel/src/smithy4s/http4s/kernel/package.scala
+++ b/modules/http4s-kernel/src/smithy4s/http4s/kernel/package.scala
@@ -29,6 +29,8 @@ import smithy4s.http.{HttpMethod => Smithy4sHttpMethod}
 import smithy4s.http.{HttpRequest => Smithy4sHttpRequest}
 import smithy4s.http.{HttpResponse => Smithy4sHttpResponse}
 import smithy4s.http.{HttpUri => Smithy4sHttpUri}
+import smithy4s.http.HttpUriOrigin
+import smithy4s.http.HttpUriAuthority
 import cats.MonadThrow
 import cats.effect.Concurrent
 import fs2.Stream
@@ -58,15 +60,18 @@ package object kernel {
   }
 
   def toSmithy4sHttpUri(uri: Uri, pathParams: Option[PathParams] = None): Smithy4sHttpUri = {
-    val uriScheme = uri.scheme match {
-      case Some(Uri.Scheme.https) => Smithy4sHttpUriScheme.Https
-      case _                      => Smithy4sHttpUriScheme.Http
+    val uriScheme = uri.scheme.map {
+      case Uri.Scheme.https => Smithy4sHttpUriScheme.Https
+      case _                => Smithy4sHttpUriScheme.Http
     }
-
+    val origin = uri.host.map(_.renderString).map { host =>
+      HttpUriOrigin(
+        uriScheme,
+        HttpUriAuthority(host, uri.port)
+      )
+    }
     Smithy4sHttpUri(
-      uriScheme,
-      uri.host.map(_.renderString),
-      uri.port,
+      origin,
       uri.path.segments.map(_.decoded()),
       getQueryParams(uri),
       pathParams
@@ -98,15 +103,15 @@ package object kernel {
 
   def fromSmithy4sHttpUri(uri: Smithy4sHttpUri): Uri = {
     val path = Uri.Path.Root.addSegments(uri.path.map(Uri.Path.Segment(_)).toVector)
-    val authority = uri.host.map(h => Uri.Authority(host = Uri.RegName(h), port = uri.port))
+    val authority =
+      uri.host.map(h => Uri.Authority(host = Uri.RegName(h), port = uri.port))
     Uri(
       path = path,
       authority = authority,
-      scheme = Some {
-        uri.scheme match {
-          case Smithy4sHttpUriScheme.Http  => Uri.Scheme.http
-          case Smithy4sHttpUriScheme.Https => Uri.Scheme.https
-        }
+      scheme = uri.scheme.map {
+        case Smithy4sHttpUriScheme.Http  => Uri.Scheme.http
+        case Smithy4sHttpUriScheme.Https => Uri.Scheme.https
+
       }
     ).withMultiValueQueryParams(uri.queryParams)
   }

--- a/modules/http4s-kernel/test/src/smithy4s/http4s/kernel/Http4sConversionSpec.scala
+++ b/modules/http4s-kernel/test/src/smithy4s/http4s/kernel/Http4sConversionSpec.scala
@@ -66,21 +66,21 @@ object Http4sConversionSpec extends SimpleIOSuite {
 
   pureTest("URI: http4s to smithy4s defaults to http") {
     assert.same(
-      smithy4s.http.HttpUriScheme.Http,
+      Some(smithy4s.http.HttpUriScheme.Http),
       toSmithy4sHttpUri(uri"/").scheme
     )
   }
 
   pureTest("URI: http4s to smithy4s keeps http scheme") {
     assert.same(
-      smithy4s.http.HttpUriScheme.Http,
+      Some(smithy4s.http.HttpUriScheme.Http),
       toSmithy4sHttpUri(uri"http://localhost").scheme
     )
   }
 
   pureTest("URI: http4s to smithy4s keeps https scheme") {
     assert.same(
-      smithy4s.http.HttpUriScheme.Https,
+      Some(smithy4s.http.HttpUriScheme.Https),
       toSmithy4sHttpUri(uri"https://localhost").scheme
     )
   }
@@ -123,9 +123,9 @@ object Http4sConversionSpec extends SimpleIOSuite {
   }
 
   private def aSmithy4sUri(scheme: HttpUriScheme) =
-    smithy4s.http.HttpUri(
+    smithy4s.http.HttpUri.absolute(
       scheme = scheme,
-      host = None,
+      host = "example.com",
       port = None,
       path = IndexedSeq.empty,
       queryParams = Map.empty,

--- a/modules/http4s-kernel/test/src/smithy4s/http4s/kernel/Http4sConversionSpec.scala
+++ b/modules/http4s-kernel/test/src/smithy4s/http4s/kernel/Http4sConversionSpec.scala
@@ -26,21 +26,16 @@ object Http4sConversionSpec extends SimpleIOSuite {
   // note: these actually work (http4s runs them as HTTP GET against localhost:80)
   http4sToSmithyAndBackUriTest(
     uri"/",
-    uri"http:/"
+    uri"/"
   )
 
   http4sToSmithyAndBackUriTest(
     uri"/hello",
-    uri"http:/hello"
+    uri"/hello"
   )
 
   http4sToSmithyAndBackUriTest(
     uri"http://example.com",
-    uri"http://example.com/"
-  )
-
-  http4sToSmithyAndBackUriTest(
-    uri"//example.com",
     uri"http://example.com/"
   )
 
@@ -63,13 +58,6 @@ object Http4sConversionSpec extends SimpleIOSuite {
     uri"http://localhost/",
     uri"http://localhost/"
   )
-
-  pureTest("URI: http4s to smithy4s defaults to http") {
-    assert.same(
-      Some(smithy4s.http.HttpUriScheme.Http),
-      toSmithy4sHttpUri(uri"/").scheme
-    )
-  }
 
   pureTest("URI: http4s to smithy4s keeps http scheme") {
     assert.same(


### PR DESCRIPTION
This PR changes the model of HttpUri in a more strict fashion based off RFC 3986. In particular it does not allow construction of
   - a Uri with a scheme but no host
   - a Uri with a port without a host

While HttpUri still models both relative and absolute Uri's , any uri with either scheme or port must contain host.

For lack of better term I called the optional data type a HttpUriOrigin after [RFC 6454](https://www.rfc-editor.org/rfc/rfc6454.html) which seemed to contain the the most accurate description of `Scheme + Authority` 
Happy to change the naming to anything else 
