### PR TITLE
Log a warning when a transformer is unresolved

### DIFF
--- a/modules/codegen/src/smithy4s/codegen/internals/ModelLoader.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/ModelLoader.scala
@@ -111,14 +111,19 @@ private[codegen] object ModelLoader {
     val serviceFactory =
       ProjectionTransformer.createServiceFactory(validatorClassLoader)
 
-    val trans = transformers.flatMap { t =>
+    val resolvedTransformers = transformers.flatMap { t =>
       val result = serviceFactory(t)
-      if (result.isPresent()) Some(result.get) else None
+      if (result.isPresent()) Some(result.get)
+      else {
+        System.err.println(s"[smithy4s] Warning: unresolved transformer: $t")
+        None
+      }
     }
 
-    val transformedModel = trans.foldLeft(preTransformationModel)((m, t) =>
-      t.transform(TransformContext.builder().model(m).build())
-    )
+    val transformedModel =
+      resolvedTransformers.foldLeft(preTransformationModel)((m, t) =>
+        t.transform(TransformContext.builder().model(m).build())
+      )
 
     val postTransformationModel = Model
       .assembler(validatorClassLoader)


### PR DESCRIPTION
It can be useful in the absence of a convenient debugger. The current behavior of dropping missing transformers quietly can be too much :)

## PR Checklist (not all items are relevant to all PRs)

- [ ] Added unit-tests (for runtime code)
- [ ] Added bootstrapped code + smoke tests (when the rendering logic is modified)
- [ ] Added build-plugins integration tests (when reflection loading is required at codegen-time)
- [ ] Added alloy compliance tests (when simpleRestJson protocol behaviour is expanded/updated)
- [ ] Updated dynamic module to match generated-code behaviour
- [ ] Added documentation
- [ ] Updated changelog
