### PR TITLE
fix uri encoding issue for conversion to java.net.URI , plus add tests

### DIFF
--- a/modules/bootstrapped/test/src/smithy4s/http/HttpUriSpec.scala
+++ b/modules/bootstrapped/test/src/smithy4s/http/HttpUriSpec.scala
@@ -39,4 +39,30 @@ final class HttpUriSpec extends FunSuite {
     val uri = httpUri.toURI
     assertEquals(httpUri, HttpUri.fromURI(uri))
   }
+
+  test("Roundtrip preserves uri encoding from java.net.URI") {
+    // This URI contains spaces, which should be encoded as %20
+    val uri = URI.create("http://example.com/foo%20bar?baz=qux%20quux")
+    val httpUri = HttpUri.fromURI(uri)
+    assertEquals(uri, httpUri.toURI)
+    assert(httpUri.path == IndexedSeq("foo bar"))
+    assert(httpUri.queryParams == Map("baz" -> List("qux quux")))
+  }
+  test("Roundtrip preserves uri encoding from HttpUri") {
+    // This HttpUri contains spaces, which should be encoded as %20, however HttpUri stores data in its decoded form
+    // so we expect the spaces to be present in the path and query parameters.
+    val httpUri = HttpUri(
+      HttpUriScheme.Http,
+      "example.com",
+      None,
+      IndexedSeq("foo bar"),
+      Map("baz" -> List("qux quux")),
+      Option.empty
+    )
+    val uri = httpUri.toURI
+    assertEquals(httpUri, HttpUri.fromURI(uri))
+    assert(uri.getRawPath == "/foo%20bar")
+    assert(uri.getRawQuery == "baz=qux%20quux")
+  }
+
 }

--- a/modules/bootstrapped/test/src/smithy4s/http/HttpUriSpec.scala
+++ b/modules/bootstrapped/test/src/smithy4s/http/HttpUriSpec.scala
@@ -45,7 +45,7 @@ final class HttpUriSpec extends FunSuite {
     if (Platform.isNative)
       assume(
         false,
-        "This test is not applicable for Scala Native, as our version has bugs in URI parsing and encoding"
+        "This test is not applicable for Scala Native, as we are on 4.x which has bugs in URI parsing and encoding"
       )
     else {
       // This URI contains spaces, which should be encoded as %20
@@ -61,7 +61,7 @@ final class HttpUriSpec extends FunSuite {
     if (Platform.isNative)
       assume(
         false,
-        "This test is not applicable for Scala Native, as our version has bugs in URI parsing and encoding"
+        "This test is not applicable for Scala Native, as we are on 4.x which has bugs in URI parsing and encoding"
       )
     else {
       // This HttpUri contains spaces, which should be encoded as %20, however HttpUri stores data in its decoded form

--- a/modules/bootstrapped/test/src/smithy4s/http/HttpUriSpec.scala
+++ b/modules/bootstrapped/test/src/smithy4s/http/HttpUriSpec.scala
@@ -61,7 +61,7 @@ final class HttpUriSpec extends FunSuite {
     if (Platform.isNative)
       assume(
         false,
-        "This test is not applicable for Scala Native, as we are on 4.x which has bugs in URI parsing and encoding"
+        "This test is not applicable for Scala Native, as we are on 0.4.x which has bugs in URI parsing and encoding"
       )
     else {
       // This HttpUri contains spaces, which should be encoded as %20, however HttpUri stores data in its decoded form

--- a/modules/bootstrapped/test/src/smithy4s/http/HttpUriSpec.scala
+++ b/modules/bootstrapped/test/src/smithy4s/http/HttpUriSpec.scala
@@ -18,6 +18,7 @@ package smithy4s.http
 
 import munit._
 import java.net.URI
+import smithy4s.Platform
 
 final class HttpUriSpec extends FunSuite {
 
@@ -41,28 +42,43 @@ final class HttpUriSpec extends FunSuite {
   }
 
   test("Roundtrip preserves uri encoding from java.net.URI") {
-    // This URI contains spaces, which should be encoded as %20
-    val uri = URI.create("http://example.com/foo%20bar?baz=qux%20quux")
-    val httpUri = HttpUri.fromURI(uri)
-    assertEquals(uri, httpUri.toURI)
-    assert(httpUri.path == IndexedSeq("foo bar"))
-    assert(httpUri.queryParams == Map("baz" -> List("qux quux")))
+    if (Platform.isNative)
+      assume(
+        false,
+        "This test is not applicable for Scala Native, as our version has bugs in URI parsing and encoding"
+      )
+    else {
+      // This URI contains spaces, which should be encoded as %20
+      val uri = URI.create("http://example.com/foo%20bar?baz=qux%20quux")
+      val httpUri = HttpUri.fromURI(uri)
+      assertEquals(uri, httpUri.toURI)
+      assert(httpUri.path == IndexedSeq("foo bar"))
+      assert(httpUri.queryParams == Map("baz" -> List("qux quux")))
+    }
   }
+
   test("Roundtrip preserves uri encoding from HttpUri") {
-    // This HttpUri contains spaces, which should be encoded as %20, however HttpUri stores data in its decoded form
-    // so we expect the spaces to be present in the path and query parameters.
-    val httpUri = HttpUri(
-      HttpUriScheme.Http,
-      "example.com",
-      None,
-      IndexedSeq("foo bar"),
-      Map("baz" -> List("qux quux")),
-      Option.empty
-    )
-    val uri = httpUri.toURI
-    assertEquals(httpUri, HttpUri.fromURI(uri))
-    assert(uri.getRawPath == "/foo%20bar")
-    assert(uri.getRawQuery == "baz=qux%20quux")
+    if (Platform.isNative)
+      assume(
+        false,
+        "This test is not applicable for Scala Native, as our version has bugs in URI parsing and encoding"
+      )
+    else {
+      // This HttpUri contains spaces, which should be encoded as %20, however HttpUri stores data in its decoded form
+      // so we expect the spaces to be present in the path and query parameters.
+      val httpUri = HttpUri(
+        HttpUriScheme.Http,
+        "example.com",
+        None,
+        IndexedSeq("foo bar"),
+        Map("baz" -> List("qux quux")),
+        Option.empty
+      )
+      val uri = httpUri.toURI
+      assertEquals(httpUri, HttpUri.fromURI(uri))
+      assert(uri.getRawPath == "/foo%20bar")
+      assert(uri.getRawQuery == "baz=qux%20quux")
+    }
   }
 
 }

--- a/modules/codegen/src/smithy4s/codegen/CodegenRecord.scala
+++ b/modules/codegen/src/smithy4s/codegen/CodegenRecord.scala
@@ -17,8 +17,8 @@
 package smithy4s.codegen
 
 import software.amazon.smithy.model.Model
-import software.amazon.smithy.model.node.Node
 import software.amazon.smithy.model.SourceLocation
+import software.amazon.smithy.model.node.Node
 
 import scala.jdk.CollectionConverters._
 import scala.jdk.OptionConverters._

--- a/modules/codegen/src/smithy4s/codegen/internals/CodegenImpl.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/CodegenImpl.scala
@@ -22,14 +22,14 @@ import smithy4s.codegen.CodegenEntry.FromDisk
 import smithy4s.codegen.CodegenEntry.FromMemory
 import smithy4s.codegen.transformers._
 import software.amazon.smithy.model.Model
+import software.amazon.smithy.model.SourceLocation
 import software.amazon.smithy.model.node.Node
 import software.amazon.smithy.model.shapes.ModelSerializer
 import software.amazon.smithy.model.transform.ModelTransformer
 import software.amazon.smithy.openapi.OpenApiConfig
-import software.amazon.smithy.model.SourceLocation
-import scala.util.matching.Regex
 
 import scala.jdk.CollectionConverters._
+import scala.util.matching.Regex
 
 private[codegen] object CodegenImpl { self =>
 

--- a/modules/codegen/src/smithy4s/codegen/internals/SmithyToIR.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/SmithyToIR.scala
@@ -34,6 +34,7 @@ import smithy4s.meta.ValidateNewtypeTrait
 import smithy4s.meta.VectorTrait
 import software.amazon.smithy.aws.traits.ServiceTrait
 import software.amazon.smithy.model.Model
+import software.amazon.smithy.model.knowledge.TopDownIndex
 import software.amazon.smithy.model.node._
 import software.amazon.smithy.model.selector.PathFinder
 import software.amazon.smithy.model.shapes._
@@ -42,19 +43,18 @@ import software.amazon.smithy.model.traits.RequiredTrait
 import software.amazon.smithy.model.traits.TimestampFormatTrait
 import software.amazon.smithy.model.traits._
 
-import scala.annotation.nowarn
-import scala.jdk.CollectionConverters._
-
-import Type.Alias
 import java.time.Instant
 import java.time.ZonedDateTime
-import java.util.Locale
-import java.time.temporal.ChronoField
 import java.time.format.DateTimeFormatterBuilder
-import scala.util.Try
+import java.time.temporal.ChronoField
+import java.util.Locale
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
-import software.amazon.smithy.model.knowledge.TopDownIndex
+import scala.annotation.nowarn
+import scala.jdk.CollectionConverters._
+import scala.util.Try
+
+import Type.Alias
 
 private[codegen] object SmithyToIR {
 

--- a/modules/codegen/src/smithy4s/codegen/internals/ToLine.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/ToLine.scala
@@ -18,12 +18,12 @@ package smithy4s.codegen.internals
 
 import cats.data.Chain
 import cats.implicits.toFoldableOps
+import cats.kernel.Eq
 import cats.kernel.Monoid
 
 import java.util.UUID
 
 import LineSegment._
-import cats.kernel.Eq
 
 private[internals] trait ToLine[A] {
   def render(a: A): Line

--- a/modules/codegen/src/smithy4s/codegen/transformers/ValidatedNewtypesTransformer.scala
+++ b/modules/codegen/src/smithy4s/codegen/transformers/ValidatedNewtypesTransformer.scala
@@ -16,6 +16,7 @@
 
 package smithy4s.codegen.transformers
 
+import smithy4s.codegen.CodegenRecord
 import smithy4s.meta.UnwrapTrait
 import smithy4s.meta.ValidateNewtypeTrait
 import software.amazon.smithy.build.ProjectionTransformer
@@ -30,7 +31,6 @@ import software.amazon.smithy.model.traits.PatternTrait
 import software.amazon.smithy.model.traits.RangeTrait
 
 import scala.jdk.OptionConverters._
-import smithy4s.codegen.CodegenRecord
 
 class ValidatedNewtypesTransformer extends ProjectionTransformer {
 

--- a/modules/core/src/smithy4s/http/HttpUri.scala
+++ b/modules/core/src/smithy4s/http/HttpUri.scala
@@ -37,17 +37,14 @@ final case class HttpUri(
       case HttpUriScheme.Http  => "http"
       case HttpUriScheme.Https => "https"
     }
-    val portStr = port.map(":" + _).getOrElse("")
+
     val pathStr = path.mkString("/", "/", "")
-    val queryStr =
-      if (queryParams.isEmpty) ""
-      else
-        "?" + queryParams
-          .map { case (k, v) =>
-            v.map(vv => s"$k=$vv").mkString("&")
-          }
-          .mkString("&")
-    new URI(s"$schemeStr://$host$portStr$pathStr$queryStr")
+    val queryStr = queryParams
+      .map { case (k, v) =>
+        v.map(vv => s"$k=$vv").mkString("&")
+      }
+      .mkString("&")
+    new URI(schemeStr, null, host, port.getOrElse(-1), pathStr, queryStr, null)
   }
 }
 
@@ -95,5 +92,14 @@ object HttpUri
       }
       .getOrElse(Map.empty)
     HttpUri(scheme, host, port, path, queryParams, None)
+  }
+
+  def safeToInt(value: String): Option[Int] = {
+    try {
+      Some(value.toInt)
+    } catch {
+      case _: NumberFormatException => None
+    }
+
   }
 }

--- a/modules/core/src/smithy4s/http/HttpUri.scala
+++ b/modules/core/src/smithy4s/http/HttpUri.scala
@@ -93,13 +93,4 @@ object HttpUri
       .getOrElse(Map.empty)
     HttpUri(scheme, host, port, path, queryParams, None)
   }
-
-  def safeToInt(value: String): Option[Int] = {
-    try {
-      Some(value.toInt)
-    } catch {
-      case _: NumberFormatException => None
-    }
-
-  }
 }

--- a/modules/protocol-tests/test/src/smithy4s/api/validation/AdtTraitValidatorSpec.scala
+++ b/modules/protocol-tests/test/src/smithy4s/api/validation/AdtTraitValidatorSpec.scala
@@ -20,6 +20,7 @@ import software.amazon.smithy.model.shapes._
 import software.amazon.smithy.model.validation.Severity
 import software.amazon.smithy.model.validation.ValidationEvent
 import weaver._
+
 import ModelUtils._
 
 object AdtTraitValidatorSpec extends FunSuite {

--- a/modules/protocol-tests/test/src/smithy4s/api/validation/ModelUtils.scala
+++ b/modules/protocol-tests/test/src/smithy4s/api/validation/ModelUtils.scala
@@ -17,10 +17,11 @@
 package smithy4s.api.validation
 
 import software.amazon.smithy.model.Model
-import software.amazon.smithy.model.validation.ValidationEvent
-import software.amazon.smithy.model.validation.ValidatedResult
-import scala.jdk.CollectionConverters._
 import software.amazon.smithy.model.SourceLocation
+import software.amazon.smithy.model.validation.ValidatedResult
+import software.amazon.smithy.model.validation.ValidationEvent
+
+import scala.jdk.CollectionConverters._
 
 private object ModelUtils {
 


### PR DESCRIPTION
the wrong constructor for java.net.URI was used [here](https://github.com/disneystreaming/smithy4s/blob/3ebf4b919963607c59ab6cd35208a057f4b7220f/modules/core/src/smithy4s/http/HttpUri.scala#L50) which takes in a raw string and does not apply encoding.
This PR fixes that and introduces some tests for it
Add filter for Native platform for url encoding roundtrip tests , as there is a bug in scala-native and was only patched in later versions