### PR TITLE
[http4s] add onError method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ When adding entries, please treat them as if they could end up in a release any 
 
 Thank you!
 
+# 0.18.38
+
+* http4s: onError method added to the RouteBuilder in [#1755](https://github.com/disneystreaming/smithy4s/pull/1755) 
+
 # 0.18.37
 
 * json: Allow decoding nulls for optional fields in defaults (fixes [#1581](https://github.com/disneystreaming/smithy4s/issues/1581)) in [#1744](https://github.com/disneystreaming/smithy4s/pull/1744)

--- a/build.sbt
+++ b/build.sbt
@@ -291,19 +291,10 @@ lazy val core = projectMatrix
       ProblemFilters.exclude[DirectMissingMethodProblem](
         "smithy4s.http.HttpUnaryServerRouter#PartialFunctionRouter.this"
       ),
-      ProblemFilters.exclude[DirectMissingMethodProblem](
-        "smithy4s.http.HttpUnaryServerRouter.partialFunction"
-      ),
       // Breaking bin-compat to walk back ambiguous methods introduced in
       // https://github.com/disneystreaming/smithy4s/pull/1669
       ProblemFilters.exclude[IncompatibleMethTypeProblem](
         "smithy4s.http.HttpUnaryServerRouter.partialFunction"
-      ),
-      ProblemFilters.exclude[DirectMissingMethodProblem](
-        "smithy4s.http.HttpUnaryServerRouter.apply"
-      ),
-      ProblemFilters.exclude[DirectMissingMethodProblem](
-        "smithy4s.server.UnaryServerEndpoint.apply"
       )
     )
   )

--- a/build.sbt
+++ b/build.sbt
@@ -291,10 +291,19 @@ lazy val core = projectMatrix
       ProblemFilters.exclude[DirectMissingMethodProblem](
         "smithy4s.http.HttpUnaryServerRouter#PartialFunctionRouter.this"
       ),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+        "smithy4s.http.HttpUnaryServerRouter.partialFunction"
+      ),
       // Breaking bin-compat to walk back ambiguous methods introduced in
       // https://github.com/disneystreaming/smithy4s/pull/1669
       ProblemFilters.exclude[IncompatibleMethTypeProblem](
         "smithy4s.http.HttpUnaryServerRouter.partialFunction"
+      ),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+        "smithy4s.http.HttpUnaryServerRouter.apply"
+      ),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+        "smithy4s.server.UnaryServerEndpoint.apply"
       )
     )
   )

--- a/modules/cats/src/smithy4s/interopcats/package.scala
+++ b/modules/cats/src/smithy4s/interopcats/package.scala
@@ -34,6 +34,12 @@ package object interopcats {
       def raiseError[A](e: Throwable): F[A] = MonadThrow[F].raiseError(e)
       def handleErrorWith[A](fa: F[A])(f: Throwable => F[A]): F[A] =
         MonadThrow[F].handleErrorWith(fa)(f)
+
+      override def onError[A](
+          fa: F[A]
+      )(f: PartialFunction[Throwable, F[Unit]]): F[A] =
+        MonadThrow[F].onError(fa)(f)
+
     }
 
   implicit def monoidEndpointMiddleware[Construct]

--- a/modules/core/src/smithy4s/capability/MonadThrowLike.scala
+++ b/modules/core/src/smithy4s/capability/MonadThrowLike.scala
@@ -22,6 +22,12 @@ trait MonadThrowLike[F[_]] extends Zipper[F] {
   def flatMap[A, B](fa: F[A])(f: A => F[B]): F[B]
   def raiseError[A](e: Throwable): F[A]
   def handleErrorWith[A](fa: F[A])(f: Throwable => F[A]): F[A]
+  def onError[A](fa: F[A])(f: PartialFunction[Throwable, F[Unit]]): F[A] = {
+    handleErrorWith(fa) { throwable =>
+      f.andThen(_ => raiseError[A](throwable))
+        .applyOrElse(throwable, (_: Throwable) => raiseError(throwable))
+    }
+  }
 
   final def liftEither[E <: Throwable, A](either: Either[E, A]): F[A] =
     either match {

--- a/modules/core/src/smithy4s/capability/MonadThrowLike.scala
+++ b/modules/core/src/smithy4s/capability/MonadThrowLike.scala
@@ -24,7 +24,7 @@ trait MonadThrowLike[F[_]] extends Zipper[F] {
   def handleErrorWith[A](fa: F[A])(f: Throwable => F[A]): F[A]
   def onError[A](fa: F[A])(f: PartialFunction[Throwable, F[Unit]]): F[A] = {
     handleErrorWith(fa) { throwable =>
-      f.andThen(_ => raiseError[A](throwable))
+      f.andThen(flatMap(_)(_ => raiseError[A](throwable)))
         .applyOrElse(throwable, (_: Throwable) => raiseError(throwable))
     }
   }

--- a/modules/core/src/smithy4s/http/HttpUnaryServerRouter.scala
+++ b/modules/core/src/smithy4s/http/HttpUnaryServerRouter.scala
@@ -58,7 +58,8 @@ object HttpUnaryServerRouter {
       endpointMiddleware: Endpoint.Middleware[Request => F[Response]],
       getMethod: Request => HttpMethod,
       getUri: Request => HttpUri,
-      addDecodedPathParams: (Request, PathParams) => Request
+      addDecodedPathParams: (Request, PathParams) => Request,
+      onError: PartialFunction[Throwable, F[Unit]] = PartialFunction.empty
   )(implicit F: MonadThrowLike[F]): Request => Option[F[Response]] = {
     new KleisliRouter[Alg, service.Operation, F, Request, Response](
       service,
@@ -68,7 +69,8 @@ object HttpUnaryServerRouter {
       getMethod,
       getUri,
       addDecodedPathParams,
-      encodeErrorsBeforeMiddleware
+      encodeErrorsBeforeMiddleware,
+      onError
     )
   }
 
@@ -78,7 +80,8 @@ object HttpUnaryServerRouter {
     */
   def partialFunction[Alg[_[_, _, _, _, _]], F[_], RequestHead, Request, Response](
       service: smithy4s.Service[Alg],
-      encodeErrorsBeforeMiddleware: Boolean
+      encodeErrorsBeforeMiddleware: Boolean,
+      onError: PartialFunction[Throwable, F[Unit]]
   )(
       impl: service.Impl[F],
       makeServerCodecs: UnaryServerCodecs.Make[F, Request, Response],
@@ -95,7 +98,8 @@ object HttpUnaryServerRouter {
       getMethod,
       getUri,
       addDecodedPathParams,
-      encodeErrorsBeforeMiddleware
+      encodeErrorsBeforeMiddleware,
+      onError
     )
   }
 
@@ -117,7 +121,8 @@ object HttpUnaryServerRouter {
       getMethod,
       getUri,
       addDecodedPathParams,
-      encodeErrorsBeforeMiddleware = false
+      encodeErrorsBeforeMiddleware = false,
+      onError = PartialFunction.empty
     )
   }
 
@@ -129,7 +134,8 @@ object HttpUnaryServerRouter {
       getMethod: Request => HttpMethod,
       getUri: Request => HttpUri,
       addDecodedPathParams: (Request, PathParams) => Request,
-      encodeErrorsBeforeMiddleware: Boolean
+      encodeErrorsBeforeMiddleware: Boolean,
+      onError: PartialFunction[Throwable, F[Unit]]
   )(implicit F: MonadThrowLike[F])
       extends (Request => Option[F[Response]]) {
 
@@ -169,7 +175,8 @@ object HttpUnaryServerRouter {
           endpoint,
           makeServerCodecs(endpoint.schema),
           endpointMiddleware.prepare(service)(endpoint),
-          encodeErrorsBeforeMiddleware
+          encodeErrorsBeforeMiddleware,
+          onError
         )
         HttpEndpointHandler(httpEndpoint, handler)
       }
@@ -194,7 +201,8 @@ object HttpUnaryServerRouter {
       getMethod: RequestHead => HttpMethod,
       getUri: RequestHead => HttpUri,
       addDecodedPathParams: (Request, PathParams) => Request,
-      encodeErrorsBeforeMiddleware: Boolean
+      encodeErrorsBeforeMiddleware: Boolean,
+      onError: PartialFunction[Throwable, F[Unit]]
   )(implicit F: MonadThrowLike[F])
       extends PartialFunction[RequestHead, Request => F[Response]] {
 
@@ -233,7 +241,8 @@ object HttpUnaryServerRouter {
           endpoint,
           makeServerCodecs(endpoint.schema),
           endpointMiddleware.prepare(service)(endpoint),
-          encodeErrorsBeforeMiddleware
+          encodeErrorsBeforeMiddleware,
+          onError
         )
         HttpEndpointHandler(httpEndpoint, handler)
       }

--- a/modules/core/src/smithy4s/http/HttpUnaryServerRouter.scala
+++ b/modules/core/src/smithy4s/http/HttpUnaryServerRouter.scala
@@ -39,14 +39,13 @@ object HttpUnaryServerRouter {
       getUri: Request => HttpUri,
       addDecodedPathParams: (Request, PathParams) => Request
   )(implicit F: MonadThrowLike[F]): Request => Option[F[Response]] = {
-    apply(service, encodeErrorsBeforeMiddleware = false)(
+    apply(service, encodeErrorsBeforeMiddleware = false, onError = PartialFunction.empty)(
       impl,
       makeServerCodecs,
       endpointMiddleware,
       getMethod,
       getUri,
-      addDecodedPathParams,
-      PartialFunction.empty
+      addDecodedPathParams
     )
   }
 
@@ -59,8 +58,29 @@ object HttpUnaryServerRouter {
       endpointMiddleware: Endpoint.Middleware[Request => F[Response]],
       getMethod: Request => HttpMethod,
       getUri: Request => HttpUri,
-      addDecodedPathParams: (Request, PathParams) => Request,
+      addDecodedPathParams: (Request, PathParams) => Request
+  )(implicit F: MonadThrowLike[F]): Request => Option[F[Response]] = {
+    apply(service, encodeErrorsBeforeMiddleware, PartialFunction.empty)(
+      impl,
+      makeServerCodecs,
+      endpointMiddleware,
+      getMethod,
+      getUri,
+      addDecodedPathParams
+    )
+  }
+
+  def apply[Alg[_[_, _, _, _, _]], F[_], Request, Response](
+      service: smithy4s.Service[Alg],
+      encodeErrorsBeforeMiddleware: Boolean,
       onError: PartialFunction[Throwable, F[Unit]]
+  )(
+      impl: service.Impl[F],
+      makeServerCodecs: UnaryServerCodecs.Make[F, Request, Response],
+      endpointMiddleware: Endpoint.Middleware[Request => F[Response]],
+      getMethod: Request => HttpMethod,
+      getUri: Request => HttpUri,
+      addDecodedPathParams: (Request, PathParams) => Request
   )(implicit F: MonadThrowLike[F]): Request => Option[F[Response]] = {
     new KleisliRouter[Alg, service.Operation, F, Request, Response](
       service,
@@ -105,6 +125,31 @@ object HttpUnaryServerRouter {
   }
 
   def partialFunction[Alg[_[_, _, _, _, _]], F[_], RequestHead, Request, Response](
+      service: smithy4s.Service[Alg],
+      encodeErrorsBeforeMiddleware: Boolean
+  )(
+      impl: service.Impl[F],
+      makeServerCodecs: UnaryServerCodecs.Make[F, Request, Response],
+      endpointMiddleware: Endpoint.Middleware[Request => F[Response]],
+      getMethod: RequestHead => HttpMethod,
+      getUri: RequestHead => HttpUri,
+      addDecodedPathParams: (Request, PathParams) => Request
+  )(implicit F: MonadThrowLike[F]): PartialFunction[RequestHead, Request => F[Response]] = {
+    partialFunction(
+      service,
+      encodeErrorsBeforeMiddleware,
+      PartialFunction.empty
+    )(
+      impl,
+      makeServerCodecs,
+      endpointMiddleware,
+      getMethod,
+      getUri,
+      addDecodedPathParams
+    )
+  }
+
+  def partialFunction[Alg[_[_, _, _, _, _]], F[_], RequestHead, Request, Response](
       service: smithy4s.Service[Alg]
   )(
       impl: service.Impl[F],
@@ -114,16 +159,17 @@ object HttpUnaryServerRouter {
       getUri: RequestHead => HttpUri,
       addDecodedPathParams: (Request, PathParams) => Request
   )(implicit F: MonadThrowLike[F]): PartialFunction[RequestHead, Request => F[Response]] = {
-    new PartialFunctionRouter[Alg, service.Operation, F, RequestHead, Request, Response](
+    partialFunction(
       service,
-      service.toPolyFunction[smithy4s.kinds.Kind1[F]#toKind5](impl),
+      encodeErrorsBeforeMiddleware = false,
+      onError = PartialFunction.empty
+    )(
+      impl,
       makeServerCodecs,
       endpointMiddleware,
       getMethod,
       getUri,
-      addDecodedPathParams,
-      encodeErrorsBeforeMiddleware = false,
-      onError = PartialFunction.empty
+      addDecodedPathParams
     )
   }
 

--- a/modules/core/src/smithy4s/http/HttpUnaryServerRouter.scala
+++ b/modules/core/src/smithy4s/http/HttpUnaryServerRouter.scala
@@ -45,7 +45,8 @@ object HttpUnaryServerRouter {
       endpointMiddleware,
       getMethod,
       getUri,
-      addDecodedPathParams
+      addDecodedPathParams,
+      PartialFunction.empty
     )
   }
 
@@ -59,7 +60,7 @@ object HttpUnaryServerRouter {
       getMethod: Request => HttpMethod,
       getUri: Request => HttpUri,
       addDecodedPathParams: (Request, PathParams) => Request,
-      onError: PartialFunction[Throwable, F[Unit]] = PartialFunction.empty
+      onError: PartialFunction[Throwable, F[Unit]]
   )(implicit F: MonadThrowLike[F]): Request => Option[F[Response]] = {
     new KleisliRouter[Alg, service.Operation, F, Request, Response](
       service,

--- a/modules/core/src/smithy4s/server/UnaryServerEndpoint.scala
+++ b/modules/core/src/smithy4s/server/UnaryServerEndpoint.scala
@@ -39,6 +39,24 @@ object UnaryServerEndpoint {
       onError = PartialFunction.empty
     )
   }
+  def apply[F[_], Op[_, _, _, _, _], Request, Response, I, E, O, SI, SO](
+      interpreter: FunctorInterpreter[Op, F],
+      endpoint: Endpoint[Op, I, E, O, SI, SO],
+      codecs: UnaryServerCodecs[F, Request, Response, I, E, O],
+      middleware: (Request => F[Response]) => (Request => F[Response]),
+      encodeErrorsBeforeMiddleware: Boolean
+  )(implicit
+      F: MonadThrowLike[F]
+  ): Request => F[Response] = {
+    apply(
+      interpreter,
+      endpoint,
+      codecs,
+      middleware,
+      encodeErrorsBeforeMiddleware,
+      onError = PartialFunction.empty
+    )
+  }
 
   def apply[F[_], Op[_, _, _, _, _], Request, Response, I, E, O, SI, SO](
       interpreter: FunctorInterpreter[Op, F],

--- a/modules/core/src/smithy4s/server/UnaryServerEndpoint.scala
+++ b/modules/core/src/smithy4s/server/UnaryServerEndpoint.scala
@@ -30,7 +30,14 @@ object UnaryServerEndpoint {
       codecs: UnaryServerCodecs[F, Request, Response, I, E, O],
       middleware: (Request => F[Response]) => (Request => F[Response])
   )(implicit F: MonadThrowLike[F]): Request => F[Response] = {
-    apply(interpreter, endpoint, codecs, middleware, encodeErrorsBeforeMiddleware = false)
+    apply(
+      interpreter,
+      endpoint,
+      codecs,
+      middleware,
+      encodeErrorsBeforeMiddleware = false,
+      onError = PartialFunction.empty
+    )
   }
 
   def apply[F[_], Op[_, _, _, _, _], Request, Response, I, E, O, SI, SO](
@@ -38,8 +45,10 @@ object UnaryServerEndpoint {
       endpoint: Endpoint[Op, I, E, O, SI, SO],
       codecs: UnaryServerCodecs[F, Request, Response, I, E, O],
       middleware: (Request => F[Response]) => (Request => F[Response]),
-      encodeErrorsBeforeMiddleware: Boolean
+      encodeErrorsBeforeMiddleware: Boolean,
+      onError: PartialFunction[Throwable, F[Unit]]
   )(implicit F: MonadThrowLike[F]): Request => F[Response] = {
+
     def errorResponse(throwable: Throwable): F[Response] = throwable match {
       case endpoint.Error((_, e)) =>
         codecs.errorEncoder(e)
@@ -55,11 +64,15 @@ object UnaryServerEndpoint {
       }
     }
 
+    val withErrorObserver = base.andThen { resp =>
+      F.onError(resp)(onError)
+    }
+
     val withErrorsEncoded =
       if (encodeErrorsBeforeMiddleware)
-        base.andThen { F.handleErrorWith(_)(errorResponse) }
+        withErrorObserver.andThen { F.handleErrorWith(_)(errorResponse) }
       else
-        base
+        withErrorObserver
 
     val withMiddleware = middleware(withErrorsEncoded)
     withMiddleware.andThen { F.handleErrorWith(_)(errorResponse) }

--- a/modules/docs/resources/markdown/03-protocols/04-simple-rest-json/02-server.md
+++ b/modules/docs/resources/markdown/03-protocols/04-simple-rest-json/02-server.md
@@ -62,14 +62,17 @@ myRoutes.mapErrors{
   case e: PayloadError => MyClientError(...)
 }.resource
 ```
-
-Additionally, there is an `onError` method that installs a routine to run upon all errors that occur along the path, whether defined in Smithy or not. This will also run on errors that have been raised in smithy4s middleware.
+ #### Observing errors 
+You can also observe errors that are raised along the route, and log them or perform some other effect. For example, you can log errors like this:
 
 ```scala
 myRoutes.onError{
-  case e: PayloadError => IO.println(s"unhandled error logged ${e.getMessage}")
+  case e: PayloadError => 
+    IO.println(s"payload error logged ${e.getMessage}")
 }.resource
 ```
+onError takes a partial function that matches the errors you want to observe, and returns an `IO[Unit]` that will be executed when the error occurs.
+
 
 ## Wiring the routes
 

--- a/modules/docs/resources/markdown/03-protocols/04-simple-rest-json/02-server.md
+++ b/modules/docs/resources/markdown/03-protocols/04-simple-rest-json/02-server.md
@@ -63,7 +63,7 @@ myRoutes.mapErrors{
 }.resource
 ```
 
-An addition there is a `onError` method available to allow one to install a routine to run upon all errors that occur along the path ,whether defined in Smithy or not . This will also run on errors that hav e been raised in middleware.
+An addition there is an `onError` method that installs a routine to run upon all errors that occur along the path, whether defined in Smithy or not. This will also run on errors that have been raised in middleware.
 
 ```scala
 myRoutes.onError{

--- a/modules/docs/resources/markdown/03-protocols/04-simple-rest-json/02-server.md
+++ b/modules/docs/resources/markdown/03-protocols/04-simple-rest-json/02-server.md
@@ -63,7 +63,7 @@ myRoutes.mapErrors{
 }.resource
 ```
 
-An addition there is an `onError` method that installs a routine to run upon all errors that occur along the path, whether defined in Smithy or not. This will also run on errors that have been raised in middleware.
+Additionally, there is an `onError` method that installs a routine to run upon all errors that occur along the path, whether defined in Smithy or not. This will also run on errors that have been raised in smithy4s middleware.
 
 ```scala
 myRoutes.onError{

--- a/modules/docs/resources/markdown/03-protocols/04-simple-rest-json/02-server.md
+++ b/modules/docs/resources/markdown/03-protocols/04-simple-rest-json/02-server.md
@@ -63,10 +63,10 @@ myRoutes.mapErrors{
 }.resource
 ```
 
-An addition there is a `flatTapErrors` method available to allow one access to non smithy defined errors, without transforming the error type.
+An addition there is a `onError` method available to allow one to install a routine to run upon all errors that occur along the path ,whether defined in Smithy or not . This will also run on errors that hav e been raised in middleware.
 
 ```scala
-myRoutes.flatTapErrors{
+myRoutes.onError{
   case e:PayloadError => IO.println(s"unhandled error logged ${e.getMessage}")
 }.resource
 ```

--- a/modules/docs/resources/markdown/03-protocols/04-simple-rest-json/02-server.md
+++ b/modules/docs/resources/markdown/03-protocols/04-simple-rest-json/02-server.md
@@ -63,6 +63,14 @@ myRoutes.mapErrors{
 }.resource
 ```
 
+An addition there is a `flatTapErrors` method available to allow one access to non smithy defined errors, without transforming the error type.
+
+```scala
+myRoutes.flatTapErrors{
+  case e:PayloadError => IO.println(s"unhandled error logged ${e.getMessage}")
+}.resource
+```
+
 ## Wiring the routes
 
 As a reminder, to wire those routes into a server, you need something like:

--- a/modules/docs/resources/markdown/03-protocols/04-simple-rest-json/02-server.md
+++ b/modules/docs/resources/markdown/03-protocols/04-simple-rest-json/02-server.md
@@ -67,7 +67,7 @@ An addition there is an `onError` method that installs a routine to run upon all
 
 ```scala
 myRoutes.onError{
-  case e:PayloadError => IO.println(s"unhandled error logged ${e.getMessage}")
+  case e: PayloadError => IO.println(s"unhandled error logged ${e.getMessage}")
 }.resource
 ```
 

--- a/modules/http4s/src/smithy4s/http4s/ServerEndpointMiddleware.scala
+++ b/modules/http4s/src/smithy4s/http4s/ServerEndpointMiddleware.scala
@@ -52,15 +52,4 @@ object ServerEndpointMiddleware {
         )
       }
     }
-
-  def onError[F[_]: MonadThrow](
-      handler: PartialFunction[Throwable, F[Unit]]
-  ): ServerEndpointMiddleware[F] =
-    new ServerEndpointMiddleware[F] {
-      def prepare[Alg[_[_, _, _, _, _]]](service: Service[Alg])(
-          endpoint: Endpoint[service.Operation, _, _, _, _, _]
-      ): HttpApp[F] => HttpApp[F] = http => {
-        Kleisli(req => http(req).onError(handler))
-      }
-    }
 }

--- a/modules/http4s/src/smithy4s/http4s/ServerEndpointMiddleware.scala
+++ b/modules/http4s/src/smithy4s/http4s/ServerEndpointMiddleware.scala
@@ -53,4 +53,14 @@ object ServerEndpointMiddleware {
       }
     }
 
+  def onError[F[_]: MonadThrow](
+      handler: PartialFunction[Throwable, F[Unit]]
+  ): ServerEndpointMiddleware[F] =
+    new ServerEndpointMiddleware[F] {
+      def prepare[Alg[_[_, _, _, _, _]]](service: Service[Alg])(
+          endpoint: Endpoint[service.Operation, _, _, _, _, _]
+      ): HttpApp[F] => HttpApp[F] = http => {
+        Kleisli(req => http(req).onError(handler))
+      }
+    }
 }

--- a/modules/http4s/src/smithy4s/http4s/SimpleProtocolBuilder.scala
+++ b/modules/http4s/src/smithy4s/http4s/SimpleProtocolBuilder.scala
@@ -135,7 +135,7 @@ abstract class SimpleProtocolBuilder[P](
       service: smithy4s.Service[Alg],
       impl: FunctorAlgebra[Alg, F],
       errorTransformation: PartialFunction[Throwable, F[Throwable]],
-      onError: PartialFunction[Throwable, F[Unit]] = PartialFunction.empty,
+      onError: PartialFunction[Throwable, F[Unit]],
       middleware: ServerEndpointMiddleware[F],
       encodeErrorsBeforeMiddleware: Boolean
   )(implicit

--- a/modules/http4s/src/smithy4s/http4s/SimpleProtocolBuilder.scala
+++ b/modules/http4s/src/smithy4s/http4s/SimpleProtocolBuilder.scala
@@ -224,14 +224,15 @@ abstract class SimpleProtocolBuilder[P](
         .map { _ =>
           val errorHandler =
             ServerEndpointMiddleware.flatMapErrors(errorTransformation)
-          // This middleware needs to only run once and should be the last one to run
           val finalMiddleware =
-            errorHandler
-              .andThen(middleware)
-              .andThen(errorHandler)
+            errorHandler.andThen(middleware).andThen(errorHandler)
 
           val router =
-            HttpUnaryServerRouter(service, encodeErrorsBeforeMiddleware)(
+            HttpUnaryServerRouter(
+              service,
+              encodeErrorsBeforeMiddleware,
+              onError
+            )(
               impl,
               simpleProtocolCodecs.makeServerCodecs[F],
               finalMiddleware.biject(_.run)(HttpApp(_)),
@@ -240,8 +241,7 @@ abstract class SimpleProtocolBuilder[P](
               getUri =
                 (request: Request[F]) => toSmithy4sHttpUri(request.uri, None),
               addDecodedPathParams = (request: Request[F], pathParams) =>
-                request.withAttribute(pathParamsKey, pathParams),
-              onError
+                request.withAttribute(pathParamsKey, pathParams)
             )
           HttpRoutes(
             router.andThen(OptionT.fromOption(_).flatMap(OptionT.liftF(_)))

--- a/modules/http4s/src/smithy4s/http4s/SimpleProtocolBuilder.scala
+++ b/modules/http4s/src/smithy4s/http4s/SimpleProtocolBuilder.scala
@@ -183,6 +183,21 @@ abstract class SimpleProtocolBuilder[P](
     ): RouterBuilder[Alg, F] =
       copy(errorTransformation = fe)
 
+    /**
+     * provides a way to run an side effect for errors that are not in the smithy spec (has no effect on errors from spec).
+     * i.e log errors or send them to a monitoring service.
+     * 
+    * */
+
+    def flatTapErrors(
+        fe: PartialFunction[Throwable, F[Unit]]
+    ): RouterBuilder[Alg, F] = {
+      copy(errorTransformation = {
+        case t if (fe.isDefinedAt(t)) =>
+          fe(t) *> t.pure[F]
+      })
+    }
+
     def middleware(
         mid: ServerEndpointMiddleware[F]
     ): RouterBuilder[Alg, F] =

--- a/modules/http4s/src/smithy4s/http4s/SimpleProtocolBuilder.scala
+++ b/modules/http4s/src/smithy4s/http4s/SimpleProtocolBuilder.scala
@@ -225,12 +225,10 @@ abstract class SimpleProtocolBuilder[P](
           val errorHandler =
             ServerEndpointMiddleware.flatMapErrors(errorTransformation)
           // This middleware needs to only run once and should be the last one to run
-          val onErrorMiddleware = ServerEndpointMiddleware.onError(onError)
           val finalMiddleware =
             errorHandler
               .andThen(middleware)
               .andThen(errorHandler)
-              .andThen(onErrorMiddleware)
 
           val router =
             HttpUnaryServerRouter(service, encodeErrorsBeforeMiddleware)(
@@ -242,7 +240,8 @@ abstract class SimpleProtocolBuilder[P](
               getUri =
                 (request: Request[F]) => toSmithy4sHttpUri(request.uri, None),
               addDecodedPathParams = (request: Request[F], pathParams) =>
-                request.withAttribute(pathParamsKey, pathParams)
+                request.withAttribute(pathParamsKey, pathParams),
+              onError
             )
           HttpRoutes(
             router.andThen(OptionT.fromOption(_).flatMap(OptionT.liftF(_)))

--- a/modules/http4s/src/smithy4s/http4s/SimpleProtocolBuilder.scala
+++ b/modules/http4s/src/smithy4s/http4s/SimpleProtocolBuilder.scala
@@ -60,6 +60,7 @@ abstract class SimpleProtocolBuilder[P](
       service,
       impl,
       PartialFunction.empty,
+      PartialFunction.empty,
       Endpoint.Middleware.noop,
       encodeErrorsBeforeMiddleware = false
     )
@@ -78,6 +79,7 @@ abstract class SimpleProtocolBuilder[P](
       new RouterBuilder[Alg, F](
         service,
         impl,
+        PartialFunction.empty,
         PartialFunction.empty,
         Endpoint.Middleware.noop,
         encodeErrorsBeforeMiddleware = false
@@ -133,6 +135,7 @@ abstract class SimpleProtocolBuilder[P](
       service: smithy4s.Service[Alg],
       impl: FunctorAlgebra[Alg, F],
       errorTransformation: PartialFunction[Throwable, F[Throwable]],
+      onError: PartialFunction[Throwable, F[Unit]] = PartialFunction.empty,
       middleware: ServerEndpointMiddleware[F],
       encodeErrorsBeforeMiddleware: Boolean
   )(implicit
@@ -184,18 +187,14 @@ abstract class SimpleProtocolBuilder[P](
       copy(errorTransformation = fe)
 
     /**
-     * provides a way to run an side effect for errors that are not in the smithy spec (has no effect on errors from spec).
-     * i.e log errors or send them to a monitoring service.
+     * Registers a handler for ALL errors including those defined in the Smithy spec.
      * 
-    * */
+    **/
 
-    def flatTapErrors(
+    def onError(
         fe: PartialFunction[Throwable, F[Unit]]
     ): RouterBuilder[Alg, F] = {
-      copy(errorTransformation = {
-        case t if (fe.isDefinedAt(t)) =>
-          fe(t) *> t.pure[F]
-      })
+      copy(onError = fe)
     }
 
     def middleware(
@@ -225,8 +224,14 @@ abstract class SimpleProtocolBuilder[P](
         .map { _ =>
           val errorHandler =
             ServerEndpointMiddleware.flatMapErrors(errorTransformation)
+          // This middleware needs to only run once and should be the last one to run
+          val onErrorMiddleware = ServerEndpointMiddleware.onError(onError)
           val finalMiddleware =
-            errorHandler.andThen(middleware).andThen(errorHandler)
+            errorHandler
+              .andThen(middleware)
+              .andThen(errorHandler)
+              .andThen(onErrorMiddleware)
+
           val router =
             HttpUnaryServerRouter(service, encodeErrorsBeforeMiddleware)(
               impl,
@@ -252,6 +257,7 @@ abstract class SimpleProtocolBuilder[P](
         impl: FunctorAlgebra[Alg, F] = impl,
         errorTransformation: PartialFunction[Throwable, F[Throwable]] =
           errorTransformation,
+        onError: PartialFunction[Throwable, F[Unit]] = onError,
         middleware: ServerEndpointMiddleware[F] = middleware,
         encodeErrorsBeforeMiddleware: Boolean = encodeErrorsBeforeMiddleware
     ): RouterBuilder[Alg, F] =
@@ -259,6 +265,7 @@ abstract class SimpleProtocolBuilder[P](
         service,
         impl,
         errorTransformation,
+        onError,
         middleware,
         encodeErrorsBeforeMiddleware
       )

--- a/modules/http4s/src/smithy4s/http4s/SimpleProtocolBuilder.scala
+++ b/modules/http4s/src/smithy4s/http4s/SimpleProtocolBuilder.scala
@@ -188,9 +188,7 @@ abstract class SimpleProtocolBuilder[P](
 
     /**
      * Registers a handler for ALL errors including those defined in the Smithy spec.
-     * 
-    **/
-
+     **/
     def onError(
         fe: PartialFunction[Throwable, F[Unit]]
     ): RouterBuilder[Alg, F] = {

--- a/modules/http4s/test/src/smithy4s/http4s/ServerEndpointMiddlewareSpec.scala
+++ b/modules/http4s/test/src/smithy4s/http4s/ServerEndpointMiddlewareSpec.scala
@@ -40,16 +40,19 @@ object ServerEndpointMiddlewareSpec extends SimpleIOSuite {
       extends RuntimeException(
         "Expected to recover via flatmapError or mapError"
       )
-
-  test("server - middleware can throw and mapped / flatmapped") {
-    val middleware = new ServerEndpointMiddleware.Simple[IO]() {
-      def prepareWithHints(
-          serviceHints: Hints,
-          endpointHints: Hints
-      ): HttpApp[IO] => HttpApp[IO] = { inputApp =>
-        HttpApp[IO] { _ => IO.raiseError(new MiddlewareException) }
-      }
+  val middleware = new ServerEndpointMiddleware.Simple[IO]() {
+    def prepareWithHints(
+        serviceHints: Hints,
+        endpointHints: Hints
+    ): HttpApp[IO] => HttpApp[IO] = { inputApp =>
+      HttpApp[IO] { _ => IO.raiseError(new MiddlewareException) }
     }
+  }
+
+  test(
+    "server - middleware can throw and mapped / flatmapped"
+  ) {
+
     def runOnService(service: HttpRoutes[IO]): IO[Expectations] =
       service(Request[IO](Method.POST, Uri.unsafeFromString("/bob")))
         .flatMap(res => OptionT.pure(expect.eql(res.status.code, 599)))
@@ -81,30 +84,33 @@ object ServerEndpointMiddlewareSpec extends SimpleIOSuite {
     )
     List(throwCheck, pureCheck).combineAll
   }
-  test("flatTap bypasses errors defined in Smithy  runs side effect ") {
+  test("onError routine is installed for smithy defined errors") {
     for {
       ref <- Ref.of[IO, Option[String]](None)
 
       tap: PartialFunction[Throwable, IO[Unit]] = { case e =>
-        IO.println("failing ... ") *> ref.set(Some(e.getMessage))
+        ref.set(Some(e.getMessage))
       }
 
       routes = SimpleRestJsonBuilder
         .routes(FailingHelloImpl)
-        .flatTapErrors(tap)
+        .onError(tap)
         .make
         .toOption
         .get
 
       req = Request[IO](Method.POST, uri"/boom")
-      _ <- routes.run(req).value.attempt
+      res <- routes.run(req).value.attempt
 
       sideEffect <- ref.get
 
-    } yield expect(sideEffect.isEmpty)
+    } yield expect(
+      res.isRight &&
+        sideEffect.contains("to be encoded before middleware is applied")
+    )
 
   }
-  test("flatTap hanbdles errors not defined in Smithy ") {
+  test("onError routine is installed for NON smithy defined errors") {
     for {
       ref <- Ref.of[IO, Option[String]](None)
 
@@ -114,7 +120,7 @@ object ServerEndpointMiddlewareSpec extends SimpleIOSuite {
 
       routes = SimpleRestJsonBuilder
         .routes(new FailingHelloImpl(new RuntimeException("to be tapped")))
-        .flatTapErrors(tap)
+        .onError(tap)
         .make
         .toOption
         .get
@@ -129,7 +135,35 @@ object ServerEndpointMiddlewareSpec extends SimpleIOSuite {
     )
 
   }
+  test("onError routine has access to middleware created errors too ") {
 
+    for {
+      ref <- Ref.of[IO, Option[String]](None)
+
+      tap: PartialFunction[Throwable, IO[Unit]] = { case e =>
+        ref.set(Some(e.getMessage))
+      }
+      routes = SimpleRestJsonBuilder
+        .routes(HelloImpl)
+        .middleware(middleware)
+        .onError(tap)
+        .flatMapErrors { case _: MiddlewareException =>
+          IO.pure(SpecificServerError(Some("test")))
+
+        }
+        .make
+        .toOption
+        .get
+
+      req = Request[IO](Method.POST, uri"/bob")
+      res <- routes.run(req).value.attempt
+
+      sideEffect <- ref.get
+
+    } yield expect(
+      res.isRight && sideEffect.contains("test")
+    )
+  }
   test("server - middleware can catch spec error") {
     val catchSpecErrorMiddleware = new ServerEndpointMiddleware.Simple[IO]() {
       def prepareWithHints(

--- a/modules/http4s/test/src/smithy4s/http4s/ServerEndpointMiddlewareSpec.scala
+++ b/modules/http4s/test/src/smithy4s/http4s/ServerEndpointMiddlewareSpec.scala
@@ -27,6 +27,8 @@ import org.http4s.HttpApp
 import org.http4s.Uri
 import org.http4s._
 import org.http4s.client.Client
+import cats.effect.Ref
+import org.http4s.syntax.literals._
 import smithy4s.example.hello._
 import weaver._
 
@@ -79,6 +81,54 @@ object ServerEndpointMiddlewareSpec extends SimpleIOSuite {
     )
     List(throwCheck, pureCheck).combineAll
   }
+  test("flatTap bypasses errors defined in Smithy  runs side effect ") {
+    for {
+      ref <- Ref.of[IO, Option[String]](None)
+
+      tap: PartialFunction[Throwable, IO[Unit]] = { case e =>
+        IO.println("failing ... ") *> ref.set(Some(e.getMessage))
+      }
+
+      routes = SimpleRestJsonBuilder
+        .routes(FailingHelloImpl)
+        .flatTapErrors(tap)
+        .make
+        .toOption
+        .get
+
+      req = Request[IO](Method.POST, uri"/boom")
+      _ <- routes.run(req).value.attempt
+
+      sideEffect <- ref.get
+
+    } yield expect(sideEffect.isEmpty)
+
+  }
+  test("flatTap hanbdles errors not defined in Smithy ") {
+    for {
+      ref <- Ref.of[IO, Option[String]](None)
+
+      tap: PartialFunction[Throwable, IO[Unit]] = { case e =>
+        ref.set(Some(e.getMessage))
+      }
+
+      routes = SimpleRestJsonBuilder
+        .routes(new FailingHelloImpl(new RuntimeException("to be tapped")))
+        .flatTapErrors(tap)
+        .make
+        .toOption
+        .get
+
+      req = Request[IO](Method.POST, uri"/bob")
+      res <- routes.run(req).value.attempt
+
+      sideEffect <- ref.get
+
+    } yield expect(
+      res.isLeft && sideEffect.contains("to be tapped")
+    )
+
+  }
 
   test("server - middleware can catch spec error") {
     val catchSpecErrorMiddleware = new ServerEndpointMiddleware.Simple[IO]() {
@@ -95,12 +145,7 @@ object ServerEndpointMiddlewareSpec extends SimpleIOSuite {
     }
 
     SimpleRestJsonBuilder
-      .routes(new HelloWorldService[IO] {
-        def hello(name: String, town: Option[String]): IO[Greeting] =
-          IO.raiseError(
-            SpecificServerError(Some("to be caught in middleware"))
-          )
-      })
+      .routes(FailingHelloImpl)
       .middleware(catchSpecErrorMiddleware)
       .make
       .toOption
@@ -130,14 +175,7 @@ object ServerEndpointMiddlewareSpec extends SimpleIOSuite {
 
     SimpleRestJsonBuilder
       .routes(
-        new HelloWorldService[IO] {
-          def hello(name: String, town: Option[String]): IO[Greeting] =
-            IO.raiseError(
-              SpecificServerError(
-                Some("to be encoded before middleware is applied")
-              )
-            )
-        }
+        FailingHelloImpl
       )
       .encodeErrorsBeforeMiddleware(true)
       .middleware(middleware)
@@ -244,6 +282,18 @@ object ServerEndpointMiddlewareSpec extends SimpleIOSuite {
 
     expect(client)
   }
+
+  private class FailingHelloImpl(throwable: Throwable)
+      extends HelloWorldService[IO] {
+    def hello(name: String, town: Option[String]): IO[Greeting] =
+      throwable.raiseError[IO, Greeting]
+  }
+  private object FailingHelloImpl
+      extends FailingHelloImpl(
+        SpecificServerError(
+          Some("to be encoded before middleware is applied")
+        )
+      )
 
   private object HelloImpl extends HelloWorldService[IO] {
     def hello(name: String, town: Option[String]): IO[Greeting] = IO.pure(

--- a/modules/http4s/test/src/smithy4s/http4s/ServerEndpointMiddlewareSpec.scala
+++ b/modules/http4s/test/src/smithy4s/http4s/ServerEndpointMiddlewareSpec.scala
@@ -135,7 +135,9 @@ object ServerEndpointMiddlewareSpec extends SimpleIOSuite {
     )
 
   }
-  test("onError routine has access to middleware created errors too ") {
+  test(
+    "onError routine does not have access to errors raised in Middleware"
+  ) {
 
     for {
       ref <- Ref.of[IO, Option[String]](None)
@@ -161,7 +163,7 @@ object ServerEndpointMiddlewareSpec extends SimpleIOSuite {
       sideEffect <- ref.get
 
     } yield expect(
-      res.isRight && sideEffect.contains("test")
+      res.isRight && sideEffect.isEmpty
     )
   }
   test("server - middleware can catch spec error") {


### PR DESCRIPTION
The goal of this PR is to introduce another method `onError` to the RouterBuilder. This allows the user to provide  an effectful routine to run upon any error whether defined in spec or otherwise.
This will run on errors raised in the middleware too.

## PR Checklist (not all items are relevant to all PRs)

- [x] Added unit-tests (for runtime code)
- [x] Added documentation
- [x] Updated changelog
