### PR TITLE
Fix Hints methods to distinguish member and target hints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ When adding entries, please treat them as if they could end up in a release any 
 
 Thank you!
 
+# 0.18.38
+
+* core: Fix Hints methods to distinguish member and target hints (fixes [#1658](https://github.com/disneystreaming/smithy4s/issues/1658)) in [#1756](https://github.com/disneystreaming/smithy4s/pull/1756)
+
 # 0.18.37
 
 * json: Allow decoding nulls for optional fields in defaults (fixes [#1581](https://github.com/disneystreaming/smithy4s/issues/1581)) in [#1744](https://github.com/disneystreaming/smithy4s/pull/1744)

--- a/modules/bootstrapped/test/src/smithy4s/HintsSpec.scala
+++ b/modules/bootstrapped/test/src/smithy4s/HintsSpec.scala
@@ -173,37 +173,60 @@ class HintsSpec() extends FunSuite {
     "Hints#filter and toString handle member and target bindings correctly"
   ) {
     import Document.syntax._
-    val staticMemberHint = HttpHeader("X-Member")
-    val staticTargetHint = HttpLabel()
-    val dynamicMemberHint = Hints.dynamic("smithy.api#jsonName" -> "foo")
-    val dynamicTargetHint = Hints.dynamic("smithy.api#documentation" -> "doc")
     val hints = Hints
-      .member(staticMemberHint)
-      .addMemberHints(dynamicMemberHint)
-      .addTargetHints(staticTargetHint)
-      .addTargetHints(dynamicTargetHint)
+      .member(HttpHeader("X-Member"))
+      .addMemberHints(Hints.dynamic("smithy.api#jsonName" -> "foo"))
+      .addTargetHints(HttpLabel())
+      .addTargetHints(Hints.dynamic("smithy.api#documentation" -> "doc"))
 
-    val expectedMemberStr =
-      s"${HttpHeader.id} -> $staticMemberHint, ${JsonName.id} -> ${Document
-        .obj(JsonName.id.show -> Document.DString("foo"))}"
-    val expectedTargetStr =
-      s"${HttpLabel.id} -> $staticTargetHint, ${Documentation.id} -> ${Document
-        .obj(Documentation.id.show -> Document.DString("doc"))}"
+    val memberHintsString =
+      """smithy.api#httpHeader -> X-Member, smithy.api#jsonName -> {smithy.api#jsonName="foo"}"""
+    val targetHintsString =
+      """smithy.api#httpLabel -> HttpLabel(), smithy.api#documentation -> {smithy.api#documentation="doc"}"""
     val expectedToString =
-      s"Hints(member=[$expectedMemberStr], target=[$expectedTargetStr])"
+      s"""Hints(member=[$memberHintsString], target=[$targetHintsString])"""
+
     expect.same(hints.toString, expectedToString)
+  }
+
+  test("Hints#filter preserves member and target hints for no-op filter") {
+    import Document.syntax._
+    val hints = Hints.empty
+      .addMemberHints(HttpHeader("X-Member"))
+      .addMemberHints(Hints.dynamic("smithy.api#jsonName" -> "foo"))
+      .addTargetHints(HttpLabel())
+      .addTargetHints(Hints.dynamic("smithy.api#documentation" -> "doc"))
 
     val filtered = hints.filter(_ => true)
+    expect.same(filtered.memberHints, hints.memberHints)
+    expect.same(filtered.targetHints, hints.targetHints)
     expect.same(filtered, hints)
+  }
 
-    expect.same(
-      filtered.memberHints,
-      Hints.member(staticMemberHint).addMemberHints(dynamicMemberHint)
-    )
-    expect.same(
-      filtered.targetHints,
-      Hints(staticTargetHint).addTargetHints(dynamicTargetHint)
-    )
+  test("Hints#filter returns empty hints when predicate is false") {
+    import Document.syntax._
+    val hints = Hints.empty
+      .addMemberHints(HttpHeader("X-Member"))
+      .addMemberHints(Hints.dynamic("smithy.api#jsonName" -> "foo"))
+      .addTargetHints(HttpLabel())
+      .addTargetHints(Hints.dynamic("smithy.api#documentation" -> "doc"))
+
+    val filtered = hints.filter(_ => false)
+    expect.same(filtered, Hints.empty)
+  }
+
+  test("Hints#filter selects specific hints by keyId") {
+    val hints = Hints.empty
+      .addMemberHints(HttpHeader("X-Member"))
+      .addTargetHints(HttpLabel())
+
+    val filtered = hints.filter(_.keyId == HttpLabel.id)
+    expect.same(filtered, Hints(HttpLabel()))
+  }
+
+  test("Hints#filter on empty hints returns empty hints") {
+    val filtered = Hints.empty.filter(_ => true)
+    expect.same(filtered, Hints.empty)
   }
 
   private def makeLazyHints(hints: => Hints): (Hints, () => Boolean) = {

--- a/modules/bootstrapped/test/src/smithy4s/HintsSpec.scala
+++ b/modules/bootstrapped/test/src/smithy4s/HintsSpec.scala
@@ -170,11 +170,11 @@ class HintsSpec() extends FunSuite {
   }
 
   test(
-    "Hints#filter and toString handle member and target bindings correctly"
+    "Hints#toString handles member and target bindings correctly"
   ) {
     import Document.syntax._
-    val hints = Hints
-      .member(HttpHeader("X-Member"))
+    val hints = Hints.empty
+      .addMemberHints(HttpHeader("X-Member"))
       .addMemberHints(Hints.dynamic("smithy.api#jsonName" -> "foo"))
       .addTargetHints(HttpLabel())
       .addTargetHints(Hints.dynamic("smithy.api#documentation" -> "doc"))
@@ -187,6 +187,25 @@ class HintsSpec() extends FunSuite {
       s"""Hints(member=[$memberHintsString], target=[$targetHintsString])"""
 
     expect.same(hints.toString, expectedToString)
+  }
+
+  test(
+    "Hints#filter handles member and target bindings correctly"
+  ) {
+    import Document.syntax._
+    val hints = Hints.empty
+      .addMemberHints(HttpHeader("X-Member"))
+      .addMemberHints(Hints.dynamic("smithy.api#jsonName" -> "foo"))
+      .addTargetHints(JsonName("foo"))
+      .addTargetHints(Hints.dynamic("smithy.api#documentation" -> "doc"))
+
+    val filteredHints = hints.filter(_.keyId == JsonName.id)
+    val expectedHints = Hints.empty
+      .addMemberHints(Hints.dynamic("smithy.api#jsonName" -> "foo"))
+      .addTargetHints(JsonName("foo"))
+
+    expect.same(filteredHints.memberHints, expectedHints.memberHints)
+    expect.same(filteredHints.targetHints, expectedHints.targetHints)
   }
 
   test("Hints#filter preserves member and target hints for no-op filter") {

--- a/modules/bootstrapped/test/src/smithy4s/HintsSpec.scala
+++ b/modules/bootstrapped/test/src/smithy4s/HintsSpec.scala
@@ -169,6 +169,30 @@ class HintsSpec() extends FunSuite {
     assertEquals(hints.get(Tags), Some(Tags(List("one", "two", "three"))))
   }
 
+  test("Hints#filter and toString handle static and dynamic bindings correctly") {
+    import Document.syntax._
+    val staticMemberHint = HttpHeader("X-Member")
+    val staticTargetHint = HttpLabel()
+    val dynamicMemberHint = Hints.dynamic("smithy.api#jsonName" -> "foo")
+    val dynamicTargetHint = Hints.dynamic("smithy.api#documentation" -> "doc")
+    val hints = Hints
+      .member(staticMemberHint)
+      .addMemberHints(dynamicMemberHint)
+      .addTargetHints(staticTargetHint)
+      .addTargetHints(dynamicTargetHint)
+
+    val expectedMemberStr = s"${HttpHeader.id} -> $staticMemberHint, ${JsonName.id} -> ${Document.obj(JsonName.id.show -> Document.DString("foo"))}"
+    val expectedTargetStr = s"${HttpLabel.id} -> $staticTargetHint, ${Documentation.id} -> ${Document.obj(Documentation.id.show -> Document.DString("doc"))}"
+    val expectedToString = s"Hints(member=[$expectedMemberStr], target=[$expectedTargetStr])"
+    expect.same(hints.toString, expectedToString)
+
+    val filtered = hints.filter(_ => true)
+    expect.same(filtered, hints)
+
+    expect.same(filtered.memberHints, Hints.member(staticMemberHint).addMemberHints(dynamicMemberHint))
+    expect.same(filtered.targetHints, Hints(staticTargetHint).addTargetHints(dynamicTargetHint))
+  }
+
   private def makeLazyHints(hints: => Hints): (Hints, () => Boolean) = {
     var evaled = false
 

--- a/modules/bootstrapped/test/src/smithy4s/HintsSpec.scala
+++ b/modules/bootstrapped/test/src/smithy4s/HintsSpec.scala
@@ -170,7 +170,7 @@ class HintsSpec() extends FunSuite {
   }
 
   test(
-    "Hints#filter and toString handle static and dynamic bindings correctly"
+    "Hints#filter and toString handle member and target bindings correctly"
   ) {
     import Document.syntax._
     val staticMemberHint = HttpHeader("X-Member")

--- a/modules/bootstrapped/test/src/smithy4s/HintsSpec.scala
+++ b/modules/bootstrapped/test/src/smithy4s/HintsSpec.scala
@@ -169,7 +169,9 @@ class HintsSpec() extends FunSuite {
     assertEquals(hints.get(Tags), Some(Tags(List("one", "two", "three"))))
   }
 
-  test("Hints#filter and toString handle static and dynamic bindings correctly") {
+  test(
+    "Hints#filter and toString handle static and dynamic bindings correctly"
+  ) {
     import Document.syntax._
     val staticMemberHint = HttpHeader("X-Member")
     val staticTargetHint = HttpLabel()
@@ -181,16 +183,27 @@ class HintsSpec() extends FunSuite {
       .addTargetHints(staticTargetHint)
       .addTargetHints(dynamicTargetHint)
 
-    val expectedMemberStr = s"${HttpHeader.id} -> $staticMemberHint, ${JsonName.id} -> ${Document.obj(JsonName.id.show -> Document.DString("foo"))}"
-    val expectedTargetStr = s"${HttpLabel.id} -> $staticTargetHint, ${Documentation.id} -> ${Document.obj(Documentation.id.show -> Document.DString("doc"))}"
-    val expectedToString = s"Hints(member=[$expectedMemberStr], target=[$expectedTargetStr])"
+    val expectedMemberStr =
+      s"${HttpHeader.id} -> $staticMemberHint, ${JsonName.id} -> ${Document
+        .obj(JsonName.id.show -> Document.DString("foo"))}"
+    val expectedTargetStr =
+      s"${HttpLabel.id} -> $staticTargetHint, ${Documentation.id} -> ${Document
+        .obj(Documentation.id.show -> Document.DString("doc"))}"
+    val expectedToString =
+      s"Hints(member=[$expectedMemberStr], target=[$expectedTargetStr])"
     expect.same(hints.toString, expectedToString)
 
     val filtered = hints.filter(_ => true)
     expect.same(filtered, hints)
 
-    expect.same(filtered.memberHints, Hints.member(staticMemberHint).addMemberHints(dynamicMemberHint))
-    expect.same(filtered.targetHints, Hints(staticTargetHint).addTargetHints(dynamicTargetHint))
+    expect.same(
+      filtered.memberHints,
+      Hints.member(staticMemberHint).addMemberHints(dynamicMemberHint)
+    )
+    expect.same(
+      filtered.targetHints,
+      Hints(staticTargetHint).addTargetHints(dynamicTargetHint)
+    )
   }
 
   private def makeLazyHints(hints: => Hints): (Hints, () => Boolean) = {

--- a/modules/core/src/ShapeTag.scala
+++ b/modules/core/src/ShapeTag.scala
@@ -17,7 +17,12 @@
 package smithy4s
 
 /**
-  * A tag that can be used as keys for higher-kinded maps
+  * A tag that can be used as keys for higher-kinded maps.
+  *
+  * Note: The assumption is that ShapeTags can be compared against each other using **instance equality**.
+  * This means that two ShapeTags based on the same schema/type may not be considered equal if they don't come from the exact same instance.
+  * You can find an example of instance equality (`eq`) being used in [[smithy4s.Hints]].
+  * More discussion on this topic: https://github.com/disneystreaming/smithy4s/issues/1658#issuecomment-2685543923
   */
 trait ShapeTag[A] extends HasId {
   def schema: Schema[A]

--- a/modules/core/src/smithy4s/Hints.scala
+++ b/modules/core/src/smithy4s/Hints.scala
@@ -181,8 +181,7 @@ object Hints {
       )
 
     override def toString(): String =
-      s"Hints(memberHints = ${memberHintsMap.values.mkString(", ")}, targetHints = ${targetHintsMap.values
-        .mkString(", ")})"
+      s"Hints(${all.mkString(", ")})"
 
     override def equals(obj: Any): Boolean = obj match {
       case h: Hints =>

--- a/modules/core/src/smithy4s/Hints.scala
+++ b/modules/core/src/smithy4s/Hints.scala
@@ -55,8 +55,8 @@ trait Hints {
   final def get[T](nt: AbstractNewtype[T]): Option[nt.Type] = get(nt.tag)
   final def filter(predicate: Hint => Boolean): Hints =
     Hints.Impl(
-      memberHintsMap = memberHintsMap.filter((_, h) => predicate(h)),
-      targetHintsMap = targetHintsMap.filter((_, h) => predicate(h))
+      memberHintsMap = memberHintsMap.filter { case (_, h) => predicate(h) },
+      targetHintsMap = targetHintsMap.filter { case (_, h) => predicate(h) }
     )
   final def filterNot(predicate: Hint => Boolean): Hints =
     filter(h => !predicate(h))

--- a/modules/core/src/smithy4s/Hints.scala
+++ b/modules/core/src/smithy4s/Hints.scala
@@ -181,7 +181,8 @@ object Hints {
       )
 
     override def toString(): String =
-      s"Hints(${all.mkString(", ")})"
+      s"Hints(memberHints = ${memberHintsMap.values.mkString(", ")}, targetHints = ${targetHintsMap.values
+        .mkString(", ")})"
 
     override def equals(obj: Any): Boolean = obj match {
       case h: Hints =>

--- a/modules/core/src/smithy4s/Hints.scala
+++ b/modules/core/src/smithy4s/Hints.scala
@@ -34,8 +34,11 @@ trait Hints {
   def isEmpty: Boolean
   def all: Iterable[Hints.Binding]
 
-  def memberHintsMap: Map[ShapeId, Hints.Binding] = memberHintsMap
-  def targetHintsMap: Map[ShapeId, Hints.Binding] = targetHintsMap
+  def memberHintsMap: Map[ShapeId, Hints.Binding]
+  def targetHintsMap: Map[ShapeId, Hints.Binding]
+  
+  def toMemberMap: Map[ShapeId, Hints.Binding] = memberHintsMap
+  def toTargetMap: Map[ShapeId, Hints.Binding] = targetHintsMap
 
   /**
     * Returns a map of hints from both level, the member-level having priority

--- a/modules/core/src/smithy4s/Hints.scala
+++ b/modules/core/src/smithy4s/Hints.scala
@@ -34,8 +34,8 @@ trait Hints {
   def isEmpty: Boolean
   def all: Iterable[Hints.Binding]
 
-  def memberHintsMap: Map[ShapeId, Hints.Binding]
-  def targetHintsMap: Map[ShapeId, Hints.Binding]
+  def memberHintsMap: Map[ShapeId, Hints.Binding] = memberHintsMap
+  def targetHintsMap: Map[ShapeId, Hints.Binding] = targetHintsMap
 
   /**
     * Returns a map of hints from both level, the member-level having priority
@@ -178,7 +178,9 @@ object Hints {
       s"Hints(${all.mkString(", ")})"
 
     override def equals(obj: Any): Boolean = obj match {
-      case h: Hints => toMap == h.toMap
+      case h: Hints => 
+        this.memberHintsMap == h.memberHintsMap &&
+        this.targetHintsMap == h.targetHintsMap
       case _        => false
     }
 

--- a/modules/core/src/smithy4s/Hints.scala
+++ b/modules/core/src/smithy4s/Hints.scala
@@ -37,9 +37,6 @@ trait Hints {
   def memberHintsMap: Map[ShapeId, Hints.Binding]
   def targetHintsMap: Map[ShapeId, Hints.Binding]
 
-  def toMemberMap: Map[ShapeId, Hints.Binding] = memberHintsMap
-  def toTargetMap: Map[ShapeId, Hints.Binding] = targetHintsMap
-
   /**
     * Returns a map of hints from both level, the member-level having priority
     * over the target-level one.

--- a/modules/core/src/smithy4s/Hints.scala
+++ b/modules/core/src/smithy4s/Hints.scala
@@ -186,9 +186,9 @@ object Hints {
 
     override def toString(): String = {
       val memberStr =
-        memberHintsMap.map { case (k, v) => s"member:$k=$v" }.mkString(", ")
+        memberHintsMap.map { case (k, v) => s"$k -> $v" }.mkString(", ")
       val targetStr =
-        targetHintsMap.map { case (k, v) => s"target:$k=$v" }.mkString(", ")
+        targetHintsMap.map { case (k, v) => s"$k -> $v" }.mkString(", ")
       s"Hints(member=[$memberStr], target=[$targetStr])"
     }
 

--- a/modules/core/src/smithy4s/Hints.scala
+++ b/modules/core/src/smithy4s/Hints.scala
@@ -36,7 +36,7 @@ trait Hints {
 
   def memberHintsMap: Map[ShapeId, Hints.Binding]
   def targetHintsMap: Map[ShapeId, Hints.Binding]
-  
+
   def toMemberMap: Map[ShapeId, Hints.Binding] = memberHintsMap
   def toTargetMap: Map[ShapeId, Hints.Binding] = targetHintsMap
 
@@ -54,9 +54,12 @@ trait Hints {
   )
   final def get[T](nt: AbstractNewtype[T]): Option[nt.Type] = get(nt.tag)
   final def filter(predicate: Hint => Boolean): Hints =
-    Hints.fromSeq(all.filter(predicate).toSeq)
+    Hints.Impl(
+      memberHintsMap = memberHintsMap.filter((_, h) => predicate(h)),
+      targetHintsMap = targetHintsMap.filter((_, h) => predicate(h))
+    )
   final def filterNot(predicate: Hint => Boolean): Hints =
-    filter(hint => !predicate(hint))
+    filter(h => !predicate(h))
 
   /**
     *  Concatenates two set of hints. The levels are concatenated independently.
@@ -181,10 +184,10 @@ object Hints {
       s"Hints(${all.mkString(", ")})"
 
     override def equals(obj: Any): Boolean = obj match {
-      case h: Hints => 
+      case h: Hints =>
         this.memberHintsMap == h.memberHintsMap &&
-        this.targetHintsMap == h.targetHintsMap
-      case _        => false
+          this.targetHintsMap == h.targetHintsMap
+      case _ => false
     }
 
     override def hashCode(): Int = toMap.hashCode()

--- a/modules/core/src/smithy4s/Hints.scala
+++ b/modules/core/src/smithy4s/Hints.scala
@@ -55,11 +55,15 @@ trait Hints {
   final def get[T](nt: AbstractNewtype[T]): Option[nt.Type] = get(nt.tag)
   final def filter(predicate: Hint => Boolean): Hints =
     Hints.Impl(
-      memberHintsMap = memberHintsMap.filter { case (_, h) => predicate(h) },
-      targetHintsMap = targetHintsMap.filter { case (_, h) => predicate(h) }
+      memberHintsMap = memberHintsMap.filter { case (_, hint) =>
+        predicate(hint)
+      },
+      targetHintsMap = targetHintsMap.filter { case (_, hint) =>
+        predicate(hint)
+      }
     )
   final def filterNot(predicate: Hint => Boolean): Hints =
-    filter(h => !predicate(h))
+    filter(hint => !predicate(hint))
 
   /**
     *  Concatenates two set of hints. The levels are concatenated independently.
@@ -180,8 +184,13 @@ object Hints {
         targetHintsMap = targetHintsMap ++ hints.toMap
       )
 
-    override def toString(): String =
-      s"Hints(${all.mkString(", ")})"
+    override def toString(): String = {
+      val memberStr =
+        memberHintsMap.map { case (k, v) => s"member:$k=$v" }.mkString(", ")
+      val targetStr =
+        targetHintsMap.map { case (k, v) => s"target:$k=$v" }.mkString(", ")
+      s"Hints(member=[$memberStr], target=[$targetStr])"
+    }
 
     override def equals(obj: Any): Boolean = obj match {
       case h: Hints =>


### PR DESCRIPTION
This PR fixes #1658 by modifying that methods on `Hints` (such as `filter`, `equals`, and `toString`) preserve the distinction between `memberHints` and `targetHints`.


## PR Checklist (not all items are relevant to all PRs)
- [x] Added unit-tests (for runtime code)
- [ ] Added bootstrapped code + smoke tests (when the rendering logic is modified)
- [ ] Added build-plugins integration tests (when reflection loading is required at codegen-time)
- [ ] Added alloy compliance tests (when simpleRestJson protocol behaviour is expanded/updated)
- [ ] Updated dynamic module to match generated-code behaviour
- [ ] Added documentation
- [x] Updated changelog

Closes Strange things happening in Hints #1658