### PR TITLE
Sort service operations for rendering

### DIFF
--- a/modules/bootstrapped/src/generated/com/amazonaws/dynamodb/DynamoDB.scala
+++ b/modules/bootstrapped/src/generated/com/amazonaws/dynamodb/DynamoDB.scala
@@ -35,6 +35,8 @@ import smithy4s.schema.Schema.union
 trait DynamoDBGen[F[_, _, _, _, _]] {
   self =>
 
+  /** <p>Returns the regional endpoint information.</p> */
+  def describeEndpoints(): F[DescribeEndpointsRequest, Nothing, DescribeEndpointsResponse, Nothing, Nothing]
   /** <p>Returns an array of table names associated with the current account and endpoint. The output
     *       from <code>ListTables</code> is paginated, with each page returning a maximum of 100 table
     *       names.</p>
@@ -46,8 +48,6 @@ trait DynamoDBGen[F[_, _, _, _, _]] {
     *   <p>A maximum number of table names to return. If this parameter is not specified, the limit is 100.</p>
     */
   def listTables(exclusiveStartTableName: Option[TableName] = None, limit: Option[ListTablesInputLimit] = None): F[ListTablesInput, DynamoDBOperation.ListTablesError, ListTablesOutput, Nothing, Nothing]
-  /** <p>Returns the regional endpoint information.</p> */
-  def describeEndpoints(): F[DescribeEndpointsRequest, Nothing, DescribeEndpointsResponse, Nothing, Nothing]
 
   final def transform: Transformation.PartiallyApplied[DynamoDBGen[F]] = Transformation.of[DynamoDBGen[F]](this)
 }
@@ -75,8 +75,8 @@ object DynamoDBGen extends Service.Mixin[DynamoDBGen, DynamoDBOperation] {
   }
 
   val endpoints: Vector[smithy4s.Endpoint[DynamoDBOperation, _, _, _, _, _]] = Vector(
-    DynamoDBOperation.ListTables,
     DynamoDBOperation.DescribeEndpoints,
+    DynamoDBOperation.ListTables,
   )
 
   def input[I, E, O, SI, SO](op: DynamoDBOperation[I, E, O, SI, SO]): I = op.input
@@ -103,20 +103,32 @@ sealed trait DynamoDBOperation[Input, Err, Output, StreamedInput, StreamedOutput
 object DynamoDBOperation {
 
   object reified extends DynamoDBGen[DynamoDBOperation] {
-    def listTables(exclusiveStartTableName: Option[TableName] = None, limit: Option[ListTablesInputLimit] = None): ListTables = ListTables(ListTablesInput(exclusiveStartTableName, limit))
     def describeEndpoints(): DescribeEndpoints = DescribeEndpoints(DescribeEndpointsRequest())
+    def listTables(exclusiveStartTableName: Option[TableName] = None, limit: Option[ListTablesInputLimit] = None): ListTables = ListTables(ListTablesInput(exclusiveStartTableName, limit))
   }
   class Transformed[P[_, _, _, _, _], P1[_ ,_ ,_ ,_ ,_]](alg: DynamoDBGen[P], f: PolyFunction5[P, P1]) extends DynamoDBGen[P1] {
-    def listTables(exclusiveStartTableName: Option[TableName] = None, limit: Option[ListTablesInputLimit] = None): P1[ListTablesInput, DynamoDBOperation.ListTablesError, ListTablesOutput, Nothing, Nothing] = f[ListTablesInput, DynamoDBOperation.ListTablesError, ListTablesOutput, Nothing, Nothing](alg.listTables(exclusiveStartTableName, limit))
     def describeEndpoints(): P1[DescribeEndpointsRequest, Nothing, DescribeEndpointsResponse, Nothing, Nothing] = f[DescribeEndpointsRequest, Nothing, DescribeEndpointsResponse, Nothing, Nothing](alg.describeEndpoints())
+    def listTables(exclusiveStartTableName: Option[TableName] = None, limit: Option[ListTablesInputLimit] = None): P1[ListTablesInput, DynamoDBOperation.ListTablesError, ListTablesOutput, Nothing, Nothing] = f[ListTablesInput, DynamoDBOperation.ListTablesError, ListTablesOutput, Nothing, Nothing](alg.listTables(exclusiveStartTableName, limit))
   }
 
   def toPolyFunction[P[_, _, _, _, _]](impl: DynamoDBGen[P]): PolyFunction5[DynamoDBOperation, P] = new PolyFunction5[DynamoDBOperation, P] {
     def apply[I, E, O, SI, SO](op: DynamoDBOperation[I, E, O, SI, SO]): P[I, E, O, SI, SO] = op.run(impl) 
   }
+  final case class DescribeEndpoints(input: DescribeEndpointsRequest) extends DynamoDBOperation[DescribeEndpointsRequest, Nothing, DescribeEndpointsResponse, Nothing, Nothing] {
+    def run[F[_, _, _, _, _]](impl: DynamoDBGen[F]): F[DescribeEndpointsRequest, Nothing, DescribeEndpointsResponse, Nothing, Nothing] = impl.describeEndpoints()
+    def ordinal: Int = 0
+    def endpoint: smithy4s.Endpoint[DynamoDBOperation,DescribeEndpointsRequest, Nothing, DescribeEndpointsResponse, Nothing, Nothing] = DescribeEndpoints
+  }
+  object DescribeEndpoints extends smithy4s.Endpoint[DynamoDBOperation,DescribeEndpointsRequest, Nothing, DescribeEndpointsResponse, Nothing, Nothing] {
+    val schema: OperationSchema[DescribeEndpointsRequest, Nothing, DescribeEndpointsResponse, Nothing, Nothing] = Schema.operation(ShapeId("com.amazonaws.dynamodb", "DescribeEndpoints"))
+      .withInput(DescribeEndpointsRequest.schema)
+      .withOutput(DescribeEndpointsResponse.schema)
+      .withHints(smithy.api.Documentation("<p>Returns the regional endpoint information.</p>"))
+    def wrap(input: DescribeEndpointsRequest): DescribeEndpoints = DescribeEndpoints(input)
+  }
   final case class ListTables(input: ListTablesInput) extends DynamoDBOperation[ListTablesInput, DynamoDBOperation.ListTablesError, ListTablesOutput, Nothing, Nothing] {
     def run[F[_, _, _, _, _]](impl: DynamoDBGen[F]): F[ListTablesInput, DynamoDBOperation.ListTablesError, ListTablesOutput, Nothing, Nothing] = impl.listTables(input.exclusiveStartTableName, input.limit)
-    def ordinal: Int = 0
+    def ordinal: Int = 1
     def endpoint: smithy4s.Endpoint[DynamoDBOperation,ListTablesInput, DynamoDBOperation.ListTablesError, ListTablesOutput, Nothing, Nothing] = ListTables
   }
   object ListTables extends smithy4s.Endpoint[DynamoDBOperation,ListTablesInput, DynamoDBOperation.ListTablesError, ListTablesOutput, Nothing, Nothing] {
@@ -192,18 +204,6 @@ object DynamoDBOperation {
       case ListTablesError.InternalServerErrorCase(e) => e
       case ListTablesError.InvalidEndpointExceptionCase(e) => e
     }
-  }
-  final case class DescribeEndpoints(input: DescribeEndpointsRequest) extends DynamoDBOperation[DescribeEndpointsRequest, Nothing, DescribeEndpointsResponse, Nothing, Nothing] {
-    def run[F[_, _, _, _, _]](impl: DynamoDBGen[F]): F[DescribeEndpointsRequest, Nothing, DescribeEndpointsResponse, Nothing, Nothing] = impl.describeEndpoints()
-    def ordinal: Int = 1
-    def endpoint: smithy4s.Endpoint[DynamoDBOperation,DescribeEndpointsRequest, Nothing, DescribeEndpointsResponse, Nothing, Nothing] = DescribeEndpoints
-  }
-  object DescribeEndpoints extends smithy4s.Endpoint[DynamoDBOperation,DescribeEndpointsRequest, Nothing, DescribeEndpointsResponse, Nothing, Nothing] {
-    val schema: OperationSchema[DescribeEndpointsRequest, Nothing, DescribeEndpointsResponse, Nothing, Nothing] = Schema.operation(ShapeId("com.amazonaws.dynamodb", "DescribeEndpoints"))
-      .withInput(DescribeEndpointsRequest.schema)
-      .withOutput(DescribeEndpointsResponse.schema)
-      .withHints(smithy.api.Documentation("<p>Returns the regional endpoint information.</p>"))
-    def wrap(input: DescribeEndpointsRequest): DescribeEndpoints = DescribeEndpoints(input)
   }
 }
 

--- a/modules/bootstrapped/src/generated/smithy4s/benchmark/BenchmarkService.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/benchmark/BenchmarkService.scala
@@ -14,8 +14,8 @@ import smithy4s.schema.Schema.unit
 trait BenchmarkServiceGen[F[_, _, _, _, _]] {
   self =>
 
-  def sendString(key: String, bucketName: String, body: String): F[SendStringInput, Nothing, Unit, Nothing, Nothing]
   def createObject(key: String, bucketName: String, payload: S3Object): F[CreateObjectInput, Nothing, Unit, Nothing, Nothing]
+  def sendString(key: String, bucketName: String, body: String): F[SendStringInput, Nothing, Unit, Nothing, Nothing]
 
   final def transform: Transformation.PartiallyApplied[BenchmarkServiceGen[F]] = Transformation.of[BenchmarkServiceGen[F]](this)
 }
@@ -35,8 +35,8 @@ object BenchmarkServiceGen extends Service.Mixin[BenchmarkServiceGen, BenchmarkS
   }
 
   val endpoints: Vector[smithy4s.Endpoint[BenchmarkServiceOperation, _, _, _, _, _]] = Vector(
-    BenchmarkServiceOperation.SendString,
     BenchmarkServiceOperation.CreateObject,
+    BenchmarkServiceOperation.SendString,
   )
 
   def input[I, E, O, SI, SO](op: BenchmarkServiceOperation[I, E, O, SI, SO]): I = op.input
@@ -61,32 +61,20 @@ sealed trait BenchmarkServiceOperation[Input, Err, Output, StreamedInput, Stream
 object BenchmarkServiceOperation {
 
   object reified extends BenchmarkServiceGen[BenchmarkServiceOperation] {
-    def sendString(key: String, bucketName: String, body: String): SendString = SendString(SendStringInput(key, bucketName, body))
     def createObject(key: String, bucketName: String, payload: S3Object): CreateObject = CreateObject(CreateObjectInput(key, bucketName, payload))
+    def sendString(key: String, bucketName: String, body: String): SendString = SendString(SendStringInput(key, bucketName, body))
   }
   class Transformed[P[_, _, _, _, _], P1[_ ,_ ,_ ,_ ,_]](alg: BenchmarkServiceGen[P], f: PolyFunction5[P, P1]) extends BenchmarkServiceGen[P1] {
-    def sendString(key: String, bucketName: String, body: String): P1[SendStringInput, Nothing, Unit, Nothing, Nothing] = f[SendStringInput, Nothing, Unit, Nothing, Nothing](alg.sendString(key, bucketName, body))
     def createObject(key: String, bucketName: String, payload: S3Object): P1[CreateObjectInput, Nothing, Unit, Nothing, Nothing] = f[CreateObjectInput, Nothing, Unit, Nothing, Nothing](alg.createObject(key, bucketName, payload))
+    def sendString(key: String, bucketName: String, body: String): P1[SendStringInput, Nothing, Unit, Nothing, Nothing] = f[SendStringInput, Nothing, Unit, Nothing, Nothing](alg.sendString(key, bucketName, body))
   }
 
   def toPolyFunction[P[_, _, _, _, _]](impl: BenchmarkServiceGen[P]): PolyFunction5[BenchmarkServiceOperation, P] = new PolyFunction5[BenchmarkServiceOperation, P] {
     def apply[I, E, O, SI, SO](op: BenchmarkServiceOperation[I, E, O, SI, SO]): P[I, E, O, SI, SO] = op.run(impl) 
   }
-  final case class SendString(input: SendStringInput) extends BenchmarkServiceOperation[SendStringInput, Nothing, Unit, Nothing, Nothing] {
-    def run[F[_, _, _, _, _]](impl: BenchmarkServiceGen[F]): F[SendStringInput, Nothing, Unit, Nothing, Nothing] = impl.sendString(input.key, input.bucketName, input.body)
-    def ordinal: Int = 0
-    def endpoint: smithy4s.Endpoint[BenchmarkServiceOperation,SendStringInput, Nothing, Unit, Nothing, Nothing] = SendString
-  }
-  object SendString extends smithy4s.Endpoint[BenchmarkServiceOperation,SendStringInput, Nothing, Unit, Nothing, Nothing] {
-    val schema: OperationSchema[SendStringInput, Nothing, Unit, Nothing, Nothing] = Schema.operation(ShapeId("smithy4s.benchmark", "SendString"))
-      .withInput(SendStringInput.schema)
-      .withOutput(unit)
-      .withHints(smithy.api.Http(method = smithy.api.NonEmptyString("POST"), uri = smithy.api.NonEmptyString("/simple/{bucketName}/{key}"), code = 200))
-    def wrap(input: SendStringInput): SendString = SendString(input)
-  }
   final case class CreateObject(input: CreateObjectInput) extends BenchmarkServiceOperation[CreateObjectInput, Nothing, Unit, Nothing, Nothing] {
     def run[F[_, _, _, _, _]](impl: BenchmarkServiceGen[F]): F[CreateObjectInput, Nothing, Unit, Nothing, Nothing] = impl.createObject(input.key, input.bucketName, input.payload)
-    def ordinal: Int = 1
+    def ordinal: Int = 0
     def endpoint: smithy4s.Endpoint[BenchmarkServiceOperation,CreateObjectInput, Nothing, Unit, Nothing, Nothing] = CreateObject
   }
   object CreateObject extends smithy4s.Endpoint[BenchmarkServiceOperation,CreateObjectInput, Nothing, Unit, Nothing, Nothing] {
@@ -95,6 +83,18 @@ object BenchmarkServiceOperation {
       .withOutput(unit)
       .withHints(smithy.api.Http(method = smithy.api.NonEmptyString("POST"), uri = smithy.api.NonEmptyString("/complex/{bucketName}/{key}"), code = 200))
     def wrap(input: CreateObjectInput): CreateObject = CreateObject(input)
+  }
+  final case class SendString(input: SendStringInput) extends BenchmarkServiceOperation[SendStringInput, Nothing, Unit, Nothing, Nothing] {
+    def run[F[_, _, _, _, _]](impl: BenchmarkServiceGen[F]): F[SendStringInput, Nothing, Unit, Nothing, Nothing] = impl.sendString(input.key, input.bucketName, input.body)
+    def ordinal: Int = 1
+    def endpoint: smithy4s.Endpoint[BenchmarkServiceOperation,SendStringInput, Nothing, Unit, Nothing, Nothing] = SendString
+  }
+  object SendString extends smithy4s.Endpoint[BenchmarkServiceOperation,SendStringInput, Nothing, Unit, Nothing, Nothing] {
+    val schema: OperationSchema[SendStringInput, Nothing, Unit, Nothing, Nothing] = Schema.operation(ShapeId("smithy4s.benchmark", "SendString"))
+      .withInput(SendStringInput.schema)
+      .withOutput(unit)
+      .withHints(smithy.api.Http(method = smithy.api.NonEmptyString("POST"), uri = smithy.api.NonEmptyString("/simple/{bucketName}/{key}"), code = 200))
+    def wrap(input: SendStringInput): SendString = SendString(input)
   }
 }
 

--- a/modules/bootstrapped/src/generated/smithy4s/example/DummyService.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/DummyService.scala
@@ -18,9 +18,9 @@ import smithy4s.schema.Schema.unit
 trait DummyServiceGen[F[_, _, _, _, _]] {
   self =>
 
-  def dummyPath(str: String, int: Int, ts1: Timestamp, ts2: Timestamp, ts3: Timestamp, ts4: Timestamp, b: Boolean, ie: Numbers): F[PathParams, Nothing, Unit, Nothing, Nothing]
   def dummy(str: Option[String] = None, int: Option[Int] = None, ts1: Option[Timestamp] = None, ts2: Option[Timestamp] = None, ts3: Option[Timestamp] = None, ts4: Option[Timestamp] = None, b: Option[Boolean] = None, sl: Option[List[String]] = None, ie: Option[Numbers] = None, on: Option[OpenNums] = None, ons: Option[OpenNumsStr] = None, dbl: Option[Double] = None, slm: Option[Map[String, String]] = None): F[Queries, Nothing, Unit, Nothing, Nothing]
   def dummyHostPrefix(label1: String, label2: String, label3: HostLabelEnum): F[HostLabelInput, Nothing, Unit, Nothing, Nothing]
+  def dummyPath(str: String, int: Int, ts1: Timestamp, ts2: Timestamp, ts3: Timestamp, ts4: Timestamp, b: Boolean, ie: Numbers): F[PathParams, Nothing, Unit, Nothing, Nothing]
 
   final def transform: Transformation.PartiallyApplied[DummyServiceGen[F]] = Transformation.of[DummyServiceGen[F]](this)
 }
@@ -42,9 +42,9 @@ object DummyServiceGen extends Service.Mixin[DummyServiceGen, DummyServiceOperat
   }
 
   val endpoints: Vector[smithy4s.Endpoint[DummyServiceOperation, _, _, _, _, _]] = Vector(
-    DummyServiceOperation.DummyPath,
     DummyServiceOperation.Dummy,
     DummyServiceOperation.DummyHostPrefix,
+    DummyServiceOperation.DummyPath,
   )
 
   def input[I, E, O, SI, SO](op: DummyServiceOperation[I, E, O, SI, SO]): I = op.input
@@ -69,34 +69,22 @@ sealed trait DummyServiceOperation[Input, Err, Output, StreamedInput, StreamedOu
 object DummyServiceOperation {
 
   object reified extends DummyServiceGen[DummyServiceOperation] {
-    def dummyPath(str: String, int: Int, ts1: Timestamp, ts2: Timestamp, ts3: Timestamp, ts4: Timestamp, b: Boolean, ie: Numbers): DummyPath = DummyPath(PathParams(str, int, ts1, ts2, ts3, ts4, b, ie))
     def dummy(str: Option[String] = None, int: Option[Int] = None, ts1: Option[Timestamp] = None, ts2: Option[Timestamp] = None, ts3: Option[Timestamp] = None, ts4: Option[Timestamp] = None, b: Option[Boolean] = None, sl: Option[List[String]] = None, ie: Option[Numbers] = None, on: Option[OpenNums] = None, ons: Option[OpenNumsStr] = None, dbl: Option[Double] = None, slm: Option[Map[String, String]] = None): Dummy = Dummy(Queries(str, int, ts1, ts2, ts3, ts4, b, sl, ie, on, ons, dbl, slm))
     def dummyHostPrefix(label1: String, label2: String, label3: HostLabelEnum): DummyHostPrefix = DummyHostPrefix(HostLabelInput(label1, label2, label3))
+    def dummyPath(str: String, int: Int, ts1: Timestamp, ts2: Timestamp, ts3: Timestamp, ts4: Timestamp, b: Boolean, ie: Numbers): DummyPath = DummyPath(PathParams(str, int, ts1, ts2, ts3, ts4, b, ie))
   }
   class Transformed[P[_, _, _, _, _], P1[_ ,_ ,_ ,_ ,_]](alg: DummyServiceGen[P], f: PolyFunction5[P, P1]) extends DummyServiceGen[P1] {
-    def dummyPath(str: String, int: Int, ts1: Timestamp, ts2: Timestamp, ts3: Timestamp, ts4: Timestamp, b: Boolean, ie: Numbers): P1[PathParams, Nothing, Unit, Nothing, Nothing] = f[PathParams, Nothing, Unit, Nothing, Nothing](alg.dummyPath(str, int, ts1, ts2, ts3, ts4, b, ie))
     def dummy(str: Option[String] = None, int: Option[Int] = None, ts1: Option[Timestamp] = None, ts2: Option[Timestamp] = None, ts3: Option[Timestamp] = None, ts4: Option[Timestamp] = None, b: Option[Boolean] = None, sl: Option[List[String]] = None, ie: Option[Numbers] = None, on: Option[OpenNums] = None, ons: Option[OpenNumsStr] = None, dbl: Option[Double] = None, slm: Option[Map[String, String]] = None): P1[Queries, Nothing, Unit, Nothing, Nothing] = f[Queries, Nothing, Unit, Nothing, Nothing](alg.dummy(str, int, ts1, ts2, ts3, ts4, b, sl, ie, on, ons, dbl, slm))
     def dummyHostPrefix(label1: String, label2: String, label3: HostLabelEnum): P1[HostLabelInput, Nothing, Unit, Nothing, Nothing] = f[HostLabelInput, Nothing, Unit, Nothing, Nothing](alg.dummyHostPrefix(label1, label2, label3))
+    def dummyPath(str: String, int: Int, ts1: Timestamp, ts2: Timestamp, ts3: Timestamp, ts4: Timestamp, b: Boolean, ie: Numbers): P1[PathParams, Nothing, Unit, Nothing, Nothing] = f[PathParams, Nothing, Unit, Nothing, Nothing](alg.dummyPath(str, int, ts1, ts2, ts3, ts4, b, ie))
   }
 
   def toPolyFunction[P[_, _, _, _, _]](impl: DummyServiceGen[P]): PolyFunction5[DummyServiceOperation, P] = new PolyFunction5[DummyServiceOperation, P] {
     def apply[I, E, O, SI, SO](op: DummyServiceOperation[I, E, O, SI, SO]): P[I, E, O, SI, SO] = op.run(impl) 
   }
-  final case class DummyPath(input: PathParams) extends DummyServiceOperation[PathParams, Nothing, Unit, Nothing, Nothing] {
-    def run[F[_, _, _, _, _]](impl: DummyServiceGen[F]): F[PathParams, Nothing, Unit, Nothing, Nothing] = impl.dummyPath(input.str, input.int, input.ts1, input.ts2, input.ts3, input.ts4, input.b, input.ie)
-    def ordinal: Int = 0
-    def endpoint: smithy4s.Endpoint[DummyServiceOperation,PathParams, Nothing, Unit, Nothing, Nothing] = DummyPath
-  }
-  object DummyPath extends smithy4s.Endpoint[DummyServiceOperation,PathParams, Nothing, Unit, Nothing, Nothing] {
-    val schema: OperationSchema[PathParams, Nothing, Unit, Nothing, Nothing] = Schema.operation(ShapeId("smithy4s.example", "DummyPath"))
-      .withInput(PathParams.schema)
-      .withOutput(unit)
-      .withHints(smithy.api.Http(method = smithy.api.NonEmptyString("GET"), uri = smithy.api.NonEmptyString("/dummy-path/{str}/{int}/{ts1}/{ts2}/{ts3}/{ts4}/{b}/{ie}?value=foo&baz=bar"), code = 200), smithy.api.Readonly())
-    def wrap(input: PathParams): DummyPath = DummyPath(input)
-  }
   final case class Dummy(input: Queries) extends DummyServiceOperation[Queries, Nothing, Unit, Nothing, Nothing] {
     def run[F[_, _, _, _, _]](impl: DummyServiceGen[F]): F[Queries, Nothing, Unit, Nothing, Nothing] = impl.dummy(input.str, input.int, input.ts1, input.ts2, input.ts3, input.ts4, input.b, input.sl, input.ie, input.on, input.ons, input.dbl, input.slm)
-    def ordinal: Int = 1
+    def ordinal: Int = 0
     def endpoint: smithy4s.Endpoint[DummyServiceOperation,Queries, Nothing, Unit, Nothing, Nothing] = Dummy
   }
   object Dummy extends smithy4s.Endpoint[DummyServiceOperation,Queries, Nothing, Unit, Nothing, Nothing] {
@@ -108,7 +96,7 @@ object DummyServiceOperation {
   }
   final case class DummyHostPrefix(input: HostLabelInput) extends DummyServiceOperation[HostLabelInput, Nothing, Unit, Nothing, Nothing] {
     def run[F[_, _, _, _, _]](impl: DummyServiceGen[F]): F[HostLabelInput, Nothing, Unit, Nothing, Nothing] = impl.dummyHostPrefix(input.label1, input.label2, input.label3)
-    def ordinal: Int = 2
+    def ordinal: Int = 1
     def endpoint: smithy4s.Endpoint[DummyServiceOperation,HostLabelInput, Nothing, Unit, Nothing, Nothing] = DummyHostPrefix
   }
   object DummyHostPrefix extends smithy4s.Endpoint[DummyServiceOperation,HostLabelInput, Nothing, Unit, Nothing, Nothing] {
@@ -117,6 +105,18 @@ object DummyServiceOperation {
       .withOutput(unit)
       .withHints(smithy.api.Endpoint(hostPrefix = smithy.api.NonEmptyString("foo.{label1}--abc{label2}.{label3}.secure.")), smithy.api.Http(method = smithy.api.NonEmptyString("POST"), uri = smithy.api.NonEmptyString("/dummy"), code = 200))
     def wrap(input: HostLabelInput): DummyHostPrefix = DummyHostPrefix(input)
+  }
+  final case class DummyPath(input: PathParams) extends DummyServiceOperation[PathParams, Nothing, Unit, Nothing, Nothing] {
+    def run[F[_, _, _, _, _]](impl: DummyServiceGen[F]): F[PathParams, Nothing, Unit, Nothing, Nothing] = impl.dummyPath(input.str, input.int, input.ts1, input.ts2, input.ts3, input.ts4, input.b, input.ie)
+    def ordinal: Int = 2
+    def endpoint: smithy4s.Endpoint[DummyServiceOperation,PathParams, Nothing, Unit, Nothing, Nothing] = DummyPath
+  }
+  object DummyPath extends smithy4s.Endpoint[DummyServiceOperation,PathParams, Nothing, Unit, Nothing, Nothing] {
+    val schema: OperationSchema[PathParams, Nothing, Unit, Nothing, Nothing] = Schema.operation(ShapeId("smithy4s.example", "DummyPath"))
+      .withInput(PathParams.schema)
+      .withOutput(unit)
+      .withHints(smithy.api.Http(method = smithy.api.NonEmptyString("GET"), uri = smithy.api.NonEmptyString("/dummy-path/{str}/{int}/{ts1}/{ts2}/{ts3}/{ts4}/{b}/{ie}?value=foo&baz=bar"), code = 200), smithy.api.Readonly())
+    def wrap(input: PathParams): DummyPath = DummyPath(input)
   }
 }
 

--- a/modules/bootstrapped/src/generated/smithy4s/example/KVStore.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/KVStore.scala
@@ -17,9 +17,9 @@ import smithy4s.schema.Schema.unit
 trait KVStoreGen[F[_, _, _, _, _]] {
   self =>
 
-  def put(key: String, value: String): F[KeyValue, KVStoreOperation.PutError, Unit, Nothing, Nothing]
-  def get(key: String): F[Key, KVStoreOperation.GetError, Value, Nothing, Nothing]
   def delete(key: String): F[Key, KVStoreOperation.DeleteError, Unit, Nothing, Nothing]
+  def get(key: String): F[Key, KVStoreOperation.GetError, Value, Nothing, Nothing]
+  def put(key: String, value: String): F[KeyValue, KVStoreOperation.PutError, Unit, Nothing, Nothing]
 
   final def transform: Transformation.PartiallyApplied[KVStoreGen[F]] = Transformation.of[KVStoreGen[F]](this)
 }
@@ -39,9 +39,9 @@ object KVStoreGen extends Service.Mixin[KVStoreGen, KVStoreOperation] {
   }
 
   val endpoints: Vector[smithy4s.Endpoint[KVStoreOperation, _, _, _, _, _]] = Vector(
-    KVStoreOperation.Put,
-    KVStoreOperation.Get,
     KVStoreOperation.Delete,
+    KVStoreOperation.Get,
+    KVStoreOperation.Put,
   )
 
   def input[I, E, O, SI, SO](op: KVStoreOperation[I, E, O, SI, SO]): I = op.input
@@ -54,12 +54,12 @@ object KVStoreGen extends Service.Mixin[KVStoreGen, KVStoreOperation] {
   def fromPolyFunction[P[_, _, _, _, _]](f: PolyFunction5[KVStoreOperation, P]): KVStoreGen[P] = new KVStoreOperation.Transformed(reified, f)
   def toPolyFunction[P[_, _, _, _, _]](impl: KVStoreGen[P]): PolyFunction5[KVStoreOperation, P] = KVStoreOperation.toPolyFunction(impl)
 
-  type PutError = KVStoreOperation.PutError
-  val PutError = KVStoreOperation.PutError
-  type GetError = KVStoreOperation.GetError
-  val GetError = KVStoreOperation.GetError
   type DeleteError = KVStoreOperation.DeleteError
   val DeleteError = KVStoreOperation.DeleteError
+  type GetError = KVStoreOperation.GetError
+  val GetError = KVStoreOperation.GetError
+  type PutError = KVStoreOperation.PutError
+  val PutError = KVStoreOperation.PutError
 }
 
 sealed trait KVStoreOperation[Input, Err, Output, StreamedInput, StreamedOutput] {
@@ -72,81 +72,95 @@ sealed trait KVStoreOperation[Input, Err, Output, StreamedInput, StreamedOutput]
 object KVStoreOperation {
 
   object reified extends KVStoreGen[KVStoreOperation] {
-    def put(key: String, value: String): Put = Put(KeyValue(key, value))
-    def get(key: String): Get = Get(Key(key))
     def delete(key: String): Delete = Delete(Key(key))
+    def get(key: String): Get = Get(Key(key))
+    def put(key: String, value: String): Put = Put(KeyValue(key, value))
   }
   class Transformed[P[_, _, _, _, _], P1[_ ,_ ,_ ,_ ,_]](alg: KVStoreGen[P], f: PolyFunction5[P, P1]) extends KVStoreGen[P1] {
-    def put(key: String, value: String): P1[KeyValue, KVStoreOperation.PutError, Unit, Nothing, Nothing] = f[KeyValue, KVStoreOperation.PutError, Unit, Nothing, Nothing](alg.put(key, value))
-    def get(key: String): P1[Key, KVStoreOperation.GetError, Value, Nothing, Nothing] = f[Key, KVStoreOperation.GetError, Value, Nothing, Nothing](alg.get(key))
     def delete(key: String): P1[Key, KVStoreOperation.DeleteError, Unit, Nothing, Nothing] = f[Key, KVStoreOperation.DeleteError, Unit, Nothing, Nothing](alg.delete(key))
+    def get(key: String): P1[Key, KVStoreOperation.GetError, Value, Nothing, Nothing] = f[Key, KVStoreOperation.GetError, Value, Nothing, Nothing](alg.get(key))
+    def put(key: String, value: String): P1[KeyValue, KVStoreOperation.PutError, Unit, Nothing, Nothing] = f[KeyValue, KVStoreOperation.PutError, Unit, Nothing, Nothing](alg.put(key, value))
   }
 
   def toPolyFunction[P[_, _, _, _, _]](impl: KVStoreGen[P]): PolyFunction5[KVStoreOperation, P] = new PolyFunction5[KVStoreOperation, P] {
     def apply[I, E, O, SI, SO](op: KVStoreOperation[I, E, O, SI, SO]): P[I, E, O, SI, SO] = op.run(impl) 
   }
-  final case class Put(input: KeyValue) extends KVStoreOperation[KeyValue, KVStoreOperation.PutError, Unit, Nothing, Nothing] {
-    def run[F[_, _, _, _, _]](impl: KVStoreGen[F]): F[KeyValue, KVStoreOperation.PutError, Unit, Nothing, Nothing] = impl.put(input.key, input.value)
+  final case class Delete(input: Key) extends KVStoreOperation[Key, KVStoreOperation.DeleteError, Unit, Nothing, Nothing] {
+    def run[F[_, _, _, _, _]](impl: KVStoreGen[F]): F[Key, KVStoreOperation.DeleteError, Unit, Nothing, Nothing] = impl.delete(input.key)
     def ordinal: Int = 0
-    def endpoint: smithy4s.Endpoint[KVStoreOperation,KeyValue, KVStoreOperation.PutError, Unit, Nothing, Nothing] = Put
+    def endpoint: smithy4s.Endpoint[KVStoreOperation,Key, KVStoreOperation.DeleteError, Unit, Nothing, Nothing] = Delete
   }
-  object Put extends smithy4s.Endpoint[KVStoreOperation,KeyValue, KVStoreOperation.PutError, Unit, Nothing, Nothing] {
-    val schema: OperationSchema[KeyValue, KVStoreOperation.PutError, Unit, Nothing, Nothing] = Schema.operation(ShapeId("smithy4s.example", "Put"))
-      .withInput(KeyValue.schema)
-      .withError(PutError.errorSchema)
+  object Delete extends smithy4s.Endpoint[KVStoreOperation,Key, KVStoreOperation.DeleteError, Unit, Nothing, Nothing] {
+    val schema: OperationSchema[Key, KVStoreOperation.DeleteError, Unit, Nothing, Nothing] = Schema.operation(ShapeId("smithy4s.example", "Delete"))
+      .withInput(Key.schema)
+      .withError(DeleteError.errorSchema)
       .withOutput(unit)
-    def wrap(input: KeyValue): Put = Put(input)
+    def wrap(input: Key): Delete = Delete(input)
   }
-  sealed trait PutError extends scala.Product with scala.Serializable { self =>
-    @inline final def widen: PutError = this
+  sealed trait DeleteError extends scala.Product with scala.Serializable { self =>
+    @inline final def widen: DeleteError = this
     def $ordinal: Int
 
     object project {
-      def unauthorizedError: Option[UnauthorizedError] = PutError.UnauthorizedErrorCase.alt.project.lift(self).map(_.unauthorizedError)
+      def unauthorizedError: Option[UnauthorizedError] = DeleteError.UnauthorizedErrorCase.alt.project.lift(self).map(_.unauthorizedError)
+      def keyNotFoundError: Option[KeyNotFoundError] = DeleteError.KeyNotFoundErrorCase.alt.project.lift(self).map(_.keyNotFoundError)
     }
 
-    def accept[A](visitor: PutError.Visitor[A]): A = this match {
-      case value: PutError.UnauthorizedErrorCase => visitor.unauthorizedError(value.unauthorizedError)
+    def accept[A](visitor: DeleteError.Visitor[A]): A = this match {
+      case value: DeleteError.UnauthorizedErrorCase => visitor.unauthorizedError(value.unauthorizedError)
+      case value: DeleteError.KeyNotFoundErrorCase => visitor.keyNotFoundError(value.keyNotFoundError)
     }
   }
-  object PutError extends ErrorSchema.Companion[PutError] {
+  object DeleteError extends ErrorSchema.Companion[DeleteError] {
 
-    def unauthorizedError(unauthorizedError: UnauthorizedError): PutError = UnauthorizedErrorCase(unauthorizedError)
+    def unauthorizedError(unauthorizedError: UnauthorizedError): DeleteError = UnauthorizedErrorCase(unauthorizedError)
+    def keyNotFoundError(keyNotFoundError: KeyNotFoundError): DeleteError = KeyNotFoundErrorCase(keyNotFoundError)
 
-    val id: ShapeId = ShapeId("smithy4s.example", "PutError")
+    val id: ShapeId = ShapeId("smithy4s.example", "DeleteError")
 
     val hints: Hints = Hints.empty
 
-    final case class UnauthorizedErrorCase(unauthorizedError: UnauthorizedError) extends PutError { final def $ordinal: Int = 0 }
+    final case class UnauthorizedErrorCase(unauthorizedError: UnauthorizedError) extends DeleteError { final def $ordinal: Int = 0 }
+    final case class KeyNotFoundErrorCase(keyNotFoundError: KeyNotFoundError) extends DeleteError { final def $ordinal: Int = 1 }
 
     object UnauthorizedErrorCase {
       val hints: Hints = Hints.empty
-      val schema: Schema[PutError.UnauthorizedErrorCase] = bijection(UnauthorizedError.schema.addHints(hints), PutError.UnauthorizedErrorCase(_), _.unauthorizedError)
-      val alt = schema.oneOf[PutError]("UnauthorizedError")
+      val schema: Schema[DeleteError.UnauthorizedErrorCase] = bijection(UnauthorizedError.schema.addHints(hints), DeleteError.UnauthorizedErrorCase(_), _.unauthorizedError)
+      val alt = schema.oneOf[DeleteError]("UnauthorizedError")
+    }
+    object KeyNotFoundErrorCase {
+      val hints: Hints = Hints.empty
+      val schema: Schema[DeleteError.KeyNotFoundErrorCase] = bijection(KeyNotFoundError.schema.addHints(hints), DeleteError.KeyNotFoundErrorCase(_), _.keyNotFoundError)
+      val alt = schema.oneOf[DeleteError]("KeyNotFoundError")
     }
 
     trait Visitor[A] {
       def unauthorizedError(value: UnauthorizedError): A
+      def keyNotFoundError(value: KeyNotFoundError): A
     }
 
     object Visitor {
       trait Default[A] extends Visitor[A] {
         def default: A
         def unauthorizedError(value: UnauthorizedError): A = default
+        def keyNotFoundError(value: KeyNotFoundError): A = default
       }
     }
 
-    implicit val schema: Schema[PutError] = union(
-      PutError.UnauthorizedErrorCase.alt,
+    implicit val schema: Schema[DeleteError] = union(
+      DeleteError.UnauthorizedErrorCase.alt,
+      DeleteError.KeyNotFoundErrorCase.alt,
     ){
       _.$ordinal
     }
-    def liftError(throwable: Throwable): Option[PutError] = throwable match {
-      case e: UnauthorizedError => Some(PutError.UnauthorizedErrorCase(e))
+    def liftError(throwable: Throwable): Option[DeleteError] = throwable match {
+      case e: UnauthorizedError => Some(DeleteError.UnauthorizedErrorCase(e))
+      case e: KeyNotFoundError => Some(DeleteError.KeyNotFoundErrorCase(e))
       case _ => None
     }
-    def unliftError(e: PutError): Throwable = e match {
-      case PutError.UnauthorizedErrorCase(e) => e
+    def unliftError(e: DeleteError): Throwable = e match {
+      case DeleteError.UnauthorizedErrorCase(e) => e
+      case DeleteError.KeyNotFoundErrorCase(e) => e
     }
   }
   final case class Get(input: Key) extends KVStoreOperation[Key, KVStoreOperation.GetError, Value, Nothing, Nothing] {
@@ -227,82 +241,68 @@ object KVStoreOperation {
       case GetError.KeyNotFoundErrorCase(e) => e
     }
   }
-  final case class Delete(input: Key) extends KVStoreOperation[Key, KVStoreOperation.DeleteError, Unit, Nothing, Nothing] {
-    def run[F[_, _, _, _, _]](impl: KVStoreGen[F]): F[Key, KVStoreOperation.DeleteError, Unit, Nothing, Nothing] = impl.delete(input.key)
+  final case class Put(input: KeyValue) extends KVStoreOperation[KeyValue, KVStoreOperation.PutError, Unit, Nothing, Nothing] {
+    def run[F[_, _, _, _, _]](impl: KVStoreGen[F]): F[KeyValue, KVStoreOperation.PutError, Unit, Nothing, Nothing] = impl.put(input.key, input.value)
     def ordinal: Int = 2
-    def endpoint: smithy4s.Endpoint[KVStoreOperation,Key, KVStoreOperation.DeleteError, Unit, Nothing, Nothing] = Delete
+    def endpoint: smithy4s.Endpoint[KVStoreOperation,KeyValue, KVStoreOperation.PutError, Unit, Nothing, Nothing] = Put
   }
-  object Delete extends smithy4s.Endpoint[KVStoreOperation,Key, KVStoreOperation.DeleteError, Unit, Nothing, Nothing] {
-    val schema: OperationSchema[Key, KVStoreOperation.DeleteError, Unit, Nothing, Nothing] = Schema.operation(ShapeId("smithy4s.example", "Delete"))
-      .withInput(Key.schema)
-      .withError(DeleteError.errorSchema)
+  object Put extends smithy4s.Endpoint[KVStoreOperation,KeyValue, KVStoreOperation.PutError, Unit, Nothing, Nothing] {
+    val schema: OperationSchema[KeyValue, KVStoreOperation.PutError, Unit, Nothing, Nothing] = Schema.operation(ShapeId("smithy4s.example", "Put"))
+      .withInput(KeyValue.schema)
+      .withError(PutError.errorSchema)
       .withOutput(unit)
-    def wrap(input: Key): Delete = Delete(input)
+    def wrap(input: KeyValue): Put = Put(input)
   }
-  sealed trait DeleteError extends scala.Product with scala.Serializable { self =>
-    @inline final def widen: DeleteError = this
+  sealed trait PutError extends scala.Product with scala.Serializable { self =>
+    @inline final def widen: PutError = this
     def $ordinal: Int
 
     object project {
-      def unauthorizedError: Option[UnauthorizedError] = DeleteError.UnauthorizedErrorCase.alt.project.lift(self).map(_.unauthorizedError)
-      def keyNotFoundError: Option[KeyNotFoundError] = DeleteError.KeyNotFoundErrorCase.alt.project.lift(self).map(_.keyNotFoundError)
+      def unauthorizedError: Option[UnauthorizedError] = PutError.UnauthorizedErrorCase.alt.project.lift(self).map(_.unauthorizedError)
     }
 
-    def accept[A](visitor: DeleteError.Visitor[A]): A = this match {
-      case value: DeleteError.UnauthorizedErrorCase => visitor.unauthorizedError(value.unauthorizedError)
-      case value: DeleteError.KeyNotFoundErrorCase => visitor.keyNotFoundError(value.keyNotFoundError)
+    def accept[A](visitor: PutError.Visitor[A]): A = this match {
+      case value: PutError.UnauthorizedErrorCase => visitor.unauthorizedError(value.unauthorizedError)
     }
   }
-  object DeleteError extends ErrorSchema.Companion[DeleteError] {
+  object PutError extends ErrorSchema.Companion[PutError] {
 
-    def unauthorizedError(unauthorizedError: UnauthorizedError): DeleteError = UnauthorizedErrorCase(unauthorizedError)
-    def keyNotFoundError(keyNotFoundError: KeyNotFoundError): DeleteError = KeyNotFoundErrorCase(keyNotFoundError)
+    def unauthorizedError(unauthorizedError: UnauthorizedError): PutError = UnauthorizedErrorCase(unauthorizedError)
 
-    val id: ShapeId = ShapeId("smithy4s.example", "DeleteError")
+    val id: ShapeId = ShapeId("smithy4s.example", "PutError")
 
     val hints: Hints = Hints.empty
 
-    final case class UnauthorizedErrorCase(unauthorizedError: UnauthorizedError) extends DeleteError { final def $ordinal: Int = 0 }
-    final case class KeyNotFoundErrorCase(keyNotFoundError: KeyNotFoundError) extends DeleteError { final def $ordinal: Int = 1 }
+    final case class UnauthorizedErrorCase(unauthorizedError: UnauthorizedError) extends PutError { final def $ordinal: Int = 0 }
 
     object UnauthorizedErrorCase {
       val hints: Hints = Hints.empty
-      val schema: Schema[DeleteError.UnauthorizedErrorCase] = bijection(UnauthorizedError.schema.addHints(hints), DeleteError.UnauthorizedErrorCase(_), _.unauthorizedError)
-      val alt = schema.oneOf[DeleteError]("UnauthorizedError")
-    }
-    object KeyNotFoundErrorCase {
-      val hints: Hints = Hints.empty
-      val schema: Schema[DeleteError.KeyNotFoundErrorCase] = bijection(KeyNotFoundError.schema.addHints(hints), DeleteError.KeyNotFoundErrorCase(_), _.keyNotFoundError)
-      val alt = schema.oneOf[DeleteError]("KeyNotFoundError")
+      val schema: Schema[PutError.UnauthorizedErrorCase] = bijection(UnauthorizedError.schema.addHints(hints), PutError.UnauthorizedErrorCase(_), _.unauthorizedError)
+      val alt = schema.oneOf[PutError]("UnauthorizedError")
     }
 
     trait Visitor[A] {
       def unauthorizedError(value: UnauthorizedError): A
-      def keyNotFoundError(value: KeyNotFoundError): A
     }
 
     object Visitor {
       trait Default[A] extends Visitor[A] {
         def default: A
         def unauthorizedError(value: UnauthorizedError): A = default
-        def keyNotFoundError(value: KeyNotFoundError): A = default
       }
     }
 
-    implicit val schema: Schema[DeleteError] = union(
-      DeleteError.UnauthorizedErrorCase.alt,
-      DeleteError.KeyNotFoundErrorCase.alt,
+    implicit val schema: Schema[PutError] = union(
+      PutError.UnauthorizedErrorCase.alt,
     ){
       _.$ordinal
     }
-    def liftError(throwable: Throwable): Option[DeleteError] = throwable match {
-      case e: UnauthorizedError => Some(DeleteError.UnauthorizedErrorCase(e))
-      case e: KeyNotFoundError => Some(DeleteError.KeyNotFoundErrorCase(e))
+    def liftError(throwable: Throwable): Option[PutError] = throwable match {
+      case e: UnauthorizedError => Some(PutError.UnauthorizedErrorCase(e))
       case _ => None
     }
-    def unliftError(e: DeleteError): Throwable = e match {
-      case DeleteError.UnauthorizedErrorCase(e) => e
-      case DeleteError.KeyNotFoundErrorCase(e) => e
+    def unliftError(e: PutError): Throwable = e match {
+      case PutError.UnauthorizedErrorCase(e) => e
     }
   }
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/Library.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/Library.scala
@@ -14,9 +14,9 @@ import smithy4s.schema.Schema.unit
 trait LibraryGen[F[_, _, _, _, _]] {
   self =>
 
-  def listPublishers(): F[Unit, Nothing, ListPublishersOutput, Nothing, Nothing]
-  def getBook(): F[Unit, Nothing, Unit, Nothing, Nothing]
   def buyBook(): F[Unit, Nothing, Unit, Nothing, Nothing]
+  def getBook(): F[Unit, Nothing, Unit, Nothing, Nothing]
+  def listPublishers(): F[Unit, Nothing, ListPublishersOutput, Nothing, Nothing]
 
   final def transform: Transformation.PartiallyApplied[LibraryGen[F]] = Transformation.of[LibraryGen[F]](this)
 }
@@ -36,9 +36,9 @@ object LibraryGen extends Service.Mixin[LibraryGen, LibraryOperation] {
   }
 
   val endpoints: Vector[smithy4s.Endpoint[LibraryOperation, _, _, _, _, _]] = Vector(
-    LibraryOperation.ListPublishers,
-    LibraryOperation.GetBook,
     LibraryOperation.BuyBook,
+    LibraryOperation.GetBook,
+    LibraryOperation.ListPublishers,
   )
 
   def input[I, E, O, SI, SO](op: LibraryOperation[I, E, O, SI, SO]): I = op.input
@@ -63,31 +63,30 @@ sealed trait LibraryOperation[Input, Err, Output, StreamedInput, StreamedOutput]
 object LibraryOperation {
 
   object reified extends LibraryGen[LibraryOperation] {
-    def listPublishers(): ListPublishers = ListPublishers()
-    def getBook(): GetBook = GetBook()
     def buyBook(): BuyBook = BuyBook()
+    def getBook(): GetBook = GetBook()
+    def listPublishers(): ListPublishers = ListPublishers()
   }
   class Transformed[P[_, _, _, _, _], P1[_ ,_ ,_ ,_ ,_]](alg: LibraryGen[P], f: PolyFunction5[P, P1]) extends LibraryGen[P1] {
-    def listPublishers(): P1[Unit, Nothing, ListPublishersOutput, Nothing, Nothing] = f[Unit, Nothing, ListPublishersOutput, Nothing, Nothing](alg.listPublishers())
-    def getBook(): P1[Unit, Nothing, Unit, Nothing, Nothing] = f[Unit, Nothing, Unit, Nothing, Nothing](alg.getBook())
     def buyBook(): P1[Unit, Nothing, Unit, Nothing, Nothing] = f[Unit, Nothing, Unit, Nothing, Nothing](alg.buyBook())
+    def getBook(): P1[Unit, Nothing, Unit, Nothing, Nothing] = f[Unit, Nothing, Unit, Nothing, Nothing](alg.getBook())
+    def listPublishers(): P1[Unit, Nothing, ListPublishersOutput, Nothing, Nothing] = f[Unit, Nothing, ListPublishersOutput, Nothing, Nothing](alg.listPublishers())
   }
 
   def toPolyFunction[P[_, _, _, _, _]](impl: LibraryGen[P]): PolyFunction5[LibraryOperation, P] = new PolyFunction5[LibraryOperation, P] {
     def apply[I, E, O, SI, SO](op: LibraryOperation[I, E, O, SI, SO]): P[I, E, O, SI, SO] = op.run(impl) 
   }
-  final case class ListPublishers() extends LibraryOperation[Unit, Nothing, ListPublishersOutput, Nothing, Nothing] {
-    def run[F[_, _, _, _, _]](impl: LibraryGen[F]): F[Unit, Nothing, ListPublishersOutput, Nothing, Nothing] = impl.listPublishers()
+  final case class BuyBook() extends LibraryOperation[Unit, Nothing, Unit, Nothing, Nothing] {
+    def run[F[_, _, _, _, _]](impl: LibraryGen[F]): F[Unit, Nothing, Unit, Nothing, Nothing] = impl.buyBook()
     def ordinal: Int = 0
     def input: Unit = ()
-    def endpoint: smithy4s.Endpoint[LibraryOperation,Unit, Nothing, ListPublishersOutput, Nothing, Nothing] = ListPublishers
+    def endpoint: smithy4s.Endpoint[LibraryOperation,Unit, Nothing, Unit, Nothing, Nothing] = BuyBook
   }
-  object ListPublishers extends smithy4s.Endpoint[LibraryOperation,Unit, Nothing, ListPublishersOutput, Nothing, Nothing] {
-    val schema: OperationSchema[Unit, Nothing, ListPublishersOutput, Nothing, Nothing] = Schema.operation(ShapeId("smithy4s.example", "ListPublishers"))
+  object BuyBook extends smithy4s.Endpoint[LibraryOperation,Unit, Nothing, Unit, Nothing, Nothing] {
+    val schema: OperationSchema[Unit, Nothing, Unit, Nothing, Nothing] = Schema.operation(ShapeId("smithy4s.example", "BuyBook"))
       .withInput(unit)
-      .withOutput(ListPublishersOutput.schema)
-      .withHints(smithy.api.Readonly())
-    def wrap(input: Unit): ListPublishers = ListPublishers()
+      .withOutput(unit)
+    def wrap(input: Unit): BuyBook = BuyBook()
   }
   final case class GetBook() extends LibraryOperation[Unit, Nothing, Unit, Nothing, Nothing] {
     def run[F[_, _, _, _, _]](impl: LibraryGen[F]): F[Unit, Nothing, Unit, Nothing, Nothing] = impl.getBook()
@@ -102,17 +101,18 @@ object LibraryOperation {
       .withHints(smithy.api.Readonly())
     def wrap(input: Unit): GetBook = GetBook()
   }
-  final case class BuyBook() extends LibraryOperation[Unit, Nothing, Unit, Nothing, Nothing] {
-    def run[F[_, _, _, _, _]](impl: LibraryGen[F]): F[Unit, Nothing, Unit, Nothing, Nothing] = impl.buyBook()
+  final case class ListPublishers() extends LibraryOperation[Unit, Nothing, ListPublishersOutput, Nothing, Nothing] {
+    def run[F[_, _, _, _, _]](impl: LibraryGen[F]): F[Unit, Nothing, ListPublishersOutput, Nothing, Nothing] = impl.listPublishers()
     def ordinal: Int = 2
     def input: Unit = ()
-    def endpoint: smithy4s.Endpoint[LibraryOperation,Unit, Nothing, Unit, Nothing, Nothing] = BuyBook
+    def endpoint: smithy4s.Endpoint[LibraryOperation,Unit, Nothing, ListPublishersOutput, Nothing, Nothing] = ListPublishers
   }
-  object BuyBook extends smithy4s.Endpoint[LibraryOperation,Unit, Nothing, Unit, Nothing, Nothing] {
-    val schema: OperationSchema[Unit, Nothing, Unit, Nothing, Nothing] = Schema.operation(ShapeId("smithy4s.example", "BuyBook"))
+  object ListPublishers extends smithy4s.Endpoint[LibraryOperation,Unit, Nothing, ListPublishersOutput, Nothing, Nothing] {
+    val schema: OperationSchema[Unit, Nothing, ListPublishersOutput, Nothing, Nothing] = Schema.operation(ShapeId("smithy4s.example", "ListPublishers"))
       .withInput(unit)
-      .withOutput(unit)
-    def wrap(input: Unit): BuyBook = BuyBook()
+      .withOutput(ListPublishersOutput.schema)
+      .withHints(smithy.api.Readonly())
+    def wrap(input: Unit): ListPublishers = ListPublishers()
   }
 }
 

--- a/modules/bootstrapped/src/generated/smithy4s/example/NameCollision.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/NameCollision.scala
@@ -16,8 +16,8 @@ import smithy4s.schema.Schema.unit
 trait NameCollisionGen[F[_, _, _, _, _]] {
   self =>
 
-  def myOp(): F[Unit, NameCollisionOperation.MyOpError, Unit, Nothing, Nothing]
   def endpoint(): F[Unit, Nothing, Unit, Nothing, Nothing]
+  def myOp(): F[Unit, NameCollisionOperation.MyOpError, Unit, Nothing, Nothing]
 
   final def transform: Transformation.PartiallyApplied[NameCollisionGen[F]] = Transformation.of[NameCollisionGen[F]](this)
 }
@@ -37,8 +37,8 @@ object NameCollisionGen extends Service.Mixin[NameCollisionGen, NameCollisionOpe
   }
 
   val endpoints: Vector[smithy4s.Endpoint[NameCollisionOperation, _, _, _, _, _]] = Vector(
-    NameCollisionOperation.MyOp,
     NameCollisionOperation.Endpoint,
+    NameCollisionOperation.MyOp,
   )
 
   def input[I, E, O, SI, SO](op: NameCollisionOperation[I, E, O, SI, SO]): I = op.input
@@ -65,20 +65,32 @@ sealed trait NameCollisionOperation[Input, Err, Output, StreamedInput, StreamedO
 object NameCollisionOperation {
 
   object reified extends NameCollisionGen[NameCollisionOperation] {
-    def myOp(): MyOp = MyOp()
     def endpoint(): Endpoint = Endpoint()
+    def myOp(): MyOp = MyOp()
   }
   class Transformed[P[_, _, _, _, _], P1[_ ,_ ,_ ,_ ,_]](alg: NameCollisionGen[P], f: PolyFunction5[P, P1]) extends NameCollisionGen[P1] {
-    def myOp(): P1[Unit, NameCollisionOperation.MyOpError, Unit, Nothing, Nothing] = f[Unit, NameCollisionOperation.MyOpError, Unit, Nothing, Nothing](alg.myOp())
     def endpoint(): P1[Unit, Nothing, Unit, Nothing, Nothing] = f[Unit, Nothing, Unit, Nothing, Nothing](alg.endpoint())
+    def myOp(): P1[Unit, NameCollisionOperation.MyOpError, Unit, Nothing, Nothing] = f[Unit, NameCollisionOperation.MyOpError, Unit, Nothing, Nothing](alg.myOp())
   }
 
   def toPolyFunction[P[_, _, _, _, _]](impl: NameCollisionGen[P]): PolyFunction5[NameCollisionOperation, P] = new PolyFunction5[NameCollisionOperation, P] {
     def apply[I, E, O, SI, SO](op: NameCollisionOperation[I, E, O, SI, SO]): P[I, E, O, SI, SO] = op.run(impl) 
   }
+  final case class Endpoint() extends NameCollisionOperation[Unit, Nothing, Unit, Nothing, Nothing] {
+    def run[F[_, _, _, _, _]](impl: NameCollisionGen[F]): F[Unit, Nothing, Unit, Nothing, Nothing] = impl.endpoint()
+    def ordinal: Int = 0
+    def input: Unit = ()
+    def endpoint: smithy4s.Endpoint[NameCollisionOperation,Unit, Nothing, Unit, Nothing, Nothing] = Endpoint
+  }
+  object Endpoint extends smithy4s.Endpoint[NameCollisionOperation,Unit, Nothing, Unit, Nothing, Nothing] {
+    val schema: OperationSchema[Unit, Nothing, Unit, Nothing, Nothing] = Schema.operation(ShapeId("smithy4s.example", "Endpoint"))
+      .withInput(unit)
+      .withOutput(unit)
+    def wrap(input: Unit): Endpoint = Endpoint()
+  }
   final case class MyOp() extends NameCollisionOperation[Unit, NameCollisionOperation.MyOpError, Unit, Nothing, Nothing] {
     def run[F[_, _, _, _, _]](impl: NameCollisionGen[F]): F[Unit, NameCollisionOperation.MyOpError, Unit, Nothing, Nothing] = impl.myOp()
-    def ordinal: Int = 0
+    def ordinal: Int = 1
     def input: Unit = ()
     def endpoint: smithy4s.Endpoint[NameCollisionOperation,Unit, NameCollisionOperation.MyOpError, Unit, Nothing, Nothing] = MyOp
   }
@@ -140,18 +152,6 @@ object NameCollisionOperation {
     def unliftError(e: MyOpError): Throwable = e match {
       case MyOpError.MyOpErrorCase(e) => e
     }
-  }
-  final case class Endpoint() extends NameCollisionOperation[Unit, Nothing, Unit, Nothing, Nothing] {
-    def run[F[_, _, _, _, _]](impl: NameCollisionGen[F]): F[Unit, Nothing, Unit, Nothing, Nothing] = impl.endpoint()
-    def ordinal: Int = 1
-    def input: Unit = ()
-    def endpoint: smithy4s.Endpoint[NameCollisionOperation,Unit, Nothing, Unit, Nothing, Nothing] = Endpoint
-  }
-  object Endpoint extends smithy4s.Endpoint[NameCollisionOperation,Unit, Nothing, Unit, Nothing, Nothing] {
-    val schema: OperationSchema[Unit, Nothing, Unit, Nothing, Nothing] = Schema.operation(ShapeId("smithy4s.example", "Endpoint"))
-      .withInput(unit)
-      .withOutput(unit)
-    def wrap(input: Unit): Endpoint = Endpoint()
   }
 }
 

--- a/modules/bootstrapped/src/generated/smithy4s/example/ObjectCollision.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/ObjectCollision.scala
@@ -14,15 +14,15 @@ import smithy4s.schema.Schema.unit
 trait ObjectCollisionGen[F[_, _, _, _, _]] {
   self =>
 
+  def _clone(): F[Unit, Nothing, Unit, Nothing, Nothing]
+  def _equals(): F[Unit, Nothing, Unit, Nothing, Nothing]
   def _finalize(): F[Unit, Nothing, Unit, Nothing, Nothing]
   def _getClass(): F[Unit, Nothing, Unit, Nothing, Nothing]
-  def _equals(): F[Unit, Nothing, Unit, Nothing, Nothing]
-  def _toString(): F[Unit, Nothing, Unit, Nothing, Nothing]
-  def _notify(): F[Unit, Nothing, Unit, Nothing, Nothing]
   def _hashCode(): F[Unit, Nothing, Unit, Nothing, Nothing]
-  def _wait(): F[Unit, Nothing, Unit, Nothing, Nothing]
-  def _clone(): F[Unit, Nothing, Unit, Nothing, Nothing]
+  def _notify(): F[Unit, Nothing, Unit, Nothing, Nothing]
   def _notifyAll(): F[Unit, Nothing, Unit, Nothing, Nothing]
+  def _toString(): F[Unit, Nothing, Unit, Nothing, Nothing]
+  def _wait(): F[Unit, Nothing, Unit, Nothing, Nothing]
 
   final def transform: Transformation.PartiallyApplied[ObjectCollisionGen[F]] = Transformation.of[ObjectCollisionGen[F]](this)
 }
@@ -42,15 +42,15 @@ object ObjectCollisionGen extends Service.Mixin[ObjectCollisionGen, ObjectCollis
   }
 
   val endpoints: Vector[smithy4s.Endpoint[ObjectCollisionOperation, _, _, _, _, _]] = Vector(
+    ObjectCollisionOperation.Clone,
+    ObjectCollisionOperation.Equals,
     ObjectCollisionOperation.Finalize,
     ObjectCollisionOperation.GetClass,
-    ObjectCollisionOperation.Equals,
-    ObjectCollisionOperation.ToString,
-    ObjectCollisionOperation.Notify,
     ObjectCollisionOperation.HashCode,
-    ObjectCollisionOperation.Wait,
-    ObjectCollisionOperation.Clone,
+    ObjectCollisionOperation.Notify,
     ObjectCollisionOperation.NotifyAll,
+    ObjectCollisionOperation.ToString,
+    ObjectCollisionOperation.Wait,
   )
 
   def input[I, E, O, SI, SO](op: ObjectCollisionOperation[I, E, O, SI, SO]): I = op.input
@@ -75,34 +75,58 @@ sealed trait ObjectCollisionOperation[Input, Err, Output, StreamedInput, Streame
 object ObjectCollisionOperation {
 
   object reified extends ObjectCollisionGen[ObjectCollisionOperation] {
+    def _clone(): Clone = Clone()
+    def _equals(): Equals = Equals()
     def _finalize(): Finalize = Finalize()
     def _getClass(): GetClass = GetClass()
-    def _equals(): Equals = Equals()
-    def _toString(): ToString = ToString()
-    def _notify(): Notify = Notify()
     def _hashCode(): HashCode = HashCode()
-    def _wait(): Wait = Wait()
-    def _clone(): Clone = Clone()
+    def _notify(): Notify = Notify()
     def _notifyAll(): NotifyAll = NotifyAll()
+    def _toString(): ToString = ToString()
+    def _wait(): Wait = Wait()
   }
   class Transformed[P[_, _, _, _, _], P1[_ ,_ ,_ ,_ ,_]](alg: ObjectCollisionGen[P], f: PolyFunction5[P, P1]) extends ObjectCollisionGen[P1] {
+    def _clone(): P1[Unit, Nothing, Unit, Nothing, Nothing] = f[Unit, Nothing, Unit, Nothing, Nothing](alg._clone())
+    def _equals(): P1[Unit, Nothing, Unit, Nothing, Nothing] = f[Unit, Nothing, Unit, Nothing, Nothing](alg._equals())
     def _finalize(): P1[Unit, Nothing, Unit, Nothing, Nothing] = f[Unit, Nothing, Unit, Nothing, Nothing](alg._finalize())
     def _getClass(): P1[Unit, Nothing, Unit, Nothing, Nothing] = f[Unit, Nothing, Unit, Nothing, Nothing](alg._getClass())
-    def _equals(): P1[Unit, Nothing, Unit, Nothing, Nothing] = f[Unit, Nothing, Unit, Nothing, Nothing](alg._equals())
-    def _toString(): P1[Unit, Nothing, Unit, Nothing, Nothing] = f[Unit, Nothing, Unit, Nothing, Nothing](alg._toString())
-    def _notify(): P1[Unit, Nothing, Unit, Nothing, Nothing] = f[Unit, Nothing, Unit, Nothing, Nothing](alg._notify())
     def _hashCode(): P1[Unit, Nothing, Unit, Nothing, Nothing] = f[Unit, Nothing, Unit, Nothing, Nothing](alg._hashCode())
-    def _wait(): P1[Unit, Nothing, Unit, Nothing, Nothing] = f[Unit, Nothing, Unit, Nothing, Nothing](alg._wait())
-    def _clone(): P1[Unit, Nothing, Unit, Nothing, Nothing] = f[Unit, Nothing, Unit, Nothing, Nothing](alg._clone())
+    def _notify(): P1[Unit, Nothing, Unit, Nothing, Nothing] = f[Unit, Nothing, Unit, Nothing, Nothing](alg._notify())
     def _notifyAll(): P1[Unit, Nothing, Unit, Nothing, Nothing] = f[Unit, Nothing, Unit, Nothing, Nothing](alg._notifyAll())
+    def _toString(): P1[Unit, Nothing, Unit, Nothing, Nothing] = f[Unit, Nothing, Unit, Nothing, Nothing](alg._toString())
+    def _wait(): P1[Unit, Nothing, Unit, Nothing, Nothing] = f[Unit, Nothing, Unit, Nothing, Nothing](alg._wait())
   }
 
   def toPolyFunction[P[_, _, _, _, _]](impl: ObjectCollisionGen[P]): PolyFunction5[ObjectCollisionOperation, P] = new PolyFunction5[ObjectCollisionOperation, P] {
     def apply[I, E, O, SI, SO](op: ObjectCollisionOperation[I, E, O, SI, SO]): P[I, E, O, SI, SO] = op.run(impl) 
   }
+  final case class Clone() extends ObjectCollisionOperation[Unit, Nothing, Unit, Nothing, Nothing] {
+    def run[F[_, _, _, _, _]](impl: ObjectCollisionGen[F]): F[Unit, Nothing, Unit, Nothing, Nothing] = impl._clone()
+    def ordinal: Int = 0
+    def input: Unit = ()
+    def endpoint: smithy4s.Endpoint[ObjectCollisionOperation,Unit, Nothing, Unit, Nothing, Nothing] = Clone
+  }
+  object Clone extends smithy4s.Endpoint[ObjectCollisionOperation,Unit, Nothing, Unit, Nothing, Nothing] {
+    val schema: OperationSchema[Unit, Nothing, Unit, Nothing, Nothing] = Schema.operation(ShapeId("smithy4s.example", "Clone"))
+      .withInput(unit)
+      .withOutput(unit)
+    def wrap(input: Unit): Clone = Clone()
+  }
+  final case class Equals() extends ObjectCollisionOperation[Unit, Nothing, Unit, Nothing, Nothing] {
+    def run[F[_, _, _, _, _]](impl: ObjectCollisionGen[F]): F[Unit, Nothing, Unit, Nothing, Nothing] = impl._equals()
+    def ordinal: Int = 1
+    def input: Unit = ()
+    def endpoint: smithy4s.Endpoint[ObjectCollisionOperation,Unit, Nothing, Unit, Nothing, Nothing] = Equals
+  }
+  object Equals extends smithy4s.Endpoint[ObjectCollisionOperation,Unit, Nothing, Unit, Nothing, Nothing] {
+    val schema: OperationSchema[Unit, Nothing, Unit, Nothing, Nothing] = Schema.operation(ShapeId("smithy4s.example", "Equals"))
+      .withInput(unit)
+      .withOutput(unit)
+    def wrap(input: Unit): Equals = Equals()
+  }
   final case class Finalize() extends ObjectCollisionOperation[Unit, Nothing, Unit, Nothing, Nothing] {
     def run[F[_, _, _, _, _]](impl: ObjectCollisionGen[F]): F[Unit, Nothing, Unit, Nothing, Nothing] = impl._finalize()
-    def ordinal: Int = 0
+    def ordinal: Int = 2
     def input: Unit = ()
     def endpoint: smithy4s.Endpoint[ObjectCollisionOperation,Unit, Nothing, Unit, Nothing, Nothing] = Finalize
   }
@@ -114,7 +138,7 @@ object ObjectCollisionOperation {
   }
   final case class GetClass() extends ObjectCollisionOperation[Unit, Nothing, Unit, Nothing, Nothing] {
     def run[F[_, _, _, _, _]](impl: ObjectCollisionGen[F]): F[Unit, Nothing, Unit, Nothing, Nothing] = impl._getClass()
-    def ordinal: Int = 1
+    def ordinal: Int = 3
     def input: Unit = ()
     def endpoint: smithy4s.Endpoint[ObjectCollisionOperation,Unit, Nothing, Unit, Nothing, Nothing] = GetClass
   }
@@ -124,45 +148,9 @@ object ObjectCollisionOperation {
       .withOutput(unit)
     def wrap(input: Unit): GetClass = GetClass()
   }
-  final case class Equals() extends ObjectCollisionOperation[Unit, Nothing, Unit, Nothing, Nothing] {
-    def run[F[_, _, _, _, _]](impl: ObjectCollisionGen[F]): F[Unit, Nothing, Unit, Nothing, Nothing] = impl._equals()
-    def ordinal: Int = 2
-    def input: Unit = ()
-    def endpoint: smithy4s.Endpoint[ObjectCollisionOperation,Unit, Nothing, Unit, Nothing, Nothing] = Equals
-  }
-  object Equals extends smithy4s.Endpoint[ObjectCollisionOperation,Unit, Nothing, Unit, Nothing, Nothing] {
-    val schema: OperationSchema[Unit, Nothing, Unit, Nothing, Nothing] = Schema.operation(ShapeId("smithy4s.example", "Equals"))
-      .withInput(unit)
-      .withOutput(unit)
-    def wrap(input: Unit): Equals = Equals()
-  }
-  final case class ToString() extends ObjectCollisionOperation[Unit, Nothing, Unit, Nothing, Nothing] {
-    def run[F[_, _, _, _, _]](impl: ObjectCollisionGen[F]): F[Unit, Nothing, Unit, Nothing, Nothing] = impl._toString()
-    def ordinal: Int = 3
-    def input: Unit = ()
-    def endpoint: smithy4s.Endpoint[ObjectCollisionOperation,Unit, Nothing, Unit, Nothing, Nothing] = ToString
-  }
-  object ToString extends smithy4s.Endpoint[ObjectCollisionOperation,Unit, Nothing, Unit, Nothing, Nothing] {
-    val schema: OperationSchema[Unit, Nothing, Unit, Nothing, Nothing] = Schema.operation(ShapeId("smithy4s.example", "ToString"))
-      .withInput(unit)
-      .withOutput(unit)
-    def wrap(input: Unit): ToString = ToString()
-  }
-  final case class Notify() extends ObjectCollisionOperation[Unit, Nothing, Unit, Nothing, Nothing] {
-    def run[F[_, _, _, _, _]](impl: ObjectCollisionGen[F]): F[Unit, Nothing, Unit, Nothing, Nothing] = impl._notify()
-    def ordinal: Int = 4
-    def input: Unit = ()
-    def endpoint: smithy4s.Endpoint[ObjectCollisionOperation,Unit, Nothing, Unit, Nothing, Nothing] = Notify
-  }
-  object Notify extends smithy4s.Endpoint[ObjectCollisionOperation,Unit, Nothing, Unit, Nothing, Nothing] {
-    val schema: OperationSchema[Unit, Nothing, Unit, Nothing, Nothing] = Schema.operation(ShapeId("smithy4s.example", "Notify"))
-      .withInput(unit)
-      .withOutput(unit)
-    def wrap(input: Unit): Notify = Notify()
-  }
   final case class HashCode() extends ObjectCollisionOperation[Unit, Nothing, Unit, Nothing, Nothing] {
     def run[F[_, _, _, _, _]](impl: ObjectCollisionGen[F]): F[Unit, Nothing, Unit, Nothing, Nothing] = impl._hashCode()
-    def ordinal: Int = 5
+    def ordinal: Int = 4
     def input: Unit = ()
     def endpoint: smithy4s.Endpoint[ObjectCollisionOperation,Unit, Nothing, Unit, Nothing, Nothing] = HashCode
   }
@@ -172,33 +160,21 @@ object ObjectCollisionOperation {
       .withOutput(unit)
     def wrap(input: Unit): HashCode = HashCode()
   }
-  final case class Wait() extends ObjectCollisionOperation[Unit, Nothing, Unit, Nothing, Nothing] {
-    def run[F[_, _, _, _, _]](impl: ObjectCollisionGen[F]): F[Unit, Nothing, Unit, Nothing, Nothing] = impl._wait()
-    def ordinal: Int = 6
+  final case class Notify() extends ObjectCollisionOperation[Unit, Nothing, Unit, Nothing, Nothing] {
+    def run[F[_, _, _, _, _]](impl: ObjectCollisionGen[F]): F[Unit, Nothing, Unit, Nothing, Nothing] = impl._notify()
+    def ordinal: Int = 5
     def input: Unit = ()
-    def endpoint: smithy4s.Endpoint[ObjectCollisionOperation,Unit, Nothing, Unit, Nothing, Nothing] = Wait
+    def endpoint: smithy4s.Endpoint[ObjectCollisionOperation,Unit, Nothing, Unit, Nothing, Nothing] = Notify
   }
-  object Wait extends smithy4s.Endpoint[ObjectCollisionOperation,Unit, Nothing, Unit, Nothing, Nothing] {
-    val schema: OperationSchema[Unit, Nothing, Unit, Nothing, Nothing] = Schema.operation(ShapeId("smithy4s.example", "Wait"))
+  object Notify extends smithy4s.Endpoint[ObjectCollisionOperation,Unit, Nothing, Unit, Nothing, Nothing] {
+    val schema: OperationSchema[Unit, Nothing, Unit, Nothing, Nothing] = Schema.operation(ShapeId("smithy4s.example", "Notify"))
       .withInput(unit)
       .withOutput(unit)
-    def wrap(input: Unit): Wait = Wait()
-  }
-  final case class Clone() extends ObjectCollisionOperation[Unit, Nothing, Unit, Nothing, Nothing] {
-    def run[F[_, _, _, _, _]](impl: ObjectCollisionGen[F]): F[Unit, Nothing, Unit, Nothing, Nothing] = impl._clone()
-    def ordinal: Int = 7
-    def input: Unit = ()
-    def endpoint: smithy4s.Endpoint[ObjectCollisionOperation,Unit, Nothing, Unit, Nothing, Nothing] = Clone
-  }
-  object Clone extends smithy4s.Endpoint[ObjectCollisionOperation,Unit, Nothing, Unit, Nothing, Nothing] {
-    val schema: OperationSchema[Unit, Nothing, Unit, Nothing, Nothing] = Schema.operation(ShapeId("smithy4s.example", "Clone"))
-      .withInput(unit)
-      .withOutput(unit)
-    def wrap(input: Unit): Clone = Clone()
+    def wrap(input: Unit): Notify = Notify()
   }
   final case class NotifyAll() extends ObjectCollisionOperation[Unit, Nothing, Unit, Nothing, Nothing] {
     def run[F[_, _, _, _, _]](impl: ObjectCollisionGen[F]): F[Unit, Nothing, Unit, Nothing, Nothing] = impl._notifyAll()
-    def ordinal: Int = 8
+    def ordinal: Int = 6
     def input: Unit = ()
     def endpoint: smithy4s.Endpoint[ObjectCollisionOperation,Unit, Nothing, Unit, Nothing, Nothing] = NotifyAll
   }
@@ -207,6 +183,30 @@ object ObjectCollisionOperation {
       .withInput(unit)
       .withOutput(unit)
     def wrap(input: Unit): NotifyAll = NotifyAll()
+  }
+  final case class ToString() extends ObjectCollisionOperation[Unit, Nothing, Unit, Nothing, Nothing] {
+    def run[F[_, _, _, _, _]](impl: ObjectCollisionGen[F]): F[Unit, Nothing, Unit, Nothing, Nothing] = impl._toString()
+    def ordinal: Int = 7
+    def input: Unit = ()
+    def endpoint: smithy4s.Endpoint[ObjectCollisionOperation,Unit, Nothing, Unit, Nothing, Nothing] = ToString
+  }
+  object ToString extends smithy4s.Endpoint[ObjectCollisionOperation,Unit, Nothing, Unit, Nothing, Nothing] {
+    val schema: OperationSchema[Unit, Nothing, Unit, Nothing, Nothing] = Schema.operation(ShapeId("smithy4s.example", "ToString"))
+      .withInput(unit)
+      .withOutput(unit)
+    def wrap(input: Unit): ToString = ToString()
+  }
+  final case class Wait() extends ObjectCollisionOperation[Unit, Nothing, Unit, Nothing, Nothing] {
+    def run[F[_, _, _, _, _]](impl: ObjectCollisionGen[F]): F[Unit, Nothing, Unit, Nothing, Nothing] = impl._wait()
+    def ordinal: Int = 8
+    def input: Unit = ()
+    def endpoint: smithy4s.Endpoint[ObjectCollisionOperation,Unit, Nothing, Unit, Nothing, Nothing] = Wait
+  }
+  object Wait extends smithy4s.Endpoint[ObjectCollisionOperation,Unit, Nothing, Unit, Nothing, Nothing] {
+    val schema: OperationSchema[Unit, Nothing, Unit, Nothing, Nothing] = Schema.operation(ShapeId("smithy4s.example", "Wait"))
+      .withInput(unit)
+      .withOutput(unit)
+    def wrap(input: Unit): Wait = Wait()
   }
 }
 

--- a/modules/bootstrapped/src/generated/smithy4s/example/PizzaAdminService.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/PizzaAdminService.scala
@@ -17,20 +17,20 @@ import smithy4s.schema.Schema.unit
 trait PizzaAdminServiceGen[F[_, _, _, _, _]] {
   self =>
 
-  def headerEndpoint(uppercaseHeader: Option[String] = None, capitalizedHeader: Option[String] = None, lowercaseHeader: Option[String] = None, mixedHeader: Option[String] = None): F[HeaderEndpointData, Nothing, HeaderEndpointData, Nothing, Nothing]
+  def addMenuItem(restaurant: String, menuItem: MenuItem): F[AddMenuItemRequest, PizzaAdminServiceOperation.AddMenuItemError, AddMenuItemResult, Nothing, Nothing]
   def customCode(code: Int): F[CustomCodeInput, PizzaAdminServiceOperation.CustomCodeError, CustomCodeOutput, Nothing, Nothing]
-  def optionalOutput(): F[Unit, Nothing, OptionalOutputOutput, Nothing, Nothing]
   def echo(pathParam: String, body: EchoBody, queryParam: Option[String] = None): F[EchoInput, Nothing, Unit, Nothing, Nothing]
+  def getEnum(aa: TheEnum): F[GetEnumInput, PizzaAdminServiceOperation.GetEnumError, GetEnumOutput, Nothing, Nothing]
   def getIntEnum(aa: EnumResult): F[GetIntEnumInput, PizzaAdminServiceOperation.GetIntEnumError, GetIntEnumOutput, Nothing, Nothing]
+  def getMenu(restaurant: String): F[GetMenuRequest, PizzaAdminServiceOperation.GetMenuError, GetMenuResult, Nothing, Nothing]
+  def headerEndpoint(uppercaseHeader: Option[String] = None, capitalizedHeader: Option[String] = None, lowercaseHeader: Option[String] = None, mixedHeader: Option[String] = None): F[HeaderEndpointData, Nothing, HeaderEndpointData, Nothing, Nothing]
+  def headRequest(): F[Unit, Nothing, HeadRequestOutput, Nothing, Nothing]
+  def health(query: Option[String] = None): F[HealthRequest, PizzaAdminServiceOperation.HealthError, HealthResponse, Nothing, Nothing]
+  def noContentRequest(): F[Unit, Nothing, Unit, Nothing, Nothing]
+  def optionalOutput(): F[Unit, Nothing, OptionalOutputOutput, Nothing, Nothing]
+  def reservation(name: String, town: Option[String] = None): F[ReservationInput, Nothing, ReservationOutput, Nothing, Nothing]
   def roundTrip(label: String, header: Option[String] = None, query: Option[String] = None, body: Option[String] = None): F[RoundTripData, Nothing, RoundTripData, Nothing, Nothing]
   def version(): F[Unit, Nothing, VersionOutput, Nothing, Nothing]
-  def reservation(name: String, town: Option[String] = None): F[ReservationInput, Nothing, ReservationOutput, Nothing, Nothing]
-  def getEnum(aa: TheEnum): F[GetEnumInput, PizzaAdminServiceOperation.GetEnumError, GetEnumOutput, Nothing, Nothing]
-  def headRequest(): F[Unit, Nothing, HeadRequestOutput, Nothing, Nothing]
-  def noContentRequest(): F[Unit, Nothing, Unit, Nothing, Nothing]
-  def addMenuItem(restaurant: String, menuItem: MenuItem): F[AddMenuItemRequest, PizzaAdminServiceOperation.AddMenuItemError, AddMenuItemResult, Nothing, Nothing]
-  def health(query: Option[String] = None): F[HealthRequest, PizzaAdminServiceOperation.HealthError, HealthResponse, Nothing, Nothing]
-  def getMenu(restaurant: String): F[GetMenuRequest, PizzaAdminServiceOperation.GetMenuError, GetMenuResult, Nothing, Nothing]
 
   final def transform: Transformation.PartiallyApplied[PizzaAdminServiceGen[F]] = Transformation.of[PizzaAdminServiceGen[F]](this)
 }
@@ -52,20 +52,20 @@ object PizzaAdminServiceGen extends Service.Mixin[PizzaAdminServiceGen, PizzaAdm
   }
 
   val endpoints: Vector[smithy4s.Endpoint[PizzaAdminServiceOperation, _, _, _, _, _]] = Vector(
-    PizzaAdminServiceOperation.HeaderEndpoint,
+    PizzaAdminServiceOperation.AddMenuItem,
     PizzaAdminServiceOperation.CustomCode,
-    PizzaAdminServiceOperation.OptionalOutput,
     PizzaAdminServiceOperation.Echo,
+    PizzaAdminServiceOperation.GetEnum,
     PizzaAdminServiceOperation.GetIntEnum,
+    PizzaAdminServiceOperation.GetMenu,
+    PizzaAdminServiceOperation.HeaderEndpoint,
+    PizzaAdminServiceOperation.HeadRequest,
+    PizzaAdminServiceOperation.Health,
+    PizzaAdminServiceOperation.NoContentRequest,
+    PizzaAdminServiceOperation.OptionalOutput,
+    PizzaAdminServiceOperation.Reservation,
     PizzaAdminServiceOperation.RoundTrip,
     PizzaAdminServiceOperation.Version,
-    PizzaAdminServiceOperation.Reservation,
-    PizzaAdminServiceOperation.GetEnum,
-    PizzaAdminServiceOperation.HeadRequest,
-    PizzaAdminServiceOperation.NoContentRequest,
-    PizzaAdminServiceOperation.AddMenuItem,
-    PizzaAdminServiceOperation.Health,
-    PizzaAdminServiceOperation.GetMenu,
   )
 
   def input[I, E, O, SI, SO](op: PizzaAdminServiceOperation[I, E, O, SI, SO]): I = op.input
@@ -78,18 +78,18 @@ object PizzaAdminServiceGen extends Service.Mixin[PizzaAdminServiceGen, PizzaAdm
   def fromPolyFunction[P[_, _, _, _, _]](f: PolyFunction5[PizzaAdminServiceOperation, P]): PizzaAdminServiceGen[P] = new PizzaAdminServiceOperation.Transformed(reified, f)
   def toPolyFunction[P[_, _, _, _, _]](impl: PizzaAdminServiceGen[P]): PolyFunction5[PizzaAdminServiceOperation, P] = PizzaAdminServiceOperation.toPolyFunction(impl)
 
-  type CustomCodeError = PizzaAdminServiceOperation.CustomCodeError
-  val CustomCodeError = PizzaAdminServiceOperation.CustomCodeError
-  type GetIntEnumError = PizzaAdminServiceOperation.GetIntEnumError
-  val GetIntEnumError = PizzaAdminServiceOperation.GetIntEnumError
-  type GetEnumError = PizzaAdminServiceOperation.GetEnumError
-  val GetEnumError = PizzaAdminServiceOperation.GetEnumError
   type AddMenuItemError = PizzaAdminServiceOperation.AddMenuItemError
   val AddMenuItemError = PizzaAdminServiceOperation.AddMenuItemError
-  type HealthError = PizzaAdminServiceOperation.HealthError
-  val HealthError = PizzaAdminServiceOperation.HealthError
+  type CustomCodeError = PizzaAdminServiceOperation.CustomCodeError
+  val CustomCodeError = PizzaAdminServiceOperation.CustomCodeError
+  type GetEnumError = PizzaAdminServiceOperation.GetEnumError
+  val GetEnumError = PizzaAdminServiceOperation.GetEnumError
+  type GetIntEnumError = PizzaAdminServiceOperation.GetIntEnumError
+  val GetIntEnumError = PizzaAdminServiceOperation.GetIntEnumError
   type GetMenuError = PizzaAdminServiceOperation.GetMenuError
   val GetMenuError = PizzaAdminServiceOperation.GetMenuError
+  type HealthError = PizzaAdminServiceOperation.HealthError
+  val HealthError = PizzaAdminServiceOperation.HealthError
 }
 
 sealed trait PizzaAdminServiceOperation[Input, Err, Output, StreamedInput, StreamedOutput] {
@@ -102,339 +102,44 @@ sealed trait PizzaAdminServiceOperation[Input, Err, Output, StreamedInput, Strea
 object PizzaAdminServiceOperation {
 
   object reified extends PizzaAdminServiceGen[PizzaAdminServiceOperation] {
-    def headerEndpoint(uppercaseHeader: Option[String] = None, capitalizedHeader: Option[String] = None, lowercaseHeader: Option[String] = None, mixedHeader: Option[String] = None): HeaderEndpoint = HeaderEndpoint(HeaderEndpointData(uppercaseHeader, capitalizedHeader, lowercaseHeader, mixedHeader))
+    def addMenuItem(restaurant: String, menuItem: MenuItem): AddMenuItem = AddMenuItem(AddMenuItemRequest(restaurant, menuItem))
     def customCode(code: Int): CustomCode = CustomCode(CustomCodeInput(code))
-    def optionalOutput(): OptionalOutput = OptionalOutput()
     def echo(pathParam: String, body: EchoBody, queryParam: Option[String] = None): Echo = Echo(EchoInput(pathParam, body, queryParam))
+    def getEnum(aa: TheEnum): GetEnum = GetEnum(GetEnumInput(aa))
     def getIntEnum(aa: EnumResult): GetIntEnum = GetIntEnum(GetIntEnumInput(aa))
+    def getMenu(restaurant: String): GetMenu = GetMenu(GetMenuRequest(restaurant))
+    def headerEndpoint(uppercaseHeader: Option[String] = None, capitalizedHeader: Option[String] = None, lowercaseHeader: Option[String] = None, mixedHeader: Option[String] = None): HeaderEndpoint = HeaderEndpoint(HeaderEndpointData(uppercaseHeader, capitalizedHeader, lowercaseHeader, mixedHeader))
+    def headRequest(): HeadRequest = HeadRequest()
+    def health(query: Option[String] = None): Health = Health(HealthRequest(query))
+    def noContentRequest(): NoContentRequest = NoContentRequest()
+    def optionalOutput(): OptionalOutput = OptionalOutput()
+    def reservation(name: String, town: Option[String] = None): Reservation = Reservation(ReservationInput(name, town))
     def roundTrip(label: String, header: Option[String] = None, query: Option[String] = None, body: Option[String] = None): RoundTrip = RoundTrip(RoundTripData(label, header, query, body))
     def version(): Version = Version()
-    def reservation(name: String, town: Option[String] = None): Reservation = Reservation(ReservationInput(name, town))
-    def getEnum(aa: TheEnum): GetEnum = GetEnum(GetEnumInput(aa))
-    def headRequest(): HeadRequest = HeadRequest()
-    def noContentRequest(): NoContentRequest = NoContentRequest()
-    def addMenuItem(restaurant: String, menuItem: MenuItem): AddMenuItem = AddMenuItem(AddMenuItemRequest(restaurant, menuItem))
-    def health(query: Option[String] = None): Health = Health(HealthRequest(query))
-    def getMenu(restaurant: String): GetMenu = GetMenu(GetMenuRequest(restaurant))
   }
   class Transformed[P[_, _, _, _, _], P1[_ ,_ ,_ ,_ ,_]](alg: PizzaAdminServiceGen[P], f: PolyFunction5[P, P1]) extends PizzaAdminServiceGen[P1] {
-    def headerEndpoint(uppercaseHeader: Option[String] = None, capitalizedHeader: Option[String] = None, lowercaseHeader: Option[String] = None, mixedHeader: Option[String] = None): P1[HeaderEndpointData, Nothing, HeaderEndpointData, Nothing, Nothing] = f[HeaderEndpointData, Nothing, HeaderEndpointData, Nothing, Nothing](alg.headerEndpoint(uppercaseHeader, capitalizedHeader, lowercaseHeader, mixedHeader))
+    def addMenuItem(restaurant: String, menuItem: MenuItem): P1[AddMenuItemRequest, PizzaAdminServiceOperation.AddMenuItemError, AddMenuItemResult, Nothing, Nothing] = f[AddMenuItemRequest, PizzaAdminServiceOperation.AddMenuItemError, AddMenuItemResult, Nothing, Nothing](alg.addMenuItem(restaurant, menuItem))
     def customCode(code: Int): P1[CustomCodeInput, PizzaAdminServiceOperation.CustomCodeError, CustomCodeOutput, Nothing, Nothing] = f[CustomCodeInput, PizzaAdminServiceOperation.CustomCodeError, CustomCodeOutput, Nothing, Nothing](alg.customCode(code))
-    def optionalOutput(): P1[Unit, Nothing, OptionalOutputOutput, Nothing, Nothing] = f[Unit, Nothing, OptionalOutputOutput, Nothing, Nothing](alg.optionalOutput())
     def echo(pathParam: String, body: EchoBody, queryParam: Option[String] = None): P1[EchoInput, Nothing, Unit, Nothing, Nothing] = f[EchoInput, Nothing, Unit, Nothing, Nothing](alg.echo(pathParam, body, queryParam))
+    def getEnum(aa: TheEnum): P1[GetEnumInput, PizzaAdminServiceOperation.GetEnumError, GetEnumOutput, Nothing, Nothing] = f[GetEnumInput, PizzaAdminServiceOperation.GetEnumError, GetEnumOutput, Nothing, Nothing](alg.getEnum(aa))
     def getIntEnum(aa: EnumResult): P1[GetIntEnumInput, PizzaAdminServiceOperation.GetIntEnumError, GetIntEnumOutput, Nothing, Nothing] = f[GetIntEnumInput, PizzaAdminServiceOperation.GetIntEnumError, GetIntEnumOutput, Nothing, Nothing](alg.getIntEnum(aa))
+    def getMenu(restaurant: String): P1[GetMenuRequest, PizzaAdminServiceOperation.GetMenuError, GetMenuResult, Nothing, Nothing] = f[GetMenuRequest, PizzaAdminServiceOperation.GetMenuError, GetMenuResult, Nothing, Nothing](alg.getMenu(restaurant))
+    def headerEndpoint(uppercaseHeader: Option[String] = None, capitalizedHeader: Option[String] = None, lowercaseHeader: Option[String] = None, mixedHeader: Option[String] = None): P1[HeaderEndpointData, Nothing, HeaderEndpointData, Nothing, Nothing] = f[HeaderEndpointData, Nothing, HeaderEndpointData, Nothing, Nothing](alg.headerEndpoint(uppercaseHeader, capitalizedHeader, lowercaseHeader, mixedHeader))
+    def headRequest(): P1[Unit, Nothing, HeadRequestOutput, Nothing, Nothing] = f[Unit, Nothing, HeadRequestOutput, Nothing, Nothing](alg.headRequest())
+    def health(query: Option[String] = None): P1[HealthRequest, PizzaAdminServiceOperation.HealthError, HealthResponse, Nothing, Nothing] = f[HealthRequest, PizzaAdminServiceOperation.HealthError, HealthResponse, Nothing, Nothing](alg.health(query))
+    def noContentRequest(): P1[Unit, Nothing, Unit, Nothing, Nothing] = f[Unit, Nothing, Unit, Nothing, Nothing](alg.noContentRequest())
+    def optionalOutput(): P1[Unit, Nothing, OptionalOutputOutput, Nothing, Nothing] = f[Unit, Nothing, OptionalOutputOutput, Nothing, Nothing](alg.optionalOutput())
+    def reservation(name: String, town: Option[String] = None): P1[ReservationInput, Nothing, ReservationOutput, Nothing, Nothing] = f[ReservationInput, Nothing, ReservationOutput, Nothing, Nothing](alg.reservation(name, town))
     def roundTrip(label: String, header: Option[String] = None, query: Option[String] = None, body: Option[String] = None): P1[RoundTripData, Nothing, RoundTripData, Nothing, Nothing] = f[RoundTripData, Nothing, RoundTripData, Nothing, Nothing](alg.roundTrip(label, header, query, body))
     def version(): P1[Unit, Nothing, VersionOutput, Nothing, Nothing] = f[Unit, Nothing, VersionOutput, Nothing, Nothing](alg.version())
-    def reservation(name: String, town: Option[String] = None): P1[ReservationInput, Nothing, ReservationOutput, Nothing, Nothing] = f[ReservationInput, Nothing, ReservationOutput, Nothing, Nothing](alg.reservation(name, town))
-    def getEnum(aa: TheEnum): P1[GetEnumInput, PizzaAdminServiceOperation.GetEnumError, GetEnumOutput, Nothing, Nothing] = f[GetEnumInput, PizzaAdminServiceOperation.GetEnumError, GetEnumOutput, Nothing, Nothing](alg.getEnum(aa))
-    def headRequest(): P1[Unit, Nothing, HeadRequestOutput, Nothing, Nothing] = f[Unit, Nothing, HeadRequestOutput, Nothing, Nothing](alg.headRequest())
-    def noContentRequest(): P1[Unit, Nothing, Unit, Nothing, Nothing] = f[Unit, Nothing, Unit, Nothing, Nothing](alg.noContentRequest())
-    def addMenuItem(restaurant: String, menuItem: MenuItem): P1[AddMenuItemRequest, PizzaAdminServiceOperation.AddMenuItemError, AddMenuItemResult, Nothing, Nothing] = f[AddMenuItemRequest, PizzaAdminServiceOperation.AddMenuItemError, AddMenuItemResult, Nothing, Nothing](alg.addMenuItem(restaurant, menuItem))
-    def health(query: Option[String] = None): P1[HealthRequest, PizzaAdminServiceOperation.HealthError, HealthResponse, Nothing, Nothing] = f[HealthRequest, PizzaAdminServiceOperation.HealthError, HealthResponse, Nothing, Nothing](alg.health(query))
-    def getMenu(restaurant: String): P1[GetMenuRequest, PizzaAdminServiceOperation.GetMenuError, GetMenuResult, Nothing, Nothing] = f[GetMenuRequest, PizzaAdminServiceOperation.GetMenuError, GetMenuResult, Nothing, Nothing](alg.getMenu(restaurant))
   }
 
   def toPolyFunction[P[_, _, _, _, _]](impl: PizzaAdminServiceGen[P]): PolyFunction5[PizzaAdminServiceOperation, P] = new PolyFunction5[PizzaAdminServiceOperation, P] {
     def apply[I, E, O, SI, SO](op: PizzaAdminServiceOperation[I, E, O, SI, SO]): P[I, E, O, SI, SO] = op.run(impl) 
   }
-  final case class HeaderEndpoint(input: HeaderEndpointData) extends PizzaAdminServiceOperation[HeaderEndpointData, Nothing, HeaderEndpointData, Nothing, Nothing] {
-    def run[F[_, _, _, _, _]](impl: PizzaAdminServiceGen[F]): F[HeaderEndpointData, Nothing, HeaderEndpointData, Nothing, Nothing] = impl.headerEndpoint(input.uppercaseHeader, input.capitalizedHeader, input.lowercaseHeader, input.mixedHeader)
-    def ordinal: Int = 0
-    def endpoint: smithy4s.Endpoint[PizzaAdminServiceOperation,HeaderEndpointData, Nothing, HeaderEndpointData, Nothing, Nothing] = HeaderEndpoint
-  }
-  object HeaderEndpoint extends smithy4s.Endpoint[PizzaAdminServiceOperation,HeaderEndpointData, Nothing, HeaderEndpointData, Nothing, Nothing] {
-    val schema: OperationSchema[HeaderEndpointData, Nothing, HeaderEndpointData, Nothing, Nothing] = Schema.operation(ShapeId("smithy4s.example", "HeaderEndpoint"))
-      .withInput(HeaderEndpointData.schema)
-      .withOutput(HeaderEndpointData.schema)
-      .withHints(smithy.api.Http(method = smithy.api.NonEmptyString("POST"), uri = smithy.api.NonEmptyString("/headers/"), code = 200))
-    def wrap(input: HeaderEndpointData): HeaderEndpoint = HeaderEndpoint(input)
-  }
-  final case class CustomCode(input: CustomCodeInput) extends PizzaAdminServiceOperation[CustomCodeInput, PizzaAdminServiceOperation.CustomCodeError, CustomCodeOutput, Nothing, Nothing] {
-    def run[F[_, _, _, _, _]](impl: PizzaAdminServiceGen[F]): F[CustomCodeInput, PizzaAdminServiceOperation.CustomCodeError, CustomCodeOutput, Nothing, Nothing] = impl.customCode(input.code)
-    def ordinal: Int = 1
-    def endpoint: smithy4s.Endpoint[PizzaAdminServiceOperation,CustomCodeInput, PizzaAdminServiceOperation.CustomCodeError, CustomCodeOutput, Nothing, Nothing] = CustomCode
-  }
-  object CustomCode extends smithy4s.Endpoint[PizzaAdminServiceOperation,CustomCodeInput, PizzaAdminServiceOperation.CustomCodeError, CustomCodeOutput, Nothing, Nothing] {
-    val schema: OperationSchema[CustomCodeInput, PizzaAdminServiceOperation.CustomCodeError, CustomCodeOutput, Nothing, Nothing] = Schema.operation(ShapeId("smithy4s.example", "CustomCode"))
-      .withInput(CustomCodeInput.schema)
-      .withError(CustomCodeError.errorSchema)
-      .withOutput(CustomCodeOutput.schema)
-      .withHints(smithy.api.Http(method = smithy.api.NonEmptyString("GET"), uri = smithy.api.NonEmptyString("/custom-code/{code}"), code = 200), smithy.api.Readonly())
-    def wrap(input: CustomCodeInput): CustomCode = CustomCode(input)
-  }
-  sealed trait CustomCodeError extends scala.Product with scala.Serializable { self =>
-    @inline final def widen: CustomCodeError = this
-    def $ordinal: Int
-
-    object project {
-      def unknownServerError: Option[UnknownServerError] = CustomCodeError.UnknownServerErrorCase.alt.project.lift(self).map(_.unknownServerError)
-    }
-
-    def accept[A](visitor: CustomCodeError.Visitor[A]): A = this match {
-      case value: CustomCodeError.UnknownServerErrorCase => visitor.unknownServerError(value.unknownServerError)
-    }
-  }
-  object CustomCodeError extends ErrorSchema.Companion[CustomCodeError] {
-
-    def unknownServerError(unknownServerError: UnknownServerError): CustomCodeError = UnknownServerErrorCase(unknownServerError)
-
-    val id: ShapeId = ShapeId("smithy4s.example", "CustomCodeError")
-
-    val hints: Hints = Hints.empty
-
-    final case class UnknownServerErrorCase(unknownServerError: UnknownServerError) extends CustomCodeError { final def $ordinal: Int = 0 }
-
-    object UnknownServerErrorCase {
-      val hints: Hints = Hints.empty
-      val schema: Schema[CustomCodeError.UnknownServerErrorCase] = bijection(UnknownServerError.schema.addHints(hints), CustomCodeError.UnknownServerErrorCase(_), _.unknownServerError)
-      val alt = schema.oneOf[CustomCodeError]("UnknownServerError")
-    }
-
-    trait Visitor[A] {
-      def unknownServerError(value: UnknownServerError): A
-    }
-
-    object Visitor {
-      trait Default[A] extends Visitor[A] {
-        def default: A
-        def unknownServerError(value: UnknownServerError): A = default
-      }
-    }
-
-    implicit val schema: Schema[CustomCodeError] = union(
-      CustomCodeError.UnknownServerErrorCase.alt,
-    ){
-      _.$ordinal
-    }
-    def liftError(throwable: Throwable): Option[CustomCodeError] = throwable match {
-      case e: UnknownServerError => Some(CustomCodeError.UnknownServerErrorCase(e))
-      case _ => None
-    }
-    def unliftError(e: CustomCodeError): Throwable = e match {
-      case CustomCodeError.UnknownServerErrorCase(e) => e
-    }
-  }
-  final case class OptionalOutput() extends PizzaAdminServiceOperation[Unit, Nothing, OptionalOutputOutput, Nothing, Nothing] {
-    def run[F[_, _, _, _, _]](impl: PizzaAdminServiceGen[F]): F[Unit, Nothing, OptionalOutputOutput, Nothing, Nothing] = impl.optionalOutput()
-    def ordinal: Int = 2
-    def input: Unit = ()
-    def endpoint: smithy4s.Endpoint[PizzaAdminServiceOperation,Unit, Nothing, OptionalOutputOutput, Nothing, Nothing] = OptionalOutput
-  }
-  object OptionalOutput extends smithy4s.Endpoint[PizzaAdminServiceOperation,Unit, Nothing, OptionalOutputOutput, Nothing, Nothing] {
-    val schema: OperationSchema[Unit, Nothing, OptionalOutputOutput, Nothing, Nothing] = Schema.operation(ShapeId("smithy4s.example", "OptionalOutput"))
-      .withInput(unit)
-      .withOutput(OptionalOutputOutput.schema)
-      .withHints(smithy.api.Http(method = smithy.api.NonEmptyString("GET"), uri = smithy.api.NonEmptyString("/optional-output"), code = 200), smithy.api.Readonly())
-    def wrap(input: Unit): OptionalOutput = OptionalOutput()
-  }
-  final case class Echo(input: EchoInput) extends PizzaAdminServiceOperation[EchoInput, Nothing, Unit, Nothing, Nothing] {
-    def run[F[_, _, _, _, _]](impl: PizzaAdminServiceGen[F]): F[EchoInput, Nothing, Unit, Nothing, Nothing] = impl.echo(input.pathParam, input.body, input.queryParam)
-    def ordinal: Int = 3
-    def endpoint: smithy4s.Endpoint[PizzaAdminServiceOperation,EchoInput, Nothing, Unit, Nothing, Nothing] = Echo
-  }
-  object Echo extends smithy4s.Endpoint[PizzaAdminServiceOperation,EchoInput, Nothing, Unit, Nothing, Nothing] {
-    val schema: OperationSchema[EchoInput, Nothing, Unit, Nothing, Nothing] = Schema.operation(ShapeId("smithy4s.example", "Echo"))
-      .withInput(EchoInput.schema)
-      .withOutput(unit)
-      .withHints(smithy.api.Http(method = smithy.api.NonEmptyString("POST"), uri = smithy.api.NonEmptyString("/echo/{pathParam}"), code = 200))
-    def wrap(input: EchoInput): Echo = Echo(input)
-  }
-  final case class GetIntEnum(input: GetIntEnumInput) extends PizzaAdminServiceOperation[GetIntEnumInput, PizzaAdminServiceOperation.GetIntEnumError, GetIntEnumOutput, Nothing, Nothing] {
-    def run[F[_, _, _, _, _]](impl: PizzaAdminServiceGen[F]): F[GetIntEnumInput, PizzaAdminServiceOperation.GetIntEnumError, GetIntEnumOutput, Nothing, Nothing] = impl.getIntEnum(input.aa)
-    def ordinal: Int = 4
-    def endpoint: smithy4s.Endpoint[PizzaAdminServiceOperation,GetIntEnumInput, PizzaAdminServiceOperation.GetIntEnumError, GetIntEnumOutput, Nothing, Nothing] = GetIntEnum
-  }
-  object GetIntEnum extends smithy4s.Endpoint[PizzaAdminServiceOperation,GetIntEnumInput, PizzaAdminServiceOperation.GetIntEnumError, GetIntEnumOutput, Nothing, Nothing] {
-    val schema: OperationSchema[GetIntEnumInput, PizzaAdminServiceOperation.GetIntEnumError, GetIntEnumOutput, Nothing, Nothing] = Schema.operation(ShapeId("smithy4s.example", "GetIntEnum"))
-      .withInput(GetIntEnumInput.schema)
-      .withError(GetIntEnumError.errorSchema)
-      .withOutput(GetIntEnumOutput.schema)
-      .withHints(smithy.api.Http(method = smithy.api.NonEmptyString("GET"), uri = smithy.api.NonEmptyString("/get-int-enum/{aa}"), code = 200), smithy.api.Readonly())
-    def wrap(input: GetIntEnumInput): GetIntEnum = GetIntEnum(input)
-  }
-  sealed trait GetIntEnumError extends scala.Product with scala.Serializable { self =>
-    @inline final def widen: GetIntEnumError = this
-    def $ordinal: Int
-
-    object project {
-      def unknownServerError: Option[UnknownServerError] = GetIntEnumError.UnknownServerErrorCase.alt.project.lift(self).map(_.unknownServerError)
-    }
-
-    def accept[A](visitor: GetIntEnumError.Visitor[A]): A = this match {
-      case value: GetIntEnumError.UnknownServerErrorCase => visitor.unknownServerError(value.unknownServerError)
-    }
-  }
-  object GetIntEnumError extends ErrorSchema.Companion[GetIntEnumError] {
-
-    def unknownServerError(unknownServerError: UnknownServerError): GetIntEnumError = UnknownServerErrorCase(unknownServerError)
-
-    val id: ShapeId = ShapeId("smithy4s.example", "GetIntEnumError")
-
-    val hints: Hints = Hints.empty
-
-    final case class UnknownServerErrorCase(unknownServerError: UnknownServerError) extends GetIntEnumError { final def $ordinal: Int = 0 }
-
-    object UnknownServerErrorCase {
-      val hints: Hints = Hints.empty
-      val schema: Schema[GetIntEnumError.UnknownServerErrorCase] = bijection(UnknownServerError.schema.addHints(hints), GetIntEnumError.UnknownServerErrorCase(_), _.unknownServerError)
-      val alt = schema.oneOf[GetIntEnumError]("UnknownServerError")
-    }
-
-    trait Visitor[A] {
-      def unknownServerError(value: UnknownServerError): A
-    }
-
-    object Visitor {
-      trait Default[A] extends Visitor[A] {
-        def default: A
-        def unknownServerError(value: UnknownServerError): A = default
-      }
-    }
-
-    implicit val schema: Schema[GetIntEnumError] = union(
-      GetIntEnumError.UnknownServerErrorCase.alt,
-    ){
-      _.$ordinal
-    }
-    def liftError(throwable: Throwable): Option[GetIntEnumError] = throwable match {
-      case e: UnknownServerError => Some(GetIntEnumError.UnknownServerErrorCase(e))
-      case _ => None
-    }
-    def unliftError(e: GetIntEnumError): Throwable = e match {
-      case GetIntEnumError.UnknownServerErrorCase(e) => e
-    }
-  }
-  final case class RoundTrip(input: RoundTripData) extends PizzaAdminServiceOperation[RoundTripData, Nothing, RoundTripData, Nothing, Nothing] {
-    def run[F[_, _, _, _, _]](impl: PizzaAdminServiceGen[F]): F[RoundTripData, Nothing, RoundTripData, Nothing, Nothing] = impl.roundTrip(input.label, input.header, input.query, input.body)
-    def ordinal: Int = 5
-    def endpoint: smithy4s.Endpoint[PizzaAdminServiceOperation,RoundTripData, Nothing, RoundTripData, Nothing, Nothing] = RoundTrip
-  }
-  object RoundTrip extends smithy4s.Endpoint[PizzaAdminServiceOperation,RoundTripData, Nothing, RoundTripData, Nothing, Nothing] {
-    val schema: OperationSchema[RoundTripData, Nothing, RoundTripData, Nothing, Nothing] = Schema.operation(ShapeId("smithy4s.example", "RoundTrip"))
-      .withInput(RoundTripData.schema)
-      .withOutput(RoundTripData.schema)
-      .withHints(smithy.api.Http(method = smithy.api.NonEmptyString("POST"), uri = smithy.api.NonEmptyString("/roundTrip/{label}"), code = 200))
-    def wrap(input: RoundTripData): RoundTrip = RoundTrip(input)
-  }
-  final case class Version() extends PizzaAdminServiceOperation[Unit, Nothing, VersionOutput, Nothing, Nothing] {
-    def run[F[_, _, _, _, _]](impl: PizzaAdminServiceGen[F]): F[Unit, Nothing, VersionOutput, Nothing, Nothing] = impl.version()
-    def ordinal: Int = 6
-    def input: Unit = ()
-    def endpoint: smithy4s.Endpoint[PizzaAdminServiceOperation,Unit, Nothing, VersionOutput, Nothing, Nothing] = Version
-  }
-  object Version extends smithy4s.Endpoint[PizzaAdminServiceOperation,Unit, Nothing, VersionOutput, Nothing, Nothing] {
-    val schema: OperationSchema[Unit, Nothing, VersionOutput, Nothing, Nothing] = Schema.operation(ShapeId("smithy4s.example", "Version"))
-      .withInput(unit)
-      .withOutput(VersionOutput.schema)
-      .withHints(smithy.api.Http(method = smithy.api.NonEmptyString("GET"), uri = smithy.api.NonEmptyString("/version"), code = 200), smithy.api.Readonly())
-    def wrap(input: Unit): Version = Version()
-  }
-  final case class Reservation(input: ReservationInput) extends PizzaAdminServiceOperation[ReservationInput, Nothing, ReservationOutput, Nothing, Nothing] {
-    def run[F[_, _, _, _, _]](impl: PizzaAdminServiceGen[F]): F[ReservationInput, Nothing, ReservationOutput, Nothing, Nothing] = impl.reservation(input.name, input.town)
-    def ordinal: Int = 7
-    def endpoint: smithy4s.Endpoint[PizzaAdminServiceOperation,ReservationInput, Nothing, ReservationOutput, Nothing, Nothing] = Reservation
-  }
-  object Reservation extends smithy4s.Endpoint[PizzaAdminServiceOperation,ReservationInput, Nothing, ReservationOutput, Nothing, Nothing] {
-    val schema: OperationSchema[ReservationInput, Nothing, ReservationOutput, Nothing, Nothing] = Schema.operation(ShapeId("smithy4s.example", "Reservation"))
-      .withInput(ReservationInput.schema)
-      .withOutput(ReservationOutput.schema)
-      .withHints(smithy.api.Http(method = smithy.api.NonEmptyString("POST"), uri = smithy.api.NonEmptyString("/book/{name}"), code = 200))
-    def wrap(input: ReservationInput): Reservation = Reservation(input)
-  }
-  final case class GetEnum(input: GetEnumInput) extends PizzaAdminServiceOperation[GetEnumInput, PizzaAdminServiceOperation.GetEnumError, GetEnumOutput, Nothing, Nothing] {
-    def run[F[_, _, _, _, _]](impl: PizzaAdminServiceGen[F]): F[GetEnumInput, PizzaAdminServiceOperation.GetEnumError, GetEnumOutput, Nothing, Nothing] = impl.getEnum(input.aa)
-    def ordinal: Int = 8
-    def endpoint: smithy4s.Endpoint[PizzaAdminServiceOperation,GetEnumInput, PizzaAdminServiceOperation.GetEnumError, GetEnumOutput, Nothing, Nothing] = GetEnum
-  }
-  object GetEnum extends smithy4s.Endpoint[PizzaAdminServiceOperation,GetEnumInput, PizzaAdminServiceOperation.GetEnumError, GetEnumOutput, Nothing, Nothing] {
-    val schema: OperationSchema[GetEnumInput, PizzaAdminServiceOperation.GetEnumError, GetEnumOutput, Nothing, Nothing] = Schema.operation(ShapeId("smithy4s.example", "GetEnum"))
-      .withInput(GetEnumInput.schema)
-      .withError(GetEnumError.errorSchema)
-      .withOutput(GetEnumOutput.schema)
-      .withHints(smithy.api.Http(method = smithy.api.NonEmptyString("GET"), uri = smithy.api.NonEmptyString("/get-enum/{aa}"), code = 200), smithy.api.Readonly())
-    def wrap(input: GetEnumInput): GetEnum = GetEnum(input)
-  }
-  sealed trait GetEnumError extends scala.Product with scala.Serializable { self =>
-    @inline final def widen: GetEnumError = this
-    def $ordinal: Int
-
-    object project {
-      def unknownServerError: Option[UnknownServerError] = GetEnumError.UnknownServerErrorCase.alt.project.lift(self).map(_.unknownServerError)
-    }
-
-    def accept[A](visitor: GetEnumError.Visitor[A]): A = this match {
-      case value: GetEnumError.UnknownServerErrorCase => visitor.unknownServerError(value.unknownServerError)
-    }
-  }
-  object GetEnumError extends ErrorSchema.Companion[GetEnumError] {
-
-    def unknownServerError(unknownServerError: UnknownServerError): GetEnumError = UnknownServerErrorCase(unknownServerError)
-
-    val id: ShapeId = ShapeId("smithy4s.example", "GetEnumError")
-
-    val hints: Hints = Hints.empty
-
-    final case class UnknownServerErrorCase(unknownServerError: UnknownServerError) extends GetEnumError { final def $ordinal: Int = 0 }
-
-    object UnknownServerErrorCase {
-      val hints: Hints = Hints.empty
-      val schema: Schema[GetEnumError.UnknownServerErrorCase] = bijection(UnknownServerError.schema.addHints(hints), GetEnumError.UnknownServerErrorCase(_), _.unknownServerError)
-      val alt = schema.oneOf[GetEnumError]("UnknownServerError")
-    }
-
-    trait Visitor[A] {
-      def unknownServerError(value: UnknownServerError): A
-    }
-
-    object Visitor {
-      trait Default[A] extends Visitor[A] {
-        def default: A
-        def unknownServerError(value: UnknownServerError): A = default
-      }
-    }
-
-    implicit val schema: Schema[GetEnumError] = union(
-      GetEnumError.UnknownServerErrorCase.alt,
-    ){
-      _.$ordinal
-    }
-    def liftError(throwable: Throwable): Option[GetEnumError] = throwable match {
-      case e: UnknownServerError => Some(GetEnumError.UnknownServerErrorCase(e))
-      case _ => None
-    }
-    def unliftError(e: GetEnumError): Throwable = e match {
-      case GetEnumError.UnknownServerErrorCase(e) => e
-    }
-  }
-  final case class HeadRequest() extends PizzaAdminServiceOperation[Unit, Nothing, HeadRequestOutput, Nothing, Nothing] {
-    def run[F[_, _, _, _, _]](impl: PizzaAdminServiceGen[F]): F[Unit, Nothing, HeadRequestOutput, Nothing, Nothing] = impl.headRequest()
-    def ordinal: Int = 9
-    def input: Unit = ()
-    def endpoint: smithy4s.Endpoint[PizzaAdminServiceOperation,Unit, Nothing, HeadRequestOutput, Nothing, Nothing] = HeadRequest
-  }
-  object HeadRequest extends smithy4s.Endpoint[PizzaAdminServiceOperation,Unit, Nothing, HeadRequestOutput, Nothing, Nothing] {
-    val schema: OperationSchema[Unit, Nothing, HeadRequestOutput, Nothing, Nothing] = Schema.operation(ShapeId("smithy4s.example", "HeadRequest"))
-      .withInput(unit)
-      .withOutput(HeadRequestOutput.schema)
-      .withHints(smithy.api.Http(method = smithy.api.NonEmptyString("HEAD"), uri = smithy.api.NonEmptyString("/head-request"), code = 200), smithy.api.Readonly())
-    def wrap(input: Unit): HeadRequest = HeadRequest()
-  }
-  final case class NoContentRequest() extends PizzaAdminServiceOperation[Unit, Nothing, Unit, Nothing, Nothing] {
-    def run[F[_, _, _, _, _]](impl: PizzaAdminServiceGen[F]): F[Unit, Nothing, Unit, Nothing, Nothing] = impl.noContentRequest()
-    def ordinal: Int = 10
-    def input: Unit = ()
-    def endpoint: smithy4s.Endpoint[PizzaAdminServiceOperation,Unit, Nothing, Unit, Nothing, Nothing] = NoContentRequest
-  }
-  object NoContentRequest extends smithy4s.Endpoint[PizzaAdminServiceOperation,Unit, Nothing, Unit, Nothing, Nothing] {
-    val schema: OperationSchema[Unit, Nothing, Unit, Nothing, Nothing] = Schema.operation(ShapeId("smithy4s.example", "NoContentRequest"))
-      .withInput(unit)
-      .withOutput(unit)
-      .withHints(smithy.api.Http(method = smithy.api.NonEmptyString("GET"), uri = smithy.api.NonEmptyString("/no-content"), code = 204), smithy.api.Readonly())
-    def wrap(input: Unit): NoContentRequest = NoContentRequest()
-  }
   final case class AddMenuItem(input: AddMenuItemRequest) extends PizzaAdminServiceOperation[AddMenuItemRequest, PizzaAdminServiceOperation.AddMenuItemError, AddMenuItemResult, Nothing, Nothing] {
     def run[F[_, _, _, _, _]](impl: PizzaAdminServiceGen[F]): F[AddMenuItemRequest, PizzaAdminServiceOperation.AddMenuItemError, AddMenuItemResult, Nothing, Nothing] = impl.addMenuItem(input.restaurant, input.menuItem)
-    def ordinal: Int = 11
+    def ordinal: Int = 0
     def endpoint: smithy4s.Endpoint[PizzaAdminServiceOperation,AddMenuItemRequest, PizzaAdminServiceOperation.AddMenuItemError, AddMenuItemResult, Nothing, Nothing] = AddMenuItem
   }
   object AddMenuItem extends smithy4s.Endpoint[PizzaAdminServiceOperation,AddMenuItemRequest, PizzaAdminServiceOperation.AddMenuItemError, AddMenuItemResult, Nothing, Nothing] {
@@ -525,45 +230,45 @@ object PizzaAdminServiceOperation {
       case AddMenuItemError.GenericClientErrorCase(e) => e
     }
   }
-  final case class Health(input: HealthRequest) extends PizzaAdminServiceOperation[HealthRequest, PizzaAdminServiceOperation.HealthError, HealthResponse, Nothing, Nothing] {
-    def run[F[_, _, _, _, _]](impl: PizzaAdminServiceGen[F]): F[HealthRequest, PizzaAdminServiceOperation.HealthError, HealthResponse, Nothing, Nothing] = impl.health(input.query)
-    def ordinal: Int = 12
-    def endpoint: smithy4s.Endpoint[PizzaAdminServiceOperation,HealthRequest, PizzaAdminServiceOperation.HealthError, HealthResponse, Nothing, Nothing] = Health
+  final case class CustomCode(input: CustomCodeInput) extends PizzaAdminServiceOperation[CustomCodeInput, PizzaAdminServiceOperation.CustomCodeError, CustomCodeOutput, Nothing, Nothing] {
+    def run[F[_, _, _, _, _]](impl: PizzaAdminServiceGen[F]): F[CustomCodeInput, PizzaAdminServiceOperation.CustomCodeError, CustomCodeOutput, Nothing, Nothing] = impl.customCode(input.code)
+    def ordinal: Int = 1
+    def endpoint: smithy4s.Endpoint[PizzaAdminServiceOperation,CustomCodeInput, PizzaAdminServiceOperation.CustomCodeError, CustomCodeOutput, Nothing, Nothing] = CustomCode
   }
-  object Health extends smithy4s.Endpoint[PizzaAdminServiceOperation,HealthRequest, PizzaAdminServiceOperation.HealthError, HealthResponse, Nothing, Nothing] {
-    val schema: OperationSchema[HealthRequest, PizzaAdminServiceOperation.HealthError, HealthResponse, Nothing, Nothing] = Schema.operation(ShapeId("smithy4s.example", "Health"))
-      .withInput(HealthRequest.schema)
-      .withError(HealthError.errorSchema)
-      .withOutput(HealthResponse.schema)
-      .withHints(smithy.api.Http(method = smithy.api.NonEmptyString("GET"), uri = smithy.api.NonEmptyString("/health"), code = 200), smithy.api.Readonly())
-    def wrap(input: HealthRequest): Health = Health(input)
+  object CustomCode extends smithy4s.Endpoint[PizzaAdminServiceOperation,CustomCodeInput, PizzaAdminServiceOperation.CustomCodeError, CustomCodeOutput, Nothing, Nothing] {
+    val schema: OperationSchema[CustomCodeInput, PizzaAdminServiceOperation.CustomCodeError, CustomCodeOutput, Nothing, Nothing] = Schema.operation(ShapeId("smithy4s.example", "CustomCode"))
+      .withInput(CustomCodeInput.schema)
+      .withError(CustomCodeError.errorSchema)
+      .withOutput(CustomCodeOutput.schema)
+      .withHints(smithy.api.Http(method = smithy.api.NonEmptyString("GET"), uri = smithy.api.NonEmptyString("/custom-code/{code}"), code = 200), smithy.api.Readonly())
+    def wrap(input: CustomCodeInput): CustomCode = CustomCode(input)
   }
-  sealed trait HealthError extends scala.Product with scala.Serializable { self =>
-    @inline final def widen: HealthError = this
+  sealed trait CustomCodeError extends scala.Product with scala.Serializable { self =>
+    @inline final def widen: CustomCodeError = this
     def $ordinal: Int
 
     object project {
-      def unknownServerError: Option[UnknownServerError] = HealthError.UnknownServerErrorCase.alt.project.lift(self).map(_.unknownServerError)
+      def unknownServerError: Option[UnknownServerError] = CustomCodeError.UnknownServerErrorCase.alt.project.lift(self).map(_.unknownServerError)
     }
 
-    def accept[A](visitor: HealthError.Visitor[A]): A = this match {
-      case value: HealthError.UnknownServerErrorCase => visitor.unknownServerError(value.unknownServerError)
+    def accept[A](visitor: CustomCodeError.Visitor[A]): A = this match {
+      case value: CustomCodeError.UnknownServerErrorCase => visitor.unknownServerError(value.unknownServerError)
     }
   }
-  object HealthError extends ErrorSchema.Companion[HealthError] {
+  object CustomCodeError extends ErrorSchema.Companion[CustomCodeError] {
 
-    def unknownServerError(unknownServerError: UnknownServerError): HealthError = UnknownServerErrorCase(unknownServerError)
+    def unknownServerError(unknownServerError: UnknownServerError): CustomCodeError = UnknownServerErrorCase(unknownServerError)
 
-    val id: ShapeId = ShapeId("smithy4s.example", "HealthError")
+    val id: ShapeId = ShapeId("smithy4s.example", "CustomCodeError")
 
     val hints: Hints = Hints.empty
 
-    final case class UnknownServerErrorCase(unknownServerError: UnknownServerError) extends HealthError { final def $ordinal: Int = 0 }
+    final case class UnknownServerErrorCase(unknownServerError: UnknownServerError) extends CustomCodeError { final def $ordinal: Int = 0 }
 
     object UnknownServerErrorCase {
       val hints: Hints = Hints.empty
-      val schema: Schema[HealthError.UnknownServerErrorCase] = bijection(UnknownServerError.schema.addHints(hints), HealthError.UnknownServerErrorCase(_), _.unknownServerError)
-      val alt = schema.oneOf[HealthError]("UnknownServerError")
+      val schema: Schema[CustomCodeError.UnknownServerErrorCase] = bijection(UnknownServerError.schema.addHints(hints), CustomCodeError.UnknownServerErrorCase(_), _.unknownServerError)
+      val alt = schema.oneOf[CustomCodeError]("UnknownServerError")
     }
 
     trait Visitor[A] {
@@ -577,22 +282,164 @@ object PizzaAdminServiceOperation {
       }
     }
 
-    implicit val schema: Schema[HealthError] = union(
-      HealthError.UnknownServerErrorCase.alt,
+    implicit val schema: Schema[CustomCodeError] = union(
+      CustomCodeError.UnknownServerErrorCase.alt,
     ){
       _.$ordinal
     }
-    def liftError(throwable: Throwable): Option[HealthError] = throwable match {
-      case e: UnknownServerError => Some(HealthError.UnknownServerErrorCase(e))
+    def liftError(throwable: Throwable): Option[CustomCodeError] = throwable match {
+      case e: UnknownServerError => Some(CustomCodeError.UnknownServerErrorCase(e))
       case _ => None
     }
-    def unliftError(e: HealthError): Throwable = e match {
-      case HealthError.UnknownServerErrorCase(e) => e
+    def unliftError(e: CustomCodeError): Throwable = e match {
+      case CustomCodeError.UnknownServerErrorCase(e) => e
+    }
+  }
+  final case class Echo(input: EchoInput) extends PizzaAdminServiceOperation[EchoInput, Nothing, Unit, Nothing, Nothing] {
+    def run[F[_, _, _, _, _]](impl: PizzaAdminServiceGen[F]): F[EchoInput, Nothing, Unit, Nothing, Nothing] = impl.echo(input.pathParam, input.body, input.queryParam)
+    def ordinal: Int = 2
+    def endpoint: smithy4s.Endpoint[PizzaAdminServiceOperation,EchoInput, Nothing, Unit, Nothing, Nothing] = Echo
+  }
+  object Echo extends smithy4s.Endpoint[PizzaAdminServiceOperation,EchoInput, Nothing, Unit, Nothing, Nothing] {
+    val schema: OperationSchema[EchoInput, Nothing, Unit, Nothing, Nothing] = Schema.operation(ShapeId("smithy4s.example", "Echo"))
+      .withInput(EchoInput.schema)
+      .withOutput(unit)
+      .withHints(smithy.api.Http(method = smithy.api.NonEmptyString("POST"), uri = smithy.api.NonEmptyString("/echo/{pathParam}"), code = 200))
+    def wrap(input: EchoInput): Echo = Echo(input)
+  }
+  final case class GetEnum(input: GetEnumInput) extends PizzaAdminServiceOperation[GetEnumInput, PizzaAdminServiceOperation.GetEnumError, GetEnumOutput, Nothing, Nothing] {
+    def run[F[_, _, _, _, _]](impl: PizzaAdminServiceGen[F]): F[GetEnumInput, PizzaAdminServiceOperation.GetEnumError, GetEnumOutput, Nothing, Nothing] = impl.getEnum(input.aa)
+    def ordinal: Int = 3
+    def endpoint: smithy4s.Endpoint[PizzaAdminServiceOperation,GetEnumInput, PizzaAdminServiceOperation.GetEnumError, GetEnumOutput, Nothing, Nothing] = GetEnum
+  }
+  object GetEnum extends smithy4s.Endpoint[PizzaAdminServiceOperation,GetEnumInput, PizzaAdminServiceOperation.GetEnumError, GetEnumOutput, Nothing, Nothing] {
+    val schema: OperationSchema[GetEnumInput, PizzaAdminServiceOperation.GetEnumError, GetEnumOutput, Nothing, Nothing] = Schema.operation(ShapeId("smithy4s.example", "GetEnum"))
+      .withInput(GetEnumInput.schema)
+      .withError(GetEnumError.errorSchema)
+      .withOutput(GetEnumOutput.schema)
+      .withHints(smithy.api.Http(method = smithy.api.NonEmptyString("GET"), uri = smithy.api.NonEmptyString("/get-enum/{aa}"), code = 200), smithy.api.Readonly())
+    def wrap(input: GetEnumInput): GetEnum = GetEnum(input)
+  }
+  sealed trait GetEnumError extends scala.Product with scala.Serializable { self =>
+    @inline final def widen: GetEnumError = this
+    def $ordinal: Int
+
+    object project {
+      def unknownServerError: Option[UnknownServerError] = GetEnumError.UnknownServerErrorCase.alt.project.lift(self).map(_.unknownServerError)
+    }
+
+    def accept[A](visitor: GetEnumError.Visitor[A]): A = this match {
+      case value: GetEnumError.UnknownServerErrorCase => visitor.unknownServerError(value.unknownServerError)
+    }
+  }
+  object GetEnumError extends ErrorSchema.Companion[GetEnumError] {
+
+    def unknownServerError(unknownServerError: UnknownServerError): GetEnumError = UnknownServerErrorCase(unknownServerError)
+
+    val id: ShapeId = ShapeId("smithy4s.example", "GetEnumError")
+
+    val hints: Hints = Hints.empty
+
+    final case class UnknownServerErrorCase(unknownServerError: UnknownServerError) extends GetEnumError { final def $ordinal: Int = 0 }
+
+    object UnknownServerErrorCase {
+      val hints: Hints = Hints.empty
+      val schema: Schema[GetEnumError.UnknownServerErrorCase] = bijection(UnknownServerError.schema.addHints(hints), GetEnumError.UnknownServerErrorCase(_), _.unknownServerError)
+      val alt = schema.oneOf[GetEnumError]("UnknownServerError")
+    }
+
+    trait Visitor[A] {
+      def unknownServerError(value: UnknownServerError): A
+    }
+
+    object Visitor {
+      trait Default[A] extends Visitor[A] {
+        def default: A
+        def unknownServerError(value: UnknownServerError): A = default
+      }
+    }
+
+    implicit val schema: Schema[GetEnumError] = union(
+      GetEnumError.UnknownServerErrorCase.alt,
+    ){
+      _.$ordinal
+    }
+    def liftError(throwable: Throwable): Option[GetEnumError] = throwable match {
+      case e: UnknownServerError => Some(GetEnumError.UnknownServerErrorCase(e))
+      case _ => None
+    }
+    def unliftError(e: GetEnumError): Throwable = e match {
+      case GetEnumError.UnknownServerErrorCase(e) => e
+    }
+  }
+  final case class GetIntEnum(input: GetIntEnumInput) extends PizzaAdminServiceOperation[GetIntEnumInput, PizzaAdminServiceOperation.GetIntEnumError, GetIntEnumOutput, Nothing, Nothing] {
+    def run[F[_, _, _, _, _]](impl: PizzaAdminServiceGen[F]): F[GetIntEnumInput, PizzaAdminServiceOperation.GetIntEnumError, GetIntEnumOutput, Nothing, Nothing] = impl.getIntEnum(input.aa)
+    def ordinal: Int = 4
+    def endpoint: smithy4s.Endpoint[PizzaAdminServiceOperation,GetIntEnumInput, PizzaAdminServiceOperation.GetIntEnumError, GetIntEnumOutput, Nothing, Nothing] = GetIntEnum
+  }
+  object GetIntEnum extends smithy4s.Endpoint[PizzaAdminServiceOperation,GetIntEnumInput, PizzaAdminServiceOperation.GetIntEnumError, GetIntEnumOutput, Nothing, Nothing] {
+    val schema: OperationSchema[GetIntEnumInput, PizzaAdminServiceOperation.GetIntEnumError, GetIntEnumOutput, Nothing, Nothing] = Schema.operation(ShapeId("smithy4s.example", "GetIntEnum"))
+      .withInput(GetIntEnumInput.schema)
+      .withError(GetIntEnumError.errorSchema)
+      .withOutput(GetIntEnumOutput.schema)
+      .withHints(smithy.api.Http(method = smithy.api.NonEmptyString("GET"), uri = smithy.api.NonEmptyString("/get-int-enum/{aa}"), code = 200), smithy.api.Readonly())
+    def wrap(input: GetIntEnumInput): GetIntEnum = GetIntEnum(input)
+  }
+  sealed trait GetIntEnumError extends scala.Product with scala.Serializable { self =>
+    @inline final def widen: GetIntEnumError = this
+    def $ordinal: Int
+
+    object project {
+      def unknownServerError: Option[UnknownServerError] = GetIntEnumError.UnknownServerErrorCase.alt.project.lift(self).map(_.unknownServerError)
+    }
+
+    def accept[A](visitor: GetIntEnumError.Visitor[A]): A = this match {
+      case value: GetIntEnumError.UnknownServerErrorCase => visitor.unknownServerError(value.unknownServerError)
+    }
+  }
+  object GetIntEnumError extends ErrorSchema.Companion[GetIntEnumError] {
+
+    def unknownServerError(unknownServerError: UnknownServerError): GetIntEnumError = UnknownServerErrorCase(unknownServerError)
+
+    val id: ShapeId = ShapeId("smithy4s.example", "GetIntEnumError")
+
+    val hints: Hints = Hints.empty
+
+    final case class UnknownServerErrorCase(unknownServerError: UnknownServerError) extends GetIntEnumError { final def $ordinal: Int = 0 }
+
+    object UnknownServerErrorCase {
+      val hints: Hints = Hints.empty
+      val schema: Schema[GetIntEnumError.UnknownServerErrorCase] = bijection(UnknownServerError.schema.addHints(hints), GetIntEnumError.UnknownServerErrorCase(_), _.unknownServerError)
+      val alt = schema.oneOf[GetIntEnumError]("UnknownServerError")
+    }
+
+    trait Visitor[A] {
+      def unknownServerError(value: UnknownServerError): A
+    }
+
+    object Visitor {
+      trait Default[A] extends Visitor[A] {
+        def default: A
+        def unknownServerError(value: UnknownServerError): A = default
+      }
+    }
+
+    implicit val schema: Schema[GetIntEnumError] = union(
+      GetIntEnumError.UnknownServerErrorCase.alt,
+    ){
+      _.$ordinal
+    }
+    def liftError(throwable: Throwable): Option[GetIntEnumError] = throwable match {
+      case e: UnknownServerError => Some(GetIntEnumError.UnknownServerErrorCase(e))
+      case _ => None
+    }
+    def unliftError(e: GetIntEnumError): Throwable = e match {
+      case GetIntEnumError.UnknownServerErrorCase(e) => e
     }
   }
   final case class GetMenu(input: GetMenuRequest) extends PizzaAdminServiceOperation[GetMenuRequest, PizzaAdminServiceOperation.GetMenuError, GetMenuResult, Nothing, Nothing] {
     def run[F[_, _, _, _, _]](impl: PizzaAdminServiceGen[F]): F[GetMenuRequest, PizzaAdminServiceOperation.GetMenuError, GetMenuResult, Nothing, Nothing] = impl.getMenu(input.restaurant)
-    def ordinal: Int = 13
+    def ordinal: Int = 5
     def endpoint: smithy4s.Endpoint[PizzaAdminServiceOperation,GetMenuRequest, PizzaAdminServiceOperation.GetMenuError, GetMenuResult, Nothing, Nothing] = GetMenu
   }
   object GetMenu extends smithy4s.Endpoint[PizzaAdminServiceOperation,GetMenuRequest, PizzaAdminServiceOperation.GetMenuError, GetMenuResult, Nothing, Nothing] {
@@ -696,6 +543,159 @@ object PizzaAdminServiceOperation {
       case GetMenuError.FallbackError2Case(e) => e
       case GetMenuError.GenericClientErrorCase(e) => e
     }
+  }
+  final case class HeaderEndpoint(input: HeaderEndpointData) extends PizzaAdminServiceOperation[HeaderEndpointData, Nothing, HeaderEndpointData, Nothing, Nothing] {
+    def run[F[_, _, _, _, _]](impl: PizzaAdminServiceGen[F]): F[HeaderEndpointData, Nothing, HeaderEndpointData, Nothing, Nothing] = impl.headerEndpoint(input.uppercaseHeader, input.capitalizedHeader, input.lowercaseHeader, input.mixedHeader)
+    def ordinal: Int = 6
+    def endpoint: smithy4s.Endpoint[PizzaAdminServiceOperation,HeaderEndpointData, Nothing, HeaderEndpointData, Nothing, Nothing] = HeaderEndpoint
+  }
+  object HeaderEndpoint extends smithy4s.Endpoint[PizzaAdminServiceOperation,HeaderEndpointData, Nothing, HeaderEndpointData, Nothing, Nothing] {
+    val schema: OperationSchema[HeaderEndpointData, Nothing, HeaderEndpointData, Nothing, Nothing] = Schema.operation(ShapeId("smithy4s.example", "HeaderEndpoint"))
+      .withInput(HeaderEndpointData.schema)
+      .withOutput(HeaderEndpointData.schema)
+      .withHints(smithy.api.Http(method = smithy.api.NonEmptyString("POST"), uri = smithy.api.NonEmptyString("/headers/"), code = 200))
+    def wrap(input: HeaderEndpointData): HeaderEndpoint = HeaderEndpoint(input)
+  }
+  final case class HeadRequest() extends PizzaAdminServiceOperation[Unit, Nothing, HeadRequestOutput, Nothing, Nothing] {
+    def run[F[_, _, _, _, _]](impl: PizzaAdminServiceGen[F]): F[Unit, Nothing, HeadRequestOutput, Nothing, Nothing] = impl.headRequest()
+    def ordinal: Int = 7
+    def input: Unit = ()
+    def endpoint: smithy4s.Endpoint[PizzaAdminServiceOperation,Unit, Nothing, HeadRequestOutput, Nothing, Nothing] = HeadRequest
+  }
+  object HeadRequest extends smithy4s.Endpoint[PizzaAdminServiceOperation,Unit, Nothing, HeadRequestOutput, Nothing, Nothing] {
+    val schema: OperationSchema[Unit, Nothing, HeadRequestOutput, Nothing, Nothing] = Schema.operation(ShapeId("smithy4s.example", "HeadRequest"))
+      .withInput(unit)
+      .withOutput(HeadRequestOutput.schema)
+      .withHints(smithy.api.Http(method = smithy.api.NonEmptyString("HEAD"), uri = smithy.api.NonEmptyString("/head-request"), code = 200), smithy.api.Readonly())
+    def wrap(input: Unit): HeadRequest = HeadRequest()
+  }
+  final case class Health(input: HealthRequest) extends PizzaAdminServiceOperation[HealthRequest, PizzaAdminServiceOperation.HealthError, HealthResponse, Nothing, Nothing] {
+    def run[F[_, _, _, _, _]](impl: PizzaAdminServiceGen[F]): F[HealthRequest, PizzaAdminServiceOperation.HealthError, HealthResponse, Nothing, Nothing] = impl.health(input.query)
+    def ordinal: Int = 8
+    def endpoint: smithy4s.Endpoint[PizzaAdminServiceOperation,HealthRequest, PizzaAdminServiceOperation.HealthError, HealthResponse, Nothing, Nothing] = Health
+  }
+  object Health extends smithy4s.Endpoint[PizzaAdminServiceOperation,HealthRequest, PizzaAdminServiceOperation.HealthError, HealthResponse, Nothing, Nothing] {
+    val schema: OperationSchema[HealthRequest, PizzaAdminServiceOperation.HealthError, HealthResponse, Nothing, Nothing] = Schema.operation(ShapeId("smithy4s.example", "Health"))
+      .withInput(HealthRequest.schema)
+      .withError(HealthError.errorSchema)
+      .withOutput(HealthResponse.schema)
+      .withHints(smithy.api.Http(method = smithy.api.NonEmptyString("GET"), uri = smithy.api.NonEmptyString("/health"), code = 200), smithy.api.Readonly())
+    def wrap(input: HealthRequest): Health = Health(input)
+  }
+  sealed trait HealthError extends scala.Product with scala.Serializable { self =>
+    @inline final def widen: HealthError = this
+    def $ordinal: Int
+
+    object project {
+      def unknownServerError: Option[UnknownServerError] = HealthError.UnknownServerErrorCase.alt.project.lift(self).map(_.unknownServerError)
+    }
+
+    def accept[A](visitor: HealthError.Visitor[A]): A = this match {
+      case value: HealthError.UnknownServerErrorCase => visitor.unknownServerError(value.unknownServerError)
+    }
+  }
+  object HealthError extends ErrorSchema.Companion[HealthError] {
+
+    def unknownServerError(unknownServerError: UnknownServerError): HealthError = UnknownServerErrorCase(unknownServerError)
+
+    val id: ShapeId = ShapeId("smithy4s.example", "HealthError")
+
+    val hints: Hints = Hints.empty
+
+    final case class UnknownServerErrorCase(unknownServerError: UnknownServerError) extends HealthError { final def $ordinal: Int = 0 }
+
+    object UnknownServerErrorCase {
+      val hints: Hints = Hints.empty
+      val schema: Schema[HealthError.UnknownServerErrorCase] = bijection(UnknownServerError.schema.addHints(hints), HealthError.UnknownServerErrorCase(_), _.unknownServerError)
+      val alt = schema.oneOf[HealthError]("UnknownServerError")
+    }
+
+    trait Visitor[A] {
+      def unknownServerError(value: UnknownServerError): A
+    }
+
+    object Visitor {
+      trait Default[A] extends Visitor[A] {
+        def default: A
+        def unknownServerError(value: UnknownServerError): A = default
+      }
+    }
+
+    implicit val schema: Schema[HealthError] = union(
+      HealthError.UnknownServerErrorCase.alt,
+    ){
+      _.$ordinal
+    }
+    def liftError(throwable: Throwable): Option[HealthError] = throwable match {
+      case e: UnknownServerError => Some(HealthError.UnknownServerErrorCase(e))
+      case _ => None
+    }
+    def unliftError(e: HealthError): Throwable = e match {
+      case HealthError.UnknownServerErrorCase(e) => e
+    }
+  }
+  final case class NoContentRequest() extends PizzaAdminServiceOperation[Unit, Nothing, Unit, Nothing, Nothing] {
+    def run[F[_, _, _, _, _]](impl: PizzaAdminServiceGen[F]): F[Unit, Nothing, Unit, Nothing, Nothing] = impl.noContentRequest()
+    def ordinal: Int = 9
+    def input: Unit = ()
+    def endpoint: smithy4s.Endpoint[PizzaAdminServiceOperation,Unit, Nothing, Unit, Nothing, Nothing] = NoContentRequest
+  }
+  object NoContentRequest extends smithy4s.Endpoint[PizzaAdminServiceOperation,Unit, Nothing, Unit, Nothing, Nothing] {
+    val schema: OperationSchema[Unit, Nothing, Unit, Nothing, Nothing] = Schema.operation(ShapeId("smithy4s.example", "NoContentRequest"))
+      .withInput(unit)
+      .withOutput(unit)
+      .withHints(smithy.api.Http(method = smithy.api.NonEmptyString("GET"), uri = smithy.api.NonEmptyString("/no-content"), code = 204), smithy.api.Readonly())
+    def wrap(input: Unit): NoContentRequest = NoContentRequest()
+  }
+  final case class OptionalOutput() extends PizzaAdminServiceOperation[Unit, Nothing, OptionalOutputOutput, Nothing, Nothing] {
+    def run[F[_, _, _, _, _]](impl: PizzaAdminServiceGen[F]): F[Unit, Nothing, OptionalOutputOutput, Nothing, Nothing] = impl.optionalOutput()
+    def ordinal: Int = 10
+    def input: Unit = ()
+    def endpoint: smithy4s.Endpoint[PizzaAdminServiceOperation,Unit, Nothing, OptionalOutputOutput, Nothing, Nothing] = OptionalOutput
+  }
+  object OptionalOutput extends smithy4s.Endpoint[PizzaAdminServiceOperation,Unit, Nothing, OptionalOutputOutput, Nothing, Nothing] {
+    val schema: OperationSchema[Unit, Nothing, OptionalOutputOutput, Nothing, Nothing] = Schema.operation(ShapeId("smithy4s.example", "OptionalOutput"))
+      .withInput(unit)
+      .withOutput(OptionalOutputOutput.schema)
+      .withHints(smithy.api.Http(method = smithy.api.NonEmptyString("GET"), uri = smithy.api.NonEmptyString("/optional-output"), code = 200), smithy.api.Readonly())
+    def wrap(input: Unit): OptionalOutput = OptionalOutput()
+  }
+  final case class Reservation(input: ReservationInput) extends PizzaAdminServiceOperation[ReservationInput, Nothing, ReservationOutput, Nothing, Nothing] {
+    def run[F[_, _, _, _, _]](impl: PizzaAdminServiceGen[F]): F[ReservationInput, Nothing, ReservationOutput, Nothing, Nothing] = impl.reservation(input.name, input.town)
+    def ordinal: Int = 11
+    def endpoint: smithy4s.Endpoint[PizzaAdminServiceOperation,ReservationInput, Nothing, ReservationOutput, Nothing, Nothing] = Reservation
+  }
+  object Reservation extends smithy4s.Endpoint[PizzaAdminServiceOperation,ReservationInput, Nothing, ReservationOutput, Nothing, Nothing] {
+    val schema: OperationSchema[ReservationInput, Nothing, ReservationOutput, Nothing, Nothing] = Schema.operation(ShapeId("smithy4s.example", "Reservation"))
+      .withInput(ReservationInput.schema)
+      .withOutput(ReservationOutput.schema)
+      .withHints(smithy.api.Http(method = smithy.api.NonEmptyString("POST"), uri = smithy.api.NonEmptyString("/book/{name}"), code = 200))
+    def wrap(input: ReservationInput): Reservation = Reservation(input)
+  }
+  final case class RoundTrip(input: RoundTripData) extends PizzaAdminServiceOperation[RoundTripData, Nothing, RoundTripData, Nothing, Nothing] {
+    def run[F[_, _, _, _, _]](impl: PizzaAdminServiceGen[F]): F[RoundTripData, Nothing, RoundTripData, Nothing, Nothing] = impl.roundTrip(input.label, input.header, input.query, input.body)
+    def ordinal: Int = 12
+    def endpoint: smithy4s.Endpoint[PizzaAdminServiceOperation,RoundTripData, Nothing, RoundTripData, Nothing, Nothing] = RoundTrip
+  }
+  object RoundTrip extends smithy4s.Endpoint[PizzaAdminServiceOperation,RoundTripData, Nothing, RoundTripData, Nothing, Nothing] {
+    val schema: OperationSchema[RoundTripData, Nothing, RoundTripData, Nothing, Nothing] = Schema.operation(ShapeId("smithy4s.example", "RoundTrip"))
+      .withInput(RoundTripData.schema)
+      .withOutput(RoundTripData.schema)
+      .withHints(smithy.api.Http(method = smithy.api.NonEmptyString("POST"), uri = smithy.api.NonEmptyString("/roundTrip/{label}"), code = 200))
+    def wrap(input: RoundTripData): RoundTrip = RoundTrip(input)
+  }
+  final case class Version() extends PizzaAdminServiceOperation[Unit, Nothing, VersionOutput, Nothing, Nothing] {
+    def run[F[_, _, _, _, _]](impl: PizzaAdminServiceGen[F]): F[Unit, Nothing, VersionOutput, Nothing, Nothing] = impl.version()
+    def ordinal: Int = 13
+    def input: Unit = ()
+    def endpoint: smithy4s.Endpoint[PizzaAdminServiceOperation,Unit, Nothing, VersionOutput, Nothing, Nothing] = Version
+  }
+  object Version extends smithy4s.Endpoint[PizzaAdminServiceOperation,Unit, Nothing, VersionOutput, Nothing, Nothing] {
+    val schema: OperationSchema[Unit, Nothing, VersionOutput, Nothing, Nothing] = Schema.operation(ShapeId("smithy4s.example", "Version"))
+      .withInput(unit)
+      .withOutput(VersionOutput.schema)
+      .withHints(smithy.api.Http(method = smithy.api.NonEmptyString("GET"), uri = smithy.api.NonEmptyString("/version"), code = 200), smithy.api.Readonly())
+    def wrap(input: Unit): Version = Version()
   }
 }
 

--- a/modules/bootstrapped/src/generated/smithy4s/example/StreamedObjects.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/StreamedObjects.scala
@@ -15,8 +15,8 @@ import smithy4s.schema.StreamingSchema
 trait StreamedObjectsGen[F[_, _, _, _, _]] {
   self =>
 
-  def putStreamedObject(key: String): F[PutStreamedObjectInput, Nothing, Unit, StreamedBlob, Nothing]
   def getStreamedObject(key: String): F[GetStreamedObjectInput, Nothing, GetStreamedObjectOutput, Nothing, StreamedBlob]
+  def putStreamedObject(key: String): F[PutStreamedObjectInput, Nothing, Unit, StreamedBlob, Nothing]
 
   final def transform: Transformation.PartiallyApplied[StreamedObjectsGen[F]] = Transformation.of[StreamedObjectsGen[F]](this)
 }
@@ -36,8 +36,8 @@ object StreamedObjectsGen extends Service.Mixin[StreamedObjectsGen, StreamedObje
   }
 
   val endpoints: Vector[smithy4s.Endpoint[StreamedObjectsOperation, _, _, _, _, _]] = Vector(
-    StreamedObjectsOperation.PutStreamedObject,
     StreamedObjectsOperation.GetStreamedObject,
+    StreamedObjectsOperation.PutStreamedObject,
   )
 
   def input[I, E, O, SI, SO](op: StreamedObjectsOperation[I, E, O, SI, SO]): I = op.input
@@ -62,32 +62,20 @@ sealed trait StreamedObjectsOperation[Input, Err, Output, StreamedInput, Streame
 object StreamedObjectsOperation {
 
   object reified extends StreamedObjectsGen[StreamedObjectsOperation] {
-    def putStreamedObject(key: String): PutStreamedObject = PutStreamedObject(PutStreamedObjectInput(key))
     def getStreamedObject(key: String): GetStreamedObject = GetStreamedObject(GetStreamedObjectInput(key))
+    def putStreamedObject(key: String): PutStreamedObject = PutStreamedObject(PutStreamedObjectInput(key))
   }
   class Transformed[P[_, _, _, _, _], P1[_ ,_ ,_ ,_ ,_]](alg: StreamedObjectsGen[P], f: PolyFunction5[P, P1]) extends StreamedObjectsGen[P1] {
-    def putStreamedObject(key: String): P1[PutStreamedObjectInput, Nothing, Unit, StreamedBlob, Nothing] = f[PutStreamedObjectInput, Nothing, Unit, StreamedBlob, Nothing](alg.putStreamedObject(key))
     def getStreamedObject(key: String): P1[GetStreamedObjectInput, Nothing, GetStreamedObjectOutput, Nothing, StreamedBlob] = f[GetStreamedObjectInput, Nothing, GetStreamedObjectOutput, Nothing, StreamedBlob](alg.getStreamedObject(key))
+    def putStreamedObject(key: String): P1[PutStreamedObjectInput, Nothing, Unit, StreamedBlob, Nothing] = f[PutStreamedObjectInput, Nothing, Unit, StreamedBlob, Nothing](alg.putStreamedObject(key))
   }
 
   def toPolyFunction[P[_, _, _, _, _]](impl: StreamedObjectsGen[P]): PolyFunction5[StreamedObjectsOperation, P] = new PolyFunction5[StreamedObjectsOperation, P] {
     def apply[I, E, O, SI, SO](op: StreamedObjectsOperation[I, E, O, SI, SO]): P[I, E, O, SI, SO] = op.run(impl) 
   }
-  final case class PutStreamedObject(input: PutStreamedObjectInput) extends StreamedObjectsOperation[PutStreamedObjectInput, Nothing, Unit, StreamedBlob, Nothing] {
-    def run[F[_, _, _, _, _]](impl: StreamedObjectsGen[F]): F[PutStreamedObjectInput, Nothing, Unit, StreamedBlob, Nothing] = impl.putStreamedObject(input.key)
-    def ordinal: Int = 0
-    def endpoint: smithy4s.Endpoint[StreamedObjectsOperation,PutStreamedObjectInput, Nothing, Unit, StreamedBlob, Nothing] = PutStreamedObject
-  }
-  object PutStreamedObject extends smithy4s.Endpoint[StreamedObjectsOperation,PutStreamedObjectInput, Nothing, Unit, StreamedBlob, Nothing] {
-    val schema: OperationSchema[PutStreamedObjectInput, Nothing, Unit, StreamedBlob, Nothing] = Schema.operation(ShapeId("smithy4s.example", "PutStreamedObject"))
-      .withInput(PutStreamedObjectInput.schema)
-      .withOutput(unit)
-      .withStreamedInput(StreamingSchema("PutStreamedObjectInput", StreamedBlob.schema.addHints(smithy.api.Default(smithy4s.Document.fromString("")))))
-    def wrap(input: PutStreamedObjectInput): PutStreamedObject = PutStreamedObject(input)
-  }
   final case class GetStreamedObject(input: GetStreamedObjectInput) extends StreamedObjectsOperation[GetStreamedObjectInput, Nothing, GetStreamedObjectOutput, Nothing, StreamedBlob] {
     def run[F[_, _, _, _, _]](impl: StreamedObjectsGen[F]): F[GetStreamedObjectInput, Nothing, GetStreamedObjectOutput, Nothing, StreamedBlob] = impl.getStreamedObject(input.key)
-    def ordinal: Int = 1
+    def ordinal: Int = 0
     def endpoint: smithy4s.Endpoint[StreamedObjectsOperation,GetStreamedObjectInput, Nothing, GetStreamedObjectOutput, Nothing, StreamedBlob] = GetStreamedObject
   }
   object GetStreamedObject extends smithy4s.Endpoint[StreamedObjectsOperation,GetStreamedObjectInput, Nothing, GetStreamedObjectOutput, Nothing, StreamedBlob] {
@@ -96,6 +84,18 @@ object StreamedObjectsOperation {
       .withOutput(GetStreamedObjectOutput.schema)
       .withStreamedOutput(StreamingSchema("GetStreamedObjectOutput", StreamedBlob.schema.addHints(smithy.api.Default(smithy4s.Document.fromString("")))))
     def wrap(input: GetStreamedObjectInput): GetStreamedObject = GetStreamedObject(input)
+  }
+  final case class PutStreamedObject(input: PutStreamedObjectInput) extends StreamedObjectsOperation[PutStreamedObjectInput, Nothing, Unit, StreamedBlob, Nothing] {
+    def run[F[_, _, _, _, _]](impl: StreamedObjectsGen[F]): F[PutStreamedObjectInput, Nothing, Unit, StreamedBlob, Nothing] = impl.putStreamedObject(input.key)
+    def ordinal: Int = 1
+    def endpoint: smithy4s.Endpoint[StreamedObjectsOperation,PutStreamedObjectInput, Nothing, Unit, StreamedBlob, Nothing] = PutStreamedObject
+  }
+  object PutStreamedObject extends smithy4s.Endpoint[StreamedObjectsOperation,PutStreamedObjectInput, Nothing, Unit, StreamedBlob, Nothing] {
+    val schema: OperationSchema[PutStreamedObjectInput, Nothing, Unit, StreamedBlob, Nothing] = Schema.operation(ShapeId("smithy4s.example", "PutStreamedObject"))
+      .withInput(PutStreamedObjectInput.schema)
+      .withOutput(unit)
+      .withStreamedInput(StreamingSchema("PutStreamedObjectInput", StreamedBlob.schema.addHints(smithy.api.Default(smithy4s.Document.fromString("")))))
+    def wrap(input: PutStreamedObjectInput): PutStreamedObject = PutStreamedObject(input)
   }
 }
 

--- a/modules/bootstrapped/src/generated/smithy4s/example/Weather.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/Weather.scala
@@ -18,8 +18,8 @@ import smithy4s.schema.Schema.unit
 trait WeatherGen[F[_, _, _, _, _]] {
   self =>
 
-  def getCurrentTime(): F[Unit, Nothing, GetCurrentTimeOutput, Nothing, Nothing]
   def getCity(cityId: CityId): F[GetCityInput, WeatherOperation.GetCityError, GetCityOutput, Nothing, Nothing]
+  def getCurrentTime(): F[Unit, Nothing, GetCurrentTimeOutput, Nothing, Nothing]
   def getForecast(cityId: CityId): F[GetForecastInput, Nothing, GetForecastOutput, Nothing, Nothing]
   def listCities(nextToken: Option[String] = None, pageSize: Option[Int] = None): F[ListCitiesInput, Nothing, ListCitiesOutput, Nothing, Nothing]
 
@@ -44,8 +44,8 @@ object WeatherGen extends Service.Mixin[WeatherGen, WeatherOperation] {
   }
 
   val endpoints: Vector[smithy4s.Endpoint[WeatherOperation, _, _, _, _, _]] = Vector(
-    WeatherOperation.GetCurrentTime,
     WeatherOperation.GetCity,
+    WeatherOperation.GetCurrentTime,
     WeatherOperation.GetForecast,
     WeatherOperation.ListCities,
   )
@@ -74,14 +74,14 @@ sealed trait WeatherOperation[Input, Err, Output, StreamedInput, StreamedOutput]
 object WeatherOperation {
 
   object reified extends WeatherGen[WeatherOperation] {
-    def getCurrentTime(): GetCurrentTime = GetCurrentTime()
     def getCity(cityId: CityId): GetCity = GetCity(GetCityInput(cityId))
+    def getCurrentTime(): GetCurrentTime = GetCurrentTime()
     def getForecast(cityId: CityId): GetForecast = GetForecast(GetForecastInput(cityId))
     def listCities(nextToken: Option[String] = None, pageSize: Option[Int] = None): ListCities = ListCities(ListCitiesInput(nextToken, pageSize))
   }
   class Transformed[P[_, _, _, _, _], P1[_ ,_ ,_ ,_ ,_]](alg: WeatherGen[P], f: PolyFunction5[P, P1]) extends WeatherGen[P1] {
-    def getCurrentTime(): P1[Unit, Nothing, GetCurrentTimeOutput, Nothing, Nothing] = f[Unit, Nothing, GetCurrentTimeOutput, Nothing, Nothing](alg.getCurrentTime())
     def getCity(cityId: CityId): P1[GetCityInput, WeatherOperation.GetCityError, GetCityOutput, Nothing, Nothing] = f[GetCityInput, WeatherOperation.GetCityError, GetCityOutput, Nothing, Nothing](alg.getCity(cityId))
+    def getCurrentTime(): P1[Unit, Nothing, GetCurrentTimeOutput, Nothing, Nothing] = f[Unit, Nothing, GetCurrentTimeOutput, Nothing, Nothing](alg.getCurrentTime())
     def getForecast(cityId: CityId): P1[GetForecastInput, Nothing, GetForecastOutput, Nothing, Nothing] = f[GetForecastInput, Nothing, GetForecastOutput, Nothing, Nothing](alg.getForecast(cityId))
     def listCities(nextToken: Option[String] = None, pageSize: Option[Int] = None): P1[ListCitiesInput, Nothing, ListCitiesOutput, Nothing, Nothing] = f[ListCitiesInput, Nothing, ListCitiesOutput, Nothing, Nothing](alg.listCities(nextToken, pageSize))
   }
@@ -89,22 +89,9 @@ object WeatherOperation {
   def toPolyFunction[P[_, _, _, _, _]](impl: WeatherGen[P]): PolyFunction5[WeatherOperation, P] = new PolyFunction5[WeatherOperation, P] {
     def apply[I, E, O, SI, SO](op: WeatherOperation[I, E, O, SI, SO]): P[I, E, O, SI, SO] = op.run(impl) 
   }
-  final case class GetCurrentTime() extends WeatherOperation[Unit, Nothing, GetCurrentTimeOutput, Nothing, Nothing] {
-    def run[F[_, _, _, _, _]](impl: WeatherGen[F]): F[Unit, Nothing, GetCurrentTimeOutput, Nothing, Nothing] = impl.getCurrentTime()
-    def ordinal: Int = 0
-    def input: Unit = ()
-    def endpoint: smithy4s.Endpoint[WeatherOperation,Unit, Nothing, GetCurrentTimeOutput, Nothing, Nothing] = GetCurrentTime
-  }
-  object GetCurrentTime extends smithy4s.Endpoint[WeatherOperation,Unit, Nothing, GetCurrentTimeOutput, Nothing, Nothing] {
-    val schema: OperationSchema[Unit, Nothing, GetCurrentTimeOutput, Nothing, Nothing] = Schema.operation(ShapeId("smithy4s.example", "GetCurrentTime"))
-      .withInput(unit)
-      .withOutput(GetCurrentTimeOutput.schema)
-      .withHints(smithy.api.Readonly())
-    def wrap(input: Unit): GetCurrentTime = GetCurrentTime()
-  }
   final case class GetCity(input: GetCityInput) extends WeatherOperation[GetCityInput, WeatherOperation.GetCityError, GetCityOutput, Nothing, Nothing] {
     def run[F[_, _, _, _, _]](impl: WeatherGen[F]): F[GetCityInput, WeatherOperation.GetCityError, GetCityOutput, Nothing, Nothing] = impl.getCity(input.cityId)
-    def ordinal: Int = 1
+    def ordinal: Int = 0
     def endpoint: smithy4s.Endpoint[WeatherOperation,GetCityInput, WeatherOperation.GetCityError, GetCityOutput, Nothing, Nothing] = GetCity
   }
   object GetCity extends smithy4s.Endpoint[WeatherOperation,GetCityInput, WeatherOperation.GetCityError, GetCityOutput, Nothing, Nothing] {
@@ -166,6 +153,19 @@ object WeatherOperation {
     def unliftError(e: GetCityError): Throwable = e match {
       case GetCityError.NoSuchResourceCase(e) => e
     }
+  }
+  final case class GetCurrentTime() extends WeatherOperation[Unit, Nothing, GetCurrentTimeOutput, Nothing, Nothing] {
+    def run[F[_, _, _, _, _]](impl: WeatherGen[F]): F[Unit, Nothing, GetCurrentTimeOutput, Nothing, Nothing] = impl.getCurrentTime()
+    def ordinal: Int = 1
+    def input: Unit = ()
+    def endpoint: smithy4s.Endpoint[WeatherOperation,Unit, Nothing, GetCurrentTimeOutput, Nothing, Nothing] = GetCurrentTime
+  }
+  object GetCurrentTime extends smithy4s.Endpoint[WeatherOperation,Unit, Nothing, GetCurrentTimeOutput, Nothing, Nothing] {
+    val schema: OperationSchema[Unit, Nothing, GetCurrentTimeOutput, Nothing, Nothing] = Schema.operation(ShapeId("smithy4s.example", "GetCurrentTime"))
+      .withInput(unit)
+      .withOutput(GetCurrentTimeOutput.schema)
+      .withHints(smithy.api.Readonly())
+    def wrap(input: Unit): GetCurrentTime = GetCurrentTime()
   }
   final case class GetForecast(input: GetForecastInput) extends WeatherOperation[GetForecastInput, Nothing, GetForecastOutput, Nothing, Nothing] {
     def run[F[_, _, _, _, _]](impl: WeatherGen[F]): F[GetForecastInput, Nothing, GetForecastOutput, Nothing, Nothing] = impl.getForecast(input.cityId)

--- a/modules/bootstrapped/src/generated/smithy4s/example/collision/ReservedNameService.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/collision/ReservedNameService.scala
@@ -14,10 +14,10 @@ import smithy4s.schema.Schema.unit
 trait ReservedNameServiceGen[F[_, _, _, _, _]] {
   self =>
 
-  def set(set: scala.collection.immutable.Set[smithy4s.example.collision.String]): F[SetInput, Nothing, Unit, Nothing, Nothing]
-  def option(value: scala.Option[smithy4s.example.collision.String] = None): F[OptionInput, Nothing, Unit, Nothing, Nothing]
-  def map(value: scala.collection.immutable.Map[smithy4s.example.collision.String, smithy4s.example.collision.String]): F[MapInput, Nothing, Unit, Nothing, Nothing]
   def list(list: scala.List[smithy4s.example.collision.String]): F[ListInput, Nothing, Unit, Nothing, Nothing]
+  def map(value: scala.collection.immutable.Map[smithy4s.example.collision.String, smithy4s.example.collision.String]): F[MapInput, Nothing, Unit, Nothing, Nothing]
+  def option(value: scala.Option[smithy4s.example.collision.String] = None): F[OptionInput, Nothing, Unit, Nothing, Nothing]
+  def set(set: scala.collection.immutable.Set[smithy4s.example.collision.String]): F[SetInput, Nothing, Unit, Nothing, Nothing]
 
   final def transform: Transformation.PartiallyApplied[ReservedNameServiceGen[F]] = Transformation.of[ReservedNameServiceGen[F]](this)
 }
@@ -39,10 +39,10 @@ object ReservedNameServiceGen extends Service.Mixin[ReservedNameServiceGen, Rese
   }
 
   val endpoints: Vector[smithy4s.Endpoint[ReservedNameServiceOperation, _, _, _, _, _]] = Vector(
-    ReservedNameServiceOperation.Set,
-    ReservedNameServiceOperation.Option,
-    ReservedNameServiceOperation.Map,
     ReservedNameServiceOperation.List,
+    ReservedNameServiceOperation.Map,
+    ReservedNameServiceOperation.Option,
+    ReservedNameServiceOperation.Set,
   )
 
   def input[I, E, O, SI, SO](op: ReservedNameServiceOperation[I, E, O, SI, SO]): I = op.input
@@ -67,48 +67,36 @@ sealed trait ReservedNameServiceOperation[Input, Err, Output, StreamedInput, Str
 object ReservedNameServiceOperation {
 
   object reified extends ReservedNameServiceGen[ReservedNameServiceOperation] {
-    def set(set: scala.collection.immutable.Set[smithy4s.example.collision.String]): Set = Set(SetInput(set))
-    def option(value: scala.Option[smithy4s.example.collision.String] = None): Option = Option(OptionInput(value))
-    def map(value: scala.collection.immutable.Map[smithy4s.example.collision.String, smithy4s.example.collision.String]): Map = Map(MapInput(value))
     def list(list: scala.List[smithy4s.example.collision.String]): List = List(ListInput(list))
+    def map(value: scala.collection.immutable.Map[smithy4s.example.collision.String, smithy4s.example.collision.String]): Map = Map(MapInput(value))
+    def option(value: scala.Option[smithy4s.example.collision.String] = None): Option = Option(OptionInput(value))
+    def set(set: scala.collection.immutable.Set[smithy4s.example.collision.String]): Set = Set(SetInput(set))
   }
   class Transformed[P[_, _, _, _, _], P1[_ ,_ ,_ ,_ ,_]](alg: ReservedNameServiceGen[P], f: PolyFunction5[P, P1]) extends ReservedNameServiceGen[P1] {
-    def set(set: scala.collection.immutable.Set[smithy4s.example.collision.String]): P1[SetInput, Nothing, Unit, Nothing, Nothing] = f[SetInput, Nothing, Unit, Nothing, Nothing](alg.set(set))
-    def option(value: scala.Option[smithy4s.example.collision.String] = None): P1[OptionInput, Nothing, Unit, Nothing, Nothing] = f[OptionInput, Nothing, Unit, Nothing, Nothing](alg.option(value))
-    def map(value: scala.collection.immutable.Map[smithy4s.example.collision.String, smithy4s.example.collision.String]): P1[MapInput, Nothing, Unit, Nothing, Nothing] = f[MapInput, Nothing, Unit, Nothing, Nothing](alg.map(value))
     def list(list: scala.List[smithy4s.example.collision.String]): P1[ListInput, Nothing, Unit, Nothing, Nothing] = f[ListInput, Nothing, Unit, Nothing, Nothing](alg.list(list))
+    def map(value: scala.collection.immutable.Map[smithy4s.example.collision.String, smithy4s.example.collision.String]): P1[MapInput, Nothing, Unit, Nothing, Nothing] = f[MapInput, Nothing, Unit, Nothing, Nothing](alg.map(value))
+    def option(value: scala.Option[smithy4s.example.collision.String] = None): P1[OptionInput, Nothing, Unit, Nothing, Nothing] = f[OptionInput, Nothing, Unit, Nothing, Nothing](alg.option(value))
+    def set(set: scala.collection.immutable.Set[smithy4s.example.collision.String]): P1[SetInput, Nothing, Unit, Nothing, Nothing] = f[SetInput, Nothing, Unit, Nothing, Nothing](alg.set(set))
   }
 
   def toPolyFunction[P[_, _, _, _, _]](impl: ReservedNameServiceGen[P]): PolyFunction5[ReservedNameServiceOperation, P] = new PolyFunction5[ReservedNameServiceOperation, P] {
     def apply[I, E, O, SI, SO](op: ReservedNameServiceOperation[I, E, O, SI, SO]): P[I, E, O, SI, SO] = op.run(impl) 
   }
-  final case class Set(input: SetInput) extends ReservedNameServiceOperation[SetInput, Nothing, Unit, Nothing, Nothing] {
-    def run[F[_, _, _, _, _]](impl: ReservedNameServiceGen[F]): F[SetInput, Nothing, Unit, Nothing, Nothing] = impl.set(input.set)
+  final case class List(input: ListInput) extends ReservedNameServiceOperation[ListInput, Nothing, Unit, Nothing, Nothing] {
+    def run[F[_, _, _, _, _]](impl: ReservedNameServiceGen[F]): F[ListInput, Nothing, Unit, Nothing, Nothing] = impl.list(input.list)
     def ordinal: Int = 0
-    def endpoint: smithy4s.Endpoint[ReservedNameServiceOperation,SetInput, Nothing, Unit, Nothing, Nothing] = Set
+    def endpoint: smithy4s.Endpoint[ReservedNameServiceOperation,ListInput, Nothing, Unit, Nothing, Nothing] = List
   }
-  object Set extends smithy4s.Endpoint[ReservedNameServiceOperation,SetInput, Nothing, Unit, Nothing, Nothing] {
-    val schema: OperationSchema[SetInput, Nothing, Unit, Nothing, Nothing] = Schema.operation(ShapeId("smithy4s.example.collision", "Set"))
-      .withInput(SetInput.schema)
+  object List extends smithy4s.Endpoint[ReservedNameServiceOperation,ListInput, Nothing, Unit, Nothing, Nothing] {
+    val schema: OperationSchema[ListInput, Nothing, Unit, Nothing, Nothing] = Schema.operation(ShapeId("smithy4s.example.collision", "List"))
+      .withInput(ListInput.schema)
       .withOutput(unit)
-      .withHints(smithy.api.Http(method = smithy.api.NonEmptyString("POST"), uri = smithy.api.NonEmptyString("/api/set/"), code = 204))
-    def wrap(input: SetInput): Set = Set(input)
-  }
-  final case class Option(input: OptionInput) extends ReservedNameServiceOperation[OptionInput, Nothing, Unit, Nothing, Nothing] {
-    def run[F[_, _, _, _, _]](impl: ReservedNameServiceGen[F]): F[OptionInput, Nothing, Unit, Nothing, Nothing] = impl.option(input.value)
-    def ordinal: Int = 1
-    def endpoint: smithy4s.Endpoint[ReservedNameServiceOperation,OptionInput, Nothing, Unit, Nothing, Nothing] = Option
-  }
-  object Option extends smithy4s.Endpoint[ReservedNameServiceOperation,OptionInput, Nothing, Unit, Nothing, Nothing] {
-    val schema: OperationSchema[OptionInput, Nothing, Unit, Nothing, Nothing] = Schema.operation(ShapeId("smithy4s.example.collision", "Option"))
-      .withInput(OptionInput.schema)
-      .withOutput(unit)
-      .withHints(smithy.api.Http(method = smithy.api.NonEmptyString("POST"), uri = smithy.api.NonEmptyString("/api/option/"), code = 204))
-    def wrap(input: OptionInput): Option = Option(input)
+      .withHints(smithy.api.Http(method = smithy.api.NonEmptyString("POST"), uri = smithy.api.NonEmptyString("/api/list/"), code = 204))
+    def wrap(input: ListInput): List = List(input)
   }
   final case class Map(input: MapInput) extends ReservedNameServiceOperation[MapInput, Nothing, Unit, Nothing, Nothing] {
     def run[F[_, _, _, _, _]](impl: ReservedNameServiceGen[F]): F[MapInput, Nothing, Unit, Nothing, Nothing] = impl.map(input.value)
-    def ordinal: Int = 2
+    def ordinal: Int = 1
     def endpoint: smithy4s.Endpoint[ReservedNameServiceOperation,MapInput, Nothing, Unit, Nothing, Nothing] = Map
   }
   object Map extends smithy4s.Endpoint[ReservedNameServiceOperation,MapInput, Nothing, Unit, Nothing, Nothing] {
@@ -118,17 +106,29 @@ object ReservedNameServiceOperation {
       .withHints(smithy.api.Http(method = smithy.api.NonEmptyString("POST"), uri = smithy.api.NonEmptyString("/api/map/"), code = 204))
     def wrap(input: MapInput): Map = Map(input)
   }
-  final case class List(input: ListInput) extends ReservedNameServiceOperation[ListInput, Nothing, Unit, Nothing, Nothing] {
-    def run[F[_, _, _, _, _]](impl: ReservedNameServiceGen[F]): F[ListInput, Nothing, Unit, Nothing, Nothing] = impl.list(input.list)
-    def ordinal: Int = 3
-    def endpoint: smithy4s.Endpoint[ReservedNameServiceOperation,ListInput, Nothing, Unit, Nothing, Nothing] = List
+  final case class Option(input: OptionInput) extends ReservedNameServiceOperation[OptionInput, Nothing, Unit, Nothing, Nothing] {
+    def run[F[_, _, _, _, _]](impl: ReservedNameServiceGen[F]): F[OptionInput, Nothing, Unit, Nothing, Nothing] = impl.option(input.value)
+    def ordinal: Int = 2
+    def endpoint: smithy4s.Endpoint[ReservedNameServiceOperation,OptionInput, Nothing, Unit, Nothing, Nothing] = Option
   }
-  object List extends smithy4s.Endpoint[ReservedNameServiceOperation,ListInput, Nothing, Unit, Nothing, Nothing] {
-    val schema: OperationSchema[ListInput, Nothing, Unit, Nothing, Nothing] = Schema.operation(ShapeId("smithy4s.example.collision", "List"))
-      .withInput(ListInput.schema)
+  object Option extends smithy4s.Endpoint[ReservedNameServiceOperation,OptionInput, Nothing, Unit, Nothing, Nothing] {
+    val schema: OperationSchema[OptionInput, Nothing, Unit, Nothing, Nothing] = Schema.operation(ShapeId("smithy4s.example.collision", "Option"))
+      .withInput(OptionInput.schema)
       .withOutput(unit)
-      .withHints(smithy.api.Http(method = smithy.api.NonEmptyString("POST"), uri = smithy.api.NonEmptyString("/api/list/"), code = 204))
-    def wrap(input: ListInput): List = List(input)
+      .withHints(smithy.api.Http(method = smithy.api.NonEmptyString("POST"), uri = smithy.api.NonEmptyString("/api/option/"), code = 204))
+    def wrap(input: OptionInput): Option = Option(input)
+  }
+  final case class Set(input: SetInput) extends ReservedNameServiceOperation[SetInput, Nothing, Unit, Nothing, Nothing] {
+    def run[F[_, _, _, _, _]](impl: ReservedNameServiceGen[F]): F[SetInput, Nothing, Unit, Nothing, Nothing] = impl.set(input.set)
+    def ordinal: Int = 3
+    def endpoint: smithy4s.Endpoint[ReservedNameServiceOperation,SetInput, Nothing, Unit, Nothing, Nothing] = Set
+  }
+  object Set extends smithy4s.Endpoint[ReservedNameServiceOperation,SetInput, Nothing, Unit, Nothing, Nothing] {
+    val schema: OperationSchema[SetInput, Nothing, Unit, Nothing, Nothing] = Schema.operation(ShapeId("smithy4s.example.collision", "Set"))
+      .withInput(SetInput.schema)
+      .withOutput(unit)
+      .withHints(smithy.api.Http(method = smithy.api.NonEmptyString("POST"), uri = smithy.api.NonEmptyString("/api/set/"), code = 204))
+    def wrap(input: SetInput): Set = Set(input)
   }
 }
 

--- a/modules/bootstrapped/src/generated/smithy4s/example/guides/auth/HelloWorldAuthService.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/guides/auth/HelloWorldAuthService.scala
@@ -17,8 +17,8 @@ import smithy4s.schema.Schema.unit
 trait HelloWorldAuthServiceGen[F[_, _, _, _, _]] {
   self =>
 
-  def sayWorld(): F[Unit, HelloWorldAuthServiceOperation.SayWorldError, World, Nothing, Nothing]
   def healthCheck(): F[Unit, HelloWorldAuthServiceOperation.HealthCheckError, HealthCheckOutput, Nothing, Nothing]
+  def sayWorld(): F[Unit, HelloWorldAuthServiceOperation.SayWorldError, World, Nothing, Nothing]
 
   final def transform: Transformation.PartiallyApplied[HelloWorldAuthServiceGen[F]] = Transformation.of[HelloWorldAuthServiceGen[F]](this)
 }
@@ -41,8 +41,8 @@ object HelloWorldAuthServiceGen extends Service.Mixin[HelloWorldAuthServiceGen, 
   }
 
   val endpoints: Vector[smithy4s.Endpoint[HelloWorldAuthServiceOperation, _, _, _, _, _]] = Vector(
-    HelloWorldAuthServiceOperation.SayWorld,
     HelloWorldAuthServiceOperation.HealthCheck,
+    HelloWorldAuthServiceOperation.SayWorld,
   )
 
   def input[I, E, O, SI, SO](op: HelloWorldAuthServiceOperation[I, E, O, SI, SO]): I = op.input
@@ -55,10 +55,10 @@ object HelloWorldAuthServiceGen extends Service.Mixin[HelloWorldAuthServiceGen, 
   def fromPolyFunction[P[_, _, _, _, _]](f: PolyFunction5[HelloWorldAuthServiceOperation, P]): HelloWorldAuthServiceGen[P] = new HelloWorldAuthServiceOperation.Transformed(reified, f)
   def toPolyFunction[P[_, _, _, _, _]](impl: HelloWorldAuthServiceGen[P]): PolyFunction5[HelloWorldAuthServiceOperation, P] = HelloWorldAuthServiceOperation.toPolyFunction(impl)
 
-  type SayWorldError = HelloWorldAuthServiceOperation.SayWorldError
-  val SayWorldError = HelloWorldAuthServiceOperation.SayWorldError
   type HealthCheckError = HelloWorldAuthServiceOperation.HealthCheckError
   val HealthCheckError = HelloWorldAuthServiceOperation.HealthCheckError
+  type SayWorldError = HelloWorldAuthServiceOperation.SayWorldError
+  val SayWorldError = HelloWorldAuthServiceOperation.SayWorldError
 }
 
 sealed trait HelloWorldAuthServiceOperation[Input, Err, Output, StreamedInput, StreamedOutput] {
@@ -71,86 +71,20 @@ sealed trait HelloWorldAuthServiceOperation[Input, Err, Output, StreamedInput, S
 object HelloWorldAuthServiceOperation {
 
   object reified extends HelloWorldAuthServiceGen[HelloWorldAuthServiceOperation] {
-    def sayWorld(): SayWorld = SayWorld()
     def healthCheck(): HealthCheck = HealthCheck()
+    def sayWorld(): SayWorld = SayWorld()
   }
   class Transformed[P[_, _, _, _, _], P1[_ ,_ ,_ ,_ ,_]](alg: HelloWorldAuthServiceGen[P], f: PolyFunction5[P, P1]) extends HelloWorldAuthServiceGen[P1] {
-    def sayWorld(): P1[Unit, HelloWorldAuthServiceOperation.SayWorldError, World, Nothing, Nothing] = f[Unit, HelloWorldAuthServiceOperation.SayWorldError, World, Nothing, Nothing](alg.sayWorld())
     def healthCheck(): P1[Unit, HelloWorldAuthServiceOperation.HealthCheckError, HealthCheckOutput, Nothing, Nothing] = f[Unit, HelloWorldAuthServiceOperation.HealthCheckError, HealthCheckOutput, Nothing, Nothing](alg.healthCheck())
+    def sayWorld(): P1[Unit, HelloWorldAuthServiceOperation.SayWorldError, World, Nothing, Nothing] = f[Unit, HelloWorldAuthServiceOperation.SayWorldError, World, Nothing, Nothing](alg.sayWorld())
   }
 
   def toPolyFunction[P[_, _, _, _, _]](impl: HelloWorldAuthServiceGen[P]): PolyFunction5[HelloWorldAuthServiceOperation, P] = new PolyFunction5[HelloWorldAuthServiceOperation, P] {
     def apply[I, E, O, SI, SO](op: HelloWorldAuthServiceOperation[I, E, O, SI, SO]): P[I, E, O, SI, SO] = op.run(impl) 
   }
-  final case class SayWorld() extends HelloWorldAuthServiceOperation[Unit, HelloWorldAuthServiceOperation.SayWorldError, World, Nothing, Nothing] {
-    def run[F[_, _, _, _, _]](impl: HelloWorldAuthServiceGen[F]): F[Unit, HelloWorldAuthServiceOperation.SayWorldError, World, Nothing, Nothing] = impl.sayWorld()
-    def ordinal: Int = 0
-    def input: Unit = ()
-    def endpoint: smithy4s.Endpoint[HelloWorldAuthServiceOperation,Unit, HelloWorldAuthServiceOperation.SayWorldError, World, Nothing, Nothing] = SayWorld
-  }
-  object SayWorld extends smithy4s.Endpoint[HelloWorldAuthServiceOperation,Unit, HelloWorldAuthServiceOperation.SayWorldError, World, Nothing, Nothing] {
-    val schema: OperationSchema[Unit, HelloWorldAuthServiceOperation.SayWorldError, World, Nothing, Nothing] = Schema.operation(ShapeId("smithy4s.example.guides.auth", "SayWorld"))
-      .withInput(unit)
-      .withError(SayWorldError.errorSchema)
-      .withOutput(World.schema)
-      .withHints(smithy.api.Http(method = smithy.api.NonEmptyString("GET"), uri = smithy.api.NonEmptyString("/hello"), code = 200), smithy.api.Readonly())
-    def wrap(input: Unit): SayWorld = SayWorld()
-  }
-  sealed trait SayWorldError extends scala.Product with scala.Serializable { self =>
-    @inline final def widen: SayWorldError = this
-    def $ordinal: Int
-
-    object project {
-      def notAuthorizedError: Option[NotAuthorizedError] = SayWorldError.NotAuthorizedErrorCase.alt.project.lift(self).map(_.notAuthorizedError)
-    }
-
-    def accept[A](visitor: SayWorldError.Visitor[A]): A = this match {
-      case value: SayWorldError.NotAuthorizedErrorCase => visitor.notAuthorizedError(value.notAuthorizedError)
-    }
-  }
-  object SayWorldError extends ErrorSchema.Companion[SayWorldError] {
-
-    def notAuthorizedError(notAuthorizedError: NotAuthorizedError): SayWorldError = NotAuthorizedErrorCase(notAuthorizedError)
-
-    val id: ShapeId = ShapeId("smithy4s.example.guides.auth", "SayWorldError")
-
-    val hints: Hints = Hints.empty
-
-    final case class NotAuthorizedErrorCase(notAuthorizedError: NotAuthorizedError) extends SayWorldError { final def $ordinal: Int = 0 }
-
-    object NotAuthorizedErrorCase {
-      val hints: Hints = Hints.empty
-      val schema: Schema[SayWorldError.NotAuthorizedErrorCase] = bijection(NotAuthorizedError.schema.addHints(hints), SayWorldError.NotAuthorizedErrorCase(_), _.notAuthorizedError)
-      val alt = schema.oneOf[SayWorldError]("NotAuthorizedError")
-    }
-
-    trait Visitor[A] {
-      def notAuthorizedError(value: NotAuthorizedError): A
-    }
-
-    object Visitor {
-      trait Default[A] extends Visitor[A] {
-        def default: A
-        def notAuthorizedError(value: NotAuthorizedError): A = default
-      }
-    }
-
-    implicit val schema: Schema[SayWorldError] = union(
-      SayWorldError.NotAuthorizedErrorCase.alt,
-    ){
-      _.$ordinal
-    }
-    def liftError(throwable: Throwable): Option[SayWorldError] = throwable match {
-      case e: NotAuthorizedError => Some(SayWorldError.NotAuthorizedErrorCase(e))
-      case _ => None
-    }
-    def unliftError(e: SayWorldError): Throwable = e match {
-      case SayWorldError.NotAuthorizedErrorCase(e) => e
-    }
-  }
   final case class HealthCheck() extends HelloWorldAuthServiceOperation[Unit, HelloWorldAuthServiceOperation.HealthCheckError, HealthCheckOutput, Nothing, Nothing] {
     def run[F[_, _, _, _, _]](impl: HelloWorldAuthServiceGen[F]): F[Unit, HelloWorldAuthServiceOperation.HealthCheckError, HealthCheckOutput, Nothing, Nothing] = impl.healthCheck()
-    def ordinal: Int = 1
+    def ordinal: Int = 0
     def input: Unit = ()
     def endpoint: smithy4s.Endpoint[HelloWorldAuthServiceOperation,Unit, HelloWorldAuthServiceOperation.HealthCheckError, HealthCheckOutput, Nothing, Nothing] = HealthCheck
   }
@@ -212,6 +146,72 @@ object HelloWorldAuthServiceOperation {
     }
     def unliftError(e: HealthCheckError): Throwable = e match {
       case HealthCheckError.NotAuthorizedErrorCase(e) => e
+    }
+  }
+  final case class SayWorld() extends HelloWorldAuthServiceOperation[Unit, HelloWorldAuthServiceOperation.SayWorldError, World, Nothing, Nothing] {
+    def run[F[_, _, _, _, _]](impl: HelloWorldAuthServiceGen[F]): F[Unit, HelloWorldAuthServiceOperation.SayWorldError, World, Nothing, Nothing] = impl.sayWorld()
+    def ordinal: Int = 1
+    def input: Unit = ()
+    def endpoint: smithy4s.Endpoint[HelloWorldAuthServiceOperation,Unit, HelloWorldAuthServiceOperation.SayWorldError, World, Nothing, Nothing] = SayWorld
+  }
+  object SayWorld extends smithy4s.Endpoint[HelloWorldAuthServiceOperation,Unit, HelloWorldAuthServiceOperation.SayWorldError, World, Nothing, Nothing] {
+    val schema: OperationSchema[Unit, HelloWorldAuthServiceOperation.SayWorldError, World, Nothing, Nothing] = Schema.operation(ShapeId("smithy4s.example.guides.auth", "SayWorld"))
+      .withInput(unit)
+      .withError(SayWorldError.errorSchema)
+      .withOutput(World.schema)
+      .withHints(smithy.api.Http(method = smithy.api.NonEmptyString("GET"), uri = smithy.api.NonEmptyString("/hello"), code = 200), smithy.api.Readonly())
+    def wrap(input: Unit): SayWorld = SayWorld()
+  }
+  sealed trait SayWorldError extends scala.Product with scala.Serializable { self =>
+    @inline final def widen: SayWorldError = this
+    def $ordinal: Int
+
+    object project {
+      def notAuthorizedError: Option[NotAuthorizedError] = SayWorldError.NotAuthorizedErrorCase.alt.project.lift(self).map(_.notAuthorizedError)
+    }
+
+    def accept[A](visitor: SayWorldError.Visitor[A]): A = this match {
+      case value: SayWorldError.NotAuthorizedErrorCase => visitor.notAuthorizedError(value.notAuthorizedError)
+    }
+  }
+  object SayWorldError extends ErrorSchema.Companion[SayWorldError] {
+
+    def notAuthorizedError(notAuthorizedError: NotAuthorizedError): SayWorldError = NotAuthorizedErrorCase(notAuthorizedError)
+
+    val id: ShapeId = ShapeId("smithy4s.example.guides.auth", "SayWorldError")
+
+    val hints: Hints = Hints.empty
+
+    final case class NotAuthorizedErrorCase(notAuthorizedError: NotAuthorizedError) extends SayWorldError { final def $ordinal: Int = 0 }
+
+    object NotAuthorizedErrorCase {
+      val hints: Hints = Hints.empty
+      val schema: Schema[SayWorldError.NotAuthorizedErrorCase] = bijection(NotAuthorizedError.schema.addHints(hints), SayWorldError.NotAuthorizedErrorCase(_), _.notAuthorizedError)
+      val alt = schema.oneOf[SayWorldError]("NotAuthorizedError")
+    }
+
+    trait Visitor[A] {
+      def notAuthorizedError(value: NotAuthorizedError): A
+    }
+
+    object Visitor {
+      trait Default[A] extends Visitor[A] {
+        def default: A
+        def notAuthorizedError(value: NotAuthorizedError): A = default
+      }
+    }
+
+    implicit val schema: Schema[SayWorldError] = union(
+      SayWorldError.NotAuthorizedErrorCase.alt,
+    ){
+      _.$ordinal
+    }
+    def liftError(throwable: Throwable): Option[SayWorldError] = throwable match {
+      case e: NotAuthorizedError => Some(SayWorldError.NotAuthorizedErrorCase(e))
+      case _ => None
+    }
+    def unliftError(e: SayWorldError): Throwable = e match {
+      case SayWorldError.NotAuthorizedErrorCase(e) => e
     }
   }
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/test/HelloService.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/test/HelloService.scala
@@ -18,8 +18,8 @@ trait HelloServiceGen[F[_, _, _, _, _]] {
   self =>
 
   def listen(): F[Unit, Nothing, Unit, Nothing, Nothing]
-  def testPath(path: String): F[TestPathInput, Nothing, Unit, Nothing, Nothing]
   def sayHello(greeting: Option[String] = None, query: Option[String] = None, name: Option[String] = None): F[SayHelloInput, HelloServiceOperation.SayHelloError, SayHelloOutput, Nothing, Nothing]
+  def testPath(path: String): F[TestPathInput, Nothing, Unit, Nothing, Nothing]
 
   final def transform: Transformation.PartiallyApplied[HelloServiceGen[F]] = Transformation.of[HelloServiceGen[F]](this)
 }
@@ -42,8 +42,8 @@ object HelloServiceGen extends Service.Mixin[HelloServiceGen, HelloServiceOperat
 
   val endpoints: Vector[smithy4s.Endpoint[HelloServiceOperation, _, _, _, _, _]] = Vector(
     HelloServiceOperation.Listen,
-    HelloServiceOperation.TestPath,
     HelloServiceOperation.SayHello,
+    HelloServiceOperation.TestPath,
   )
 
   def input[I, E, O, SI, SO](op: HelloServiceOperation[I, E, O, SI, SO]): I = op.input
@@ -71,13 +71,13 @@ object HelloServiceOperation {
 
   object reified extends HelloServiceGen[HelloServiceOperation] {
     def listen(): Listen = Listen()
-    def testPath(path: String): TestPath = TestPath(TestPathInput(path))
     def sayHello(greeting: Option[String] = None, query: Option[String] = None, name: Option[String] = None): SayHello = SayHello(SayHelloInput(greeting, query, name))
+    def testPath(path: String): TestPath = TestPath(TestPathInput(path))
   }
   class Transformed[P[_, _, _, _, _], P1[_ ,_ ,_ ,_ ,_]](alg: HelloServiceGen[P], f: PolyFunction5[P, P1]) extends HelloServiceGen[P1] {
     def listen(): P1[Unit, Nothing, Unit, Nothing, Nothing] = f[Unit, Nothing, Unit, Nothing, Nothing](alg.listen())
-    def testPath(path: String): P1[TestPathInput, Nothing, Unit, Nothing, Nothing] = f[TestPathInput, Nothing, Unit, Nothing, Nothing](alg.testPath(path))
     def sayHello(greeting: Option[String] = None, query: Option[String] = None, name: Option[String] = None): P1[SayHelloInput, HelloServiceOperation.SayHelloError, SayHelloOutput, Nothing, Nothing] = f[SayHelloInput, HelloServiceOperation.SayHelloError, SayHelloOutput, Nothing, Nothing](alg.sayHello(greeting, query, name))
+    def testPath(path: String): P1[TestPathInput, Nothing, Unit, Nothing, Nothing] = f[TestPathInput, Nothing, Unit, Nothing, Nothing](alg.testPath(path))
   }
 
   def toPolyFunction[P[_, _, _, _, _]](impl: HelloServiceGen[P]): PolyFunction5[HelloServiceOperation, P] = new PolyFunction5[HelloServiceOperation, P] {
@@ -96,21 +96,9 @@ object HelloServiceOperation {
       .withHints(smithy.api.Http(method = smithy.api.NonEmptyString("GET"), uri = smithy.api.NonEmptyString("/listen"), code = 200), smithy.api.Readonly(), smithy.test.HttpRequestTests(List(smithy.test.HttpRequestTestCase(id = "listen", protocol = smithy4s.ShapeId(namespace = "alloy", name = "simpleRestJson"), method = "GET", uri = "/listen", host = None, resolvedHost = None, authScheme = None, queryParams = None, forbidQueryParams = None, requireQueryParams = None, headers = None, forbidHeaders = None, requireHeaders = None, body = None, bodyMediaType = None, params = None, vendorParams = None, vendorParamsShape = None, documentation = None, tags = None, appliesTo = None))))
     def wrap(input: Unit): Listen = Listen()
   }
-  final case class TestPath(input: TestPathInput) extends HelloServiceOperation[TestPathInput, Nothing, Unit, Nothing, Nothing] {
-    def run[F[_, _, _, _, _]](impl: HelloServiceGen[F]): F[TestPathInput, Nothing, Unit, Nothing, Nothing] = impl.testPath(input.path)
-    def ordinal: Int = 1
-    def endpoint: smithy4s.Endpoint[HelloServiceOperation,TestPathInput, Nothing, Unit, Nothing, Nothing] = TestPath
-  }
-  object TestPath extends smithy4s.Endpoint[HelloServiceOperation,TestPathInput, Nothing, Unit, Nothing, Nothing] {
-    val schema: OperationSchema[TestPathInput, Nothing, Unit, Nothing, Nothing] = Schema.operation(ShapeId("smithy4s.example.test", "TestPath"))
-      .withInput(TestPathInput.schema)
-      .withOutput(unit)
-      .withHints(smithy.api.Http(method = smithy.api.NonEmptyString("GET"), uri = smithy.api.NonEmptyString("/test-path/{path}"), code = 200), smithy.api.Readonly(), smithy.test.HttpRequestTests(List(smithy.test.HttpRequestTestCase(id = "TestPath", protocol = smithy4s.ShapeId(namespace = "alloy", name = "simpleRestJson"), method = "GET", uri = "/test-path/sameValue", host = None, resolvedHost = None, authScheme = None, queryParams = None, forbidQueryParams = None, requireQueryParams = None, headers = None, forbidHeaders = None, requireHeaders = None, body = None, bodyMediaType = None, params = Some(smithy4s.Document.obj("path" -> smithy4s.Document.fromString("sameValue"))), vendorParams = None, vendorParamsShape = None, documentation = None, tags = None, appliesTo = None))))
-    def wrap(input: TestPathInput): TestPath = TestPath(input)
-  }
   final case class SayHello(input: SayHelloInput) extends HelloServiceOperation[SayHelloInput, HelloServiceOperation.SayHelloError, SayHelloOutput, Nothing, Nothing] {
     def run[F[_, _, _, _, _]](impl: HelloServiceGen[F]): F[SayHelloInput, HelloServiceOperation.SayHelloError, SayHelloOutput, Nothing, Nothing] = impl.sayHello(input.greeting, input.query, input.name)
-    def ordinal: Int = 2
+    def ordinal: Int = 1
     def endpoint: smithy4s.Endpoint[HelloServiceOperation,SayHelloInput, HelloServiceOperation.SayHelloError, SayHelloOutput, Nothing, Nothing] = SayHello
   }
   object SayHello extends smithy4s.Endpoint[HelloServiceOperation,SayHelloInput, HelloServiceOperation.SayHelloError, SayHelloOutput, Nothing, Nothing] {
@@ -186,6 +174,18 @@ object HelloServiceOperation {
       case SayHelloError.SimpleErrorCase(e) => e
       case SayHelloError.ComplexErrorCase(e) => e
     }
+  }
+  final case class TestPath(input: TestPathInput) extends HelloServiceOperation[TestPathInput, Nothing, Unit, Nothing, Nothing] {
+    def run[F[_, _, _, _, _]](impl: HelloServiceGen[F]): F[TestPathInput, Nothing, Unit, Nothing, Nothing] = impl.testPath(input.path)
+    def ordinal: Int = 2
+    def endpoint: smithy4s.Endpoint[HelloServiceOperation,TestPathInput, Nothing, Unit, Nothing, Nothing] = TestPath
+  }
+  object TestPath extends smithy4s.Endpoint[HelloServiceOperation,TestPathInput, Nothing, Unit, Nothing, Nothing] {
+    val schema: OperationSchema[TestPathInput, Nothing, Unit, Nothing, Nothing] = Schema.operation(ShapeId("smithy4s.example.test", "TestPath"))
+      .withInput(TestPathInput.schema)
+      .withOutput(unit)
+      .withHints(smithy.api.Http(method = smithy.api.NonEmptyString("GET"), uri = smithy.api.NonEmptyString("/test-path/{path}"), code = 200), smithy.api.Readonly(), smithy.test.HttpRequestTests(List(smithy.test.HttpRequestTestCase(id = "TestPath", protocol = smithy4s.ShapeId(namespace = "alloy", name = "simpleRestJson"), method = "GET", uri = "/test-path/sameValue", host = None, resolvedHost = None, authScheme = None, queryParams = None, forbidQueryParams = None, requireQueryParams = None, headers = None, forbidHeaders = None, requireHeaders = None, body = None, bodyMediaType = None, params = Some(smithy4s.Document.obj("path" -> smithy4s.Document.fromString("sameValue"))), vendorParams = None, vendorParamsShape = None, documentation = None, tags = None, appliesTo = None))))
+    def wrap(input: TestPathInput): TestPath = TestPath(input)
   }
 }
 

--- a/modules/codegen/src/smithy4s/codegen/internals/SmithyToIR.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/SmithyToIR.scala
@@ -466,6 +466,8 @@ private[codegen] class SmithyToIR(
             .asScala
             .map(_.getId())
             .toList
+            // for stability
+            .sorted
 
         val operations = recursiveOperations(shape)
           .map(model.getShape(_).asScala)


### PR DESCRIPTION
This should make adding new operations more predictable.

I was going back and forth between sorting based on location and by name, but model serializing affects locations so it'd become too unpredictable.

## PR Checklist (not all items are relevant to all PRs)

- [ ] Added unit-tests (for runtime code)
- [ ] Added bootstrapped code + smoke tests (when the rendering logic is modified)
- [ ] Added build-plugins integration tests (when reflection loading is required at codegen-time)
- [ ] Added alloy compliance tests (when simpleRestJson protocol behaviour is expanded/updated)
- [ ] Updated dynamic module to match generated-code behaviour
- [ ] Added documentation
- [ ] Updated changelog
