### PR TITLE
Make JSON maxArity irrelevant for http clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Thank you!
 # 0.18.39
 
 * http4s: Partially fix [#1619](https://github.com/disneystreaming/smithy4s/issues/1619) by checking request query parameters against the static query parameters in [#1743](https://github.com/disneystreaming/smithy4s/pull/1743)
+* http4s : always set JSON maxArity to Int.MaxValue on the client side, as this mechanism was intended to protect server-side and is very detrimental to clients.
 * codegen: Add HTTP method and pattern to Scaladoc (fixes [#728](https://github.com/disneystreaming/smithy4s/issues/728)) in [#1764](https://github.com/disneystreaming/smithy4s/pull/1764)
 
 # 0.18.38

--- a/modules/http4s/src/smithy4s/http4s/SimpleRestJsonBuilder.scala
+++ b/modules/http4s/src/smithy4s/http4s/SimpleRestJsonBuilder.scala
@@ -68,7 +68,7 @@ class SimpleRestJsonBuilder private (
 
   @deprecated(
     message = """Use withFieldFilter instead.
-      
+
   Mapping:
    - explicitDefaultsEncoding = false -> FieldFilter.Default
    - explicitDefaultsEncoding = true -> FieldFilter.EncodeAll
@@ -97,6 +97,9 @@ class SimpleRestJsonBuilder private (
 
   /**
     * Transforms the underlying JSON codec compiler to change its behaviour.
+    *
+    * Note that the `.maxArity` transformation is only taken into consideration
+    * for servers.
     */
   def transformJsonCodecs(
       f: JsonPayloadCodecCompiler => JsonPayloadCodecCompiler

--- a/modules/http4s/src/smithy4s/http4s/internals/SimpleRestJsonCodecs.scala
+++ b/modules/http4s/src/smithy4s/http4s/internals/SimpleRestJsonCodecs.scala
@@ -48,7 +48,7 @@ private[http4s] class SimpleRestJsonCodecs(
 
   @deprecated(
     message = """Use withFieldFilter instead.
-      
+
   Mapping:
    - newExplicitDefaultsEncoding = false -> FieldFilter.Default
    - newExplicitDefaultsEncoding = true -> FieldFilter.EncodeAll
@@ -81,6 +81,11 @@ private[http4s] class SimpleRestJsonCodecs(
   private val payloadDecoders =
     jsonCodecs.configureJsoniterCodecCompiler(_.withHintMask(hintMask)).decoders
 
+  // ALWAYS using maximum possible arity for client side, as this mechanism is a DDOS protection
+  // that does not make sense for clients.
+  private val clientPayloadDecoders =
+    jsonCodecs.configureJsoniterCodecCompiler(_.withHintMask(hintMask).withMaxArity(Int.MaxValue)).decoders
+
   // Adding X-Amzn-Errortype as well to facilitate interop with Amazon-issued code-generators.
   private val errorHeaders = List(
     smithy4s.http.errorTypeHeader,
@@ -110,7 +115,7 @@ private[http4s] class SimpleRestJsonCodecs(
     val baseRequest = HttpRequest(HttpMethod.POST, toSmithy4sHttpUri(uri, None), Map.empty, Blob.empty)
     HttpUnaryClientCodecs.builder
       .withBodyEncoders(payloadEncoders)
-      .withSuccessBodyDecoders(payloadDecoders)
+      .withSuccessBodyDecoders(clientPayloadDecoders)
       .withErrorBodyDecoders(payloadDecoders)
       .withErrorDiscriminator(HttpDiscriminator.fromResponse(errorHeaders, _).pure[F])
       .withMetadataDecoders(Metadata.Decoder)


### PR DESCRIPTION
This mechanism was put in place as a safeguard against DDOS attacks. It has become obvious that it is very painful to have a maximum arity for JSON decoding on the client side.


