### PR TITLE
Make JSON maxArity irrelevant for http clients ERROR decoders

### DIFF
--- a/modules/http4s/src/smithy4s/http4s/internals/SimpleRestJsonCodecs.scala
+++ b/modules/http4s/src/smithy4s/http4s/internals/SimpleRestJsonCodecs.scala
@@ -116,7 +116,7 @@ private[http4s] class SimpleRestJsonCodecs(
     HttpUnaryClientCodecs.builder
       .withBodyEncoders(payloadEncoders)
       .withSuccessBodyDecoders(clientPayloadDecoders)
-      .withErrorBodyDecoders(payloadDecoders)
+      .withErrorBodyDecoders(clientPayloadDecoders)
       .withErrorDiscriminator(HttpDiscriminator.fromResponse(errorHeaders, _).pure[F])
       .withMetadataDecoders(Metadata.Decoder)
       .withMetadataEncoders(


### PR DESCRIPTION
Followup from https://github.com/disneystreaming/smithy4s/pull/1770
The error decoders for the client should also have MaxArity of Int.MaxValue
