### PR TITLE
Fix publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,6 +138,8 @@ jobs:
       - name: Publish ${{ github.ref }}
         run: sbt 'show version; ci-release'
         env:
+          # cleaning will removed generated code from bootstrapped module which will
+          # cause the repo to be dirty and change the version to a -SNAPSHOT version
           CI_CLEAN: ""
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
           PGP_SECRET: ${{ secrets.PGP_SECRET }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,6 +138,7 @@ jobs:
       - name: Publish ${{ github.ref }}
         run: sbt 'show version; ci-release'
         env:
+          CI_CLEAN: ""
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
           PGP_SECRET: ${{ secrets.PGP_SECRET }}
           SONATYPE_PASSWORD: ${{ secrets.CENTRAL_SONATYPE_PASSWORD }}


### PR DESCRIPTION
Fixes the error that showed up when trying to publish a non-snapshot build to Sonatype. The `ci-release` plugin runs the [`clean` command by default](https://github.com/sbt/sbt-ci-release/blob/main/plugin/src/main/scala/com/geirsson/CiReleasePlugin.scala#L208) and we add the generated files from the bootstrapped module into the list of files to clean https://github.com/disneystreaming/smithy4s/blob/series/0.18/build.sbt#L962-L965. 

Since files are removed, the git repo is dirty and the version get's updated mid-release. I figured if we are at the release stage we don't need to do a clean. 

## PR Checklist (not all items are relevant to all PRs)

- [ ] Added unit-tests (for runtime code)
- [ ] Added bootstrapped code + smoke tests (when the rendering logic is modified)
- [ ] Added build-plugins integration tests (when reflection loading is required at codegen-time)
- [ ] Added alloy compliance tests (when simpleRestJson protocol behaviour is expanded/updated)
- [ ] Updated dynamic module to match generated-code behaviour
- [ ] Added documentation
- [ ] Updated changelog
