### PR TITLE
bincompat tests: Use --compile-only-jar / compile-only-dependency, only filter certain forward issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Thank you!
 
 # 0.18.40
 
-* codegen: Add support for [bincompat-friendly code generation mode](https://disneystreaming.github.io/smithy4s/docs/codegen/customisation/binary-compatibility) in [#1737](https://github.com/disneystreaming/smithy4s/pull/1737/).
+* codegen: Add support for [bincompat-friendly code generation mode](https://disneystreaming.github.io/smithy4s/docs/codegen/customisation/binary-compatibility) in [#1737](https://github.com/disneystreaming/smithy4s/pull/1737/) + [#1780](https://github.com/disneystreaming/smithy4s/pull/1780).
 
 # 0.18.39
 

--- a/modules/codegen/test/src/smithy4s/codegen/BincompatCodegenIntegrationSpec.scala
+++ b/modules/codegen/test/src/smithy4s/codegen/BincompatCodegenIntegrationSpec.scala
@@ -2,8 +2,8 @@ package smithy4s.codegen
 
 import munit.FunSuite
 import com.typesafe.tools.mima.lib.MiMaLib
-import com.typesafe.tools.mima.core.ReversedMissingMethodProblem
 import cats.syntax.all._
+import com.typesafe.tools.mima.core.ReversedMissingMethodProblem
 
 class BincompatCodegenIntegrationSpec extends FunSuite {
   private val scala212 = "2.12"
@@ -577,9 +577,13 @@ class BincompatCodegenIntegrationSpec extends FunSuite {
             excludeAnnots = Nil
           )
           .filter {
-            // We only care about backwards compatibility problems
-            case _: ReversedMissingMethodProblem => false
-            case _                               => true
+            // Unions' visitor traits are immune to reversed missing method problems
+            // because the interface is sealed. If there's a new union member (new method in the visitor),
+            // the default visitor is guaranteed to have that method.
+            case prob: ReversedMissingMethodProblem
+                if prob.meth.owner.fullName.endsWith("$Visitor") =>
+              false
+            case _ => true
           }
 
         assert(

--- a/modules/codegen/test/src/smithy4s/codegen/BincompatCodegenIntegrationSpec.scala
+++ b/modules/codegen/test/src/smithy4s/codegen/BincompatCodegenIntegrationSpec.scala
@@ -701,8 +701,8 @@ class BincompatCodegenIntegrationSpec extends FunSuite {
         "--library",
         s"--scala=$scalaVersion",
         s"--output=$outputJarPath",
-        extraJars.map { j => s"--jar=$j" },
-        extraDeps.map { d => s"--dependency=$d" },
+        extraJars.map { j => s"--compile-only-jar=$j" },
+        extraDeps.map { d => s"--compile-only-dependency=$d" },
         sourceDirectories
       )
     }

--- a/modules/docs/resources/markdown/04-codegen/01-customisation/16-binary-compatibility.md
+++ b/modules/docs/resources/markdown/04-codegen/01-customisation/16-binary-compatibility.md
@@ -199,6 +199,12 @@ In addition, we need to make sure all implementations of the union's `Visitor` t
 
 This neat trick makes it only possible to subclass `Visitor.Default`, which enforces having a default case.
 
+:::info
+
+For MiMa users - MiMa doesn't take `sealed` into account, so it will report `ReversedMissingMethodProblem` issues (forward-incompatible changes) when a new union member is added.
+
+In bincompat-friendly mode, these can be considered **false positives**, and it's safe to exclude them from your binary compatibility checks. See the [instructions for filtering incompatibilities][mima-filtering] or follow the suggestion MiMa gives you.
+
 ### Enums
 
 For enums, just like for unions, we need to remove the possibility of exhaustively matching against the known set of members. This is achieved by:
@@ -212,3 +218,4 @@ For enums, just like for unions, we need to remove the possibility of exhaustive
 [bincompat-for-libs]: https://docs.scala-lang.org/overviews/core/binary-compatibility-for-library-authors.html
 [bincompat-jdk]: https://docs.oracle.com/javase/specs/jls/se24/html/jls-13.html
 [sbt-contraband]: https://www.scala-sbt.org/contraband/
+[mima-filtering]: https://github.com/lightbend-labs/mima/?tab=readme-ov-file#filtering-binary-incompatibilities


### PR DESCRIPTION
## re: `--compile-only-jar`

Just using `--jar` is kinda risky, as it can unintentionally flatten the dependency into the output jar, **unless** `--library` is used.

We _do_ use `--library`, but I think in this case it's better safe than sorry.

## re: `ReversedMissingMethodProblem`

As per docs change - the only type of change that should cause `ReversedMissingMethodProblem` is a new method in the (sealed) visitor. This change makes the test more restrictive in what it lets through, and documents that this behavior is known, to ease the users' worries.

## PR Checklist (not all items are relevant to all PRs)

- [ ] Added unit-tests (for runtime code)
- [ ] Added bootstrapped code + smoke tests (when the rendering logic is modified)
- [ ] Added build-plugins integration tests (when reflection loading is required at codegen-time)
- [ ] Added alloy compliance tests (when simpleRestJson protocol behaviour is expanded/updated)
- [ ] Updated dynamic module to match generated-code behaviour
- [x] Added documentation
- [ ] Updated changelog
