### PR TITLE
Add missing closing tags for admonitions, fix diff highlight

### DIFF
--- a/modules/docs/resources/markdown/04-codegen/01-customisation/16-binary-compatibility.md
+++ b/modules/docs/resources/markdown/04-codegen/01-customisation/16-binary-compatibility.md
@@ -161,6 +161,8 @@ Here's a non-exhaustive list of changes that are considered safe or unsafe in bi
 
 Please verify the bincompat safety of your changes before you publish them. We recommend that you use the [MiMa](https://github.com/lightbend/mima) plugin for your build tool of choice.
 
+:::
+
 ## What does the generated code look like?
 
 There are several changes we make to the codegen process in bincompat-friendly mode, so that the generated datatypes can evolve safely.
@@ -204,6 +206,8 @@ This neat trick makes it only possible to subclass `Visitor.Default`, which enfo
 For MiMa users - MiMa doesn't take `sealed` into account, so it will report `ReversedMissingMethodProblem` issues (forward-incompatible changes) when a new union member is added.
 
 In bincompat-friendly mode, these can be considered **false positives**, and it's safe to exclude them from your binary compatibility checks. See the [instructions for filtering incompatibilities][mima-filtering] or follow the suggestion MiMa gives you.
+
+:::
 
 ### Enums
 

--- a/modules/website/docusaurus.config.js
+++ b/modules/website/docusaurus.config.js
@@ -105,7 +105,7 @@ const config = {
       prism: {
         theme: lightCodeTheme,
         darkTheme: darkCodeTheme,
-        additionalLanguages: ['java', 'scala', 'kotlin'],
+        additionalLanguages: ['java', 'scala', 'kotlin', 'diff'],
       },
     }),
 };


### PR DESCRIPTION
## Admonitions

Before

<img width="1181" height="1417" alt="image" src="https://github.com/user-attachments/assets/ec3acdcc-f594-4ffc-a7da-a8884df3eab8" />

After

<img width="1426" height="372" alt="image" src="https://github.com/user-attachments/assets/4648d135-93b3-43de-811b-a7b18d41e404" />

<img width="1398" height="442" alt="image" src="https://github.com/user-attachments/assets/6898ef41-4909-41bf-a6ae-9814fab3da31" />

## Named links

Before

<img width="974" height="158" alt="image" src="https://github.com/user-attachments/assets/9cc49e0f-e31a-4899-a2fb-6d96c01a5167" />

After

<img width="1332" height="227" alt="image" src="https://github.com/user-attachments/assets/9d0209a2-a68a-4c2e-8098-c112a2688c0d" />

## Diff highlights

Before

<img width="279" height="148" alt="image" src="https://github.com/user-attachments/assets/c1ddecdd-74af-4eac-b4bd-66b7ca51d261" />

After

<img width="429" height="206" alt="image" src="https://github.com/user-attachments/assets/9f684eb4-e830-46b7-9d3a-52482ec1faaa" />



## PR Checklist (not all items are relevant to all PRs)

- [ ] Added unit-tests (for runtime code)
- [ ] Added bootstrapped code + smoke tests (when the rendering logic is modified)
- [ ] Added build-plugins integration tests (when reflection loading is required at codegen-time)
- [ ] Added alloy compliance tests (when simpleRestJson protocol behaviour is expanded/updated)
- [ ] Updated dynamic module to match generated-code behaviour
- [ ] Added documentation
- [ ] Updated changelog
