### PR TITLE
Restore path encoding semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,11 @@ Thank you!
 # 0.18.41
 
 * codegen: Avoid collision with `Schema.*` methods in certain cases of ADT unions in [#1789](https://github.com/disneystreaming/smithy4s/pull/1789)
+* http4s: Revert the default behavior of URL path encoding in [#1793](https://github.com/disneystreaming/smithy4s/pull/1793)
 
-# 0.18.40
+# 0.18.40 (broken)
+
+
 
 * codegen: Add support for [bincompat-friendly code generation mode](https://disneystreaming.github.io/smithy4s/docs/codegen/customisation/binary-compatibility) in [#1737](https://github.com/disneystreaming/smithy4s/pull/1737/) + [#1780](https://github.com/disneystreaming/smithy4s/pull/1780).
 * core: fix [#1663](https://github.com/disneystreaming/smithy4s/issues/1663) by reworking how path segments are encoded to conform with the Smithy spec in [#1668](https://github.com/disneystreaming/smithy4s/issues/1668)

--- a/modules/aws-http4s/src/smithy4s/aws/AwsClient.scala
+++ b/modules/aws-http4s/src/smithy4s/aws/AwsClient.scala
@@ -115,7 +115,9 @@ object AwsClient {
       }
 
       val clientCodecs = clientCodecsBuilder
-        .withRequestTransformation(fromSmithy4sHttpRequest[F](_, clientCodecsBuilder.hasRawHttpLabelValues).pure[F])
+        .withRequestTransformation(
+          fromSmithy4sHttpRequest[F](_, encodePathSegments = !clientCodecsBuilder.hasSmithyPathEncoding).pure[F]
+        )
         .withResponseTransformation[Response[F]](toSmithy4sHttpResponse[F](_))
         .withBaseRequest(baseRequest)
         .build()

--- a/modules/aws-http4s/src/smithy4s/aws/AwsClient.scala
+++ b/modules/aws-http4s/src/smithy4s/aws/AwsClient.scala
@@ -115,7 +115,7 @@ object AwsClient {
       }
 
       val clientCodecs = clientCodecsBuilder
-        .withRequestTransformation(fromSmithy4sHttpRequest[F](_, clientCodecsBuilder.isRawHttpLabelValues).pure[F])
+        .withRequestTransformation(fromSmithy4sHttpRequest[F](_, clientCodecsBuilder.hasRawHttpLabelValues).pure[F])
         .withResponseTransformation[Response[F]](toSmithy4sHttpResponse[F](_))
         .withBaseRequest(baseRequest)
         .build()

--- a/modules/aws-http4s/src/smithy4s/aws/AwsClient.scala
+++ b/modules/aws-http4s/src/smithy4s/aws/AwsClient.scala
@@ -115,7 +115,7 @@ object AwsClient {
       }
 
       val clientCodecs = clientCodecsBuilder
-        .withRequestTransformation(fromSmithy4sHttpRequest[F](_).pure[F])
+        .withRequestTransformation(fromSmithy4sHttpRequest[F](_, clientCodecsBuilder.isRawHttpLabelValues).pure[F])
         .withResponseTransformation[Response[F]](toSmithy4sHttpResponse[F](_))
         .withBaseRequest(baseRequest)
         .build()

--- a/modules/aws-http4s/src/smithy4s/aws/internals/AwsEc2QueryCodecs.scala
+++ b/modules/aws-http4s/src/smithy4s/aws/internals/AwsEc2QueryCodecs.scala
@@ -105,7 +105,7 @@ private[aws] object AwsEcsQueryCodecs {
       .withMetadataDecoders(Metadata.AwsDecoder)
       .withErrorDiscriminator(AwsErrorTypeDecoder.fromResponse(discriminatorDecoders))
       .withWriteEmptyStructs(_ => true)
-      .withRawHttpLabelValues(true)
+      .withSmithyPathEncoding(false)
       .withRequestMediaType("application/x-www-form-urlencoded")
   }
 

--- a/modules/aws-http4s/src/smithy4s/aws/internals/AwsJsonCodecs.scala
+++ b/modules/aws-http4s/src/smithy4s/aws/internals/AwsJsonCodecs.scala
@@ -53,7 +53,7 @@ private[aws] object AwsJsonCodecs {
       .withErrorBodyDecoders(jsonDecoders)
       .withErrorDiscriminator(AwsErrorTypeDecoder.fromResponse(jsonDecoders))
       .withRequestMediaType(contentType)
-      .withRawHttpLabelValues(true)
+      .withSmithyPathEncoding(false)
   }
 
 }

--- a/modules/aws-http4s/src/smithy4s/aws/internals/AwsQueryCodecs.scala
+++ b/modules/aws-http4s/src/smithy4s/aws/internals/AwsQueryCodecs.scala
@@ -108,7 +108,7 @@ private[aws] object AwsQueryCodecs {
       .withErrorDiscriminator(AwsErrorTypeDecoder.fromResponse(discriminatorDecoders))
       .withWriteEmptyStructs(_ => true)
       .withRequestMediaType("application/x-www-form-urlencoded")
-      .withRawHttpLabelValues(true)
+      .withSmithyPathEncoding(false)
 
   }
 

--- a/modules/aws-http4s/src/smithy4s/aws/internals/AwsRestJsonCodecs.scala
+++ b/modules/aws-http4s/src/smithy4s/aws/internals/AwsRestJsonCodecs.scala
@@ -55,7 +55,7 @@ private[aws] object AwsRestJsonCodecs {
       .withMetadataDecoders(Metadata.AwsDecoder)
       .withMetadataEncoders(Metadata.AwsEncoder)
       .withRawStringsAndBlobsPayloads
-      .withRawHttpLabelValues(false)
+      .withSmithyPathEncoding(true)
       .withRequestMediaType(contentType)
   }
 

--- a/modules/aws-http4s/src/smithy4s/aws/internals/AwsRestXmlCodecs.scala
+++ b/modules/aws-http4s/src/smithy4s/aws/internals/AwsRestXmlCodecs.scala
@@ -43,7 +43,7 @@ private[aws] object AwsRestXmlCodecs {
       .withMetadataDecoders(Metadata.AwsDecoder)
       .withMetadataEncoders(Metadata.AwsEncoder)
       .withRawStringsAndBlobsPayloads
-      .withRawHttpLabelValues(false)
+      .withSmithyPathEncoding(true)
       .withRequestMediaType("application/xml")
   }
 

--- a/modules/core/src/smithy4s/http/HttpRequest.scala
+++ b/modules/core/src/smithy4s/http/HttpRequest.scala
@@ -76,13 +76,13 @@ object HttpRequest {
 
     def fromHttpEndpoint[Body, I](
         httpEndpoint: HttpEndpoint[I],
-        rawHttpLabelValues: Boolean
+        smithyPathEncoding: Boolean
     ): Writer[Body, I] = new Writer[Body, I] {
       @annotation.nowarn("cat=deprecation")
       def write(request: HttpRequest[Body], input: I): HttpRequest[Body] = {
         val path =
-          if (rawHttpLabelValues) httpEndpoint.path(input)
-          else httpEndpoint.encodedPath(input)
+          if (smithyPathEncoding) httpEndpoint.encodedPath(input)
+          else httpEndpoint.path(input)
         val staticQueries = httpEndpoint.staticQueryParams
         val oldUri = request.uri
         val newUri =

--- a/modules/core/src/smithy4s/http/HttpUnaryClientCodecs.scala
+++ b/modules/core/src/smithy4s/http/HttpUnaryClientCodecs.scala
@@ -17,16 +17,16 @@
 package smithy4s
 package http
 
-import smithy4s.capability.MonadThrowLike
 import smithy4s.client.UnaryClientCodecs
-import smithy4s.codecs.BlobDecoder
-import smithy4s.codecs.BlobEncoder
-import smithy4s.codecs.Decoder
-import smithy4s.codecs.PayloadError
+import smithy4s.codecs.{BlobEncoder, BlobDecoder}
+import smithy4s.codecs.{Decoder}
 import smithy4s.codecs.Writer
-import smithy4s.kinds.PolyFunction5
+import smithy4s.codecs.PayloadError
 import smithy4s.schema.CachedSchemaCompiler
 import smithy4s.schema.OperationSchema
+import smithy4s.capability.MonadThrowLike
+import smithy4s.kinds.PolyFunction5
+
 // scalafmt: { maxColumn = 120 }
 object HttpUnaryClientCodecs {
 
@@ -65,7 +65,7 @@ object HttpUnaryClientCodecs {
     def withResponseTransformation[Response0](f: Response0 => F[Response]): Builder[F, Request, Response0]
     def withHostPrefixInjection(enabled: Boolean): Builder[F, Request, Response]
     def withRawHttpLabelValues(enabled: Boolean): Builder[F, Request, Response]
-    def isRawHttpLabelValues: Boolean
+    def hasRawHttpLabelValues: Boolean
     def build(): UnaryClientCodecs.Make[F, Request, Response]
   }
 
@@ -119,7 +119,7 @@ object HttpUnaryClientCodecs {
     override def withRawHttpLabelValues(enabled: Boolean): Builder[F, Request, Response] =
       copy(rawHttpLabelValues = enabled)
 
-    def isRawHttpLabelValues: Boolean = rawHttpLabelValues
+    def hasRawHttpLabelValues: Boolean = rawHttpLabelValues
 
     def build(): UnaryClientCodecs.Make[F, Request, Response] = {
       val setBody: HttpRequest.Writer[Blob, Blob] = Writer.lift((req, blob) => req.copy(body = blob))

--- a/modules/core/src/smithy4s/http/HttpUnaryClientCodecs.scala
+++ b/modules/core/src/smithy4s/http/HttpUnaryClientCodecs.scala
@@ -17,16 +17,16 @@
 package smithy4s
 package http
 
+import smithy4s.capability.MonadThrowLike
 import smithy4s.client.UnaryClientCodecs
-import smithy4s.codecs.{BlobEncoder, BlobDecoder}
-import smithy4s.codecs.{Decoder}
-import smithy4s.codecs.Writer
+import smithy4s.codecs.BlobDecoder
+import smithy4s.codecs.BlobEncoder
+import smithy4s.codecs.Decoder
 import smithy4s.codecs.PayloadError
+import smithy4s.codecs.Writer
+import smithy4s.kinds.PolyFunction5
 import smithy4s.schema.CachedSchemaCompiler
 import smithy4s.schema.OperationSchema
-import smithy4s.capability.MonadThrowLike
-import smithy4s.kinds.PolyFunction5
-
 // scalafmt: { maxColumn = 120 }
 object HttpUnaryClientCodecs {
 
@@ -46,7 +46,7 @@ object HttpUnaryClientCodecs {
       requestTransformation = F.pure(_),
       responseTransformation = F.pure(_),
       hostPrefixInjection = true,
-      rawHttpLabelValues = false
+      rawHttpLabelValues = true
     )
 
   trait Builder[F[_], Request, Response] {
@@ -65,6 +65,7 @@ object HttpUnaryClientCodecs {
     def withResponseTransformation[Response0](f: Response0 => F[Response]): Builder[F, Request, Response0]
     def withHostPrefixInjection(enabled: Boolean): Builder[F, Request, Response]
     def withRawHttpLabelValues(enabled: Boolean): Builder[F, Request, Response]
+    def isRawHttpLabelValues: Boolean
     def build(): UnaryClientCodecs.Make[F, Request, Response]
   }
 
@@ -117,6 +118,8 @@ object HttpUnaryClientCodecs {
     def withHostPrefixInjection(enabled: Boolean): Builder[F, Request, Response] = copy(hostPrefixInjection = enabled)
     override def withRawHttpLabelValues(enabled: Boolean): Builder[F, Request, Response] =
       copy(rawHttpLabelValues = enabled)
+
+    def isRawHttpLabelValues: Boolean = rawHttpLabelValues
 
     def build(): UnaryClientCodecs.Make[F, Request, Response] = {
       val setBody: HttpRequest.Writer[Blob, Blob] = Writer.lift((req, blob) => req.copy(body = blob))

--- a/modules/core/src/smithy4s/http/HttpUnaryClientCodecs.scala
+++ b/modules/core/src/smithy4s/http/HttpUnaryClientCodecs.scala
@@ -46,7 +46,7 @@ object HttpUnaryClientCodecs {
       requestTransformation = F.pure(_),
       responseTransformation = F.pure(_),
       hostPrefixInjection = true,
-      rawHttpLabelValues = true
+      smithyPathEncoding = false
     )
 
   trait Builder[F[_], Request, Response] {
@@ -64,8 +64,10 @@ object HttpUnaryClientCodecs {
     def withRequestTransformation[Request1](f: Request => F[Request1]): Builder[F, Request1, Response]
     def withResponseTransformation[Response0](f: Response0 => F[Response]): Builder[F, Request, Response0]
     def withHostPrefixInjection(enabled: Boolean): Builder[F, Request, Response]
+    @deprecated("use withSmithyPathEncoding instead (opposite meaning)", "0.18.41")
     def withRawHttpLabelValues(enabled: Boolean): Builder[F, Request, Response]
-    def hasRawHttpLabelValues: Boolean
+    def withSmithyPathEncoding(enabled: Boolean): Builder[F, Request, Response]
+    def hasSmithyPathEncoding: Boolean
     def build(): UnaryClientCodecs.Make[F, Request, Response]
   }
 
@@ -84,7 +86,7 @@ object HttpUnaryClientCodecs {
       requestTransformation: HttpRequest[Blob] => F[Request],
       responseTransformation: Response => F[HttpResponse[Blob]],
       hostPrefixInjection: Boolean,
-      rawHttpLabelValues: Boolean
+      smithyPathEncoding: Boolean
   )(implicit F: MonadThrowLike[F])
       extends Builder[F, Request, Response] {
     def withOperationPreprocessor(fk: PolyFunction5[OperationSchema, OperationSchema]): Builder[F, Request, Response] =
@@ -117,9 +119,12 @@ object HttpUnaryClientCodecs {
 
     def withHostPrefixInjection(enabled: Boolean): Builder[F, Request, Response] = copy(hostPrefixInjection = enabled)
     override def withRawHttpLabelValues(enabled: Boolean): Builder[F, Request, Response] =
-      copy(rawHttpLabelValues = enabled)
+      withSmithyPathEncoding(!enabled)
 
-    def hasRawHttpLabelValues: Boolean = rawHttpLabelValues
+    override def withSmithyPathEncoding(enabled: Boolean): Builder[F, Request, Response] =
+      copy(smithyPathEncoding = enabled)
+
+    def hasSmithyPathEncoding: Boolean = smithyPathEncoding
 
     def build(): UnaryClientCodecs.Make[F, Request, Response] = {
       val setBody: HttpRequest.Writer[Blob, Blob] = Writer.lift((req, blob) => req.copy(body = blob))
@@ -197,7 +202,7 @@ object HttpUnaryClientCodecs {
             HttpEndpoint.cast(endpoint).toOption match {
               case Some(httpEndpoint) => {
                 val httpInputEncoder =
-                  HttpRequest.Writer.fromHttpEndpoint[Blob, I](httpEndpoint, rawHttpLabelValues)
+                  HttpRequest.Writer.fromHttpEndpoint[Blob, I](httpEndpoint, smithyPathEncoding)
                 val requestEncoder =
                   inputEncoders.fromSchema(endpoint.input, inputEncoderCache)
                 httpInputEncoder.combine(requestEncoder)

--- a/modules/http4s-kernel/src/smithy4s/http4s/kernel/package.scala
+++ b/modules/http4s-kernel/src/smithy4s/http4s/kernel/package.scala
@@ -125,6 +125,8 @@ package object kernel {
 
   def fromSmithy4sHttpUri(uri: Smithy4sHttpUri, encodePathSegments: Boolean): Uri = {
     val mkSegment: String => Uri.Path.Segment =
+      // Segment.apply will call pathEncode on the segment,
+      // which is what we want if encodePathSegments is true.
       if (encodePathSegments) Uri.Path.Segment.apply
       else Uri.Path.Segment.encoded
 

--- a/modules/http4s-kernel/src/smithy4s/http4s/kernel/package.scala
+++ b/modules/http4s-kernel/src/smithy4s/http4s/kernel/package.scala
@@ -16,23 +16,23 @@
 
 package smithy4s.http4s
 
+import cats.MonadThrow
+import cats.effect.Concurrent
 import cats.effect.SyncIO
 import cats.syntax.all._
+import fs2.Chunk
+import fs2.Stream
 import org.http4s._
 import org.typelevel.ci.CIString
 import org.typelevel.vault.Key
 import smithy4s.Blob
 import smithy4s.http.CaseInsensitive
 import smithy4s.http.PathParams
-import smithy4s.http.{HttpUriScheme => Smithy4sHttpUriScheme}
 import smithy4s.http.{HttpMethod => Smithy4sHttpMethod}
 import smithy4s.http.{HttpRequest => Smithy4sHttpRequest}
 import smithy4s.http.{HttpResponse => Smithy4sHttpResponse}
 import smithy4s.http.{HttpUri => Smithy4sHttpUri}
-import cats.MonadThrow
-import cats.effect.Concurrent
-import fs2.Stream
-import fs2.Chunk
+import smithy4s.http.{HttpUriScheme => Smithy4sHttpUriScheme}
 
 // scalafmt: { maxColumn = 120}
 package object kernel {
@@ -47,7 +47,7 @@ package object kernel {
     }
   }
 
-  def fromSmithy4sHttpRequest[F[_]: MonadThrow](req: Smithy4sHttpRequest[Blob]): Request[F] = {
+  def fromSmithy4sHttpRequest[F[_]: MonadThrow](req: Smithy4sHttpRequest[Blob], rawLabels: Boolean): Request[F] = {
     val method = unsafeFromSmithy4sHttpMethod(req.method)
     val headers = toHeaders(req.headers)
     val updatedHeaders = req.body.size match {
@@ -56,7 +56,7 @@ package object kernel {
     }
     Request(
       method,
-      fromSmithy4sHttpUri(req.uri),
+      fromSmithy4sHttpUri(req.uri, rawLabels = rawLabels),
       headers = updatedHeaders,
       body = toStream(req.body)
     )
@@ -101,8 +101,12 @@ package object kernel {
       Smithy4sHttpResponse(res.status.code, headers, blob)
     }
 
-  def fromSmithy4sHttpUri(uri: Smithy4sHttpUri): Uri = {
-    val path = Uri.Path.Root.addSegments(uri.path.map(Uri.Path.Segment.encoded))
+  def fromSmithy4sHttpUri(uri: Smithy4sHttpUri, rawLabels: Boolean): Uri = {
+    val path = if (rawLabels) {
+      Uri.Path.Root.addSegments(uri.path.map(Uri.Path.Segment.encoded))
+    } else {
+      Uri.Path.Root.addSegments(uri.path.map(Uri.Path.Segment(_)))
+    }
 
     Uri(
       path = path,

--- a/modules/http4s-kernel/src/smithy4s/http4s/kernel/package.scala
+++ b/modules/http4s-kernel/src/smithy4s/http4s/kernel/package.scala
@@ -16,23 +16,23 @@
 
 package smithy4s.http4s
 
-import cats.MonadThrow
-import cats.effect.Concurrent
 import cats.effect.SyncIO
 import cats.syntax.all._
-import fs2.Chunk
-import fs2.Stream
 import org.http4s._
 import org.typelevel.ci.CIString
 import org.typelevel.vault.Key
 import smithy4s.Blob
 import smithy4s.http.CaseInsensitive
 import smithy4s.http.PathParams
+import smithy4s.http.{HttpUriScheme => Smithy4sHttpUriScheme}
 import smithy4s.http.{HttpMethod => Smithy4sHttpMethod}
 import smithy4s.http.{HttpRequest => Smithy4sHttpRequest}
 import smithy4s.http.{HttpResponse => Smithy4sHttpResponse}
 import smithy4s.http.{HttpUri => Smithy4sHttpUri}
-import smithy4s.http.{HttpUriScheme => Smithy4sHttpUriScheme}
+import cats.MonadThrow
+import cats.effect.Concurrent
+import fs2.Stream
+import fs2.Chunk
 
 // scalafmt: { maxColumn = 120}
 package object kernel {

--- a/modules/http4s-kernel/src/smithy4s/http4s/kernel/package.scala
+++ b/modules/http4s-kernel/src/smithy4s/http4s/kernel/package.scala
@@ -47,6 +47,11 @@ package object kernel {
     }
   }
 
+  @deprecated("use the overload with explicit rawLabels", "0.18.41")
+  def fromSmithy4sHttpRequest[F[_]: MonadThrow](req: Smithy4sHttpRequest[Blob]): Request[F] = {
+    fromSmithy4sHttpRequest(req, rawLabels = true)
+  }
+
   def fromSmithy4sHttpRequest[F[_]: MonadThrow](req: Smithy4sHttpRequest[Blob], rawLabels: Boolean): Request[F] = {
     val method = unsafeFromSmithy4sHttpMethod(req.method)
     val headers = toHeaders(req.headers)
@@ -100,6 +105,11 @@ package object kernel {
         .toMap
       Smithy4sHttpResponse(res.status.code, headers, blob)
     }
+
+  @deprecated("use the overload with explicit rawLabels", "0.18.41")
+  def fromSmithy4sHttpUri(uri: Smithy4sHttpUri): Uri = {
+    fromSmithy4sHttpUri(uri, rawLabels = true)
+  }
 
   def fromSmithy4sHttpUri(uri: Smithy4sHttpUri, rawLabels: Boolean): Uri = {
     val mkSegment: String => Uri.Path.Segment =

--- a/modules/http4s-kernel/src/smithy4s/http4s/kernel/package.scala
+++ b/modules/http4s-kernel/src/smithy4s/http4s/kernel/package.scala
@@ -47,12 +47,24 @@ package object kernel {
     }
   }
 
-  @deprecated("use the overload with explicit rawLabels", "0.18.41")
+  @deprecated("use the overload with explicit encodePathSegments", "0.18.41")
   def fromSmithy4sHttpRequest[F[_]: MonadThrow](req: Smithy4sHttpRequest[Blob]): Request[F] = {
-    fromSmithy4sHttpRequest(req, rawLabels = true)
+    fromSmithy4sHttpRequest(req, encodePathSegments = true)
   }
 
-  def fromSmithy4sHttpRequest[F[_]: MonadThrow](req: Smithy4sHttpRequest[Blob], rawLabels: Boolean): Request[F] = {
+  /**
+    * Converts a Smithy4sHttpRequest to an http4s Request.
+    * This method allows you to specify whether path segments should be encoded.
+    * If `encodePathSegments` is true, path segments will be encoded as per the
+    * URI encoding rules of Http4s. If false, they will be treated as already encoded.
+    * @param req
+    * @param encodePathSegments
+    * @return
+    */
+  def fromSmithy4sHttpRequest[F[_]: MonadThrow](
+      req: Smithy4sHttpRequest[Blob],
+      encodePathSegments: Boolean
+  ): Request[F] = {
     val method = unsafeFromSmithy4sHttpMethod(req.method)
     val headers = toHeaders(req.headers)
     val updatedHeaders = req.body.size match {
@@ -61,7 +73,7 @@ package object kernel {
     }
     Request(
       method,
-      fromSmithy4sHttpUri(req.uri, rawLabels = rawLabels),
+      fromSmithy4sHttpUri(req.uri, encodePathSegments = encodePathSegments),
       headers = updatedHeaders,
       body = toStream(req.body)
     )
@@ -106,14 +118,14 @@ package object kernel {
       Smithy4sHttpResponse(res.status.code, headers, blob)
     }
 
-  @deprecated("use the overload with explicit rawLabels", "0.18.41")
+  @deprecated("use the overload with explicit encodePathSegments", "0.18.41")
   def fromSmithy4sHttpUri(uri: Smithy4sHttpUri): Uri = {
-    fromSmithy4sHttpUri(uri, rawLabels = true)
+    fromSmithy4sHttpUri(uri, encodePathSegments = true)
   }
 
-  def fromSmithy4sHttpUri(uri: Smithy4sHttpUri, rawLabels: Boolean): Uri = {
+  def fromSmithy4sHttpUri(uri: Smithy4sHttpUri, encodePathSegments: Boolean): Uri = {
     val mkSegment: String => Uri.Path.Segment =
-      if (rawLabels) Uri.Path.Segment.apply
+      if (encodePathSegments) Uri.Path.Segment.apply
       else Uri.Path.Segment.encoded
 
     val path = Uri.Path.Root.addSegments(uri.path.map(mkSegment))

--- a/modules/http4s-kernel/src/smithy4s/http4s/kernel/package.scala
+++ b/modules/http4s-kernel/src/smithy4s/http4s/kernel/package.scala
@@ -102,11 +102,11 @@ package object kernel {
     }
 
   def fromSmithy4sHttpUri(uri: Smithy4sHttpUri, rawLabels: Boolean): Uri = {
-    val path = if (rawLabels) {
-      Uri.Path.Root.addSegments(uri.path.map(Uri.Path.Segment.encoded))
-    } else {
-      Uri.Path.Root.addSegments(uri.path.map(Uri.Path.Segment(_)))
-    }
+    val mkSegment: String => Uri.Path.Segment =
+      if (rawLabels) Uri.Path.Segment.apply
+      else Uri.Path.Segment.encoded
+
+    val path = Uri.Path.Root.addSegments(uri.path.map(mkSegment))
 
     Uri(
       path = path,

--- a/modules/http4s-kernel/test/src/smithy4s/http4s/kernel/Http4sConversionSpec.scala
+++ b/modules/http4s-kernel/test/src/smithy4s/http4s/kernel/Http4sConversionSpec.scala
@@ -16,11 +16,11 @@
 
 package smithy4s.http4s.kernel
 
-import weaver._
-import org.http4s.syntax.all._
-import org.http4s._
 import org.http4s.Uri._
+import org.http4s._
+import org.http4s.syntax.all._
 import smithy4s.http.HttpUriScheme
+import weaver._
 
 object Http4sConversionSpec extends SimpleIOSuite {
 
@@ -91,7 +91,8 @@ object Http4sConversionSpec extends SimpleIOSuite {
       fromSmithy4sHttpUri(
         aSmithy4sUri(
           scheme = HttpUriScheme.Http
-        )
+        ),
+        rawLabels = true
       ).scheme
     )
   }
@@ -102,7 +103,8 @@ object Http4sConversionSpec extends SimpleIOSuite {
       fromSmithy4sHttpUri(
         aSmithy4sUri(
           scheme = HttpUriScheme.Https
-        )
+        ),
+        rawLabels = true
       ).scheme
     )
   }
@@ -114,7 +116,7 @@ object Http4sConversionSpec extends SimpleIOSuite {
     pureTest(s"URI: http4s to smithy4s and back: $input -> $output") {
       expect.eql(
         output,
-        fromSmithy4sHttpUri(toSmithy4sHttpUri(input))
+        fromSmithy4sHttpUri(toSmithy4sHttpUri(input), rawLabels = true)
       )
     }
   }

--- a/modules/http4s-kernel/test/src/smithy4s/http4s/kernel/Http4sConversionSpec.scala
+++ b/modules/http4s-kernel/test/src/smithy4s/http4s/kernel/Http4sConversionSpec.scala
@@ -16,11 +16,11 @@
 
 package smithy4s.http4s.kernel
 
-import org.http4s.Uri._
-import org.http4s._
-import org.http4s.syntax.all._
-import smithy4s.http.HttpUriScheme
 import weaver._
+import org.http4s.syntax.all._
+import org.http4s._
+import org.http4s.Uri._
+import smithy4s.http.HttpUriScheme
 
 object Http4sConversionSpec extends SimpleIOSuite {
 

--- a/modules/http4s-kernel/test/src/smithy4s/http4s/kernel/Http4sConversionSpec.scala
+++ b/modules/http4s-kernel/test/src/smithy4s/http4s/kernel/Http4sConversionSpec.scala
@@ -92,7 +92,7 @@ object Http4sConversionSpec extends SimpleIOSuite {
         aSmithy4sUri(
           scheme = HttpUriScheme.Http
         ),
-        rawLabels = true
+        encodePathSegments = true
       ).scheme
     )
   }

--- a/modules/http4s-kernel/test/src/smithy4s/http4s/kernel/Http4sConversionSpec.scala
+++ b/modules/http4s-kernel/test/src/smithy4s/http4s/kernel/Http4sConversionSpec.scala
@@ -104,7 +104,7 @@ object Http4sConversionSpec extends SimpleIOSuite {
         aSmithy4sUri(
           scheme = HttpUriScheme.Https
         ),
-        rawLabels = true
+        encodePathSegments = true
       ).scheme
     )
   }
@@ -116,7 +116,7 @@ object Http4sConversionSpec extends SimpleIOSuite {
     pureTest(s"URI: http4s to smithy4s and back: $input -> $output") {
       expect.eql(
         output,
-        fromSmithy4sHttpUri(toSmithy4sHttpUri(input), rawLabels = true)
+        fromSmithy4sHttpUri(toSmithy4sHttpUri(input), encodePathSegments = true)
       )
     }
   }

--- a/modules/http4s/src/smithy4s/http4s/SimpleRestJsonBuilder.scala
+++ b/modules/http4s/src/smithy4s/http4s/SimpleRestJsonBuilder.scala
@@ -27,7 +27,7 @@ object SimpleRestJsonBuilder
         jsonCodecs = Json.payloadCodecs,
         fieldFilter = FieldFilter.Default,
         hostPrefixInjection = true,
-        rawHttpLabelValues = false
+        rawHttpLabelValues = true
       )
     )
 

--- a/modules/http4s/src/smithy4s/http4s/SimpleRestJsonBuilder.scala
+++ b/modules/http4s/src/smithy4s/http4s/SimpleRestJsonBuilder.scala
@@ -56,7 +56,7 @@ class SimpleRestJsonBuilder private (
           ),
         fieldFilter,
         hostPrefixInjection,
-        rawHttpLabelValues = false
+        rawHttpLabelValues = true
       )
     }
   }

--- a/modules/http4s/src/smithy4s/http4s/SimpleRestJsonBuilder.scala
+++ b/modules/http4s/src/smithy4s/http4s/SimpleRestJsonBuilder.scala
@@ -27,7 +27,7 @@ object SimpleRestJsonBuilder
         jsonCodecs = Json.payloadCodecs,
         fieldFilter = FieldFilter.Default,
         hostPrefixInjection = true,
-        rawHttpLabelValues = true
+        smithyPathEncoding = false
       )
     )
 
@@ -56,7 +56,7 @@ class SimpleRestJsonBuilder private (
           ),
         fieldFilter,
         hostPrefixInjection,
-        rawHttpLabelValues = true
+        smithyPathEncoding = false
       )
     }
   }
@@ -92,11 +92,18 @@ class SimpleRestJsonBuilder private (
       simpleRestJsonCodecs.withFieldFilter(fieldFilter)
     )
 
+  @deprecated(
+    "Use withSmithyPathEncoding instead (it has the opposite meaning)",
+    "0.18.41"
+  )
   def withRawHttpLabelValues(
       enabled: Boolean
   ): SimpleRestJsonBuilder =
+    withSmithyPathEncoding(!enabled)
+
+  def withSmithyPathEncoding(enabled: Boolean): SimpleRestJsonBuilder =
     new SimpleRestJsonBuilder(
-      simpleRestJsonCodecs.withRawHttpLabelValues(enabled)
+      simpleRestJsonCodecs.withSmithyPathEncoding(enabled)
     )
 
   def disableHostPrefixInjection(): SimpleRestJsonBuilder =

--- a/modules/http4s/src/smithy4s/http4s/internals/SimpleRestJsonCodecs.scala
+++ b/modules/http4s/src/smithy4s/http4s/internals/SimpleRestJsonCodecs.scala
@@ -134,7 +134,7 @@ private[http4s] class SimpleRestJsonCodecs(
       )
       .withBaseRequest(_ => baseRequest.pure[F])
       .withRequestMediaType("application/json")
-      .withRequestTransformation(fromSmithy4sHttpRequest[F](_).pure[F])
+      .withRequestTransformation(fromSmithy4sHttpRequest[F](_, rawHttpLabelValues).pure[F])
       .withResponseTransformation[Response[F]](toSmithy4sHttpResponse[F](_))
       .withHostPrefixInjection(hostPrefixInjection)
       .withRawHttpLabelValues(rawHttpLabelValues)

--- a/modules/http4s/src/smithy4s/http4s/internals/SimpleRestJsonCodecs.scala
+++ b/modules/http4s/src/smithy4s/http4s/internals/SimpleRestJsonCodecs.scala
@@ -39,13 +39,13 @@ private[http4s] class SimpleRestJsonCodecs(
     val jsonCodecs: JsonPayloadCodecCompiler,
     val fieldFilter: FieldFilter,
     val hostPrefixInjection: Boolean,
-    val rawHttpLabelValues: Boolean
+    val smithyPathEncoding: Boolean
 ) extends SimpleProtocolCodecs {
   private val hintMask =
     alloy.SimpleRestJson.protocol.hintMask
 
   def transformJsonCodecs(f: JsonPayloadCodecCompiler => JsonPayloadCodecCompiler): SimpleRestJsonCodecs =
-    new SimpleRestJsonCodecs(f(jsonCodecs), fieldFilter, hostPrefixInjection, rawHttpLabelValues)
+    new SimpleRestJsonCodecs(f(jsonCodecs), fieldFilter, hostPrefixInjection, smithyPathEncoding)
 
   @deprecated(
     message = """Use withFieldFilter instead.
@@ -70,19 +70,23 @@ private[http4s] class SimpleRestJsonCodecs(
     jsonCodecs.configureJsoniterCodecCompiler(_.withFieldFilter(fieldFilter)),
     fieldFilter,
     hostPrefixInjection,
-    rawHttpLabelValues
+    smithyPathEncoding
   )
 
+  @deprecated("Use withSmithyPathEncoding instead (it has the opposite meaning to raw http label values)", "0.18.41")
   def withRawHttpLabelValues(enabled: Boolean): SimpleRestJsonCodecs =
+    withSmithyPathEncoding(!enabled)
+
+  def withSmithyPathEncoding(enabled: Boolean): SimpleRestJsonCodecs =
     new SimpleRestJsonCodecs(
       jsonCodecs = jsonCodecs,
       fieldFilter = fieldFilter,
       hostPrefixInjection = hostPrefixInjection,
-      rawHttpLabelValues = enabled
+      smithyPathEncoding = enabled
     )
 
   def withHostPrefixInjection(newHostPrefixInjection: Boolean): SimpleRestJsonCodecs =
-    new SimpleRestJsonCodecs(jsonCodecs, fieldFilter, newHostPrefixInjection, rawHttpLabelValues)
+    new SimpleRestJsonCodecs(jsonCodecs, fieldFilter, newHostPrefixInjection, smithyPathEncoding)
 
   // val mediaType = HttpMediaType("application/json")
   private val payloadEncoders: BlobEncoder.Compiler =
@@ -134,10 +138,10 @@ private[http4s] class SimpleRestJsonCodecs(
       )
       .withBaseRequest(_ => baseRequest.pure[F])
       .withRequestMediaType("application/json")
-      .withRequestTransformation(fromSmithy4sHttpRequest[F](_, rawHttpLabelValues).pure[F])
+      .withRequestTransformation(fromSmithy4sHttpRequest[F](_, encodePathSegments = !smithyPathEncoding).pure[F])
       .withResponseTransformation[Response[F]](toSmithy4sHttpResponse[F](_))
       .withHostPrefixInjection(hostPrefixInjection)
-      .withRawHttpLabelValues(rawHttpLabelValues)
+      .withSmithyPathEncoding(smithyPathEncoding)
       .build()
 
   }

--- a/modules/http4s/test/src/smithy4s/http4s/SimpleRestJsonComplianceSuite.scala
+++ b/modules/http4s/test/src/smithy4s/http4s/SimpleRestJsonComplianceSuite.scala
@@ -96,7 +96,8 @@ object SimpleRestJsonComplianceSuite extends ProtocolComplianceSuite {
       val suppliedHost =
         testHost.map(host => Uri.unsafeFromString(s"http://$host"))
       SimpleRestJsonBuilder
-        .withRawHttpLabelValues(false)(service)
+        .withSmithyPathEncoding(true)
+        .apply(service)
         .client(Client.fromHttpApp(app))
         .uri(suppliedHost.getOrElse(baseUri))
         .resource

--- a/modules/http4s/test/src/smithy4s/http4s/SimpleRestJsonComplianceSuite.scala
+++ b/modules/http4s/test/src/smithy4s/http4s/SimpleRestJsonComplianceSuite.scala
@@ -95,7 +95,8 @@ object SimpleRestJsonComplianceSuite extends ProtocolComplianceSuite {
       val baseUri = uri"http://localhost"
       val suppliedHost =
         testHost.map(host => Uri.unsafeFromString(s"http://$host"))
-      SimpleRestJsonBuilder(service)
+      SimpleRestJsonBuilder
+        .withRawHttpLabelValues(false)(service)
         .client(Client.fromHttpApp(app))
         .uri(suppliedHost.getOrElse(baseUri))
         .resource


### PR DESCRIPTION
I haven't started on the checklist below. 
This PR is a response to this issue https://github.com/disneystreaming/smithy4s/issues/1792

The goals are multifold
- rename `rawHttpLabelValues` to `!smithyPathEncoding` (for clarity: `smithyPathEncoding` means smithy4s does the smithy-compliant path encoding, whereas `!smithyPathEncoding` means we let http4s or other frameworks encode paths)
- set default of the smithyPathEncoding to false, which allows third party interpreters to maintain status quo
- set default of the Http4s interpreter to encode paths on its own, and provide implementations for both both true and false
- derive from the UnaryClientCodecs the `smithyPathEncoding` value for AWS clients as it is hardcoded per protocol

## PR Checklist (not all items are relevant to all PRs)

- [ ] Added unit-tests (for runtime code)
- [ ] Added bootstrapped code + smoke tests (when the rendering logic is modified)
- [ ] Added build-plugins integration tests (when reflection loading is required at codegen-time)
- [ ] Added alloy compliance tests (when simpleRestJson protocol behaviour is expanded/updated)
- [ ] Updated dynamic module to match generated-code behaviour
- [ ] Added documentation
- [x] Updated changelog
