### PR TITLE
add workflow to close stale issues

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,26 @@
+name: Close Inactive PRs/Issues
+on:
+  schedule:
+    - cron: "30 1 * * *" # At 01:30
+  workflow_dispatch:
+
+jobs:
+  close-issues:
+    timeout-minutes: 15
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v9
+        with:
+          debug-only: true # set to true if you want to test things out without any real impact to issues/PRs
+          ascending: true # start with oldest items
+          operations-per-run: 500
+          days-before-stale: 45
+          days-before-close: 7
+          stale-pr-label: "stale"
+          stale-issue-label: "stale"
+          stale-pr-message: "This PR is being marked as stale since it has had no activity for 45 days. Please comment below if you wish to prevent it from closing in 7 days."
+          close-pr-message: "This PR is being closed due to having no activity for 45 days plus no response from the previous comment. You can reopen the PR if you wish to continue work on it."
+          stale-issue-message: "This issue is being marked as stale since it has had no activity for 45 days. Please comment below if you wish to prevent it from closing in 7 days."
+          close-issue-message: "This issue is being closed due to having no activity for 45 days plus no response from the previous comment. You can reopen the issue if you wish to discuss further."


### PR DESCRIPTION
Raising this PR to be able to discuss the possibility of adding a workflow like this, I noticed we have some old PRs and I think in general it is nice to focus on PRs/Issues that have active interest/contributions.

Let me know your thoughts.

## PR Checklist (not all items are relevant to all PRs)

- [ ] Added unit-tests (for runtime code)
- [ ] Added bootstrapped code + smoke tests (when the rendering logic is modified)
- [ ] Added build-plugins integration tests (when reflection loading is required at codegen-time)
- [ ] Added alloy compliance tests (when simpleRestJson protocol behaviour is expanded/updated)
- [ ] Updated dynamic module to match generated-code behaviour
- [ ] Added documentation
- [ ] Updated changelog
