### PR TITLE
fix for hints in union->unit case

### DIFF
--- a/modules/bootstrapped/src/generated/smithy4s/example/OrderType.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/OrderType.scala
@@ -66,7 +66,10 @@ object OrderType extends ShapeTag.Companion[OrderType] {
     val alt = schema.oneOf[OrderType]("inStore")
   }
   case object PreviewCase extends OrderType { final def $ordinal: Int = 2 }
-  private val PreviewCaseAlt = Schema.constant(OrderType.PreviewCase).oneOf[OrderType]("preview").addHints(hints)
+  val PreviewCaseHints: Hints = Hints(
+    smithy.api.JsonName("PREVIEW"),
+  ).lazily
+  private val PreviewCaseAlt = Schema.constant(OrderType.PreviewCase).oneOf[OrderType]("preview").addHints(PreviewCaseHints)
 
   object OnlineCase {
     val hints: Hints = Hints.empty

--- a/modules/bootstrapped/src/generated/smithy4s/example/OrderType.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/OrderType.scala
@@ -65,11 +65,13 @@ object OrderType extends ShapeTag.Companion[OrderType] {
 
     val alt = schema.oneOf[OrderType]("inStore")
   }
-  case object PreviewCase extends OrderType { final def $ordinal: Int = 2 }
-  val PreviewCaseHints: Hints = Hints(
-    smithy.api.JsonName("PREVIEW"),
-  ).lazily
-  private val PreviewCaseAlt = Schema.constant(OrderType.PreviewCase).oneOf[OrderType]("preview").addHints(PreviewCaseHints)
+  case object PreviewCase extends OrderType {
+    final def $ordinal: Int = 2
+    val PreviewCaseHints: Hints = Hints(
+      smithy.api.JsonName("PREVIEW"),
+    ).lazily
+  }
+  private val PreviewCaseAlt = Schema.constant(OrderType.PreviewCase).oneOf[OrderType]("preview").addHints(PreviewCase.PreviewCaseHints)
 
   object OnlineCase {
     val hints: Hints = Hints.empty

--- a/modules/bootstrapped/src/generated/smithy4s/example/OrderType.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/OrderType.scala
@@ -1,6 +1,5 @@
 package smithy4s.example
 
-import OrderType.PreviewCaseAlt
 import smithy4s.Hints
 import smithy4s.Schema
 import smithy4s.ShapeId
@@ -20,7 +19,7 @@ sealed trait OrderType extends scala.Product with scala.Serializable { self =>
   object project {
     def online: Option[OrderNumber] = OrderType.OnlineCase.alt.project.lift(self).map(_.online)
     def inStore: Option[OrderType.InStoreOrder] = OrderType.InStoreOrder.alt.project.lift(self)
-    def preview: Option[OrderType.PreviewCase.type] = PreviewCaseAlt.project.lift(self)
+    def preview: Option[OrderType.PreviewCase.type] = OrderType.PreviewCase.alt.project.lift(self)
   }
 
   def accept[A](visitor: OrderType.Visitor[A]): A = this match {
@@ -67,11 +66,11 @@ object OrderType extends ShapeTag.Companion[OrderType] {
   }
   case object PreviewCase extends OrderType {
     final def $ordinal: Int = 2
-    val PreviewCaseHints: Hints = Hints(
+    val hints: Hints = Hints(
       smithy.api.JsonName("PREVIEW"),
     ).lazily
+    val alt = Schema.constant(OrderType.PreviewCase).oneOf[OrderType]("preview").addHints(PreviewCase.hints)
   }
-  private val PreviewCaseAlt = Schema.constant(OrderType.PreviewCase).oneOf[OrderType]("preview").addHints(PreviewCase.PreviewCaseHints)
 
   object OnlineCase {
     val hints: Hints = Hints.empty
@@ -97,7 +96,7 @@ object OrderType extends ShapeTag.Companion[OrderType] {
   implicit val schema: Schema[OrderType] = union(
     OrderType.OnlineCase.alt,
     OrderType.InStoreOrder.alt,
-    PreviewCaseAlt,
+    OrderType.PreviewCase.alt,
   ){
     _.$ordinal
   }.withId(id).addHints(hints)

--- a/modules/bootstrapped/src/generated/smithy4s/example/RecursiveDiscriminatedOpenUnion.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/RecursiveDiscriminatedOpenUnion.scala
@@ -41,7 +41,8 @@ object RecursiveDiscriminatedOpenUnion extends ShapeTag.Companion[RecursiveDiscr
 
   final case class RecCase(rec: HasRecursiveDiscriminatedOpenUnion) extends RecursiveDiscriminatedOpenUnion { final def $ordinal: Int = 0 }
   case object EndCase extends RecursiveDiscriminatedOpenUnion { final def $ordinal: Int = 1 }
-  private val EndCaseAlt = Schema.constant(RecursiveDiscriminatedOpenUnion.EndCase).oneOf[RecursiveDiscriminatedOpenUnion]("end").addHints(hints)
+  val EndCaseHints: Hints = Hints.empty
+  private val EndCaseAlt = Schema.constant(RecursiveDiscriminatedOpenUnion.EndCase).oneOf[RecursiveDiscriminatedOpenUnion]("end").addHints(EndCaseHints)
   final case class UnknownCase(unknown: Document) extends RecursiveDiscriminatedOpenUnion { final def $ordinal: Int = 2 }
 
   object RecCase {

--- a/modules/bootstrapped/src/generated/smithy4s/example/RecursiveDiscriminatedOpenUnion.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/RecursiveDiscriminatedOpenUnion.scala
@@ -1,6 +1,5 @@
 package smithy4s.example
 
-import RecursiveDiscriminatedOpenUnion.EndCaseAlt
 import smithy4s.Document
 import smithy4s.Hints
 import smithy4s.Schema
@@ -17,7 +16,7 @@ sealed trait RecursiveDiscriminatedOpenUnion extends scala.Product with scala.Se
 
   object project {
     def rec: Option[HasRecursiveDiscriminatedOpenUnion] = RecursiveDiscriminatedOpenUnion.RecCase.alt.project.lift(self).map(_.rec)
-    def end: Option[RecursiveDiscriminatedOpenUnion.EndCase.type] = EndCaseAlt.project.lift(self)
+    def end: Option[RecursiveDiscriminatedOpenUnion.EndCase.type] = RecursiveDiscriminatedOpenUnion.EndCase.alt.project.lift(self)
     def unknown: Option[Document] = RecursiveDiscriminatedOpenUnion.UnknownCase.alt.project.lift(self).map(_.unknown)
   }
 
@@ -42,9 +41,9 @@ object RecursiveDiscriminatedOpenUnion extends ShapeTag.Companion[RecursiveDiscr
   final case class RecCase(rec: HasRecursiveDiscriminatedOpenUnion) extends RecursiveDiscriminatedOpenUnion { final def $ordinal: Int = 0 }
   case object EndCase extends RecursiveDiscriminatedOpenUnion {
     final def $ordinal: Int = 1
-    val EndCaseHints: Hints = Hints.empty
+    val hints: Hints = Hints.empty
+    val alt = Schema.constant(RecursiveDiscriminatedOpenUnion.EndCase).oneOf[RecursiveDiscriminatedOpenUnion]("end").addHints(EndCase.hints)
   }
-  private val EndCaseAlt = Schema.constant(RecursiveDiscriminatedOpenUnion.EndCase).oneOf[RecursiveDiscriminatedOpenUnion]("end").addHints(EndCase.EndCaseHints)
   final case class UnknownCase(unknown: Document) extends RecursiveDiscriminatedOpenUnion { final def $ordinal: Int = 2 }
 
   object RecCase {
@@ -77,7 +76,7 @@ object RecursiveDiscriminatedOpenUnion extends ShapeTag.Companion[RecursiveDiscr
 
   implicit val schema: Schema[RecursiveDiscriminatedOpenUnion] = recursive(union(
     RecursiveDiscriminatedOpenUnion.RecCase.alt,
-    EndCaseAlt,
+    RecursiveDiscriminatedOpenUnion.EndCase.alt,
     RecursiveDiscriminatedOpenUnion.UnknownCase.alt,
   ){
     _.$ordinal

--- a/modules/bootstrapped/src/generated/smithy4s/example/RecursiveDiscriminatedOpenUnion.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/RecursiveDiscriminatedOpenUnion.scala
@@ -40,9 +40,11 @@ object RecursiveDiscriminatedOpenUnion extends ShapeTag.Companion[RecursiveDiscr
   ).lazily
 
   final case class RecCase(rec: HasRecursiveDiscriminatedOpenUnion) extends RecursiveDiscriminatedOpenUnion { final def $ordinal: Int = 0 }
-  case object EndCase extends RecursiveDiscriminatedOpenUnion { final def $ordinal: Int = 1 }
-  val EndCaseHints: Hints = Hints.empty
-  private val EndCaseAlt = Schema.constant(RecursiveDiscriminatedOpenUnion.EndCase).oneOf[RecursiveDiscriminatedOpenUnion]("end").addHints(EndCaseHints)
+  case object EndCase extends RecursiveDiscriminatedOpenUnion {
+    final def $ordinal: Int = 1
+    val EndCaseHints: Hints = Hints.empty
+  }
+  private val EndCaseAlt = Schema.constant(RecursiveDiscriminatedOpenUnion.EndCase).oneOf[RecursiveDiscriminatedOpenUnion]("end").addHints(EndCase.EndCaseHints)
   final case class UnknownCase(unknown: Document) extends RecursiveDiscriminatedOpenUnion { final def $ordinal: Int = 2 }
 
   object RecCase {

--- a/modules/bootstrapped/src/generated/smithy4s/example/RecursiveOpenUnion.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/RecursiveOpenUnion.scala
@@ -38,9 +38,11 @@ object RecursiveOpenUnion extends ShapeTag.Companion[RecursiveOpenUnion] {
   val hints: Hints = Hints.empty
 
   final case class RecCase(rec: smithy4s.example.RecursiveOpenUnion) extends RecursiveOpenUnion { final def $ordinal: Int = 0 }
-  case object EndCase extends RecursiveOpenUnion { final def $ordinal: Int = 1 }
-  val EndCaseHints: Hints = Hints.empty
-  private val EndCaseAlt = Schema.constant(RecursiveOpenUnion.EndCase).oneOf[RecursiveOpenUnion]("end").addHints(EndCaseHints)
+  case object EndCase extends RecursiveOpenUnion {
+    final def $ordinal: Int = 1
+    val EndCaseHints: Hints = Hints.empty
+  }
+  private val EndCaseAlt = Schema.constant(RecursiveOpenUnion.EndCase).oneOf[RecursiveOpenUnion]("end").addHints(EndCase.EndCaseHints)
   final case class UnknownCase(unknown: Document) extends RecursiveOpenUnion { final def $ordinal: Int = 2 }
 
   object RecCase {

--- a/modules/bootstrapped/src/generated/smithy4s/example/RecursiveOpenUnion.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/RecursiveOpenUnion.scala
@@ -1,6 +1,5 @@
 package smithy4s.example
 
-import RecursiveOpenUnion.EndCaseAlt
 import smithy4s.Document
 import smithy4s.Hints
 import smithy4s.Schema
@@ -17,7 +16,7 @@ sealed trait RecursiveOpenUnion extends scala.Product with scala.Serializable { 
 
   object project {
     def rec: Option[smithy4s.example.RecursiveOpenUnion] = RecursiveOpenUnion.RecCase.alt.project.lift(self).map(_.rec)
-    def end: Option[RecursiveOpenUnion.EndCase.type] = EndCaseAlt.project.lift(self)
+    def end: Option[RecursiveOpenUnion.EndCase.type] = RecursiveOpenUnion.EndCase.alt.project.lift(self)
     def unknown: Option[Document] = RecursiveOpenUnion.UnknownCase.alt.project.lift(self).map(_.unknown)
   }
 
@@ -40,9 +39,9 @@ object RecursiveOpenUnion extends ShapeTag.Companion[RecursiveOpenUnion] {
   final case class RecCase(rec: smithy4s.example.RecursiveOpenUnion) extends RecursiveOpenUnion { final def $ordinal: Int = 0 }
   case object EndCase extends RecursiveOpenUnion {
     final def $ordinal: Int = 1
-    val EndCaseHints: Hints = Hints.empty
+    val hints: Hints = Hints.empty
+    val alt = Schema.constant(RecursiveOpenUnion.EndCase).oneOf[RecursiveOpenUnion]("end").addHints(EndCase.hints)
   }
-  private val EndCaseAlt = Schema.constant(RecursiveOpenUnion.EndCase).oneOf[RecursiveOpenUnion]("end").addHints(EndCase.EndCaseHints)
   final case class UnknownCase(unknown: Document) extends RecursiveOpenUnion { final def $ordinal: Int = 2 }
 
   object RecCase {
@@ -75,7 +74,7 @@ object RecursiveOpenUnion extends ShapeTag.Companion[RecursiveOpenUnion] {
 
   implicit val schema: Schema[RecursiveOpenUnion] = recursive(union(
     RecursiveOpenUnion.RecCase.alt,
-    EndCaseAlt,
+    RecursiveOpenUnion.EndCase.alt,
     RecursiveOpenUnion.UnknownCase.alt,
   ){
     _.$ordinal

--- a/modules/bootstrapped/src/generated/smithy4s/example/RecursiveOpenUnion.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/RecursiveOpenUnion.scala
@@ -39,7 +39,8 @@ object RecursiveOpenUnion extends ShapeTag.Companion[RecursiveOpenUnion] {
 
   final case class RecCase(rec: smithy4s.example.RecursiveOpenUnion) extends RecursiveOpenUnion { final def $ordinal: Int = 0 }
   case object EndCase extends RecursiveOpenUnion { final def $ordinal: Int = 1 }
-  private val EndCaseAlt = Schema.constant(RecursiveOpenUnion.EndCase).oneOf[RecursiveOpenUnion]("end").addHints(hints)
+  val EndCaseHints: Hints = Hints.empty
+  private val EndCaseAlt = Schema.constant(RecursiveOpenUnion.EndCase).oneOf[RecursiveOpenUnion]("end").addHints(EndCaseHints)
   final case class UnknownCase(unknown: Document) extends RecursiveOpenUnion { final def $ordinal: Int = 2 }
 
   object RecCase {

--- a/modules/bootstrapped/src/generated/smithy4s/example/SampleOpenDiscriminatedUnion.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/SampleOpenDiscriminatedUnion.scala
@@ -40,7 +40,8 @@ object SampleOpenDiscriminatedUnion extends ShapeTag.Companion[SampleOpenDiscrim
 
   final case class SCase(s: StructForDiscrimination) extends SampleOpenDiscriminatedUnion { final def $ordinal: Int = 0 }
   case object UCase extends SampleOpenDiscriminatedUnion { final def $ordinal: Int = 1 }
-  private val UCaseAlt = Schema.constant(SampleOpenDiscriminatedUnion.UCase).oneOf[SampleOpenDiscriminatedUnion]("u").addHints(hints)
+  val UCaseHints: Hints = Hints.empty
+  private val UCaseAlt = Schema.constant(SampleOpenDiscriminatedUnion.UCase).oneOf[SampleOpenDiscriminatedUnion]("u").addHints(UCaseHints)
   final case class UnknownCase(unknown: Document) extends SampleOpenDiscriminatedUnion { final def $ordinal: Int = 2 }
 
   object SCase {

--- a/modules/bootstrapped/src/generated/smithy4s/example/SampleOpenDiscriminatedUnion.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/SampleOpenDiscriminatedUnion.scala
@@ -1,6 +1,5 @@
 package smithy4s.example
 
-import SampleOpenDiscriminatedUnion.UCaseAlt
 import smithy4s.Document
 import smithy4s.Hints
 import smithy4s.Schema
@@ -16,7 +15,7 @@ sealed trait SampleOpenDiscriminatedUnion extends scala.Product with scala.Seria
 
   object project {
     def s: Option[StructForDiscrimination] = SampleOpenDiscriminatedUnion.SCase.alt.project.lift(self).map(_.s)
-    def u: Option[SampleOpenDiscriminatedUnion.UCase.type] = UCaseAlt.project.lift(self)
+    def u: Option[SampleOpenDiscriminatedUnion.UCase.type] = SampleOpenDiscriminatedUnion.UCase.alt.project.lift(self)
     def unknown: Option[Document] = SampleOpenDiscriminatedUnion.UnknownCase.alt.project.lift(self).map(_.unknown)
   }
 
@@ -41,9 +40,9 @@ object SampleOpenDiscriminatedUnion extends ShapeTag.Companion[SampleOpenDiscrim
   final case class SCase(s: StructForDiscrimination) extends SampleOpenDiscriminatedUnion { final def $ordinal: Int = 0 }
   case object UCase extends SampleOpenDiscriminatedUnion {
     final def $ordinal: Int = 1
-    val UCaseHints: Hints = Hints.empty
+    val hints: Hints = Hints.empty
+    val alt = Schema.constant(SampleOpenDiscriminatedUnion.UCase).oneOf[SampleOpenDiscriminatedUnion]("u").addHints(UCase.hints)
   }
-  private val UCaseAlt = Schema.constant(SampleOpenDiscriminatedUnion.UCase).oneOf[SampleOpenDiscriminatedUnion]("u").addHints(UCase.UCaseHints)
   final case class UnknownCase(unknown: Document) extends SampleOpenDiscriminatedUnion { final def $ordinal: Int = 2 }
 
   object SCase {
@@ -76,7 +75,7 @@ object SampleOpenDiscriminatedUnion extends ShapeTag.Companion[SampleOpenDiscrim
 
   implicit val schema: Schema[SampleOpenDiscriminatedUnion] = union(
     SampleOpenDiscriminatedUnion.SCase.alt,
-    UCaseAlt,
+    SampleOpenDiscriminatedUnion.UCase.alt,
     SampleOpenDiscriminatedUnion.UnknownCase.alt,
   ){
     _.$ordinal

--- a/modules/bootstrapped/src/generated/smithy4s/example/SampleOpenDiscriminatedUnion.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/SampleOpenDiscriminatedUnion.scala
@@ -39,9 +39,11 @@ object SampleOpenDiscriminatedUnion extends ShapeTag.Companion[SampleOpenDiscrim
   ).lazily
 
   final case class SCase(s: StructForDiscrimination) extends SampleOpenDiscriminatedUnion { final def $ordinal: Int = 0 }
-  case object UCase extends SampleOpenDiscriminatedUnion { final def $ordinal: Int = 1 }
-  val UCaseHints: Hints = Hints.empty
-  private val UCaseAlt = Schema.constant(SampleOpenDiscriminatedUnion.UCase).oneOf[SampleOpenDiscriminatedUnion]("u").addHints(UCaseHints)
+  case object UCase extends SampleOpenDiscriminatedUnion {
+    final def $ordinal: Int = 1
+    val UCaseHints: Hints = Hints.empty
+  }
+  private val UCaseAlt = Schema.constant(SampleOpenDiscriminatedUnion.UCase).oneOf[SampleOpenDiscriminatedUnion]("u").addHints(UCase.UCaseHints)
   final case class UnknownCase(unknown: Document) extends SampleOpenDiscriminatedUnion { final def $ordinal: Int = 2 }
 
   object SCase {

--- a/modules/bootstrapped/src/generated/smithy4s/example/SampleOpenUnion.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/SampleOpenUnion.scala
@@ -39,7 +39,8 @@ object SampleOpenUnion extends ShapeTag.Companion[SampleOpenUnion] {
 
   final case class StrCase(str: String) extends SampleOpenUnion { final def $ordinal: Int = 0 }
   case object UCase extends SampleOpenUnion { final def $ordinal: Int = 1 }
-  private val UCaseAlt = Schema.constant(SampleOpenUnion.UCase).oneOf[SampleOpenUnion]("u").addHints(hints)
+  val UCaseHints: Hints = Hints.empty
+  private val UCaseAlt = Schema.constant(SampleOpenUnion.UCase).oneOf[SampleOpenUnion]("u").addHints(UCaseHints)
   final case class UnknownCase(unknown: Document) extends SampleOpenUnion { final def $ordinal: Int = 2 }
 
   object StrCase {

--- a/modules/bootstrapped/src/generated/smithy4s/example/SampleOpenUnion.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/SampleOpenUnion.scala
@@ -38,9 +38,11 @@ object SampleOpenUnion extends ShapeTag.Companion[SampleOpenUnion] {
   val hints: Hints = Hints.empty
 
   final case class StrCase(str: String) extends SampleOpenUnion { final def $ordinal: Int = 0 }
-  case object UCase extends SampleOpenUnion { final def $ordinal: Int = 1 }
-  val UCaseHints: Hints = Hints.empty
-  private val UCaseAlt = Schema.constant(SampleOpenUnion.UCase).oneOf[SampleOpenUnion]("u").addHints(UCaseHints)
+  case object UCase extends SampleOpenUnion {
+    final def $ordinal: Int = 1
+    val UCaseHints: Hints = Hints.empty
+  }
+  private val UCaseAlt = Schema.constant(SampleOpenUnion.UCase).oneOf[SampleOpenUnion]("u").addHints(UCase.UCaseHints)
   final case class UnknownCase(unknown: Document) extends SampleOpenUnion { final def $ordinal: Int = 2 }
 
   object StrCase {

--- a/modules/bootstrapped/src/generated/smithy4s/example/SampleOpenUnion.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/SampleOpenUnion.scala
@@ -1,6 +1,5 @@
 package smithy4s.example
 
-import SampleOpenUnion.UCaseAlt
 import smithy4s.Document
 import smithy4s.Hints
 import smithy4s.Schema
@@ -17,7 +16,7 @@ sealed trait SampleOpenUnion extends scala.Product with scala.Serializable { sel
 
   object project {
     def str: Option[String] = SampleOpenUnion.StrCase.alt.project.lift(self).map(_.str)
-    def u: Option[SampleOpenUnion.UCase.type] = UCaseAlt.project.lift(self)
+    def u: Option[SampleOpenUnion.UCase.type] = SampleOpenUnion.UCase.alt.project.lift(self)
     def unknown: Option[Document] = SampleOpenUnion.UnknownCase.alt.project.lift(self).map(_.unknown)
   }
 
@@ -40,9 +39,9 @@ object SampleOpenUnion extends ShapeTag.Companion[SampleOpenUnion] {
   final case class StrCase(str: String) extends SampleOpenUnion { final def $ordinal: Int = 0 }
   case object UCase extends SampleOpenUnion {
     final def $ordinal: Int = 1
-    val UCaseHints: Hints = Hints.empty
+    val hints: Hints = Hints.empty
+    val alt = Schema.constant(SampleOpenUnion.UCase).oneOf[SampleOpenUnion]("u").addHints(UCase.hints)
   }
-  private val UCaseAlt = Schema.constant(SampleOpenUnion.UCase).oneOf[SampleOpenUnion]("u").addHints(UCase.UCaseHints)
   final case class UnknownCase(unknown: Document) extends SampleOpenUnion { final def $ordinal: Int = 2 }
 
   object StrCase {
@@ -75,7 +74,7 @@ object SampleOpenUnion extends ShapeTag.Companion[SampleOpenUnion] {
 
   implicit val schema: Schema[SampleOpenUnion] = union(
     SampleOpenUnion.StrCase.alt,
-    UCaseAlt,
+    SampleOpenUnion.UCase.alt,
     SampleOpenUnion.UnknownCase.alt,
   ){
     _.$ordinal

--- a/modules/bootstrapped/src/generated/smithy4s/example/UnionTraitWithUnitCase.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/UnionTraitWithUnitCase.scala
@@ -35,9 +35,11 @@ object UnionTraitWithUnitCase extends ShapeTag.Companion[UnionTraitWithUnitCase]
     smithy.api.Trait(selector = None, structurallyExclusive = None, conflicts = None, breakingChanges = None),
   ).lazily
 
-  case object UCase extends UnionTraitWithUnitCase { final def $ordinal: Int = 0 }
-  val UCaseHints: Hints = Hints.empty
-  private val UCaseAlt = Schema.constant(UnionTraitWithUnitCase.UCase).oneOf[UnionTraitWithUnitCase]("u").addHints(UCaseHints)
+  case object UCase extends UnionTraitWithUnitCase {
+    final def $ordinal: Int = 0
+    val UCaseHints: Hints = Hints.empty
+  }
+  private val UCaseAlt = Schema.constant(UnionTraitWithUnitCase.UCase).oneOf[UnionTraitWithUnitCase]("u").addHints(UCase.UCaseHints)
   final case class SCase(s: String) extends UnionTraitWithUnitCase { final def $ordinal: Int = 1 }
 
   object SCase {

--- a/modules/bootstrapped/src/generated/smithy4s/example/UnionTraitWithUnitCase.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/UnionTraitWithUnitCase.scala
@@ -36,7 +36,8 @@ object UnionTraitWithUnitCase extends ShapeTag.Companion[UnionTraitWithUnitCase]
   ).lazily
 
   case object UCase extends UnionTraitWithUnitCase { final def $ordinal: Int = 0 }
-  private val UCaseAlt = Schema.constant(UnionTraitWithUnitCase.UCase).oneOf[UnionTraitWithUnitCase]("u").addHints(hints)
+  val UCaseHints: Hints = Hints.empty
+  private val UCaseAlt = Schema.constant(UnionTraitWithUnitCase.UCase).oneOf[UnionTraitWithUnitCase]("u").addHints(UCaseHints)
   final case class SCase(s: String) extends UnionTraitWithUnitCase { final def $ordinal: Int = 1 }
 
   object SCase {

--- a/modules/bootstrapped/src/generated/smithy4s/example/UnionTraitWithUnitCase.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/UnionTraitWithUnitCase.scala
@@ -1,6 +1,5 @@
 package smithy4s.example
 
-import UnionTraitWithUnitCase.UCaseAlt
 import smithy4s.Hints
 import smithy4s.Schema
 import smithy4s.ShapeId
@@ -15,7 +14,7 @@ sealed trait UnionTraitWithUnitCase extends scala.Product with scala.Serializabl
   def $ordinal: Int
 
   object project {
-    def u: Option[UnionTraitWithUnitCase.UCase.type] = UCaseAlt.project.lift(self)
+    def u: Option[UnionTraitWithUnitCase.UCase.type] = UnionTraitWithUnitCase.UCase.alt.project.lift(self)
     def s: Option[String] = UnionTraitWithUnitCase.SCase.alt.project.lift(self).map(_.s)
   }
 
@@ -37,9 +36,9 @@ object UnionTraitWithUnitCase extends ShapeTag.Companion[UnionTraitWithUnitCase]
 
   case object UCase extends UnionTraitWithUnitCase {
     final def $ordinal: Int = 0
-    val UCaseHints: Hints = Hints.empty
+    val hints: Hints = Hints.empty
+    val alt = Schema.constant(UnionTraitWithUnitCase.UCase).oneOf[UnionTraitWithUnitCase]("u").addHints(UCase.hints)
   }
-  private val UCaseAlt = Schema.constant(UnionTraitWithUnitCase.UCase).oneOf[UnionTraitWithUnitCase]("u").addHints(UCase.UCaseHints)
   final case class SCase(s: String) extends UnionTraitWithUnitCase { final def $ordinal: Int = 1 }
 
   object SCase {
@@ -62,7 +61,7 @@ object UnionTraitWithUnitCase extends ShapeTag.Companion[UnionTraitWithUnitCase]
   }
 
   implicit val schema: Schema[UnionTraitWithUnitCase] = recursive(union(
-    UCaseAlt,
+    UnionTraitWithUnitCase.UCase.alt,
     UnionTraitWithUnitCase.SCase.alt,
   ){
     _.$ordinal

--- a/modules/bootstrapped/test/src/smithy4s/AdtSmokeSpec.scala
+++ b/modules/bootstrapped/test/src/smithy4s/AdtSmokeSpec.scala
@@ -32,7 +32,7 @@ class AdtSmokeSpec() extends FunSuite {
     val d3 = Document.encode(x3)
     val expected1 =
       Document.obj("inStore" -> Document.obj("id" -> Document.fromInt(1)))
-    val expected2 = Document.obj("preview" -> Document.obj())
+    val expected2 = Document.obj("PREVIEW" -> Document.obj())
     val expected3 = Document.obj("online" -> Document.fromInt(1))
     assertEquals(d1, expected1)
     assertEquals(d2, expected2)

--- a/modules/codegen/src/smithy4s/codegen/internals/Renderer.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/Renderer.scala
@@ -1096,13 +1096,9 @@ private[internals] class Renderer(compilationUnit: CompilationUnit) { self =>
     alt.member match {
       case UnionMember.ProductCase(product) =>
         line"${unionName.down(product.name)}.alt"
-      case UnionMember.TypeCase(_) =>
+      case _ =>
         val n = unionName.down(alt.name.dropWhile(_ == '_').capitalize + "Case")
         line"$n.alt"
-      case UnionMember.UnitCase =>
-        val n =
-          unionName.down(alt.name.dropWhile(_ == '_').capitalize + "CaseAlt")
-        line"$n"
     }
 
   private def renderPrisms(
@@ -1280,8 +1276,7 @@ private[internals] class Renderer(compilationUnit: CompilationUnit) { self =>
         alts.zipWithIndex.map {
           case (a @ Alt(_, realName, UnionMember.UnitCase, altHints), index) =>
             val cn = caseName(name, a)
-            val altHintsName = line"${cn.nameDef}Hints"
-            val altsHintNameRef = line"${cn.nameDef}.${altHintsName}"
+            val altsHintNameRef = line"${cn.nameDef}.hints"
             // format: off
             lines(
               documentationAnnotation(altHints),
@@ -1290,9 +1285,9 @@ private[internals] class Renderer(compilationUnit: CompilationUnit) { self =>
                 line"case object ${cn.nameDef} extends $name"
               )(
                 line"final def $$ordinal: Int = $index",
-                   renderHintsVal(altHints, Some(cn.nameDef.name))
+                   renderHintsVal(altHints),
+                  line"""val alt = $Schema_.constant($cn)${renderConstraintValidation(altHints)}.oneOf[$name](${renderStringLiteral(realName)}).addHints(${altsHintNameRef})""",
               ),
-              line"""private val ${cn.nameDef}Alt = $Schema_.constant($cn)${renderConstraintValidation(altHints)}.oneOf[$name](${renderStringLiteral(realName)}).addHints(${altsHintNameRef})""",
             )
             // format: on
           case (
@@ -1353,9 +1348,8 @@ private[internals] class Renderer(compilationUnit: CompilationUnit) { self =>
               line"implicit val schema: $Schema_[$name] = $union_"
           union
             .args {
-              caseNamesAndIsUnit.map {
-                case (caseName, false) => caseName + ".alt"
-                case (caseName, true)  => caseName + "Alt"
+              caseNamesAndIsUnit.map { case (caseName, _) =>
+                caseName + ".alt"
               }
             }
             .block {

--- a/modules/codegen/src/smithy4s/codegen/internals/Renderer.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/Renderer.scala
@@ -1280,12 +1280,14 @@ private[internals] class Renderer(compilationUnit: CompilationUnit) { self =>
         alts.zipWithIndex.map {
           case (a @ Alt(_, realName, UnionMember.UnitCase, altHints), index) =>
             val cn = caseName(name, a)
+            val altHintsName = line"${cn.nameDef}Hints"
             // format: off
             lines(
               documentationAnnotation(altHints),
               deprecationAnnotation(altHints),
               line"case object ${cn.nameDef} extends $name { final def $$ordinal: Int = $index }",
-              line"""private val ${cn.nameDef}Alt = $Schema_.constant($cn)${renderConstraintValidation(altHints)}.oneOf[$name](${renderStringLiteral(realName)}).addHints(hints)""",
+              renderHintsVal(altHints, Some(cn.nameDef.name)),
+              line"""private val ${cn.nameDef}Alt = $Schema_.constant($cn)${renderConstraintValidation(altHints)}.oneOf[$name](${renderStringLiteral(realName)}).addHints(${altHintsName})""",
             )
             // format: on
           case (
@@ -1713,8 +1715,8 @@ private[internals] class Renderer(compilationUnit: CompilationUnit) { self =>
     line"val tag: $EnumTag_[$parentType] = $EnumTag_.$tagStr"
   }
 
-  def renderHintsVal(hints: List[Hint]): Lines = {
-    val lhs = line"val hints: $Hints_"
+  def renderHintsVal(hints: List[Hint], prefix: Option[String] = None): Lines = {
+    val lhs = line"val ${prefix.fold("hints")(_ + "Hints")}: $Hints_"
 
     hints.collect { case nt: Hint.Native => nt }.sortBy(_.shapeId).map(renderHint) match {
       case Nil => lines(line"$lhs = $Hints_.empty")

--- a/modules/codegen/src/smithy4s/codegen/internals/Renderer.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/Renderer.scala
@@ -1281,13 +1281,18 @@ private[internals] class Renderer(compilationUnit: CompilationUnit) { self =>
           case (a @ Alt(_, realName, UnionMember.UnitCase, altHints), index) =>
             val cn = caseName(name, a)
             val altHintsName = line"${cn.nameDef}Hints"
+            val altsHintNameRef = line"${cn.nameDef}.${altHintsName}"
             // format: off
             lines(
               documentationAnnotation(altHints),
               deprecationAnnotation(altHints),
-              line"case object ${cn.nameDef} extends $name { final def $$ordinal: Int = $index }",
-              renderHintsVal(altHints, Some(cn.nameDef.name)),
-              line"""private val ${cn.nameDef}Alt = $Schema_.constant($cn)${renderConstraintValidation(altHints)}.oneOf[$name](${renderStringLiteral(realName)}).addHints(${altHintsName})""",
+              block(
+                line"case object ${cn.nameDef} extends $name"
+              )(
+                line"final def $$ordinal: Int = $index",
+                   renderHintsVal(altHints, Some(cn.nameDef.name))
+              ),
+              line"""private val ${cn.nameDef}Alt = $Schema_.constant($cn)${renderConstraintValidation(altHints)}.oneOf[$name](${renderStringLiteral(realName)}).addHints(${altsHintNameRef})""",
             )
             // format: on
           case (

--- a/sampleSpecs/adtMember.smithy
+++ b/sampleSpecs/adtMember.smithy
@@ -16,6 +16,7 @@ union OrderType {
     /// For an InStoreOrder a location ID isn't needed
     inStore: InStoreOrder
 
+    @jsonName("PREVIEW")
     preview: Unit
 }
 


### PR DESCRIPTION
closes #1804 
- adds an additional val in the Union companion object to hold the hints of the specific member and adds them to the `addHints` method call
- the adtmember smithy spec was used to test , as it already contained the use case of a union with a member targeting Unit. 
    -  This created the need to fix the AdtSmokeSpec 
