### PR TITLE
update canonical smithy decoder to handle offsetDateTime for protocolTests

### DIFF
--- a/modules/compliance-tests/src/smithy4s/compliancetests/internals/CanonicalSmithyDecoder.scala
+++ b/modules/compliance-tests/src/smithy4s/compliancetests/internals/CanonicalSmithyDecoder.scala
@@ -95,6 +95,7 @@ object CanonicalSmithyDecoder {
             case DString(string) =>
               OffsetDateTime.parseUnsafe(string)
             case DNumber(value) =>
+              // Since there's no offset information if we are just given the epoch seconds just default to UTC, i.e ZoneOffset zero
               val epochSeconds = value.toLong
               OffsetDateTime(
                 epochSeconds,

--- a/modules/compliance-tests/src/smithy4s/compliancetests/internals/CanonicalSmithyDecoder.scala
+++ b/modules/compliance-tests/src/smithy4s/compliancetests/internals/CanonicalSmithyDecoder.scala
@@ -73,24 +73,37 @@ object CanonicalSmithyDecoder {
         shapeId: ShapeId,
         hints: Hints,
         tag: Primitive[P]
-    ): DocumentDecoder[P] = tag match {
-      case PFloat  => float
-      case PDouble => double
-      case PTimestamp =>
-        DocumentDecoder.instance("Timestamp", "Number") {
-          case (_, DNumber(value)) =>
-            val epochSeconds = value.toLong
-            Timestamp(
-              epochSeconds,
-              ((value - epochSeconds) * 1000000000).toInt
-            )
-        }
-      case PBlob =>
-        from("Base64 binary blob") { case DString(string) =>
-          Blob(string)
-        }
-      case _ => super.primitive(shapeId, hints, tag)
-    }
+    ): DocumentDecoder[P] =
+      tag match {
+        case PFloat  => float
+        case PDouble => double
+        case PTimestamp =>
+          DocumentDecoder.instance("Timestamp", "Number") {
+            case (_, DNumber(value)) =>
+              val epochSeconds = value.toLong
+              Timestamp(
+                epochSeconds,
+                ((value - epochSeconds) * 1000000000).toInt
+              )
+          }
+        case PBlob =>
+          from("Base64 binary blob") { case DString(string) =>
+            Blob(string)
+          }
+        case POffsetDateTime =>
+          from("OffsetDateTime") {
+            case DString(string) =>
+              OffsetDateTime.parseUnsafe(string)
+            case DNumber(value) =>
+              val epochSeconds = value.toLong
+              OffsetDateTime(
+                epochSeconds,
+                ((value - epochSeconds) * 1000000000).toInt,
+                ZoneOffset.Zero
+              )
+          }
+        case _ => super.primitive(shapeId, hints, tag)
+      }
 
     val double = from("Double") {
       case DNumber(bd) =>

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -31,7 +31,7 @@ object Dependencies {
 
   val Alloy = new {
     val org = "com.disneystreaming.alloy"
-    val alloyVersion = "0.3.31-4-43290b"
+    val alloyVersion = "0.3.32"
     val core = org % "alloy-core" % alloyVersion
     val openapi = org %% "alloy-openapi" % alloyVersion
     val protobuf = org % "alloy-protobuf" % alloyVersion

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -31,7 +31,7 @@ object Dependencies {
 
   val Alloy = new {
     val org = "com.disneystreaming.alloy"
-    val alloyVersion = "0.3.31"
+    val alloyVersion = "0.3.31-4-43290b"
     val core = org % "alloy-core" % alloyVersion
     val openapi = org %% "alloy-openapi" % alloyVersion
     val protobuf = org % "alloy-protobuf" % alloyVersion


### PR DESCRIPTION
This is dependent on https://github.com/disneystreaming/alloy/pull/244.

Here's a screenshot of the protocol test from my terminal
<img width="908" height="105" alt="Screenshot 2025-08-19 at 3 51 12 PM" src="https://github.com/user-attachments/assets/f6911a47-c966-47f4-b0b7-2e5ef54b54f8" />

## PR Checklist (not all items are relevant to all PRs)

- [ ] Added unit-tests (for runtime code)
- [ ] Added bootstrapped code + smoke tests (when the rendering logic is modified)
- [ ] Added build-plugins integration tests (when reflection loading is required at codegen-time)
- [ ] Added alloy compliance tests (when simpleRestJson protocol behaviour is expanded/updated)
- [ ] Updated dynamic module to match generated-code behaviour
- [ ] Added documentation
- [ ] Updated changelog
