### PR TITLE
Update Scala Native to 0.5.x

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -839,7 +839,7 @@ lazy val protobuf = projectMatrix
         )
       else
         Seq(
-          "com.thesamet.scalapb" %%% "protobuf-runtime-scala" % "0.8.14"
+          "com.thesamet.scalapb" %%% "protobuf-runtime-scala" % "1.0.0-alpha.2"
         )
     },
     Test / fork := virtualAxes.value.contains(VirtualAxis.jvm)

--- a/build.sbt
+++ b/build.sbt
@@ -27,6 +27,11 @@ ThisBuild / resolvers += Resolver.sonatypeCentralSnapshots
 
 Global / onChangedBuildSource := ReloadOnSourceChanges
 
+// Silence binary compatibility warnings for test-interface in Scala Native 0.5.x series
+// has to include _native suffix due to https://github.com/sbt/sbt/issues/7140
+ThisBuild / libraryDependencySchemes +=
+  "org.scala-native" %% "test-interface_native0.5" % VersionScheme.Always
+
 import Smithy4sBuildPlugin._
 
 val latest2ScalaVersions = List(Scala213, Scala3)
@@ -60,7 +65,7 @@ lazy val allModules = Seq(
   docs,
   millCodegenPlugin,
   json,
-  xml,
+  // xml,
   bootstrapped,
   tests,
   http4s,
@@ -379,7 +384,7 @@ lazy val `aws-http4s` = projectMatrix
     `aws-kernel`,
     `http4s-kernel`,
     json,
-    xml,
+    // xml,
     complianceTests % "test->compile",
     dynamic % "test->compile",
     tests % "test->compile",
@@ -793,24 +798,24 @@ lazy val json = projectMatrix
  * Module that contains fs2-data-based XML encoders/decoders for the generated
  * types.
  */
-lazy val xml = projectMatrix
-  .in(file("modules/xml"))
-  .dependsOn(
-    core,
-    bootstrapped % "test->test",
-    scalacheck % "test -> compile"
-  )
-  .settings(
-    isMimaEnabled := false,
-    libraryDependencies ++= Seq(
-      Dependencies.Fs2Data.xml.value
-    ) ++ weaverDeps.value,
-    libraryDependencies ++= munitDeps.value,
-    Test / fork := virtualAxes.value.contains(VirtualAxis.jvm)
-  )
-  .jvmPlatform(allJvmScalaVersions, jvmDimSettings)
-  .jsPlatform(allJsScalaVersions, jsDimSettings)
-  .nativePlatform(allNativeScalaVersions, nativeDimSettings)
+// lazy val xml = projectMatrix
+//   .in(file("modules/xml"))
+//   .dependsOn(
+//     core,
+//     bootstrapped % "test->test",
+//     scalacheck % "test -> compile"
+//   )
+//   .settings(
+//     isMimaEnabled := false,
+//     libraryDependencies ++= Seq(
+//       Dependencies.Fs2Data.xml.value
+//     ) ++ weaverDeps.value,
+//     libraryDependencies ++= munitDeps.value,
+//     Test / fork := virtualAxes.value.contains(VirtualAxis.jvm)
+//   )
+//   .jvmPlatform(allJvmScalaVersions, jvmDimSettings)
+//   .jsPlatform(allJsScalaVersions, jsDimSettings)
+//   .nativePlatform(allNativeScalaVersions, nativeDimSettings)
 
 /**
  * Module that contains protobuf encoders/decoders for the generated
@@ -1010,7 +1015,7 @@ lazy val complianceTests = projectMatrix
         Dependencies.Http4s.circe.value,
         Dependencies.Http4s.client.value,
         Dependencies.Pprint.core.value,
-        Dependencies.Fs2Data.xml.value
+        // Dependencies.Fs2Data.xml.value
       ) ++ weaverDeps.value
     }
   )

--- a/build.sbt
+++ b/build.sbt
@@ -176,17 +176,10 @@ val weaverDeps = Def.setting {
 }
 
 val munitDeps = Def.setting {
-  if (virtualAxes.value.contains(VirtualAxis.native)) {
-    Seq(
-      Dependencies.Munit.core.value % Test,
-      Dependencies.Munit.scalacheck.value % Test
-    )
-  } else {
-    Seq(
-      Dependencies.Munit.core.value % Test,
-      Dependencies.Munit.scalacheck.value % Test
-    )
-  }
+  Seq(
+    Dependencies.Munit.core.value % Test,
+    Dependencies.Munit.scalacheck.value % Test
+  )
 }
 
 /**

--- a/build.sbt
+++ b/build.sbt
@@ -171,20 +171,20 @@ val weaverDeps = Def.setting {
     // workaround for a linking issue on Native. Appears to be related to Weaver's shading of the munit-diff dependency
     // (the linker issue mentions weaver's own sources bringing in a missing definition in munit.diff).
     // Hopefully this can be removed once we've moved to Scala Native 0.5 and there's only a single Munit version in the build.
-    Dependencies.MunitV1.diff.value % Test
+    Dependencies.Munit.diff.value % Test
   )
 }
 
 val munitDeps = Def.setting {
   if (virtualAxes.value.contains(VirtualAxis.native)) {
     Seq(
-      Dependencies.MunitV1.core.value % Test,
-      Dependencies.MunitV1.scalacheck.value % Test
+      Dependencies.Munit.core.value % Test,
+      Dependencies.Munit.scalacheck.value % Test
     )
   } else {
     Seq(
-      Dependencies.MunitV1.core.value % Test,
-      Dependencies.MunitV1.scalacheck.value % Test
+      Dependencies.Munit.core.value % Test,
+      Dependencies.Munit.scalacheck.value % Test
     )
   }
 }
@@ -556,7 +556,7 @@ lazy val codegenPlugin = (projectMatrix in file("modules/codegen-plugin"))
     Compile / unmanagedSources / excludeFilter := { f =>
       Glob("**/sbt-test/**").matches(f.toPath)
     },
-    libraryDependencies += Dependencies.MunitV1.diff.value,
+    libraryDependencies += Dependencies.Munit.diff.value,
     publishLocal := {
       // make sure that core and codegen are published before the
       // plugin is published

--- a/build.sbt
+++ b/build.sbt
@@ -173,13 +173,13 @@ val weaverDeps = Def.setting {
 val munitDeps = Def.setting {
   if (virtualAxes.value.contains(VirtualAxis.native)) {
     Seq(
-      Dependencies.MunitMilestone.core.value % Test,
-      Dependencies.MunitMilestone.scalacheck.value % Test
+      Dependencies.MunitV1.core.value % Test,
+      Dependencies.MunitV1.scalacheck.value % Test
     )
   } else {
     Seq(
-      Dependencies.Munit.core.value % Test,
-      Dependencies.Munit.scalacheck.value % Test
+      Dependencies.MunitV1.core.value % Test,
+      Dependencies.MunitV1.scalacheck.value % Test
     )
   }
 }

--- a/build.sbt
+++ b/build.sbt
@@ -65,7 +65,7 @@ lazy val allModules = Seq(
   docs,
   millCodegenPlugin,
   json,
-  // xml,
+  xml,
   bootstrapped,
   tests,
   http4s,
@@ -384,7 +384,7 @@ lazy val `aws-http4s` = projectMatrix
     `aws-kernel`,
     `http4s-kernel`,
     json,
-    // xml,
+    xml,
     complianceTests % "test->compile",
     dynamic % "test->compile",
     tests % "test->compile",
@@ -798,24 +798,24 @@ lazy val json = projectMatrix
  * Module that contains fs2-data-based XML encoders/decoders for the generated
  * types.
  */
-// lazy val xml = projectMatrix
-//   .in(file("modules/xml"))
-//   .dependsOn(
-//     core,
-//     bootstrapped % "test->test",
-//     scalacheck % "test -> compile"
-//   )
-//   .settings(
-//     isMimaEnabled := false,
-//     libraryDependencies ++= Seq(
-//       Dependencies.Fs2Data.xml.value
-//     ) ++ weaverDeps.value,
-//     libraryDependencies ++= munitDeps.value,
-//     Test / fork := virtualAxes.value.contains(VirtualAxis.jvm)
-//   )
-//   .jvmPlatform(allJvmScalaVersions, jvmDimSettings)
-//   .jsPlatform(allJsScalaVersions, jsDimSettings)
-//   .nativePlatform(allNativeScalaVersions, nativeDimSettings)
+lazy val xml = projectMatrix
+  .in(file("modules/xml"))
+  .dependsOn(
+    core,
+    bootstrapped % "test->test",
+    scalacheck % "test -> compile"
+  )
+  .settings(
+    isMimaEnabled := false,
+    libraryDependencies ++= Seq(
+      Dependencies.Fs2Data.xml.value
+    ) ++ weaverDeps.value,
+    libraryDependencies ++= munitDeps.value,
+    Test / fork := virtualAxes.value.contains(VirtualAxis.jvm)
+  )
+  .jvmPlatform(allJvmScalaVersions, jvmDimSettings)
+  .jsPlatform(allJsScalaVersions, jsDimSettings)
+  .nativePlatform(allNativeScalaVersions, nativeDimSettings)
 
 /**
  * Module that contains protobuf encoders/decoders for the generated
@@ -839,7 +839,7 @@ lazy val protobuf = projectMatrix
         )
       else
         Seq(
-          "com.thesamet.scalapb" %%% "protobuf-runtime-scala" % "1.0.0-alpha.2"
+          "com.thesamet.scalapb" %% "scalapb-runtime" % scalapb.compiler.Version.scalapbVersion
         )
     },
     Test / fork := virtualAxes.value.contains(VirtualAxis.jvm)
@@ -1015,7 +1015,7 @@ lazy val complianceTests = projectMatrix
         Dependencies.Http4s.circe.value,
         Dependencies.Http4s.client.value,
         Dependencies.Pprint.core.value,
-        // Dependencies.Fs2Data.xml.value
+        Dependencies.Fs2Data.xml.value
       ) ++ weaverDeps.value
     }
   )

--- a/modules/aws-kernel/src-native/smithy4s/aws/CryptoPlatformCompat.scala
+++ b/modules/aws-kernel/src-native/smithy4s/aws/CryptoPlatformCompat.scala
@@ -38,7 +38,7 @@ trait CryptoPlatformCompat {
     if (
       EVP_Digest(
         message.atUnsafe(0),
-        message.length.toULong,
+        message.length.toSize.toCSize,
         md.atUnsafe(0),
         size,
         EvpMdSha256,
@@ -64,7 +64,7 @@ trait CryptoPlatformCompat {
         key.atUnsafe(0),
         key.size.toInt,
         d.atUnsafe(0),
-        d.length.toULong,
+        d.length.toSize.toCSize,
         md.atUnsafe(0),
         mdLen
       ) == null

--- a/modules/codegen/test/src/smithy4s/codegen/BincompatCodegenIntegrationSpec.scala
+++ b/modules/codegen/test/src/smithy4s/codegen/BincompatCodegenIntegrationSpec.scala
@@ -20,6 +20,7 @@ import munit.FunSuite
 import com.typesafe.tools.mima.lib.MiMaLib
 import cats.syntax.all._
 import com.typesafe.tools.mima.core.ReversedMissingMethodProblem
+import scala.concurrent.duration._
 
 class BincompatCodegenIntegrationSpec extends FunSuite {
   private val scala212 = "2.12"
@@ -35,6 +36,9 @@ class BincompatCodegenIntegrationSpec extends FunSuite {
       |use smithy4s.meta#bincompatAdded
       |
       |""".stripMargin
+
+  // Extend timeout for "Bincompat-friendly struct trait" test
+  override val munitTimeout = 2.minutes
 
   scalaVersions.foreach { scalaVersion =>
     test(s"Bincompat-friendly structs (Scala $scalaVersion)") {

--- a/modules/mill-codegen-plugin/test/src-mill-0_11/smithy4s/codegen/mill/Smithy4sModuleSpec.scala
+++ b/modules/mill-codegen-plugin/test/src-mill-0_11/smithy4s/codegen/mill/Smithy4sModuleSpec.scala
@@ -28,9 +28,13 @@ import coursier.Repository
 import coursier.ivy.IvyRepository
 import mill.define.Task
 
+import scala.concurrent.duration._
+
 class Smithy4sModuleSpec extends munit.FunSuite {
   private val resourcePath =
     os.Path(Paths.get(this.getClass().getResource("/").toURI()))
+
+  override val munitTimeout = 5.minutes
 
   private object testKit extends MillTestKit
 

--- a/modules/mill-codegen-plugin/test/src-mill-0_12/smithy4s/codegen/mill/Smithy4sModuleSpec.scala
+++ b/modules/mill-codegen-plugin/test/src-mill-0_12/smithy4s/codegen/mill/Smithy4sModuleSpec.scala
@@ -26,9 +26,13 @@ import mill.scalalib.publish.VersionControl
 import coursier.Repository
 import coursier.ivy.IvyRepository
 
+import scala.concurrent.duration._
+
 class Smithy4sModuleSpec extends munit.FunSuite {
   private val resourcePath =
     os.Path(Paths.get(this.getClass().getResource("/").toURI()))
+
+  override val munitTimeout = 5.minutes
 
   private val coreDep =
     ivy"com.disneystreaming.smithy4s::smithy4s-core:${smithy4s.codegen.BuildInfo.version}"

--- a/modules/mill-codegen-plugin/test/src-mill-1/smithy4s/codegen/mill/Smithy4sModuleSpec.scala
+++ b/modules/mill-codegen-plugin/test/src-mill-1/smithy4s/codegen/mill/Smithy4sModuleSpec.scala
@@ -29,9 +29,13 @@ import munit.Location
 
 import java.nio.file.Paths
 
+import scala.concurrent.duration._
+
 class Smithy4sModuleSpec extends munit.FunSuite {
   private val resourcePath =
     os.Path(Paths.get(this.getClass().getResource("/").toURI()))
+
+  override val munitTimeout = 5.minutes
 
   private val coreDep =
     mvn"com.disneystreaming.smithy4s::smithy4s-core:${smithy4s.codegen.BuildInfo.version}"

--- a/modules/tests/src/smithy4s/tests/PizzaSpec.scala
+++ b/modules/tests/src/smithy4s/tests/PizzaSpec.scala
@@ -16,7 +16,6 @@
 
 package smithy4s.tests
 
-import cats.data.NonEmptyList
 import cats.effect._
 import cats.syntax.all._
 import io.circe._
@@ -666,9 +665,14 @@ abstract class PizzaSpec
     def expect[A: Decoder](implicit loc: SourceLocation): IO[A] =
       json.as[A] match {
         case Left(value) =>
-          IO.raiseError(AssertionException(value.message, NonEmptyList.of(loc)))
+          IO.raiseError(DeserializationFailure(value.message, loc))
         case Right(value) => IO.pure(value)
       }
   }
+
+  private case class DeserializationFailure (
+    reason: String,
+    location: SourceLocation)
+    extends RuntimeException(reason)
 
 }

--- a/modules/tests/src/smithy4s/tests/PizzaSpec.scala
+++ b/modules/tests/src/smithy4s/tests/PizzaSpec.scala
@@ -670,9 +670,9 @@ abstract class PizzaSpec
       }
   }
 
-  private case class DeserializationFailure (
-    reason: String,
-    location: SourceLocation)
-    extends RuntimeException(reason)
+  private case class DeserializationFailure(
+      reason: String,
+      location: SourceLocation
+  ) extends RuntimeException(reason)
 
 }

--- a/modules/tests/src/smithy4s/tests/ProtocolComplianceSuite.scala
+++ b/modules/tests/src/smithy4s/tests/ProtocolComplianceSuite.scala
@@ -190,26 +190,11 @@ abstract class ProtocolComplianceSuite
   def unsureWhetherShouldSucceed(
       test: ComplianceTest[IO],
       res: ComplianceTest.ComplianceResult
-  ): Expectations = {
-    res.toEither match {
-      case Left(failures) =>
-        throw new ProtocolComplianceSuite.CanceledException(
-          Some(failures.head),
-          weaver.SourceLocation.fromContext
-        )
-      case Right(_) =>
-        throw new ProtocolComplianceSuite.IgnoredException(
-          Some("Passing unknown spec"),
-          weaver.SourceLocation.fromContext
-        )
-    }
-  }
+  ): Expectations = 
+    ignore
 
-}
+  private val ignore = cats.Monoid[Expectations].empty
 
-object ProtocolComplianceSuite {
-  private[smithy4s] class CanceledException(message: Option[String], location: SourceLocation) extends RuntimeException(message.getOrElse("cancelled"))
-  private[smithy4s] class IgnoredException(message: Option[String], location: SourceLocation) extends RuntimeException(message.getOrElse("ignored"))
 }
 
 // brought over from weaver https://github.com/disneystreaming/weaver-test/blob/d5489c994ecbe84f267550fb84c25c9fba473d70/modules/core/src/weaver/Filters.scala#L5

--- a/modules/tests/src/smithy4s/tests/ProtocolComplianceSuite.scala
+++ b/modules/tests/src/smithy4s/tests/ProtocolComplianceSuite.scala
@@ -190,7 +190,7 @@ abstract class ProtocolComplianceSuite
   def unsureWhetherShouldSucceed(
       test: ComplianceTest[IO],
       res: ComplianceTest.ComplianceResult
-  ): Expectations = 
+  ): Expectations =
     ignore
 
   private val ignore = cats.Monoid[Expectations].empty

--- a/modules/tests/src/smithy4s/tests/ProtocolComplianceSuite.scala
+++ b/modules/tests/src/smithy4s/tests/ProtocolComplianceSuite.scala
@@ -193,18 +193,23 @@ abstract class ProtocolComplianceSuite
   ): Expectations = {
     res.toEither match {
       case Left(failures) =>
-        throw new weaver.CanceledException(
+        throw new ProtocolComplianceSuite.CanceledException(
           Some(failures.head),
           weaver.SourceLocation.fromContext
         )
       case Right(_) =>
-        throw new weaver.IgnoredException(
+        throw new ProtocolComplianceSuite.IgnoredException(
           Some("Passing unknown spec"),
           weaver.SourceLocation.fromContext
         )
     }
   }
 
+}
+
+object ProtocolComplianceSuite {
+  private[smithy4s] class CanceledException(message: Option[String], location: SourceLocation) extends RuntimeException(message.getOrElse("cancelled"))
+  private[smithy4s] class IgnoredException(message: Option[String], location: SourceLocation) extends RuntimeException(message.getOrElse("ignored"))
 }
 
 // brought over from weaver https://github.com/disneystreaming/weaver-test/blob/d5489c994ecbe84f267550fb84c25c9fba473d70/modules/core/src/weaver/Filters.scala#L5

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -69,7 +69,7 @@ object Dependencies {
       Def.setting("com.monovore" %%% "decline-effect" % declineVersion)
   }
   object Fs2 {
-    val fs2Version = "3.13.0-M6"
+    val fs2Version = "3.13.0"
 
     val core: Def.Initialize[ModuleID] =
       Def.setting("co.fs2" %%% "fs2-core" % fs2Version)
@@ -80,7 +80,7 @@ object Dependencies {
 
   object Fs2Data {
     val xml: Def.Initialize[ModuleID] =
-      Def.setting("org.gnieh" %%% "fs2-data-xml" % "1.11.2")
+      Def.setting("org.gnieh" %%% "fs2-data-xml" % "1.13.0")
   }
 
   object Mill {
@@ -105,10 +105,10 @@ object Dependencies {
   }
 
   val CatsEffect3: Def.Initialize[ModuleID] =
-    Def.setting("org.typelevel" %%% "cats-effect" % "3.7.0-RC1")
+    Def.setting("org.typelevel" %%% "cats-effect" % "3.7.0")
 
   object Http4s {
-    val http4sVersion = "0.23.30-161-f5b9629-SNAPSHOT"
+    val http4sVersion = "0.23.34"
 
     val emberServer: Def.Initialize[ModuleID] =
       Def.setting("org.http4s" %%% "http4s-ember-server" % http4sVersion)
@@ -126,7 +126,7 @@ object Dependencies {
 
   object Weaver {
 
-    val weaverVersion = "0.11-b0644b4-SNAPSHOT"
+    val weaverVersion = "0.12.0"
 
     val cats: Def.Initialize[ModuleID] =
       Def.setting("org.typelevel" %%% "weaver-cats" % weaverVersion)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -128,7 +128,7 @@ object Dependencies {
 
   object Weaver {
 
-    val weaverVersion = "0.10-c027a6c-SNAPSHOT"
+    val weaverVersion = "0.11-b0644b4-SNAPSHOT"
 
     val cats: Def.Initialize[ModuleID] =
       Def.setting("org.typelevel" %%% "weaver-cats" % weaverVersion)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,8 +10,7 @@ object Dependencies {
 
   val Jsoniter = new {
     val org = "com.github.plokhotnyuk.jsoniter-scala"
-    // must keep 2.30.2 until upgrade to scala native 0.5
-    val jsoniterScalaVersion = "2.30.2"
+    val jsoniterScalaVersion = "2.37.10"
     val core = Def.setting(org %%% "jsoniter-scala-core" % jsoniterScalaVersion)
     val macros = Def.setting(
       org %%% "jsoniter-scala-macros" % jsoniterScalaVersion % "compile-internal"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -110,7 +110,7 @@ object Dependencies {
     Def.setting("org.typelevel" %%% "cats-effect" % "3.7.0-RC1")
 
   object Http4s {
-    val http4sVersion = "0.23.33"
+    val http4sVersion = "0.23.30-161-f5b9629-SNAPSHOT"
 
     val emberServer: Def.Initialize[ModuleID] =
       Def.setting("org.http4s" %%% "http4s-ember-server" % http4sVersion)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -62,8 +62,7 @@ object Dependencies {
   }
 
   object Decline {
-    // must be kept at 2.4.1 until upgrade to scala-native 0.5
-    val declineVersion = "2.4.1"
+    val declineVersion = "2.5.0"
 
     val core = Def.setting("com.monovore" %%% "decline" % declineVersion)
     val effect =

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,7 @@ object Dependencies {
 
   val collectionsCompat =
     Def.setting(
-      "org.scala-lang.modules" %%% "scala-collection-compat" % "2.11.0"
+      "org.scala-lang.modules" %%% "scala-collection-compat" % "2.13.0"
     )
 
   val Jsoniter = new {
@@ -47,8 +47,7 @@ object Dependencies {
 
   val Cats = new {
     val core: Def.Initialize[ModuleID] =
-      // must remain on 2.11 until we update scala-native version
-      Def.setting("org.typelevel" %%% "cats-core" % "2.11.0")
+      Def.setting("org.typelevel" %%% "cats-core" % "2.13.0")
   }
 
   val Monocle = new {
@@ -57,8 +56,7 @@ object Dependencies {
   }
 
   object Circe {
-    // we have to stay on 0.14.8 until we move to scala-native 0.5.x
-    val circeVersion = "0.14.8"
+    val circeVersion = "0.14.14"
     val core = Def.setting("io.circe" %%% "circe-core" % circeVersion)
     val parser = Def.setting("io.circe" %%% "circe-parser" % circeVersion)
     val generic = Def.setting("io.circe" %%% "circe-generic" % circeVersion)
@@ -73,7 +71,7 @@ object Dependencies {
       Def.setting("com.monovore" %%% "decline-effect" % declineVersion)
   }
   object Fs2 {
-    val fs2Version = "3.12.2"
+    val fs2Version = "3.13.0-M6"
 
     val core: Def.Initialize[ModuleID] =
       Def.setting("co.fs2" %%% "fs2-core" % fs2Version)
@@ -104,12 +102,12 @@ object Dependencies {
   }
 
   object Pprint {
-    val pprintVersion = "0.8.1"
+    val pprintVersion = "0.9.3"
     val core = Def.setting("com.lihaoyi" %%% "pprint" % pprintVersion)
   }
 
   val CatsEffect3: Def.Initialize[ModuleID] =
-    Def.setting("org.typelevel" %%% "cats-effect" % "3.6.0")
+    Def.setting("org.typelevel" %%% "cats-effect" % "3.7.0-RC1")
 
   object Http4s {
     val http4sVersion = "0.23.33"
@@ -130,7 +128,7 @@ object Dependencies {
 
   object Weaver {
 
-    val weaverVersion = "0.10.0"
+    val weaverVersion = "0.10-c027a6c-SNAPSHOT"
 
     val cats: Def.Initialize[ModuleID] =
       Def.setting("org.typelevel" %%% "weaver-cats" % weaverVersion)
@@ -149,13 +147,13 @@ object Dependencies {
   }
   object Munit extends MunitCross("0.7.29")
   object MunitMilestone extends MunitCross("1.0.0-M6")
-  object MunitV1 extends MunitCross("1.0.0") {
+  object MunitV1 extends MunitCross("1.1.0") {
     val diff: Def.Initialize[ModuleID] =
       Def.setting("org.scalameta" %%% "munit-diff" % munitVersion)
   }
 
   val Scalacheck = new {
-    val scalacheckVersion = "1.17.1"
+    val scalacheckVersion = "1.18.1"
     val scalacheck =
       Def.setting("org.scalacheck" %%% "scalacheck" % scalacheckVersion)
   }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -143,9 +143,7 @@ object Dependencies {
     val scalacheck: Def.Initialize[ModuleID] =
       Def.setting("org.scalameta" %%% "munit-scalacheck" % munitVersion)
   }
-  object Munit extends MunitCross("0.7.29")
-  object MunitMilestone extends MunitCross("1.0.0-M6")
-  object MunitV1 extends MunitCross("1.1.0") {
+  object Munit extends MunitCross("1.1.0") {
     val diff: Def.Initialize[ModuleID] =
       Def.setting("org.scalameta" %%% "munit-diff" % munitVersion)
   }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 // format: off
 addSbtPlugin("ch.epfl.scala"        % "sbt-scalafix"                  % "0.14.5")
-addSbtPlugin("org.scala-js"         % "sbt-scalajs"                   % "1.20.2")
+addSbtPlugin("org.scala-js"         % "sbt-scalajs"                   % "1.21.0")
 addSbtPlugin("com.github.sbt"       % "sbt-pgp"                       % "2.3.1")
 addSbtPlugin("com.github.sbt"       % "sbt-dynver"                    % "5.1.0")
 addSbtPlugin("org.xerial.sbt"       % "sbt-sonatype"                  % "3.12.2")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -23,7 +23,7 @@ addSbtPlugin("org.polyvariant" % "smithy-trait-codegen-sbt" % "0.2.3")
 libraryDependencies ++= Seq(
   "com.lihaoyi" %% "os-lib" % "0.10.7",
   "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-macros" % "2.30.15",
-  "com.thesamet.scalapb" %% "compilerplugin" % "1.0.0-alpha.3"
+  "com.thesamet.scalapb" %% "compilerplugin" % "0.11.17"
 )
 
 addDependencyTreePlugin

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -11,7 +11,7 @@ addSbtPlugin("com.eed3si9n"         % "sbt-buildinfo"                 % "0.13.1"
 addSbtPlugin("com.eed3si9n"         % "sbt-projectmatrix"             % "0.11.0")
 addSbtPlugin("pl.project13.scala"   % "sbt-jmh"                       % "0.4.7")
 addSbtPlugin("de.heikoseeberger"    % "sbt-header"                    % "5.10.0")
-addSbtPlugin("org.scala-native"     % "sbt-scala-native"              % "0.5.8")
+addSbtPlugin("org.scala-native"     % "sbt-scala-native"              % "0.5.11")
 addSbtPlugin("com.github.sbt"       % "sbt-git"                       % "2.1.0")
 addSbtPlugin("com.typesafe"         % "sbt-mima-plugin"               % "1.1.5")
 addSbtPlugin("ch.epfl.scala"        % "sbt-bloop"                     % "2.0.13")
@@ -23,7 +23,7 @@ addSbtPlugin("org.polyvariant" % "smithy-trait-codegen-sbt" % "0.2.3")
 libraryDependencies ++= Seq(
   "com.lihaoyi" %% "os-lib" % "0.10.7",
   "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-macros" % "2.30.15",
-  "com.thesamet.scalapb" %% "compilerplugin" % "1.0.0-alpha.2"
+  "com.thesamet.scalapb" %% "compilerplugin" % "1.0.0-alpha.3"
 )
 
 addDependencyTreePlugin

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -23,7 +23,7 @@ addSbtPlugin("org.polyvariant" % "smithy-trait-codegen-sbt" % "0.2.3")
 libraryDependencies ++= Seq(
   "com.lihaoyi" %% "os-lib" % "0.10.7",
   "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-macros" % "2.30.15",
-  "com.thesamet.scalapb" %% "compilerplugin" % "0.11.15"
+  "com.thesamet.scalapb" %% "compilerplugin" % "1.0.0-alpha.2"
 )
 
 addDependencyTreePlugin

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -11,7 +11,7 @@ addSbtPlugin("com.eed3si9n"         % "sbt-buildinfo"                 % "0.13.1"
 addSbtPlugin("com.eed3si9n"         % "sbt-projectmatrix"             % "0.11.0")
 addSbtPlugin("pl.project13.scala"   % "sbt-jmh"                       % "0.4.7")
 addSbtPlugin("de.heikoseeberger"    % "sbt-header"                    % "5.10.0")
-addSbtPlugin("org.scala-native"     % "sbt-scala-native"              % "0.4.17")
+addSbtPlugin("org.scala-native"     % "sbt-scala-native"              % "0.5.8")
 addSbtPlugin("com.github.sbt"       % "sbt-git"                       % "2.1.0")
 addSbtPlugin("com.typesafe"         % "sbt-mima-plugin"               % "1.1.5")
 addSbtPlugin("ch.epfl.scala"        % "sbt-bloop"                     % "2.0.13")


### PR DESCRIPTION
## TODOS
- [x] rebase on top of https://github.com/disneystreaming/smithy4s/pull/1823
- [x] http4s needs SN 0.5.x version (https://github.com/http4s/http4s/pull/7708)
- [x] [fs2-data](https://github.com/gnieh/fs2-data/) needs SN 0.5.x version (https://github.com/gnieh/fs2-data/pull/704) (for now xml module is disabled)
- [x] [weaver-test #189](https://github.com/typelevel/weaver-test/pull/189) needs publishing - published in https://github.com/typelevel/weaver-test/actions/runs/17407116140/job/49414856635
- [x] `CryptoPlatformCompat` needs adjusting to 0.5.x