### PR TITLE
fix: add 'alloy.openapi' to default allowed namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ When adding entries, please treat them as if they could end up in a release any 
 
 Thank you!
 
+# 0.18.43
+
+* codegen: Allow `alloy.openapi.*` namespaces by default [#1822](https://github.com/disneystreaming/smithy4s/pull/1822)
+
 # 0.18.41
 
 * codegen: Avoid collision with `Schema.*` methods in certain cases of ADT unions in [#1789](https://github.com/disneystreaming/smithy4s/pull/1789)

--- a/build.sbt
+++ b/build.sbt
@@ -207,6 +207,7 @@ lazy val core = projectMatrix
       "smithy.api",
       "smithy.waiters",
       "alloy",
+      "alloy.openapi",
       "alloy.common",
       "alloy.proto"
     ),

--- a/modules/bootstrapped/resources/smithy4s.example.PizzaAdminService.json
+++ b/modules/bootstrapped/resources/smithy4s.example.PizzaAdminService.json
@@ -513,6 +513,7 @@
         },
         "/restaurant/{restaurant}/menu/item": {
             "post": {
+                "summary": "Add item to restaurant menu",
                 "operationId": "AddMenuItem",
                 "requestBody": {
                     "content": {

--- a/modules/bootstrapped/src/generated/smithy4s/example/PizzaAdminService.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/PizzaAdminService.scala
@@ -539,7 +539,7 @@ object PizzaAdminServiceOperation {
       .withInput(AddMenuItemRequest.schema)
       .withError(AddMenuItemError.errorSchema)
       .withOutput(AddMenuItemResult.schema)
-      .withHints(smithy.api.Http(method = smithy.api.NonEmptyString("POST"), uri = smithy.api.NonEmptyString("/restaurant/{restaurant}/menu/item"), code = 201))
+      .withHints(alloy.openapi.Summary("Add item to restaurant menu"), smithy.api.Http(method = smithy.api.NonEmptyString("POST"), uri = smithy.api.NonEmptyString("/restaurant/{restaurant}/menu/item"), code = 201))
     def wrap(input: AddMenuItemRequest): AddMenuItem = AddMenuItem(input)
   }
   sealed trait AddMenuItemError extends scala.Product with scala.Serializable { self =>

--- a/sampleSpecs/pizza.smithy
+++ b/sampleSpecs/pizza.smithy
@@ -3,6 +3,7 @@ $version: "2"
 namespace smithy4s.example
 
 use alloy#simpleRestJson
+use alloy.openapi#summary
 
 @simpleRestJson
 service PizzaAdminService with [CheckQueryService] {
@@ -26,6 +27,7 @@ service PizzaAdminService with [CheckQueryService] {
 }
 
 @http(method: "POST", uri: "/restaurant/{restaurant}/menu/item", code: 201)
+@summary("Add item to restaurant menu")
 operation AddMenuItem {
     input: AddMenuItemRequest
     errors: [


### PR DESCRIPTION
ref: https://github.com/disneystreaming/smithy4s/issues/1817

---

Note: i couldn't add alloy*, that was causing following error (among a lot of other ones)
```
[error] [core3] -- [E008] Not Found Error: /Users/tpetillot/workspace/repositories/disneystreaming/smithy4s/modules/core/src/smithy4s/schema/FieldFilter.scala:20:13 
[error] [core3] 20 |import alloy.Nullable
```