### PR TITLE
Reproduce `possible missing interpolator` weaver bug

### DIFF
--- a/modules/tests/src/smithy4s/tests/PizzaSpec.scala
+++ b/modules/tests/src/smithy4s/tests/PizzaSpec.scala
@@ -440,13 +440,11 @@ abstract class PizzaSpec
         )
         val containsAllExpectedHeaders =
           expectedHeaders.forall(h => headers.get(h._1).contains(h._2))
-        val missingHeadersMessage =
-          s"Expected to find all of $expectedHeaders inside of $headers"
         expect.same(code, 200) &&
         expect.same(body, "") &&
         expect(
           containsAllExpectedHeaders,
-          missingHeadersMessage
+          s"Expected to find all of $expectedHeaders inside of $headers"
         )
       }
   }


### PR DESCRIPTION
This is an attempt to reproduce the `possible missing interpolator` weaver bug in #1823  for https://github.com/typelevel/weaver-test/issues/191

I haven't been able to reproduce it locally.