### PR TITLE
Add OptionalTag trait with default `ScalaOptionTag`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Thank you!
 
 Add `OptionalTag` trait and add the tag to `Schema.OptionSchema` to allow Option-like types to be efficiently created.
 
-# Unseal CollectionTag
+## Unseal CollectionTag
 
 Make `CollectionTag` just a trait instead of a sealed trait to allow third party libraries to implement their own `CollectionTag` so that collections
 can be built efficiently. Existing and new usages of CollectionTags that start getting exhaustivity errors can handle unknown subtypes by using the CollectionTag instance's methods, such as `iterator` and `fromIterator`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ Thank you!
 
 # 0.19.0
 
-## Unseal CollectionTag
+## Add OptionalTag
+
+Add `OptionalTag` trait and add the tag to `Schema.OptionSchema` to allow Option-like types to be efficiently created.
+
+# Unseal CollectionTag
 
 Make `CollectionTag` just a trait instead of a sealed trait to allow third party libraries to implement their own `CollectionTag` so that collections
 can be built efficiently. Existing and new usages of CollectionTags that start getting exhaustivity errors can handle unknown subtypes by using the CollectionTag instance's methods, such as `iterator` and `fromIterator`.

--- a/modules/bootstrapped/test/src/smithy4s/CachedSchemaVisitorSpec.scala
+++ b/modules/bootstrapped/test/src/smithy4s/CachedSchemaVisitorSpec.scala
@@ -124,7 +124,10 @@ class CachedSchemaVisitorSpec() extends FunSuite {
       }
     }
 
-    def option[C[_], A](tag: OptionalTag[C], schema: Schema[A]): ConstUnit[C[A]] = discard {
+    def option[C[_], A](
+        tag: OptionalTag[C],
+        schema: Schema[A]
+    ): ConstUnit[C[A]] = discard {
       self(schema)
       counter.incrementAndGet()
     }

--- a/modules/bootstrapped/test/src/smithy4s/CachedSchemaVisitorSpec.scala
+++ b/modules/bootstrapped/test/src/smithy4s/CachedSchemaVisitorSpec.scala
@@ -124,7 +124,7 @@ class CachedSchemaVisitorSpec() extends FunSuite {
       }
     }
 
-    def option[A](schema: Schema[A]): ConstUnit[Option[A]] = discard {
+    def option[C[_], A](tag: OptionalTag[C], schema: Schema[A]): ConstUnit[C[A]] = discard {
       self(schema)
       counter.incrementAndGet()
     }

--- a/modules/bootstrapped/test/src/smithy4s/schema/HintsTransformationSpec.scala
+++ b/modules/bootstrapped/test/src/smithy4s/schema/HintsTransformationSpec.scala
@@ -258,12 +258,9 @@ class HintsTransformationSpec() extends FunSuite {
       a => underlying(a)
     }
 
-    def option[A](schema: Schema[A]): Count[Option[A]] = {
+    def option[C[_], A](tag: OptionalTag[C], schema: Schema[A]): Count[C[A]] = {
       val count = compile(schema)
-      locally {
-        case Some(a) => count(a)
-        case None    => 0
-      }
+      a => tag.fold(a, count(_), 0)
     }
 
   }

--- a/modules/cats/src/smithy4s/interopcats/SchemaVisitorHash.scala
+++ b/modules/cats/src/smithy4s/interopcats/SchemaVisitorHash.scala
@@ -200,7 +200,12 @@ final class SchemaVisitorHash(
     }
   }
 
-  override def option[C[_], A](tag: OptionalTag[C], schema: Schema[A]): Hash[C[A]] =
-    cats.instances.option.catsKernelStdHashForOption(self(schema)).contramap(tag.toScalaOption(_))
+  override def option[C[_], A](
+      tag: OptionalTag[C],
+      schema: Schema[A]
+  ): Hash[C[A]] =
+    cats.instances.option
+      .catsKernelStdHashForOption(self(schema))
+      .contramap(tag.toScalaOption(_))
 
 }

--- a/modules/cats/src/smithy4s/interopcats/SchemaVisitorHash.scala
+++ b/modules/cats/src/smithy4s/interopcats/SchemaVisitorHash.scala
@@ -196,7 +196,7 @@ final class SchemaVisitorHash(
     }
   }
 
-  override def option[A](schema: Schema[A]): Hash[Option[A]] =
-    cats.instances.option.catsKernelStdHashForOption(self(schema))
+  override def option[C[_], A](tag: OptionalTag[C], schema: Schema[A]): Hash[C[A]] =
+    cats.instances.option.catsKernelStdHashForOption(self(schema)).contramap(tag.toScalaOption(_))
 
 }

--- a/modules/cats/src/smithy4s/interopcats/SchemaVisitorShow.scala
+++ b/modules/cats/src/smithy4s/interopcats/SchemaVisitorShow.scala
@@ -151,7 +151,10 @@ final class SchemaVisitorShow(
     a => ss.value.show(a)
   }
 
-  override def option[C[_], A](tag: OptionalTag[C], schema: Schema[A]): Show[C[A]] = {
+  override def option[C[_], A](
+      tag: OptionalTag[C],
+      schema: Schema[A]
+  ): Show[C[A]] = {
     val showA = self(schema)
     Show.show[C[A]] { opt =>
       tag.fold[A, String](opt, a => s"Some(${showA.show(a)})", "None")

--- a/modules/cats/src/smithy4s/interopcats/SchemaVisitorShow.scala
+++ b/modules/cats/src/smithy4s/interopcats/SchemaVisitorShow.scala
@@ -154,7 +154,7 @@ final class SchemaVisitorShow(
   override def option[C[_], A](tag: OptionalTag[C], schema: Schema[A]): Show[C[A]] = {
     val showA = self(schema)
     Show.show[C[A]] { opt =>
-      tag.fold[A, String](opt, a => s"${tag.name}(${showA.show(a)})", "None")
+      tag.fold[A, String](opt, a => s"Some(${showA.show(a)})", "None")
     }
   }
 

--- a/modules/cats/src/smithy4s/interopcats/SchemaVisitorShow.scala
+++ b/modules/cats/src/smithy4s/interopcats/SchemaVisitorShow.scala
@@ -157,11 +157,10 @@ final class SchemaVisitorShow(
     a => ss.value.show(a)
   }
 
-  override def option[A](schema: Schema[A]): Show[Option[A]] = {
+  override def option[C[_], A](tag: OptionalTag[C], schema: Schema[A]): Show[C[A]] = {
     val showA = self(schema)
-    locally {
-      case None        => "None"
-      case Some(value) => s"Some(${showA.show(value)})"
+    Show.show[C[A]] { opt =>
+      tag.fold[A, String](opt, a => s"${tag.name}(${showA.show(a)})", "None")
     }
   }
 

--- a/modules/compliance-tests/src/smithy4s/compliancetests/internals/DefaultSchemaVisitor.scala
+++ b/modules/compliance-tests/src/smithy4s/compliancetests/internals/DefaultSchemaVisitor.scala
@@ -112,6 +112,6 @@ private[compliancetests] object DefaultSchemaVisitor extends SchemaVisitor[Id] {
     suspend.map(apply).value
   }
 
-  override def option[A](schema: Schema[A]): Id[Option[A]] = None
+  override def option[C[_], A](tag: OptionalTag[C], schema: Schema[A]): Id[C[A]] = tag.none()
 
 }

--- a/modules/compliance-tests/src/smithy4s/compliancetests/internals/DefaultSchemaVisitor.scala
+++ b/modules/compliance-tests/src/smithy4s/compliancetests/internals/DefaultSchemaVisitor.scala
@@ -112,6 +112,9 @@ private[compliancetests] object DefaultSchemaVisitor extends SchemaVisitor[Id] {
     suspend.map(apply).value
   }
 
-  override def option[C[_], A](tag: OptionalTag[C], schema: Schema[A]): Id[C[A]] = tag.none()
+  override def option[C[_], A](
+      tag: OptionalTag[C],
+      schema: Schema[A]
+  ): Id[C[A]] = tag.none()
 
 }

--- a/modules/compliance-tests/src/smithy4s/compliancetests/internals/DefaultSchemaVisitor.scala
+++ b/modules/compliance-tests/src/smithy4s/compliancetests/internals/DefaultSchemaVisitor.scala
@@ -115,6 +115,6 @@ private[compliancetests] object DefaultSchemaVisitor extends SchemaVisitor[Id] {
   override def option[C[_], A](
       tag: OptionalTag[C],
       schema: Schema[A]
-  ): Id[C[A]] = tag.none()
+  ): Id[C[A]] = tag.none
 
 }

--- a/modules/compliance-tests/src/smithy4s/compliancetests/internals/eq/EqSchemaVisitor.scala
+++ b/modules/compliance-tests/src/smithy4s/compliancetests/internals/eq/EqSchemaVisitor.scala
@@ -152,7 +152,7 @@ object EqSchemaVisitor extends SchemaVisitor[Eq] { self =>
     (x: A, y: A) => eq.value.eqv(x, y)
   }
 
-  override def option[A](schema: Schema[A]): Eq[Option[A]] = {
+  override def option[C[_], A](tag: OptionalTag[C], schema: Schema[A]): Eq[C[A]] = {
     LenientOptionalCollectionEquality(schema) match {
       case Some(eq) => eq
       case None     => Eq.catsKernelEqForOption(self(schema))
@@ -182,7 +182,7 @@ object EqSchemaVisitor extends SchemaVisitor[Eq] { self =>
     }
   }
 
-  type EqOpt[A] = Eq[Option[A]]
+  type EqOpt[C[_], A] = Eq[C[A]]
   // A sub-visitor that provides lenient equality for Option-wrapped collections,
   // where None and `Some(Empty)` are considered equivalent. s
   object LenientOptionalCollectionEquality

--- a/modules/compliance-tests/src/smithy4s/compliancetests/internals/eq/EqSchemaVisitor.scala
+++ b/modules/compliance-tests/src/smithy4s/compliancetests/internals/eq/EqSchemaVisitor.scala
@@ -161,8 +161,13 @@ object EqSchemaVisitor extends SchemaVisitor[Eq] { self =>
     (x: A, y: A) => eq.value.eqv(x, y)
   }
 
-  override def option[C[_], A](tag: OptionalTag[C], schema: Schema[A]): Eq[C[A]] = {
-    val optionEq: Eq[Option[A]] = LenientOptionalCollectionEquality(schema) match {
+  override def option[C[_], A](
+      tag: OptionalTag[C],
+      schema: Schema[A]
+  ): Eq[C[A]] = {
+    val optionEq: Eq[Option[A]] = LenientOptionalCollectionEquality(
+      schema
+    ) match {
       case Some(eq) => eq
       case None     => Eq.catsKernelEqForOption(self(schema))
     }

--- a/modules/compliance-tests/src/smithy4s/compliancetests/internals/eq/EqSchemaVisitor.scala
+++ b/modules/compliance-tests/src/smithy4s/compliancetests/internals/eq/EqSchemaVisitor.scala
@@ -162,10 +162,12 @@ object EqSchemaVisitor extends SchemaVisitor[Eq] { self =>
   }
 
   override def option[C[_], A](tag: OptionalTag[C], schema: Schema[A]): Eq[C[A]] = {
-    LenientOptionalCollectionEquality(schema) match {
+    val optionEq: Eq[Option[A]] = LenientOptionalCollectionEquality(schema) match {
       case Some(eq) => eq
       case None     => Eq.catsKernelEqForOption(self(schema))
     }
+
+    Eq.by[C[A], Option[A]](tag.toScalaOption(_))(optionEq)
   }
 
   def primitiveEq[P](primitive: Primitive[P]): Eq[P] = {
@@ -191,11 +193,12 @@ object EqSchemaVisitor extends SchemaVisitor[Eq] { self =>
     }
   }
 
-  type EqOpt[C[_], A] = Eq[C[A]]
+  type EqOpt[A] = Eq[Option[A]]
   // A sub-visitor that provides lenient equality for Option-wrapped collections,
   // where None and `Some(Empty)` are considered equivalent. s
   object LenientOptionalCollectionEquality
       extends SchemaVisitor.Optional[EqOpt] {
+
     override def collection[C[_], A](
         shapeId: ShapeId,
         hints: Hints,
@@ -231,5 +234,4 @@ object EqSchemaVisitor extends SchemaVisitor[Eq] { self =>
       }
     }
   }
-
 }

--- a/modules/core/src/smithy4s/Nullable.scala
+++ b/modules/core/src/smithy4s/Nullable.scala
@@ -67,7 +67,7 @@ object Nullable {
       schema match {
         case bs: BijectionSchema[_, _] if bs.hints.has(alloy.Nullable) =>
           bs.underlying match {
-            case os: OptionSchema[_] => Some(os.underlying)
+            case os: OptionSchema[_, _] => Some(os.underlying)
             case _                   => None
           }
         case _ => None

--- a/modules/core/src/smithy4s/Nullable.scala
+++ b/modules/core/src/smithy4s/Nullable.scala
@@ -68,7 +68,7 @@ object Nullable {
         case bs: BijectionSchema[_, _] if bs.hints.has(alloy.Nullable) =>
           bs.underlying match {
             case os: OptionSchema[_, _] => Some(os.underlying)
-            case _                   => None
+            case _                      => None
           }
         case _ => None
       }

--- a/modules/core/src/smithy4s/codecs/StringAndBlobCodecs.scala
+++ b/modules/core/src/smithy4s/codecs/StringAndBlobCodecs.scala
@@ -124,7 +124,7 @@ object StringAndBlobCodecs {
       )
 
     override def option[C[_], A](
-      tag: OptionalTag[C],
+        tag: OptionalTag[C],
         schema: Schema[A]
     ): MaybeBlobDecoder[C[A]] =
       self(schema).map(decoderA =>
@@ -183,7 +183,7 @@ object StringAndBlobCodecs {
     ): MaybeBlobEncoder[C[A]] =
       self(schema).map(writerA =>
         new BlobEncoder[C[A]] {
-          def encode(maybeA: C[A]): Blob = 
+          def encode(maybeA: C[A]): Blob =
             tag.fold(maybeA, writerA.encode(_), Blob.empty)
         }
       )

--- a/modules/core/src/smithy4s/codecs/StringAndBlobCodecs.scala
+++ b/modules/core/src/smithy4s/codecs/StringAndBlobCodecs.scala
@@ -123,14 +123,15 @@ object StringAndBlobCodecs {
         }
       )
 
-    override def option[A](
+    override def option[C[_], A](
+      tag: OptionalTag[C],
         schema: Schema[A]
-    ): MaybeBlobDecoder[Option[A]] =
+    ): MaybeBlobDecoder[C[A]] =
       self(schema).map(decoderA =>
-        new BlobDecoder[Option[A]] {
-          def decode(blob: Blob): Either[PayloadError, Option[A]] =
-            if (blob.isEmpty) Right(None)
-            else decoderA.decode(blob).map(a => Some(a))
+        new BlobDecoder[C[A]] {
+          def decode(blob: Blob): Either[PayloadError, C[A]] =
+            if (blob.isEmpty) Right(tag.none())
+            else decoderA.decode(blob).map(a => tag.some(a))
         }
       )
   }
@@ -176,15 +177,14 @@ object StringAndBlobCodecs {
     ): MaybeBlobEncoder[B] =
       self(schema).map(_.contramap(refinement.from))
 
-    override def option[A](
+    override def option[C[_], A](
+        tag: OptionalTag[C],
         schema: Schema[A]
-    ): MaybeBlobEncoder[Option[A]] =
+    ): MaybeBlobEncoder[C[A]] =
       self(schema).map(writerA =>
-        new BlobEncoder[Option[A]] {
-          def encode(maybeA: Option[A]): Blob = maybeA match {
-            case Some(a) => writerA.encode(a)
-            case None    => Blob.empty
-          }
+        new BlobEncoder[C[A]] {
+          def encode(maybeA: C[A]): Blob = 
+            tag.fold(maybeA, writerA.encode(_), Blob.empty)
         }
       )
   }

--- a/modules/core/src/smithy4s/codecs/StringAndBlobCodecs.scala
+++ b/modules/core/src/smithy4s/codecs/StringAndBlobCodecs.scala
@@ -130,7 +130,7 @@ object StringAndBlobCodecs {
       self(schema).map(decoderA =>
         new BlobDecoder[C[A]] {
           def decode(blob: Blob): Either[PayloadError, C[A]] =
-            if (blob.isEmpty) Right(tag.none())
+            if (blob.isEmpty) Right(tag.none)
             else decoderA.decode(blob).map(a => tag.some(a))
         }
       )

--- a/modules/core/src/smithy4s/http/HttpMediaType.scala
+++ b/modules/core/src/smithy4s/http/HttpMediaType.scala
@@ -77,7 +77,10 @@ object HttpMediaType extends Newtype[String] {
         refinement: Refinement[A, B]
     ): Option[String] = self(schema)
 
-    override def option[C[_], A](tag: OptionalTag[C], schema: Schema[A]): Option[String] = self(
+    override def option[C[_], A](
+        tag: OptionalTag[C],
+        schema: Schema[A]
+    ): Option[String] = self(
       schema
     )
   }

--- a/modules/core/src/smithy4s/http/HttpMediaType.scala
+++ b/modules/core/src/smithy4s/http/HttpMediaType.scala
@@ -77,7 +77,7 @@ object HttpMediaType extends Newtype[String] {
         refinement: Refinement[A, B]
     ): Option[String] = self(schema)
 
-    override def option[A](schema: Schema[A]): Option[String] = self(
+    override def option[C[_], A](tag: OptionalTag[C], schema: Schema[A]): Option[String] = self(
       schema
     )
   }

--- a/modules/core/src/smithy4s/http/internals/HttpResponseCodeSchemaVisitor.scala
+++ b/modules/core/src/smithy4s/http/internals/HttpResponseCodeSchemaVisitor.scala
@@ -27,10 +27,10 @@ import smithy4s.http.internals.HttpResponseCodeSchemaVisitor.ResponseCodeExtract
 import smithy4s.schema.EnumTag
 import smithy4s.schema.EnumValue
 import smithy4s.schema.Field
+import smithy4s.schema.OptionalTag
 import smithy4s.schema.Primitive
 import smithy4s.schema.Schema
 import smithy4s.schema.SchemaVisitor
-import smithy4s.schema.OptionalTag
 
 class HttpResponseCodeSchemaVisitor()
     extends SchemaVisitor.Default[ResponseCodeExtractor] {

--- a/modules/core/src/smithy4s/http/internals/HttpResponseCodeSchemaVisitor.scala
+++ b/modules/core/src/smithy4s/http/internals/HttpResponseCodeSchemaVisitor.scala
@@ -30,6 +30,7 @@ import smithy4s.schema.Field
 import smithy4s.schema.Primitive
 import smithy4s.schema.Schema
 import smithy4s.schema.SchemaVisitor
+import smithy4s.schema.OptionalTag
 
 class HttpResponseCodeSchemaVisitor()
     extends SchemaVisitor.Default[ResponseCodeExtractor] {
@@ -85,16 +86,17 @@ class HttpResponseCodeSchemaVisitor()
     fields.flatMap(f => compileField(f)).headOption.getOrElse(NoResponseCode)
   }
 
-  override def option[A](
+  override def option[C[_], A](
+      tag: OptionalTag[C],
       schema: Schema[A]
-  ): ResponseCodeExtractor[Option[A]] = {
+  ): ResponseCodeExtractor[C[A]] = {
     val aExt = apply(schema)
     aExt match {
       case NoResponseCode => NoResponseCode
       case RequiredResponseCode(f) =>
-        OptionalResponseCode((_: Option[A]).map(f))
+        OptionalResponseCode[C[A]](tag.toScalaOption(_).map(f))
       case OptionalResponseCode(f) =>
-        OptionalResponseCode((_: Option[A]).flatMap(f))
+        OptionalResponseCode[C[A]](tag.toScalaOption(_).flatMap(f))
     }
   }
 

--- a/modules/core/src/smithy4s/http/internals/SchemaVisitorHeaderSplit.scala
+++ b/modules/core/src/smithy4s/http/internals/SchemaVisitorHeaderSplit.scala
@@ -61,7 +61,7 @@ object SchemaVisitorHeaderSplit
       refinement: Refinement[A, B]
   ): AwsHeaderSplitter[B] = schema.compile(self): Option[String => Seq[String]]
 
-  override def option[A](schema: Schema[A]): AwsHeaderSplitter[Option[A]] =
+  override def option[C[_], A](tag: OptionalTag[C], schema: Schema[A]): AwsHeaderSplitter[C[A]] =
     schema.compile(self): Option[String => Seq[String]]
 
   override def enumeration[E](

--- a/modules/core/src/smithy4s/http/internals/SchemaVisitorHeaderSplit.scala
+++ b/modules/core/src/smithy4s/http/internals/SchemaVisitorHeaderSplit.scala
@@ -61,7 +61,10 @@ object SchemaVisitorHeaderSplit
       refinement: Refinement[A, B]
   ): AwsHeaderSplitter[B] = schema.compile(self): Option[String => Seq[String]]
 
-  override def option[C[_], A](tag: OptionalTag[C], schema: Schema[A]): AwsHeaderSplitter[C[A]] =
+  override def option[C[_], A](
+      tag: OptionalTag[C],
+      schema: Schema[A]
+  ): AwsHeaderSplitter[C[A]] =
     schema.compile(self): Option[String => Seq[String]]
 
   override def enumeration[E](

--- a/modules/core/src/smithy4s/http/internals/SchemaVisitorMetadataReader.scala
+++ b/modules/core/src/smithy4s/http/internals/SchemaVisitorMetadataReader.scala
@@ -264,5 +264,5 @@ private[http] class SchemaVisitorMetadataReader(
       tag: OptionalTag[C],
       schema: Schema[A]
   ): MetaDecode[C[A]] =
-    self(schema).map(tag(_))
+    self(schema).map(tag.fromNullable(_))
 }

--- a/modules/core/src/smithy4s/http/internals/SchemaVisitorMetadataReader.scala
+++ b/modules/core/src/smithy4s/http/internals/SchemaVisitorMetadataReader.scala
@@ -260,6 +260,9 @@ private[http] class SchemaVisitorMetadataReader(
   override def lazily[A](suspend: Lazy[Schema[A]]): MetaDecode[A] =
     EmptyMetaDecode
 
-  override def option[C[_], A](tag: OptionalTag[C], schema: Schema[A]): MetaDecode[C[A]] =
+  override def option[C[_], A](
+      tag: OptionalTag[C],
+      schema: Schema[A]
+  ): MetaDecode[C[A]] =
     self(schema).map(tag(_))
 }

--- a/modules/core/src/smithy4s/http/internals/SchemaVisitorMetadataReader.scala
+++ b/modules/core/src/smithy4s/http/internals/SchemaVisitorMetadataReader.scala
@@ -260,6 +260,6 @@ private[http] class SchemaVisitorMetadataReader(
   override def lazily[A](suspend: Lazy[Schema[A]]): MetaDecode[A] =
     EmptyMetaDecode
 
-  override def option[A](schema: Schema[A]): MetaDecode[Option[A]] =
-    self(schema).map(Some(_))
+  override def option[C[_], A](tag: OptionalTag[C], schema: Schema[A]): MetaDecode[C[A]] =
+    self(schema).map(tag(_))
 }

--- a/modules/core/src/smithy4s/http/internals/SchemaVisitorMetadataWriter.scala
+++ b/modules/core/src/smithy4s/http/internals/SchemaVisitorMetadataWriter.scala
@@ -22,12 +22,12 @@ import smithy.api.HttpQueryParams
 import smithy4s.http.internals.MetaEncode._
 import smithy4s.schema.Alt
 import smithy4s.schema.CollectionTag
-import smithy4s.schema.OptionalTag
 import smithy4s.schema.CompilationCache
 import smithy4s.schema.EnumTag
 import smithy4s.schema.EnumValue
 import smithy4s.schema.Field
 import smithy4s.schema.FieldFilter
+import smithy4s.schema.OptionalTag
 import smithy4s.schema.Primitive
 import smithy4s.schema.SchemaVisitor
 
@@ -112,7 +112,10 @@ class SchemaVisitorMetadataWriter(
 
   }
 
-  override def option[C[_], A](tag: OptionalTag[C], schema: Schema[A]): MetaEncode[C[A]] =
+  override def option[C[_], A](
+      tag: OptionalTag[C],
+      schema: Schema[A]
+  ): MetaEncode[C[A]] =
     self(schema) match {
       case StringValueMetaEncode(f) =>
         StringValueMetaEncode { optional =>

--- a/modules/core/src/smithy4s/http/internals/SchemaVisitorMetadataWriter.scala
+++ b/modules/core/src/smithy4s/http/internals/SchemaVisitorMetadataWriter.scala
@@ -22,6 +22,7 @@ import smithy.api.HttpQueryParams
 import smithy4s.http.internals.MetaEncode._
 import smithy4s.schema.Alt
 import smithy4s.schema.CollectionTag
+import smithy4s.schema.OptionalTag
 import smithy4s.schema.CompilationCache
 import smithy4s.schema.EnumTag
 import smithy4s.schema.EnumValue
@@ -111,27 +112,23 @@ class SchemaVisitorMetadataWriter(
 
   }
 
-  override def option[A](schema: Schema[A]): MetaEncode[Option[A]] =
+  override def option[C[_], A](tag: OptionalTag[C], schema: Schema[A]): MetaEncode[C[A]] =
     self(schema) match {
       case StringValueMetaEncode(f) =>
-        StringValueMetaEncode {
-          case Some(value) => f(value)
-          case None        => ""
+        StringValueMetaEncode { optional =>
+          tag.fold(optional, f(_), "")
         }
       case StringListMetaEncode(f) =>
-        StringListMetaEncode {
-          case Some(value) => f(value)
-          case None        => List.empty
+        StringListMetaEncode { optional =>
+          tag.fold(optional, f(_), List.empty)
         }
       case StringMapMetaEncode(f) =>
-        StringMapMetaEncode {
-          case Some(value) => f(value)
-          case None        => Map.empty
+        StringMapMetaEncode { optional =>
+          tag.fold(optional, f(_), Map.empty)
         }
       case StringListMapMetaEncode(f) =>
-        StringListMapMetaEncode {
-          case Some(value) => f(value)
-          case None        => Map.empty
+        StringListMapMetaEncode { optional =>
+          tag.fold(optional, f(_), Map.empty)
         }
       case EmptyMetaEncode        => EmptyMetaEncode
       case StructureMetaEncode(_) => EmptyMetaEncode

--- a/modules/core/src/smithy4s/http/internals/UrlFormDataDecoder.scala
+++ b/modules/core/src/smithy4s/http/internals/UrlFormDataDecoder.scala
@@ -41,7 +41,7 @@ private[http] trait UrlFormDataDecoder[A] { self =>
     cursor => self.decode(cursor).map(f)
 
   def optional[C[_]](tag: OptionalTag[C]): UrlFormDataDecoder[C[A]] = {
-    case UrlFormCursor(_, Nil) => Right(tag.none())
+    case UrlFormCursor(_, Nil) => Right(tag.none)
     case other                 => self.decode(other).map(tag.some(_))
   }
 }

--- a/modules/core/src/smithy4s/http/internals/UrlFormDataDecoder.scala
+++ b/modules/core/src/smithy4s/http/internals/UrlFormDataDecoder.scala
@@ -19,6 +19,7 @@ package http
 package internals
 
 import smithy4s.codecs.PayloadPath
+import smithy4s.schema.OptionalTag
 
 private[http] trait UrlFormDataDecoder[A] { self =>
 
@@ -39,9 +40,9 @@ private[http] trait UrlFormDataDecoder[A] { self =>
   def map[B](f: A => B): UrlFormDataDecoder[B] =
     cursor => self.decode(cursor).map(f)
 
-  def optional: UrlFormDataDecoder[Option[A]] = {
-    case UrlFormCursor(_, Nil) => Right(None)
-    case other                 => self.decode(other).map(Some(_))
+  def optional[C[_]](tag: OptionalTag[C]): UrlFormDataDecoder[C[A]] = {
+    case UrlFormCursor(_, Nil) => Right(tag.none())
+    case other                 => self.decode(other).map(tag.some(_))
   }
 }
 

--- a/modules/core/src/smithy4s/http/internals/UrlFormDataDecoderSchemaVisitor.scala
+++ b/modules/core/src/smithy4s/http/internals/UrlFormDataDecoderSchemaVisitor.scala
@@ -208,7 +208,10 @@ private[http] class UrlFormDataDecoderSchemaVisitor(
     underlying.decode(_)
   }
 
-  override def option[C[_], A](tag: OptionalTag[C], schema: Schema[A]): UrlFormDataDecoder[C[A]] =
+  override def option[C[_], A](
+      tag: OptionalTag[C],
+      schema: Schema[A]
+  ): UrlFormDataDecoder[C[A]] =
     compile(schema).optional(tag)
 
   private def getKey(hints: Hints, default: String): PayloadPath.Segment =

--- a/modules/core/src/smithy4s/http/internals/UrlFormDataDecoderSchemaVisitor.scala
+++ b/modules/core/src/smithy4s/http/internals/UrlFormDataDecoderSchemaVisitor.scala
@@ -208,8 +208,8 @@ private[http] class UrlFormDataDecoderSchemaVisitor(
     underlying.decode(_)
   }
 
-  override def option[A](schema: Schema[A]): UrlFormDataDecoder[Option[A]] =
-    compile(schema).optional
+  override def option[C[_], A](tag: OptionalTag[C], schema: Schema[A]): UrlFormDataDecoder[C[A]] =
+    compile(schema).optional(tag)
 
   private def getKey(hints: Hints, default: String): PayloadPath.Segment =
     hints

--- a/modules/core/src/smithy4s/http/internals/UrlFormDataEncoderSchemaVisitor.scala
+++ b/modules/core/src/smithy4s/http/internals/UrlFormDataEncoderSchemaVisitor.scala
@@ -186,10 +186,12 @@ private[http] class UrlFormDataEncoderSchemaVisitor(
     underlying.encode(_)
   }
 
-  override def option[C[_], A](tag: OptionalTag[C], schema: Schema[A]): UrlFormDataEncoder[C[A]] = {
+  override def option[C[_], A](
+      tag: OptionalTag[C],
+      schema: Schema[A]
+  ): UrlFormDataEncoder[C[A]] = {
     val encoder = compile(schema)
-    optional =>
-      tag.fold(optional, encoder.encode(_), Nil)
+    optional => tag.fold(optional, encoder.encode(_), Nil)
   }
 
   private def getKey(hints: Hints, default: String): PayloadPath.Segment =

--- a/modules/core/src/smithy4s/http/internals/UrlFormDataEncoderSchemaVisitor.scala
+++ b/modules/core/src/smithy4s/http/internals/UrlFormDataEncoderSchemaVisitor.scala
@@ -186,12 +186,10 @@ private[http] class UrlFormDataEncoderSchemaVisitor(
     underlying.encode(_)
   }
 
-  override def option[A](schema: Schema[A]): UrlFormDataEncoder[Option[A]] = {
+  override def option[C[_], A](tag: OptionalTag[C], schema: Schema[A]): UrlFormDataEncoder[C[A]] = {
     val encoder = compile(schema)
-    ({
-      case Some(value) => encoder.encode(value)
-      case None        => Nil
-    })
+    optional =>
+      tag.fold(optional, encoder.encode(_), Nil)
   }
 
   private def getKey(hints: Hints, default: String): PayloadPath.Segment =

--- a/modules/core/src/smithy4s/internals/DocumentDecoderSchemaVisitor.scala
+++ b/modules/core/src/smithy4s/internals/DocumentDecoderSchemaVisitor.scala
@@ -226,7 +226,10 @@ class DocumentDecoderSchemaVisitor(
     }
   }
 
-  def option[C[_], A](tag: OptionalTag[C], schema: Schema[A]): DocumentDecoder[C[A]] =
+  def option[C[_], A](
+      tag: OptionalTag[C],
+      schema: Schema[A]
+  ): DocumentDecoder[C[A]] =
     new DocumentDecoder[C[A]] {
       val decoder = schema.compile(self)
       val aIsNullable = schema.hints.has(Nullable) && schema.isOption

--- a/modules/core/src/smithy4s/internals/DocumentDecoderSchemaVisitor.scala
+++ b/modules/core/src/smithy4s/internals/DocumentDecoderSchemaVisitor.scala
@@ -238,7 +238,7 @@ class DocumentDecoderSchemaVisitor(
       def apply(
           history: List[PayloadPath.Segment],
           document: smithy4s.Document
-      ): C[A] = if (document == Document.DNull && !aIsNullable) tag.none()
+      ): C[A] = if (document == Document.DNull && !aIsNullable) tag.none
       else tag.some(decoder(history, document))
     }
 

--- a/modules/core/src/smithy4s/internals/DocumentDecoderSchemaVisitor.scala
+++ b/modules/core/src/smithy4s/internals/DocumentDecoderSchemaVisitor.scala
@@ -226,8 +226,8 @@ class DocumentDecoderSchemaVisitor(
     }
   }
 
-  def option[A](schema: Schema[A]): DocumentDecoder[Option[A]] =
-    new DocumentDecoder[Option[A]] {
+  def option[C[_], A](tag: OptionalTag[C], schema: Schema[A]): DocumentDecoder[C[A]] =
+    new DocumentDecoder[C[A]] {
       val decoder = schema.compile(self)
       val aIsNullable = schema.hints.has(Nullable) && schema.isOption
       def expected = decoder.expected
@@ -235,8 +235,8 @@ class DocumentDecoderSchemaVisitor(
       def apply(
           history: List[PayloadPath.Segment],
           document: smithy4s.Document
-      ): Option[A] = if (document == Document.DNull && !aIsNullable) None
-      else Some(decoder(history, document))
+      ): C[A] = if (document == Document.DNull && !aIsNullable) tag.none()
+      else tag.some(decoder(history, document))
     }
 
   override def map[K, V](

--- a/modules/core/src/smithy4s/internals/DocumentEncoderSchemaVisitor.scala
+++ b/modules/core/src/smithy4s/internals/DocumentEncoderSchemaVisitor.scala
@@ -147,7 +147,7 @@ class DocumentEncoderSchemaVisitor(
 
   override def option[C[_], A](tag: OptionalTag[C], schema: Schema[A]): DocumentEncoder[C[A]] = {
     val encoder = self(schema)
-    locally { optional =>
+    optional => {
       tag.fold(optional, encoder.apply(_), Document.DNull)
     }
   }

--- a/modules/core/src/smithy4s/internals/DocumentEncoderSchemaVisitor.scala
+++ b/modules/core/src/smithy4s/internals/DocumentEncoderSchemaVisitor.scala
@@ -145,11 +145,10 @@ class DocumentEncoderSchemaVisitor(
     from[C[A]](c => DArray(tag.iterator(c).map(encoderS.apply).toIndexedSeq))
   }
 
-  override def option[A](schema: Schema[A]): DocumentEncoder[Option[A]] = {
+  override def option[C[_], A](tag: OptionalTag[C], schema: Schema[A]): DocumentEncoder[C[A]] = {
     val encoder = self(schema)
-    locally {
-      case Some(a) => encoder.apply(a)
-      case None    => Document.DNull
+    locally { optional =>
+      tag.fold(optional, encoder.apply(_), Document.DNull)
     }
   }
 

--- a/modules/core/src/smithy4s/internals/DocumentEncoderSchemaVisitor.scala
+++ b/modules/core/src/smithy4s/internals/DocumentEncoderSchemaVisitor.scala
@@ -145,7 +145,10 @@ class DocumentEncoderSchemaVisitor(
     from[C[A]](c => DArray(tag.iterator(c).map(encoderS.apply).toIndexedSeq))
   }
 
-  override def option[C[_], A](tag: OptionalTag[C], schema: Schema[A]): DocumentEncoder[C[A]] = {
+  override def option[C[_], A](
+      tag: OptionalTag[C],
+      schema: Schema[A]
+  ): DocumentEncoder[C[A]] = {
     val encoder = self(schema)
     optional => {
       tag.fold(optional, encoder.apply(_), Document.DNull)

--- a/modules/core/src/smithy4s/internals/SchemaDescription.scala
+++ b/modules/core/src/smithy4s/internals/SchemaDescription.scala
@@ -53,8 +53,8 @@ object SchemaDescription extends SchemaVisitor[SchemaDescription] {
   override def refine[A, B](schema: Schema[A], refinement: Refinement[A,B]): SchemaDescription[B] =
     SchemaDescription.of(apply(schema))
 
-  override def option[A](schema: Schema[A]): SchemaDescription[Option[A]] =
-    SchemaDescription.of("Option")
+  override def option[C[_], A](tag: OptionalTag[C], schema: Schema[A]): SchemaDescription[C[A]] =
+    SchemaDescription.of(tag.name)
 
   override def lazily[A](suspend: Lazy[Schema[A]]): SchemaDescription[A] =
     suspend.map(s => SchemaDescription.of(apply(s))).value

--- a/modules/core/src/smithy4s/internals/SchemaDescriptionDetailed.scala
+++ b/modules/core/src/smithy4s/internals/SchemaDescriptionDetailed.scala
@@ -150,10 +150,11 @@ private[internals] object SchemaDescriptionDetailedImpl
     }
   }
 
-  override def option[A](
+  override def option[C[_], A](
+      tag: OptionalTag[C],
       schema: Schema[A]
-  ): SchemaDescriptionDetailedImpl[Option[A]] =
-    apply(schema).mapResult { desc => s"Option[$desc]" }
+  ): SchemaDescriptionDetailedImpl[C[A]] =
+    apply(schema).mapResult { desc => s"${tag.name}[$desc]" }
 
   val conversion: SchemaDescriptionDetailedImpl ~> SchemaDescription =
     new (SchemaDescriptionDetailedImpl ~> SchemaDescription) {

--- a/modules/core/src/smithy4s/schema/CollectionTag.scala
+++ b/modules/core/src/smithy4s/schema/CollectionTag.scala
@@ -154,7 +154,7 @@ object CollectionTag {
     }
     def refine[A, B](schema: Schema[A], refinement: Refinement[A,B]): MaybeCT[B] = None
     def lazily[A](suspend: Lazy[Schema[A]]): MaybeCT[A] = None
-    def option[C[_], A](tag: OptionalTag[C], schema: Schema[A]) = tag match {
+    def option[C[_], A](tag: OptionalTag[C], schema: Schema[A]): MaybeCT[C[A]] = tag match {
       case OptionalTag.ScalaOptionTag => Some(implicitly[ClassTag[Option[A]]])
       case _ => None
     }

--- a/modules/core/src/smithy4s/schema/CollectionTag.scala
+++ b/modules/core/src/smithy4s/schema/CollectionTag.scala
@@ -153,7 +153,10 @@ object CollectionTag {
     }
     def refine[A, B](schema: Schema[A], refinement: Refinement[A,B]): MaybeCT[B] = None
     def lazily[A](suspend: Lazy[Schema[A]]): MaybeCT[A] = None
-    def option[A](schema: Schema[A]) = Some(implicitly[ClassTag[Option[A]]])
+    def option[C[_], A](tag: OptionalTag[C], schema: Schema[A]) = tag match {
+      case OptionalTag.ScalaOptionTag => Some(implicitly[ClassTag[Option[A]]])
+      case _ => None
+    }
   }
   // format: off
 }

--- a/modules/core/src/smithy4s/schema/DefaultValueSchemaVisitor.scala
+++ b/modules/core/src/smithy4s/schema/DefaultValueSchemaVisitor.scala
@@ -110,5 +110,5 @@ private[schema] object DefaultValueSchemaVisitor extends SchemaVisitor[Option] {
     suspend.map(_.compile(this)).value
 
   def option[C[_], A](tag: OptionalTag[C], schema: Schema[A]): Option[C[A]] =
-    Some(tag.none())
+    Some(tag.none)
 }

--- a/modules/core/src/smithy4s/schema/DefaultValueSchemaVisitor.scala
+++ b/modules/core/src/smithy4s/schema/DefaultValueSchemaVisitor.scala
@@ -109,5 +109,5 @@ private[schema] object DefaultValueSchemaVisitor extends SchemaVisitor[Option] {
   def lazily[A](suspend: Lazy[Schema[A]]): Option[A] =
     suspend.map(_.compile(this)).value
 
-  def option[A](schema: Schema[A]): Option[Option[A]] = Some(None)
+  def option[C[_], A](tag: OptionalTag[C], schema: Schema[A]): Option[C[A]] = Some(tag.none())
 }

--- a/modules/core/src/smithy4s/schema/DefaultValueSchemaVisitor.scala
+++ b/modules/core/src/smithy4s/schema/DefaultValueSchemaVisitor.scala
@@ -109,5 +109,6 @@ private[schema] object DefaultValueSchemaVisitor extends SchemaVisitor[Option] {
   def lazily[A](suspend: Lazy[Schema[A]]): Option[A] =
     suspend.map(_.compile(this)).value
 
-  def option[C[_], A](tag: OptionalTag[C], schema: Schema[A]): Option[C[A]] = Some(tag.none())
+  def option[C[_], A](tag: OptionalTag[C], schema: Schema[A]): Option[C[A]] =
+    Some(tag.none())
 }

--- a/modules/core/src/smithy4s/schema/FieldFilter.scala
+++ b/modules/core/src/smithy4s/schema/FieldFilter.scala
@@ -109,10 +109,10 @@ object FieldFilter {
       case r: RefinementSchema[inner, a] =>
         asNonEmptyCollectionPredicate[inner](r.underlying)
           .map(_.compose(r.refinement.from))
-      case o: OptionSchema[inner] =>
+      case o: OptionSchema[f, inner] =>
         asNonEmptyCollectionPredicate(o.underlying)
           .map(predicateInner =>
-            collectionA => collectionA.exists(predicateInner)
+            collectionA => o.tag.exists(collectionA, predicateInner)
           )
       case _: MapSchema[k, v] =>
         Some(collectionA => collectionA.nonEmpty)
@@ -169,11 +169,11 @@ object FieldFilter {
 
     def apply[A](schema: Schema[A]): Predicate[A] = schema match {
       // nullables are technically never None, so we fall through
-      case OptionSchema(underlying) =>
+      case OptionSchema(tag, underlying) =>
         if (underlying.hints.has(Nullable) && !underlying.isOption)
           Function.const(false)
         else
-          _ == None
+          tag.isNone(_)
 
       case BijectionSchema(underlying, bijection) =>
         this(underlying).compose(bijection.from)

--- a/modules/core/src/smithy4s/schema/FieldFilter.scala
+++ b/modules/core/src/smithy4s/schema/FieldFilter.scala
@@ -112,7 +112,7 @@ object FieldFilter {
       case o: OptionSchema[f, inner] =>
         asNonEmptyCollectionPredicate(o.underlying)
           .map(predicateInner =>
-            collectionA => o.tag.exists(collectionA, predicateInner)
+            (collectionA: f[inner]) => o.tag.exists(collectionA, predicateInner)
           )
       case _: MapSchema[k, v] =>
         Some(collectionA => collectionA.nonEmpty)
@@ -169,11 +169,11 @@ object FieldFilter {
 
     def apply[A](schema: Schema[A]): Predicate[A] = schema match {
       // nullables are technically never None, so we fall through
-      case OptionSchema(tag, underlying) =>
-        if (underlying.hints.has(Nullable) && !underlying.isOption)
+      case o: OptionSchema[f, inner] =>
+        if (o.underlying.hints.has(Nullable) && !o.underlying.isOption)
           Function.const(false)
         else
-          tag.isNone(_)
+          (v: f[inner]) => o.tag.isNone(v)
 
       case BijectionSchema(underlying, bijection) =>
         this(underlying).compose(bijection.from)

--- a/modules/core/src/smithy4s/schema/IsPrimitive.scala
+++ b/modules/core/src/smithy4s/schema/IsPrimitive.scala
@@ -49,7 +49,10 @@ private[schema] object IsPrimitive {
         refinement: Refinement[A, B]
     ): Boolean = self(schema)
 
-    override def option[C[_], A](tag: OptionalTag[C], schema: Schema[A]): Boolean =
+    override def option[C[_], A](
+        tag: OptionalTag[C],
+        schema: Schema[A]
+    ): Boolean =
       self(schema)
 
   }

--- a/modules/core/src/smithy4s/schema/IsPrimitive.scala
+++ b/modules/core/src/smithy4s/schema/IsPrimitive.scala
@@ -1,9 +1,8 @@
 /*
  *  Copyright 2021-2025 Disney Streaming
  *
- *  Licensed under the Tomorrow Open Source Technology License, Version 1.0  "License");
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
  *  you may not use this file except in compliance with the License.
- *  p
  *  You may obtain a copy of the License at
  *
  *     https://disneystreaming.github.io/TOST-1.0.txt

--- a/modules/core/src/smithy4s/schema/IsPrimitive.scala
+++ b/modules/core/src/smithy4s/schema/IsPrimitive.scala
@@ -1,8 +1,9 @@
 /*
  *  Copyright 2021-2025 Disney Streaming
  *
- *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0  "License");
  *  you may not use this file except in compliance with the License.
+ *  p
  *  You may obtain a copy of the License at
  *
  *     https://disneystreaming.github.io/TOST-1.0.txt
@@ -48,7 +49,7 @@ private[schema] object IsPrimitive {
         refinement: Refinement[A, B]
     ): Boolean = self(schema)
 
-    override def option[A](schema: Schema[A]): Boolean =
+    override def option[C[_], A](tag: OptionalTag[C], schema: Schema[A]): Boolean =
       self(schema)
 
   }

--- a/modules/core/src/smithy4s/schema/OptionalTag.scala
+++ b/modules/core/src/smithy4s/schema/OptionalTag.scala
@@ -24,13 +24,13 @@ trait OptionalTag[C[_]] { self =>
     if (a == null) none() else some(a)
   def some[A](a: A): C[A]
   def none[A](): C[A]
-  def map[A, B](a: C[A], fn: A => B): C[B] = 
+  def map[A, B](a: C[A], fn: A => B): C[B] =
     fold[A, C[B]](a, (a: A) => some(fn(a)), none())
 
   def fromScalaOption[A](c: Option[A]): C[A] =
     c match {
       case Some(a) => some(a)
-      case None => none()
+      case None    => none()
     }
   def fold[A, B](c: C[A], isSome: A => B, isNone: => B): B
 
@@ -47,8 +47,10 @@ object OptionalTag {
     override def some[A](a: A): Option[A] = Some(a)
     override def none[A](): Option[A] = None
     override def isNone[A](c: Option[A]): Boolean = c.isEmpty
-    override def exists[A](c: Option[A], fn: A => Boolean): Boolean = c.exists(fn)
-    override def fold[A, B](c: Option[A], isSome: A => B, isNone: => B): B = c.fold(isNone)(isSome)
+    override def exists[A](c: Option[A], fn: A => Boolean): Boolean =
+      c.exists(fn)
+    override def fold[A, B](c: Option[A], isSome: A => B, isNone: => B): B =
+      c.fold(isNone)(isSome)
     override def fromScalaOption[A](c: Option[A]): Option[A] = c
     override def toScalaOption[A](c: Option[A]): Option[A] = c
   }

--- a/modules/core/src/smithy4s/schema/OptionalTag.scala
+++ b/modules/core/src/smithy4s/schema/OptionalTag.scala
@@ -24,6 +24,9 @@ trait OptionalTag[C[_]] { self =>
     if (a == null) some(a) else none()
   def some[A](a: A): C[A]
   def none[A](): C[A]
+  def map[A, B](a: C[A], fn: A => B): C[B] = 
+    fold[A, C[B]](a, (a: A) => some(fn(a)), none())
+
   def fromScalaOption[A](c: Option[A]): C[A] =
     c match {
       case Some(a) => some(a)

--- a/modules/core/src/smithy4s/schema/OptionalTag.scala
+++ b/modules/core/src/smithy4s/schema/OptionalTag.scala
@@ -20,17 +20,17 @@ package schema
 trait OptionalTag[C[_]] { self =>
   def name: String
 
-  def apply[A](a: A): C[A] =
-    if (a == null) none() else some(a)
+  def fromNullable[A](a: A): C[A] =
+    if (a == null) none else some(a)
   def some[A](a: A): C[A]
-  def none[A](): C[A]
+  def none[A]: C[A]
   def map[A, B](a: C[A], fn: A => B): C[B] =
-    fold[A, C[B]](a, (a: A) => some(fn(a)), none())
+    fold[A, C[B]](a, (a: A) => some(fn(a)), none)
 
   def fromScalaOption[A](c: Option[A]): C[A] =
     c match {
       case Some(a) => some(a)
-      case None    => none()
+      case None    => none
     }
   def fold[A, B](c: C[A], isSome: A => B, isNone: => B): B
 
@@ -45,7 +45,7 @@ object OptionalTag {
   case object ScalaOptionTag extends OptionalTag[Option] {
     override def name: String = "Option"
     override def some[A](a: A): Option[A] = Some(a)
-    override def none[A](): Option[A] = None
+    override def none[A]: Option[A] = None
     override def isNone[A](c: Option[A]): Boolean = c.isEmpty
     override def exists[A](c: Option[A], fn: A => Boolean): Boolean =
       c.exists(fn)

--- a/modules/core/src/smithy4s/schema/OptionalTag.scala
+++ b/modules/core/src/smithy4s/schema/OptionalTag.scala
@@ -21,7 +21,7 @@ trait OptionalTag[C[_]] { self =>
   def name: String
 
   def apply[A](a: A): C[A] =
-    if (a == null) some(a) else none()
+    if (a == null) none() else some(a)
   def some[A](a: A): C[A]
   def none[A](): C[A]
   def map[A, B](a: C[A], fn: A => B): C[B] = 

--- a/modules/core/src/smithy4s/schema/OptionalTag.scala
+++ b/modules/core/src/smithy4s/schema/OptionalTag.scala
@@ -1,0 +1,53 @@
+/*
+ *  Copyright 2021-2025 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package smithy4s
+package schema
+
+trait OptionalTag[C[_]] { self =>
+  def name: String
+
+  def apply[A](a: A): C[A] =
+    if (a == null) some(a) else none()
+  def some[A](a: A): C[A]
+  def none[A](): C[A]
+  def fromScalaOption[A](c: Option[A]): C[A] =
+    c match {
+      case Some(a) => some(a)
+      case None => none()
+    }
+  def fold[A, B](c: C[A], isSome: A => B, isNone: => B): B
+
+  def isNone[A](c: C[A]): Boolean
+  def exists[A](c: C[A], fn: A => Boolean): Boolean
+  def toScalaOption[A](c: C[A]): Option[A] =
+    self.fold(c, Some[A](_), None)
+}
+
+object OptionalTag {
+
+  case object ScalaOptionTag extends OptionalTag[Option] {
+    override def name: String = "Option"
+    override def some[A](a: A): Option[A] = Some(a)
+    override def none[A](): Option[A] = None
+    override def isNone[A](c: Option[A]): Boolean = c.isEmpty
+    override def exists[A](c: Option[A], fn: A => Boolean): Boolean = c.exists(fn)
+    override def fold[A, B](c: Option[A], isSome: A => B, isNone: => B): B = c.fold(isNone)(isSome)
+    override def fromScalaOption[A](c: Option[A]): Option[A] = c
+    override def toScalaOption[A](c: Option[A]): Option[A] = c
+  }
+
+}

--- a/modules/core/src/smithy4s/schema/Schema.scala
+++ b/modules/core/src/smithy4s/schema/Schema.scala
@@ -357,7 +357,7 @@ object Schema {
 
   private object OptionDefaultVisitor extends SchemaVisitor.Default[Option] {
     def default[A] : Option[A] = None
-    override def option[C[_], A](tag: OptionalTag[C], schema: Schema[A]) : Option[C[A]] = Some(tag.none())
+    override def option[C[_], A](tag: OptionalTag[C], schema: Schema[A]) : Option[C[A]] = Some(tag.none)
     override def biject[A, B](schema: Schema[A], bijection: Bijection[A, B]): Option[B] = {
       if (schema.hints.has[alloy.Nullable]) None else this.apply(schema).map(bijection.to)
     }
@@ -386,7 +386,7 @@ object Schema {
         None
       }
     
-    override def option[C[_], A](tag: OptionalTag[C], schema: Schema[A]): Option[C[A]] = Some(tag.none())
+    override def option[C[_], A](tag: OptionalTag[C], schema: Schema[A]): Option[C[A]] = Some(tag.none)
   }
 
 }

--- a/modules/core/src/smithy4s/schema/Schema.scala
+++ b/modules/core/src/smithy4s/schema/Schema.scala
@@ -49,7 +49,7 @@ sealed trait Schema[A]{
     case BijectionSchema(schema, bijection) => BijectionSchema(schema.withId(newId), bijection)
     case RefinementSchema(schema, refinement) => RefinementSchema(schema.withId(newId), refinement)
     case LazySchema(suspend) => LazySchema(suspend.map(_.withId(newId)))
-    case s: OptionSchema[a] => OptionSchema(s.underlying.withId(newId)).asInstanceOf[Schema[A]]
+    case s: OptionSchema[c, a] => OptionSchema(s.tag, s.underlying.withId(newId)).asInstanceOf[Schema[A]]
   }
 
   final def withId(namespace: String, name: String): Schema[A] = withId(ShapeId(namespace, name))
@@ -64,7 +64,7 @@ sealed trait Schema[A]{
     case BijectionSchema(schema, bijection) => BijectionSchema(schema.transformHintsLocally(f), bijection)
     case RefinementSchema(schema, refinement) => RefinementSchema(schema.transformHintsLocally(f), refinement)
     case LazySchema(suspend) => LazySchema(suspend.map(_.transformHintsLocally(f)))
-    case s: OptionSchema[a] => OptionSchema(s.underlying.transformHintsLocally(f)).asInstanceOf[Schema[A]]
+    case s: OptionSchema[c, a] => OptionSchema(s.tag, s.underlying.transformHintsLocally(f)).asInstanceOf[Schema[A]]
   }
 
 
@@ -97,7 +97,7 @@ sealed trait Schema[A]{
   final def nullable: Schema[Nullable[A]] = Nullable.schema(this)
 
   final def isOption: Boolean = this match {
-    case _: OptionSchema[_] => true
+    case _: OptionSchema[_, _] => true
     case BijectionSchema(underlying, _) => underlying.isOption
     case RefinementSchema(underlying, _) => underlying.isOption
     case _ => false
@@ -170,7 +170,7 @@ object Schema {
   final case class EnumerationSchema[E](shapeId: ShapeId, hints: Hints, tag: EnumTag[E], values: List[EnumValue[E]]) extends Schema[E]
   final case class StructSchema[S](shapeId: ShapeId, hints: Hints, fields: Vector[Field[S, _]], make: IndexedSeq[Any] => S) extends Schema[S]
   final case class UnionSchema[U](shapeId: ShapeId, hints: Hints, alternatives: Vector[Alt[U, _]], ordinal: U => Int) extends Schema[U]
-  final case class OptionSchema[A](underlying: Schema[A]) extends Schema[Option[A]]{
+  final case class OptionSchema[C[_], A](tag: OptionalTag[C], underlying: Schema[A]) extends Schema[C[A]]{
     def hints: Hints = underlying.hints
     def shapeId: ShapeId = underlying.shapeId
   }
@@ -226,8 +226,8 @@ object Schema {
         underlying(m.copy(key = this(m.key), value = this(m.value)))
       case s @ StructSchema(_, _, _, _) =>
         underlying(s.copy(fields = s.fields.map(handleField(_))))
-      case n @ OptionSchema(_) =>
-        underlying(n.copy(underlying = this(n.underlying)))
+      case o: OptionSchema[c, a] =>
+        underlying(o.copy(underlying = this(o.underlying)))
     }
 
     private def handleField[S, A](
@@ -284,7 +284,7 @@ object Schema {
   def map[K, V](k: Schema[K], v: Schema[V]): Schema[Map[K, V]] = Schema.MapSchema(placeholder, Hints.empty, k, v)
   def sparseMap[K, V](k: Schema[K], v: Schema[V]): Schema[Map[K, Option[V]]] = Schema.MapSchema(placeholder, Hints.empty, k, option(v))
 
-  def option[A](s: Schema[A]): Schema[Option[A]] = Schema.OptionSchema(s)
+  def option[A](s: Schema[A]): Schema[Option[A]] = Schema.OptionSchema(OptionalTag.ScalaOptionTag, s)
 
   def recursive[A](s: => Schema[A]): Schema[A] = Schema.LazySchema(Lazy(s))
 
@@ -357,7 +357,7 @@ object Schema {
 
   private object OptionDefaultVisitor extends SchemaVisitor.Default[Option] {
     def default[A] : Option[A] = None
-    override def option[A](schema: Schema[A]) : Option[Option[A]] = Some(None)
+    override def option[C[_], A](tag: OptionalTag[C], schema: Schema[A]) : Option[C[A]] = Some(tag.none())
     override def biject[A, B](schema: Schema[A], bijection: Bijection[A, B]): Option[B] = {
       if (schema.hints.has[alloy.Nullable]) None else this.apply(schema).map(bijection.to)
     }
@@ -386,7 +386,7 @@ object Schema {
         None
       }
     
-    override def option[A](schema: Schema[A]): Option[Option[A]] = Some(None)
+    override def option[C[_], A](tag: OptionalTag[C], schema: Schema[A]): Option[C[A]] = Some(tag.none())
   }
 
 }

--- a/modules/core/src/smithy4s/schema/SchemaVisitor.scala
+++ b/modules/core/src/smithy4s/schema/SchemaVisitor.scala
@@ -1,4 +1,4 @@
-/*schemavisito
+/*
  *  Copyright 2021-2025 Disney Streaming
  *
  *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");

--- a/modules/core/src/smithy4s/schema/SchemaVisitor.scala
+++ b/modules/core/src/smithy4s/schema/SchemaVisitor.scala
@@ -1,4 +1,5 @@
-/*
+
+/*schemavisito
  *  Copyright 2021-2025 Disney Streaming
  *
  *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
@@ -17,7 +18,7 @@
 package smithy4s
 package schema
 
-// import smithy4s.kinds.OptionK
+import smithy4s.kinds.OptionK
 
 import Schema._
 
@@ -67,9 +68,9 @@ object SchemaVisitor { outer =>
     override def option[C[_], A](tag: OptionalTag[C], schema: Schema[A]): F[C[A]] = default
   }
 
-  // trait Optional[F[_]] extends Default[OptionK[F, *]]{
-  //   def default[A]: Option[F[A]] = None
-  // }
+  trait Optional[F[_]] extends Default[OptionK[F, *]]{
+    def default[A]: Option[F[A]] = None
+  }
 
   abstract class Cached[F[_]] extends SchemaVisitor[F] {
     protected val cache: CompilationCache[F]

--- a/modules/core/src/smithy4s/schema/SchemaVisitor.scala
+++ b/modules/core/src/smithy4s/schema/SchemaVisitor.scala
@@ -17,7 +17,7 @@
 package smithy4s
 package schema
 
-import smithy4s.kinds.OptionK
+// import smithy4s.kinds.OptionK
 
 import Schema._
 
@@ -32,7 +32,7 @@ trait SchemaVisitor[F[_]] extends (Schema ~> F) { self =>
   def biject[A, B](schema: Schema[A], bijection: Bijection[A, B]): F[B]
   def refine[A, B](schema: Schema[A], refinement: Refinement[A, B]): F[B]
   def lazily[A](suspend: Lazy[Schema[A]]): F[A]
-  def option[A](schema: Schema[A]): F[Option[A]]
+  def option[C[_], A](tag: OptionalTag[C], schema: Schema[A]): F[C[A]]
 
   def apply[A](schema: Schema[A]): F[A] = schema match {
     case PrimitiveSchema(shapeId, hints, tag) => primitive(shapeId, hints, tag)
@@ -44,7 +44,7 @@ trait SchemaVisitor[F[_]] extends (Schema ~> F) { self =>
     case BijectionSchema(schema, bijection) => biject(schema, bijection)
     case RefinementSchema(schema, refinement) => refine(schema, refinement)
     case LazySchema(make) => lazily(make)
-    case OptionSchema(a) => option(a)
+    case o: OptionSchema[c, a] => option[c,a](o.tag, o.underlying)
   }
 
 }
@@ -64,13 +64,12 @@ object SchemaVisitor { outer =>
     override def biject[A, B](schema: Schema[A], bijection: Bijection[A, B]): F[B] = default
     override def refine[A, B](schema: Schema[A], refinement: Refinement[A, B]): F[B] = default
     override def lazily[A](suspend: Lazy[Schema[A]]): F[A] = default
-    override def option[A](schema: Schema[A]): F[Option[A]] = default
+    override def option[C[_], A](tag: OptionalTag[C], schema: Schema[A]): F[C[A]] = default
   }
 
-  trait Optional[F[_]] extends Default[OptionK[F, *]]{
-    def default[A]: Option[F[A]] = None
-  }
-
+  // trait Optional[F[_]] extends Default[OptionK[F, *]]{
+  //   def default[A]: Option[F[A]] = None
+  // }
 
   abstract class Cached[F[_]] extends SchemaVisitor[F] {
     protected val cache: CompilationCache[F]

--- a/modules/core/src/smithy4s/schema/SchemaVisitor.scala
+++ b/modules/core/src/smithy4s/schema/SchemaVisitor.scala
@@ -1,4 +1,3 @@
-
 /*schemavisito
  *  Copyright 2021-2025 Disney Streaming
  *

--- a/modules/decline/src/core/OptsVisitor.scala
+++ b/modules/decline/src/core/OptsVisitor.scala
@@ -359,6 +359,9 @@ object OptsVisitor extends SchemaVisitor[Opts] { self =>
         Validated.fromEither(refinement(a).leftMap(NonEmptyList.one))
       )
 
-  override def option[C[_], A](tag: OptionalTag[C], schema: Schema[A]): Opts[C[A]] =
+  override def option[C[_], A](
+      tag: OptionalTag[C],
+      schema: Schema[A]
+  ): Opts[C[A]] =
     schema.compile(this).map(tag.some(_)).withDefault(tag.none())
 }

--- a/modules/decline/src/core/OptsVisitor.scala
+++ b/modules/decline/src/core/OptsVisitor.scala
@@ -276,7 +276,7 @@ object OptsVisitor extends SchemaVisitor[Opts] { self =>
 
       case _: StructSchema[_] | _: Schema.CollectionSchema[_, _] |
           _: Schema.UnionSchema[_] | _: Schema.LazySchema[_] |
-          _: Schema.MapSchema[_, _] | _: Schema.OptionSchema[_] =>
+          _: Schema.MapSchema[_, _] | _: Schema.OptionSchema[_, _] =>
         jsonFieldPlural(member.addHints(hints))
 
     }
@@ -359,6 +359,6 @@ object OptsVisitor extends SchemaVisitor[Opts] { self =>
         Validated.fromEither(refinement(a).leftMap(NonEmptyList.one))
       )
 
-  override def option[A](schema: Schema[A]): Opts[Option[A]] =
-    schema.compile(this).orNone
+  override def option[C[_], A](tag: OptionalTag[C], schema: Schema[A]): Opts[C[A]] =
+    schema.compile(this).map(tag.some(_)).withDefault(tag.none())
 }

--- a/modules/decline/src/core/OptsVisitor.scala
+++ b/modules/decline/src/core/OptsVisitor.scala
@@ -363,5 +363,5 @@ object OptsVisitor extends SchemaVisitor[Opts] { self =>
       tag: OptionalTag[C],
       schema: Schema[A]
   ): Opts[C[A]] =
-    schema.compile(this).map(tag.some(_)).withDefault(tag.none())
+    schema.compile(this).map(tag.some(_)).withDefault(tag.none)
 }

--- a/modules/dynamic/src-jvm/internals/conversion/ToSmithyVisitor.scala
+++ b/modules/dynamic/src-jvm/internals/conversion/ToSmithyVisitor.scala
@@ -277,7 +277,10 @@ private[dynamic] object ToSmithyVisitor extends SchemaVisitor[ToSmithy] {
     }
   }
 
-  def option[C[_], A](tag: OptionalTag[C], schema: Schema[A]): ShapeRecorder[ShapeId] =
+  def option[C[_], A](
+      tag: OptionalTag[C],
+      schema: Schema[A]
+  ): ShapeRecorder[ShapeId] =
     self(schema)
 
 }

--- a/modules/dynamic/src-jvm/internals/conversion/ToSmithyVisitor.scala
+++ b/modules/dynamic/src-jvm/internals/conversion/ToSmithyVisitor.scala
@@ -277,7 +277,7 @@ private[dynamic] object ToSmithyVisitor extends SchemaVisitor[ToSmithy] {
     }
   }
 
-  def option[A](schema: Schema[A]): ShapeRecorder[ShapeId] =
+  def option[C[_], A](tag: OptionalTag[C], schema: Schema[A]): ShapeRecorder[ShapeId] =
     self(schema)
 
 }

--- a/modules/dynamic/test/src-jvm/smithy4s/dynamic/DynamicFieldModifierSpec.scala
+++ b/modules/dynamic/test/src-jvm/smithy4s/dynamic/DynamicFieldModifierSpec.scala
@@ -70,7 +70,7 @@ class DynamicFieldModifierSpec() extends DummyIO.Suite {
     checkNullable(field, false)
     field.schema match {
       case Schema.OptionSchema(_, s) => expectPrimitiveStringSchema(s)
-      case other                  => fail(s"Expected option schema, got $other")
+      case other => fail(s"Expected option schema, got $other")
     }
   }
 

--- a/modules/dynamic/test/src-jvm/smithy4s/dynamic/DynamicFieldModifierSpec.scala
+++ b/modules/dynamic/test/src-jvm/smithy4s/dynamic/DynamicFieldModifierSpec.scala
@@ -69,7 +69,7 @@ class DynamicFieldModifierSpec() extends DummyIO.Suite {
     checkRequired(field, false)
     checkNullable(field, false)
     field.schema match {
-      case Schema.OptionSchema(s) => expectPrimitiveStringSchema(s)
+      case Schema.OptionSchema(_, s) => expectPrimitiveStringSchema(s)
       case other                  => fail(s"Expected option schema, got $other")
     }
   }
@@ -108,7 +108,7 @@ class DynamicFieldModifierSpec() extends DummyIO.Suite {
     checkRequired(field, false)
     checkNullable(field, true)
     field.schema match {
-      case Schema.OptionSchema(Nullable.Schema(s)) =>
+      case Schema.OptionSchema(_, Nullable.Schema(s)) =>
         expectPrimitiveStringSchema(s)
       case other => fail(s"Expected optional nullable schema, got $other")
     }

--- a/modules/dynamic/test/src-jvm/smithy4s/dynamic/DynamicStabilitySpec.scala
+++ b/modules/dynamic/test/src-jvm/smithy4s/dynamic/DynamicStabilitySpec.scala
@@ -228,7 +228,10 @@ class DynamicStabilitySpec extends FunSuite {
       }
     }
 
-    def option[C[_], A](tag: OptionalTag[C], schema: Schema[A]): ConstUnit[C[A]] = {
+    def option[C[_], A](
+        tag: OptionalTag[C],
+        schema: Schema[A]
+    ): ConstUnit[C[A]] = {
       self(schema)
     }
   }

--- a/modules/dynamic/test/src-jvm/smithy4s/dynamic/DynamicStabilitySpec.scala
+++ b/modules/dynamic/test/src-jvm/smithy4s/dynamic/DynamicStabilitySpec.scala
@@ -228,7 +228,7 @@ class DynamicStabilitySpec extends FunSuite {
       }
     }
 
-    def option[A](schema: Schema[A]): ConstUnit[Option[A]] = {
+    def option[C[_], A](tag: OptionalTag[C], schema: Schema[A]): ConstUnit[C[A]] = {
       self(schema)
     }
   }

--- a/modules/json/src/smithy4s/json/internals/SchemaVisitorJCodec.scala
+++ b/modules/json/src/smithy4s/json/internals/SchemaVisitorJCodec.scala
@@ -1388,7 +1388,10 @@ private[smithy4s] class SchemaVisitorJCodec(
       out.writeKey(tag.value(x))
   }
 
-  override def option[C[_], A](tag: OptionalTag[C], schema: Schema[A]): JCodec[C[A]] =
+  override def option[C[_], A](
+      tag: OptionalTag[C],
+      schema: Schema[A]
+  ): JCodec[C[A]] =
     new JCodec[C[A]] {
       val underlying: JCodec[A] = self(schema)
       val aIsNullable =
@@ -1396,17 +1399,20 @@ private[smithy4s] class SchemaVisitorJCodec(
       def expecting: String = s"JsNull or ${underlying.expecting}"
       def decodeKey(in: JsonReader): C[A] = ???
       def encodeKey(x: C[A], out: JsonWriter): Unit = ???
-      def encodeValue(x: C[A], out: JsonWriter): Unit = tag.toScalaOption(x) match {
-        case None        => out.writeNull()
-        case Some(value) => underlying.encodeValue(value, out)
-      }
+      def encodeValue(x: C[A], out: JsonWriter): Unit =
+        tag.toScalaOption(x) match {
+          case None        => out.writeNull()
+          case Some(value) => underlying.encodeValue(value, out)
+        }
 
       def decodeValue(cursor: Cursor, in: JsonReader): C[A] =
         // if `A` is an option and has nullable, we delegate the handling of `null` to it.
         // This allows for supporting Json-merge patches, where the absence of value
         // and the presence of "null" have different meanings.
         if (in.isNextToken('n') && !aIsNullable)
-          tag.fromScalaOption(in.readNullOrError[Option[A]](None, "Expected null"))
+          tag.fromScalaOption(
+            in.readNullOrError[Option[A]](None, "Expected null")
+          )
         else {
           in.rollbackToken()
           tag.some(underlying.decodeValue(cursor, in))

--- a/modules/json/src/smithy4s/json/internals/SchemaVisitorJCodec.scala
+++ b/modules/json/src/smithy4s/json/internals/SchemaVisitorJCodec.scala
@@ -1388,28 +1388,28 @@ private[smithy4s] class SchemaVisitorJCodec(
       out.writeKey(tag.value(x))
   }
 
-  override def option[A](schema: Schema[A]): JCodec[Option[A]] =
-    new JCodec[Option[A]] {
+  override def option[C[_], A](tag: OptionalTag[C], schema: Schema[A]): JCodec[C[A]] =
+    new JCodec[C[A]] {
       val underlying: JCodec[A] = self(schema)
       val aIsNullable =
         schema.hints.has(Nullable) && schema.isOption
       def expecting: String = s"JsNull or ${underlying.expecting}"
-      def decodeKey(in: JsonReader): Option[A] = ???
-      def encodeKey(x: Option[A], out: JsonWriter): Unit = ???
-      def encodeValue(x: Option[A], out: JsonWriter): Unit = x match {
+      def decodeKey(in: JsonReader): C[A] = ???
+      def encodeKey(x: C[A], out: JsonWriter): Unit = ???
+      def encodeValue(x: C[A], out: JsonWriter): Unit = tag.toScalaOption(x) match {
         case None        => out.writeNull()
         case Some(value) => underlying.encodeValue(value, out)
       }
 
-      def decodeValue(cursor: Cursor, in: JsonReader): Option[A] =
+      def decodeValue(cursor: Cursor, in: JsonReader): C[A] =
         // if `A` is an option and has nullable, we delegate the handling of `null` to it.
         // This allows for supporting Json-merge patches, where the absence of value
         // and the presence of "null" have different meanings.
         if (in.isNextToken('n') && !aIsNullable)
-          in.readNullOrError[Option[A]](None, "Expected null")
+          tag.fromScalaOption(in.readNullOrError[Option[A]](None, "Expected null"))
         else {
           in.rollbackToken()
-          Some(underlying.decodeValue(cursor, in))
+          tag.some(underlying.decodeValue(cursor, in))
         }
     }
 

--- a/modules/protobuf/src/main/scala/smithy4s/protobuf/internals/TaggedCodecSchemaVisitor.scala
+++ b/modules/protobuf/src/main/scala/smithy4s/protobuf/internals/TaggedCodecSchemaVisitor.scala
@@ -366,9 +366,9 @@ private[protobuf] class TaggedCodecSchemaVisitor(val cache: CompilationCache[Tag
   def lazily[A](suspend: Lazy[Schema[A]]): TaggedCodec[A] =
     RecursiveCodec(suspend.map(this.apply))
 
-  def option[A](schema: Schema[A]): TaggedCodec[Option[A]] = {
+  def option[C[_], A](tag: OptionalTag[C], schema: Schema[A]): TaggedCodec[C[A]] = {
     val underlying = this(schema)
-    OptionCodec(underlying)
+    OptionCodec(underlying).imap(tag.fromScalaOption(_), tag.toScalaOption(_))
   }
 
 }

--- a/modules/scalacheck/src/smithy4s/scalacheck/SchemaVisitorGen.scala
+++ b/modules/scalacheck/src/smithy4s/scalacheck/SchemaVisitorGen.scala
@@ -128,7 +128,7 @@ abstract class SchemaVisitorGen extends SchemaVisitor[Gen] { self =>
   def lazily[A](suspend: Lazy[Schema[A]]): Gen[A] =
     Gen.lzy(suspend.map(_.compile(this)).value)
 
-  def option[A](schema: Schema[A]): Gen[Option[A]] = Gen.option(this(schema))
+  def option[C[_], A](tag: OptionalTag[C], schema: Schema[A]): Gen[C[A]] = Gen.option(this(schema)).map(tag.fromScalaOption(_))
 
   // //////////////////////////////////////////////////////////////////////////////////////
   // // HELPER FUNCTIONS

--- a/modules/test-utils/src/smithy4s/tests/DefaultSchemaVisitor.scala
+++ b/modules/test-utils/src/smithy4s/tests/DefaultSchemaVisitor.scala
@@ -20,10 +20,10 @@ package tests
 import cats.Id
 import smithy4s.schema.Alt
 import smithy4s.schema.CollectionTag
-import smithy4s.schema.OptionalTag
 import smithy4s.schema.EnumTag
 import smithy4s.schema.EnumValue
 import smithy4s.schema.Field
+import smithy4s.schema.OptionalTag
 import smithy4s.schema.Primitive
 import smithy4s.schema.Primitive._
 import smithy4s.schema.Schema
@@ -110,5 +110,8 @@ object DefaultSchemaVisitor extends SchemaVisitor[Id] { self =>
 
   override def lazily[A](suspend: Lazy[Schema[A]]): Id[A] = ???
 
-  override def option[C[_], A](tag: OptionalTag[C], schema: Schema[A]): Id[C[A]] = tag.none()
+  override def option[C[_], A](
+      tag: OptionalTag[C],
+      schema: Schema[A]
+  ): Id[C[A]] = tag.none()
 }

--- a/modules/test-utils/src/smithy4s/tests/DefaultSchemaVisitor.scala
+++ b/modules/test-utils/src/smithy4s/tests/DefaultSchemaVisitor.scala
@@ -20,6 +20,7 @@ package tests
 import cats.Id
 import smithy4s.schema.Alt
 import smithy4s.schema.CollectionTag
+import smithy4s.schema.OptionalTag
 import smithy4s.schema.EnumTag
 import smithy4s.schema.EnumValue
 import smithy4s.schema.Field
@@ -109,5 +110,5 @@ object DefaultSchemaVisitor extends SchemaVisitor[Id] { self =>
 
   override def lazily[A](suspend: Lazy[Schema[A]]): Id[A] = ???
 
-  override def option[A](schema: Schema[A]): Id[Option[A]] = None
+  override def option[C[_], A](tag: OptionalTag[C], schema: Schema[A]): Id[C[A]] = tag.none()
 }

--- a/modules/test-utils/src/smithy4s/tests/DefaultSchemaVisitor.scala
+++ b/modules/test-utils/src/smithy4s/tests/DefaultSchemaVisitor.scala
@@ -113,5 +113,5 @@ object DefaultSchemaVisitor extends SchemaVisitor[Id] { self =>
   override def option[C[_], A](
       tag: OptionalTag[C],
       schema: Schema[A]
-  ): Id[C[A]] = tag.none()
+  ): Id[C[A]] = tag.none
 }

--- a/modules/xml/src/smithy4s/xml/internals/XmlDecoder.scala
+++ b/modules/xml/src/smithy4s/xml/internals/XmlDecoder.scala
@@ -17,8 +17,8 @@
 package smithy4s.xml
 package internals
 
-import smithy4s.schema.OptionalTag
 import smithy4s.ConstraintError
+import smithy4s.schema.OptionalTag
 import smithy4s.xml.XmlDocument.XmlQName
 import smithy4s.xml.internals.XmlCursor._
 
@@ -57,14 +57,15 @@ private[smithy4s] trait XmlDecoder[A] { self =>
       self.decode(cursor.attr(attr))
   }
 
-  def optional[C[_]](tag: OptionalTag[C]): XmlDecoder[C[A]] = new XmlDecoder[C[A]] {
-    def decode(cursor: XmlCursor): Either[XmlDecodeError, C[A]] = {
-      cursor match {
-        case NoNode(_) => Right(tag.none())
-        case other     => self.decode(other).map(tag.some(_))
+  def optional[C[_]](tag: OptionalTag[C]): XmlDecoder[C[A]] =
+    new XmlDecoder[C[A]] {
+      def decode(cursor: XmlCursor): Either[XmlDecodeError, C[A]] = {
+        cursor match {
+          case NoNode(_) => Right(tag.none())
+          case other     => self.decode(other).map(tag.some(_))
+        }
       }
     }
-  }
   def withDefault(value: A): XmlDecoder[A] = new XmlDecoder[A] {
     def decode(cursor: XmlCursor): Either[XmlDecodeError, A] = cursor match {
       case NoNode(_) => Right(value)

--- a/modules/xml/src/smithy4s/xml/internals/XmlDecoder.scala
+++ b/modules/xml/src/smithy4s/xml/internals/XmlDecoder.scala
@@ -17,6 +17,7 @@
 package smithy4s.xml
 package internals
 
+import smithy4s.schema.OptionalTag
 import smithy4s.ConstraintError
 import smithy4s.xml.XmlDocument.XmlQName
 import smithy4s.xml.internals.XmlCursor._
@@ -55,11 +56,12 @@ private[smithy4s] trait XmlDecoder[A] { self =>
     def decode(cursor: XmlCursor): Either[XmlDecodeError, A] =
       self.decode(cursor.attr(attr))
   }
-  def optional: XmlDecoder[Option[A]] = new XmlDecoder[Option[A]] {
-    def decode(cursor: XmlCursor): Either[XmlDecodeError, Option[A]] = {
+
+  def optional[C[_]](tag: OptionalTag[C]): XmlDecoder[C[A]] = new XmlDecoder[C[A]] {
+    def decode(cursor: XmlCursor): Either[XmlDecodeError, C[A]] = {
       cursor match {
-        case NoNode(_) => Right(None)
-        case other     => self.decode(other).map(Some(_))
+        case NoNode(_) => Right(tag.none())
+        case other     => self.decode(other).map(tag.some(_))
       }
     }
   }

--- a/modules/xml/src/smithy4s/xml/internals/XmlDecoder.scala
+++ b/modules/xml/src/smithy4s/xml/internals/XmlDecoder.scala
@@ -61,7 +61,7 @@ private[smithy4s] trait XmlDecoder[A] { self =>
     new XmlDecoder[C[A]] {
       def decode(cursor: XmlCursor): Either[XmlDecodeError, C[A]] = {
         cursor match {
-          case NoNode(_) => Right(tag.none())
+          case NoNode(_) => Right(tag.none)
           case other     => self.decode(other).map(tag.some(_))
         }
       }

--- a/modules/xml/src/smithy4s/xml/internals/XmlDecoderSchemaVisitor.scala
+++ b/modules/xml/src/smithy4s/xml/internals/XmlDecoderSchemaVisitor.scala
@@ -226,8 +226,8 @@ private[smithy4s] class XmlDecoderSchemaVisitor(
     }
   }
 
-  def option[A](schema: Schema[A]): XmlDecoder[Option[A]] =
-    compile(schema).optional
+  def option[C[_], A](tag: OptionalTag[C], schema: Schema[A]): XmlDecoder[C[A]] =
+    compile(schema).optional(tag)
 
   private def getXmlName(
       hints: Hints,

--- a/modules/xml/src/smithy4s/xml/internals/XmlDecoderSchemaVisitor.scala
+++ b/modules/xml/src/smithy4s/xml/internals/XmlDecoderSchemaVisitor.scala
@@ -226,7 +226,10 @@ private[smithy4s] class XmlDecoderSchemaVisitor(
     }
   }
 
-  def option[C[_], A](tag: OptionalTag[C], schema: Schema[A]): XmlDecoder[C[A]] =
+  def option[C[_], A](
+      tag: OptionalTag[C],
+      schema: Schema[A]
+  ): XmlDecoder[C[A]] =
     compile(schema).optional(tag)
 
   private def getXmlName(

--- a/modules/xml/src/smithy4s/xml/internals/XmlEncoderSchemaVisitor.scala
+++ b/modules/xml/src/smithy4s/xml/internals/XmlEncoderSchemaVisitor.scala
@@ -181,7 +181,10 @@ private[smithy4s] class XmlEncoderSchemaVisitor(
     def encode(value: A): List[XmlContent] = underlying.encode(value)
   }
 
-  def option[C[_], A](tag: OptionalTag[C], schema: Schema[A]): XmlEncoder[C[A]] =
+  def option[C[_], A](
+      tag: OptionalTag[C],
+      schema: Schema[A]
+  ): XmlEncoder[C[A]] =
     compile(schema).optional.contramap(tag.toScalaOption(_))
 
   private def getXmlName(hints: Hints, default: String): XmlDocument.XmlQName =

--- a/modules/xml/src/smithy4s/xml/internals/XmlEncoderSchemaVisitor.scala
+++ b/modules/xml/src/smithy4s/xml/internals/XmlEncoderSchemaVisitor.scala
@@ -181,8 +181,8 @@ private[smithy4s] class XmlEncoderSchemaVisitor(
     def encode(value: A): List[XmlContent] = underlying.encode(value)
   }
 
-  def option[A](schema: Schema[A]): XmlEncoder[Option[A]] =
-    compile(schema).optional
+  def option[C[_], A](tag: OptionalTag[C], schema: Schema[A]): XmlEncoder[C[A]] =
+    compile(schema).optional.contramap(tag.toScalaOption(_))
 
   private def getXmlName(hints: Hints, default: String): XmlDocument.XmlQName =
     hints


### PR DESCRIPTION
## PR Checklist (not all items are relevant to all PRs)

- [ ] Added unit-tests (for runtime code)
- [ ] Added bootstrapped code + smoke tests (when the rendering logic is modified)
- [ ] Added build-plugins integration tests (when reflection loading is required at codegen-time)
- [ ] Added alloy compliance tests (when simpleRestJson protocol behaviour is expanded/updated)
- [ ] Updated dynamic module to match generated-code behaviour
- [ ] Added documentation
- [ ] Updated changelog
