### PR TITLE
Scala 2 Kind Projector underscore-placeholders flag support

### DIFF
--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/smithy-build-kind-projector/build.sbt
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/smithy-build-kind-projector/build.sbt
@@ -1,0 +1,24 @@
+lazy val root = (project in file("."))
+  .enablePlugins(Smithy4sCodegenPlugin)
+  .settings(
+    scalaVersion := "2.13.16",
+    addCompilerPlugin("org.typelevel" % "kind-projector" % "0.13.3" cross CrossVersion.full),
+    libraryDependencies ++= Seq(
+      "com.disneystreaming.smithy4s" %% "smithy4s-core" % smithy4sVersion.value
+    ),
+    Compile / scalacOptions ++= Seq(
+      "-Xsource:3", "-P:kind-projector:underscore-placeholders"
+    ),
+    Compile / smithyBuild := Some(baseDirectory.value / "smithy-build.json"),
+    TaskKey[Unit]("checkOpenApi") := {
+      val resourceDir = (Compile / smithy4sResourceDir).value
+      val content =
+        IO.readLines(
+          resourceDir / "smithy4s.example.ObjectService.json"
+        ).filter(_.trim().nonEmpty)
+          .mkString("")
+          .trim()
+      if (!content.contains("X-Bar") || !content.contains("3.1.0"))
+        sys.error("OpenAPI transformation was not applied")
+    }
+  )

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/smithy-build-kind-projector/project/plugins.sbt
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/smithy-build-kind-projector/project/plugins.sbt
@@ -1,0 +1,9 @@
+sys.props.get("plugin.version") match {
+  case Some(x) =>
+    addSbtPlugin("com.disneystreaming.smithy4s" % "smithy4s-sbt-codegen" % x)
+  case _ =>
+    sys.error(
+      """|The system property 'plugin.version' is not defined.
+         |Specify this property using the scriptedLaunchOpts -D.""".stripMargin
+    )
+}

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/smithy-build-kind-projector/smithy-build.json
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/smithy-build-kind-projector/smithy-build.json
@@ -1,0 +1,12 @@
+{
+  "version": "1.0",
+  "plugins": {
+    "openapi": {
+      "service": "smithy4s.example#ObjectService",
+      "version": "3.1.0",
+      "substitutions": {
+        "X-Foo": "X-Bar"
+      }
+    }
+  }
+}

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/smithy-build-kind-projector/src/main/smithy/example.smithy
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/smithy-build-kind-projector/src/main/smithy/example.smithy
@@ -1,0 +1,88 @@
+namespace smithy4s.example
+
+use alloy#simpleRestJson
+
+@simpleRestJson
+service ObjectService {
+    version: "1.0.0"
+    operations: [
+        PutObject
+        GetObject
+    ]
+}
+
+@idempotent
+@http(method: "PUT", uri: "/{bucketName}/{key}", code: 200)
+operation PutObject {
+    input: PutObjectInput
+    errors: [
+        NoMoreSpace
+    ]
+}
+
+@readonly
+@http(method: "GET", uri: "/{bucketName}/{key}", code: 200)
+operation GetObject {
+    input: GetObjectInput
+    output: GetObjectOutput
+}
+
+structure PutObjectInput {
+    // Sent in the URI label named "key".
+    @required
+    @httpLabel
+    key: String
+
+    // Sent in the URI label named "bucketName".
+    @required
+    @httpLabel
+    bucketName: String
+
+    // Sent in the X-Foo header
+    @httpHeader("X-Foo")
+    foo: String
+
+    // Sent in the query string as paramName
+    @httpQuery("paramName")
+    someValue: String
+
+    // Sent in the body
+    @httpPayload
+    @required
+    data: String
+}
+
+structure GetObjectInput {
+    // Sent in the URI label named "key".
+    @required
+    @httpLabel
+    key: String
+
+    // Sent in the URI label named "bucketName".
+    @required
+    @httpLabel
+    bucketName: String
+}
+
+structure GetObjectOutput {
+    @httpHeader("X-Size")
+    @required
+    size: Integer
+
+    @httpPayload
+    data: String
+}
+
+union Foo {
+    int: Integer
+    str: String
+}
+
+@error("server")
+@httpError(507)
+structure NoMoreSpace {
+    @required
+    message: String
+
+    foo: Foo
+}

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/smithy-build-kind-projector/test
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/smithy-build-kind-projector/test
@@ -1,0 +1,5 @@
+# check if smithy4sCodegen works
+> compile
+$ exists target/scala-2.13/src_managed/main/smithy4s/smithy4s/example/ObjectService.scala
+$ exists target/scala-2.13/resource_managed/main/smithy4s.example.ObjectService.json
+> checkOpenApi

--- a/modules/codegen-plugin/src/smithy4s/codegen/Smithy4sCodegenPlugin.scala
+++ b/modules/codegen-plugin/src/smithy4s/codegen/Smithy4sCodegenPlugin.scala
@@ -243,20 +243,39 @@ object Smithy4sCodegenPlugin extends AutoPlugin {
       // In the following scenarios we use "?" instead of "_"
       // 1. Scala version >= 3.1 ("_" is deprecated in 3.1 and becomes an error in 3.2)
       // 2. Scala version is 3 and "-source:future" or "-source future" are in scalac options
+      // 3. Scala version is 2.13.5+ and "-P:kind-projector:underscore-placeholders" are in scalac options
+      // 4. Scala version is 2.12.14+ and "-P:kind-projector:underscore-placeholders" are in scalac options
       val version = (config / scalaVersion).value
       val majorVersion = version.takeWhile(_ != '.')
       val minorVersion =
         version.drop(majorVersion.length + 1).takeWhile(_ != '.')
+      val patchVersion =
+        version.drop(majorVersion.length + minorVersion.length + 2)
+
+      val options = (config / scalacOptions).value
+
       def scalaOptionsContainsSourceFuture() = {
-        val options = (config / scalacOptions).value
         options.contains("-source:future") || options
           .sliding(2, 1)
           .contains(Seq("-source", "future"))
       }
-      (Try(majorVersion.toInt), Try(minorVersion.toInt)) match {
-        case (Success(3), Success(minorVersion)) if minorVersion >= 1 => "?"
-        case (Success(3), _) if scalaOptionsContainsSourceFuture()    => "?"
-        case _                                                        => "_"
+      def scalaOptionsContainsKindProjectorPlaceholders() =
+        options.contains("-P:kind-projector:underscore-placeholders")
+
+      (
+        Try(majorVersion.toInt),
+        Try(minorVersion.toInt),
+        Try(patchVersion.toInt)
+      ) match {
+        case (Success(3), Success(minorVersion), _) if minorVersion >= 1 => "?"
+        case (Success(3), _, _) if scalaOptionsContainsSourceFuture()    => "?"
+        case (Success(2), Success(13), Success(patchVersion))
+            if patchVersion >= 5 && scalaOptionsContainsKindProjectorPlaceholders() =>
+          "?"
+        case (Success(2), Success(12), Success(patchVersion))
+            if patchVersion >= 14 && scalaOptionsContainsKindProjectorPlaceholders() =>
+          "?"
+        case _ => "_"
       }
     },
     config / smithy4sRenderOptics := false,

--- a/modules/codegen-plugin/src/smithy4s/codegen/Smithy4sCodegenPlugin.scala
+++ b/modules/codegen-plugin/src/smithy4s/codegen/Smithy4sCodegenPlugin.scala
@@ -275,7 +275,11 @@ object Smithy4sCodegenPlugin extends AutoPlugin {
         case (Success(2), Success(12), Success(patchVersion))
             if patchVersion >= 14 && scalaOptionsContainsKindProjectorPlaceholders() =>
           "?"
-        case _ => "_"
+        case v =>
+          println("------------HERE------------------")
+          println(v)
+          println("----------------------------------------")
+          "_"
       }
     },
     config / smithy4sRenderOptics := false,

--- a/modules/codegen-plugin/src/smithy4s/codegen/Smithy4sCodegenPlugin.scala
+++ b/modules/codegen-plugin/src/smithy4s/codegen/Smithy4sCodegenPlugin.scala
@@ -275,11 +275,7 @@ object Smithy4sCodegenPlugin extends AutoPlugin {
         case (Success(2), Success(12), Success(patchVersion))
             if patchVersion >= 14 && scalaOptionsContainsKindProjectorPlaceholders() =>
           "?"
-        case v =>
-          println("------------HERE------------------")
-          println(v)
-          println("----------------------------------------")
-          "_"
+        case _ => "_"
       }
     },
     config / smithy4sRenderOptics := false,

--- a/modules/mill-codegen-plugin/src-mill-shared/smithy4s/codegen/mill/Smithy4sModuleCommon.scala
+++ b/modules/mill-codegen-plugin/src-mill-shared/smithy4s/codegen/mill/Smithy4sModuleCommon.scala
@@ -146,6 +146,8 @@ trait Smithy4sModuleCommon extends ScalaModule {
     // In the following scenarios we use "?" instead of "_"
     // 1. Scala version >= 3.1 ("_" is deprecated in 3.1 and becomes an error in 3.2)
     // 2. Scala version is 3 and "-source:future" or "-source future" are in scalac options
+    // 3. Scala version is 2.13.5+ and "-P:kind-projector:underscore-placeholders" are in scalac options
+    // 4. Scala version is 2.12.14+ and "-P:kind-projector:underscore-placeholders" are in scalac options
     val version = scalaVersion()
     val majorVersion = version.takeWhile(_ != '.')
     val minorVersion =

--- a/modules/mill-codegen-plugin/src-mill-shared/smithy4s/codegen/mill/Smithy4sModuleCommon.scala
+++ b/modules/mill-codegen-plugin/src-mill-shared/smithy4s/codegen/mill/Smithy4sModuleCommon.scala
@@ -150,16 +150,33 @@ trait Smithy4sModuleCommon extends ScalaModule {
     val majorVersion = version.takeWhile(_ != '.')
     val minorVersion =
       version.drop(majorVersion.length + 1).takeWhile(_ != '.')
+    val patchVersion =
+      version.drop(majorVersion.length + minorVersion.length + 2)
+
+    val options = scalacOptions()
+
     def scalaOptionsContainsSourceFuture() = {
-      val options = scalacOptions()
       options.contains("-source:future") || options
         .sliding(2, 1)
         .contains(Seq("-source", "future"))
     }
-    (Try(majorVersion.toInt), Try(minorVersion.toInt)) match {
-      case (Success(3), Success(minorVersion)) if minorVersion >= 1 => "?"
-      case (Success(3), _) if scalaOptionsContainsSourceFuture()    => "?"
-      case _                                                        => "_"
+    def scalaOptionsContainsKindProjectorPlaceholders() =
+      options.contains("-P:kind-projector:underscore-placeholders")
+
+    (
+      Try(majorVersion.toInt),
+      Try(minorVersion.toInt),
+      Try(patchVersion.toInt)
+    ) match {
+      case (Success(3), Success(minorVersion), _) if minorVersion >= 1 => "?"
+      case (Success(3), _, _) if scalaOptionsContainsSourceFuture()    => "?"
+      case (Success(2), Success(13), Success(patchVersion))
+          if patchVersion >= 5 && scalaOptionsContainsKindProjectorPlaceholders() =>
+        "?"
+      case (Success(2), Success(12), Success(patchVersion))
+          if patchVersion >= 14 && scalaOptionsContainsKindProjectorPlaceholders() =>
+        "?"
+      case _ => "_"
     }
   }
 

--- a/modules/mill-codegen-plugin/test/src-mill-0_11/smithy4s/codegen/mill/Smithy4sModuleSpec.scala
+++ b/modules/mill-codegen-plugin/test/src-mill-0_11/smithy4s/codegen/mill/Smithy4sModuleSpec.scala
@@ -126,6 +126,29 @@ class Smithy4sModuleSpec extends munit.FunSuite {
     )
   }
 
+  test("2.13 codegen with placeholder wildcards") {
+    object foo extends testKit.BaseModule with Smithy4sModule {
+      override def scalaVersion = "2.13.16"
+      override def ivyDeps = Agg(coreDep)
+      override def scalacPluginIvyDeps =
+        Agg(ivy"org.typelevel:::kind-projector:0.13.3")
+      override def scalacOptions =
+        Seq("-Xsource:3", "-P:kind-projector:underscore-placeholders")
+      override def millSourcePath = resourcePath / "service"
+    }
+    val ev =
+      testKit.staticTestEvaluator(foo)(FullName("codegen-wildcards-compiles"))
+
+    compileWorks(foo, ev)
+
+    val metadata =
+      ev.outPath / "smithy4sGeneratedSmithyMetadataFile.dest" / "smithy" / "generated-metadata.smithy"
+    checkFileExist(metadata, shouldExist = true)
+    assert(
+      os.read(metadata).contains("metadata smithy4sWildcardArgument = \"?\"")
+    )
+  }
+
   test("codegen with dependencies") {
     object foo extends testKit.BaseModule with Smithy4sModule {
       override def scalaVersion = "2.13.16"

--- a/modules/mill-codegen-plugin/test/src-mill-0_12/smithy4s/codegen/mill/Smithy4sModuleSpec.scala
+++ b/modules/mill-codegen-plugin/test/src-mill-0_12/smithy4s/codegen/mill/Smithy4sModuleSpec.scala
@@ -148,8 +148,11 @@ class Smithy4sModuleSpec extends munit.FunSuite {
     object foo extends TestBaseModule with Smithy4sModule {
       override def scalaVersion = "2.13.16"
       override def ivyDeps = Agg(coreDep)
+      override def scalacPluginIvyDeps =
+        Agg(ivy"org.typelevel:::kind-projector:0.13.3")
       override def scalacOptions =
         Seq("-Xsource:3", "-P:kind-projector:underscore-placeholders")
+
     }
 
     val resourceFolder = resourcePath / "service"

--- a/modules/mill-codegen-plugin/test/src-mill-0_12/smithy4s/codegen/mill/Smithy4sModuleSpec.scala
+++ b/modules/mill-codegen-plugin/test/src-mill-0_12/smithy4s/codegen/mill/Smithy4sModuleSpec.scala
@@ -144,6 +144,36 @@ class Smithy4sModuleSpec extends munit.FunSuite {
     }
   }
 
+  test("2.13 codegen with placeholder wildcards") {
+    object foo extends TestBaseModule with Smithy4sModule {
+      override def scalaVersion = "2.13.16"
+      override def ivyDeps = Agg(coreDep)
+      override def scalacOptions =
+        Seq("-Xsource:3", "-P:kind-projector:underscore-placeholders")
+    }
+
+    val resourceFolder = resourcePath / "service"
+    UnitTester(foo, resourceFolder).scoped { eval =>
+      val compileResult = eval(foo.compile)
+      assertEquals(
+        compileResult.isRight,
+        true,
+        s"Compilation failed: ${compileResult.swap.getOrElse("unknown error")}"
+      )
+
+      val metadataFile =
+        eval(foo.smithy4sGeneratedSmithyMetadataFile).toOption.get.value.path
+
+      checkFileExist(metadataFile, shouldExist = true)
+
+      assert(
+        os.read(metadataFile)
+          .contains("metadata smithy4sWildcardArgument = \"?\""),
+        clue = "Expected metadata to contain wildcard assignment"
+      )
+    }
+  }
+
   test("codegen with dependencies") {
     object foo extends TestBaseModule with Smithy4sModule {
       override def scalaVersion = "2.13.16"


### PR DESCRIPTION
Grabbed Scala versions from here: https://docs.scala-lang.org/scala3/reference/changed-features/wildcards.html 

Closes https://github.com/disneystreaming/smithy4s/issues/1829

## PR Checklist (not all items are relevant to all PRs)

- [x] Added build-plugins integration tests (when reflection loading is required at codegen-time)
