### PR TITLE
Avoid throwing MatchError when surfacing unknown errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ When adding entries, please treat them as if they could end up in a release any 
 
 Thank you!
 
+# 0.18.44
+
+* Avoid an issue in which `SurfaceError` transformations would throw a `MatchError` upon being called for an operation that doesn't declare errors in [#1846](https://github.com/disneystreaming/smithy4s/pull/1846).
+
 # 0.18.43
 
 * Add support for generating dynamic hint bindings in [#1816](https://github.com/disneystreaming/smithy4s/pull/1816)

--- a/modules/bootstrapped/test/src/smithy4s/TransformationSpec.scala
+++ b/modules/bootstrapped/test/src/smithy4s/TransformationSpec.scala
@@ -17,6 +17,7 @@
 package smithy4s
 
 import smithy4s.example._
+import smithy4s.example.greet._
 import smithy4s.kinds.PolyFunction
 import munit._
 import scala.util.{Failure, Success, Try}
@@ -107,6 +108,41 @@ class TransformationSpec() extends FunSuite {
       )
     )
 
+  }
+
+  test(
+    "surfacing unhandled errors on an operation without errors doesn't throw"
+  ) {
+    val e = new Exception("Expected, but unexpected error")
+
+    val impl: GreetService[Try] =
+      new GreetService.Default[Try](Failure(e))
+
+    type Result[E, A] = Either[Either[Throwable, E], A]
+
+    // If you hit this, you should make sure either that Greet has no errors
+    // or switch to another operation that matches this assumption.
+    // Otherwise, this test is useless.
+    require(
+      GreetServiceOperation.Greet.error.isEmpty,
+      "The issue we're testing against can only be reproduced with error-unaware operations."
+    )
+
+    val result = impl
+      .transform(new Transformation.SurfaceError[Try, Result] {
+        def apply[E, A](fa: Try[A], projectError: Throwable => Option[E])
+            : Result[E, A] =
+          fa match {
+            case Success(value) => Right(value)
+            case Failure(exception) =>
+              projectError(exception).fold[Result[E, A]](Left(Left(exception)))(
+                e => Left(Right(e))
+              )
+          }
+      })
+      .greet("hello")
+
+    expect.same(result, Left(Left(e)))
   }
 
 }

--- a/modules/core/src/smithy4s/Transformation.scala
+++ b/modules/core/src/smithy4s/Transformation.scala
@@ -88,7 +88,7 @@ object Transformation {
           def apply[I, E, O, SI, SO](op: service.Operation[I, E, O, SI, SO]): G[E,O] = {
             val endpoint = service.endpoint(op)
             val catcher: Throwable => Option[E] = endpoint.error match {
-              case None => PartialFunction.empty[Throwable, Option[E]]
+              case None => Function.const(None)
               case Some(value) => value.liftError(_)
             }
             func.apply(polyFunction(op), catcher)

--- a/modules/core/src/smithy4s/schema/Schema.scala
+++ b/modules/core/src/smithy4s/schema/Schema.scala
@@ -152,9 +152,14 @@ sealed trait Schema[A]{
   final def isUnit: Boolean = this.shapeId == ShapeId("smithy.api", "Unit")
 
   /**
-    * Turns this schema into an error schema.
+    * Turns this schema into an error schema, using a partial function.
     */
   final def error(unlift: A => Throwable)(lift: PartialFunction[Throwable, A]) : ErrorSchema[A] = ErrorSchema(this, lift.lift, unlift)
+
+  /**
+    * Turns this schema into an error schema.
+    */
+  final def error(unlift: A => Throwable)(lift: Throwable => Option[A]) : ErrorSchema[A] = ErrorSchema(this, lift, unlift)
 
 }
 


### PR DESCRIPTION
## PR Checklist (not all items are relevant to all PRs)

- [x] Added unit-tests (for runtime code)
- [ ] Added bootstrapped code + smoke tests (when the rendering logic is modified)
- [ ] Added build-plugins integration tests (when reflection loading is required at codegen-time)
- [ ] Added alloy compliance tests (when simpleRestJson protocol behaviour is expanded/updated)
- [ ] Updated dynamic module to match generated-code behaviour
- [ ] Added documentation
- [x] Updated changelog
