### PR TITLE
remove usage of alloy to test refinements

### DIFF
--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/refinements/src/main/scala/refinements/Refinements.scala
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/refinements/src/main/scala/refinements/Refinements.scala
@@ -16,7 +16,7 @@
 
 package refinements.validated
 
-import alloy.DateFormat
+import scripted.date.DateFormat
 
 import java.time.LocalDate
 import scala.util.Try

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/refinements/src/main/smithy/date.smithy
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/refinements/src/main/smithy/date.smithy
@@ -2,14 +2,17 @@ $version: "2.0"
 
 namespace scripted.date
 
-use alloy#dateFormat
+
 use smithy4s.meta#refinement
 
-apply alloy#dateFormat @refinement(
+apply dateFormat @refinement(
   targetType: "java.time.LocalDate",
   providerImport: "refinements.validated.Refinements.dateFormat.provider._"
 )
 
+@trait(selector:"*")
+structure dateFormat {
+}
 structure StructWithDate {
   @dateFormat
   @required


### PR DESCRIPTION
There is an issue with the way smithy4s currently implements custom primitives , where when one applies a refinement to a trait that marks a new primitive the refinement is ignored. This comes from [this line of code ](https://github.com/disneystreaming/smithy4s/blob/e1aaaed32510ca9c3f7cc378ce82d74df4794447/modules/codegen/src/smithy4s/codegen/internals/SmithyToIR.scala#L803) where we handle traits marking a primitive differently. There have been discussions around the desired behavior for this case , however nothing has been concluded yet. To this end , this PR is simply removing the use case making the refinement test a simple sanity test instead of testing this edge case 