### PR TITLE
Add asError replacement for error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ When adding entries, please treat them as if they could end up in a release any 
 
 Thank you!
 
+# 0.18.45
+
+* Avoid an overloaded method issue in calls to `Schema#error` in [#1861](https://github.com/disneystreaming/smithy4s/pull/1861)
+
 # 0.18.44
 
 * Avoid a name shadowing issue in which an operation with an `alg` parameter would cause compilation errors in generated code in [#1859](https://github.com/disneystreaming/smithy4s/pull/1859).

--- a/modules/bootstrapped/test/src/smithy4s/schema/SchemaSpec.scala
+++ b/modules/bootstrapped/test/src/smithy4s/schema/SchemaSpec.scala
@@ -57,14 +57,12 @@ final class SchemaSpec extends FunSuite {
 
   test("ErrorSchema can be created by users using a partial function") {
     val s = string
-    case class E(s: String) extends Throwable
 
     s.error(E(_)) { case E(s) => s }
   }
 
   test("ErrorSchema can be created by users using an optional function") {
     val s = string
-    case class E(s: String) extends Throwable
 
     val f: Throwable => Option[String] = {
       case E(s) => Some(s)
@@ -74,4 +72,5 @@ final class SchemaSpec extends FunSuite {
     s.asError(E(_))(f)
   }
 
+  case class E(s: String) extends Throwable
 }

--- a/modules/bootstrapped/test/src/smithy4s/schema/SchemaSpec.scala
+++ b/modules/bootstrapped/test/src/smithy4s/schema/SchemaSpec.scala
@@ -55,4 +55,23 @@ final class SchemaSpec extends FunSuite {
     assertEquals(field1, field2)
   }
 
+  test("ErrorSchema can be created by users using a partial function") {
+    val s = string
+    case class E(s: String) extends Throwable
+
+    s.error(E(_)) { case E(s) => s }
+  }
+
+  test("ErrorSchema can be created by users using an optional function") {
+    val s = string
+    case class E(s: String) extends Throwable
+
+    val f: Throwable => Option[String] = {
+      case E(s) => Some(s)
+      case _    => None
+    }
+
+    s.asError(E(_))(f)
+  }
+
 }

--- a/modules/bootstrapped/test/src/smithy4s/schematests/DefaultValueSpec.scala
+++ b/modules/bootstrapped/test/src/smithy4s/schematests/DefaultValueSpec.scala
@@ -15,7 +15,7 @@
  */
 
 package smithy4s
-package schema
+package schematests
 
 import munit._
 import smithy.api.TimestampFormat

--- a/modules/bootstrapped/test/src/smithy4s/schematests/FieldSpec.scala
+++ b/modules/bootstrapped/test/src/smithy4s/schematests/FieldSpec.scala
@@ -15,7 +15,7 @@
  */
 
 package smithy4s
-package schema
+package schematests
 
 import munit._
 import Schema._

--- a/modules/bootstrapped/test/src/smithy4s/schematests/HintsTransformationSpec.scala
+++ b/modules/bootstrapped/test/src/smithy4s/schematests/HintsTransformationSpec.scala
@@ -14,7 +14,7 @@
  *  limitations under the License.
  */
 
-package smithy4s.schema
+package smithy4s.schematests
 
 import munit._
 import smithy4s.Enumeration
@@ -25,7 +25,8 @@ import smithy4s.Bijection
 import smithy4s.Refinement
 import smithy4s.ShapeTag
 import cats.syntax.all._
-import Schema._
+import smithy4s.schema.Schema._
+import smithy4s.schema._
 
 class HintsTransformationSpec() extends FunSuite {
 

--- a/modules/bootstrapped/test/src/smithy4s/schematests/SchemaPartitionSpec.scala
+++ b/modules/bootstrapped/test/src/smithy4s/schematests/SchemaPartitionSpec.scala
@@ -15,11 +15,13 @@
  */
 
 package smithy4s
-package schema
+package schematests
 
 import cats.syntax.all._
 import Schema._
 import munit._
+import smithy4s.schema.SchemaPartition
+import smithy4s.schema.Field
 
 final class SchemaPartitionSpec extends FunSuite {
 

--- a/modules/bootstrapped/test/src/smithy4s/schematests/SchemaSpec.scala
+++ b/modules/bootstrapped/test/src/smithy4s/schematests/SchemaSpec.scala
@@ -15,7 +15,7 @@
  */
 
 package smithy4s
-package schema
+package schematests
 
 import munit._
 import Schema._

--- a/modules/core/src/smithy4s/schema/Schema.scala
+++ b/modules/core/src/smithy4s/schema/Schema.scala
@@ -165,7 +165,7 @@ sealed trait Schema[A]{
     * Turns this schema into an error schema.
     */
   @deprecated("This function can't be called due to having an overload. Use `asError` instead", "0.18.45")
-  private[Schema] final def error(unlift: A => Throwable)(lift: Throwable => Option[A]) : ErrorSchema[A] = ErrorSchema(this, lift, unlift)
+  private[schema] final def error(unlift: A => Throwable)(lift: Throwable => Option[A]) : ErrorSchema[A] = ErrorSchema(this, lift, unlift)
 }
 
 object Schema {

--- a/modules/core/src/smithy4s/schema/Schema.scala
+++ b/modules/core/src/smithy4s/schema/Schema.scala
@@ -159,8 +159,13 @@ sealed trait Schema[A]{
   /**
     * Turns this schema into an error schema.
     */
-  final def error(unlift: A => Throwable)(lift: Throwable => Option[A]) : ErrorSchema[A] = ErrorSchema(this, lift, unlift)
+  final def asError(unlift: A => Throwable)(lift: Throwable => Option[A]) : ErrorSchema[A] = ErrorSchema(this, lift, unlift)
 
+  /**
+    * Turns this schema into an error schema.
+    */
+  @deprecated("This function can't be called due to having an overload. Use `asError` instead", "0.18.45")
+  private[Schema] final def error(unlift: A => Throwable)(lift: Throwable => Option[A]) : ErrorSchema[A] = ErrorSchema(this, lift, unlift)
 }
 
 object Schema {


### PR DESCRIPTION
The function was never callable. In fact, adding the overload made them both uncallable. It's a wontfix in Scala 2: https://github.com/scala/bug/issues/12973

This PR hides the new method (keeping it for bincompat, just in case someone managed to call it after all, or used Scala 3), and adds a replacement in the form of `asError`.

## PR Checklist (not all items are relevant to all PRs)

- [x] Added unit-tests (for runtime code)
- [ ] Added bootstrapped code + smoke tests (when the rendering logic is modified)
- [ ] Added build-plugins integration tests (when reflection loading is required at codegen-time)
- [ ] Added alloy compliance tests (when simpleRestJson protocol behaviour is expanded/updated)
- [ ] Updated dynamic module to match generated-code behaviour
- [ ] Added documentation
- [x] Updated changelog
