### PR TITLE
[Core] - Content header writer refactor ,add content header test, and remove mediaTypeWriters

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1047,6 +1047,7 @@ lazy val bootstrapped = projectMatrix
       "smithy4s.example.hello",
       "smithy4s.example.test",
       "smithy4s.example.accept",
+      "smithy4s.example.content",
       "smithy4s.example.package",
       "smithy4s.example.protobuf",
       "weather",

--- a/modules/bootstrapped/resources/smithy4s.example.content.ContentHeaderTestService.json
+++ b/modules/bootstrapped/resources/smithy4s.example.content.ContentHeaderTestService.json
@@ -89,6 +89,61 @@
                 }
             }
         },
+        "/empty-struct": {
+            "post": {
+                "description": "Operation with empty struct - should have Content-Type when writeEmptyStructs=true, none when false",
+                "operationId": "EmptyStructOperation",
+                "responses": {
+                    "200": {
+                        "description": "EmptyStructOperation 200 response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/EmptyStructOperationOutputPayload"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/explicit-content-type": {
+            "post": {
+                "description": "Operation with explicit Content-Type header - should override default behavior",
+                "operationId": "ExplicitContentTypeHeader",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ExplicitContentTypeHeaderInputPayload"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "parameters": [
+                    {
+                        "name": "Content-Type",
+                        "in": "header",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "ExplicitContentTypeHeader 200 response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ExplicitContentTypeHeaderOutputPayload"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/no-body": {
             "get": {
                 "description": "Operation with only metadata (no body) - should not have Content-Type header",
@@ -194,6 +249,16 @@
                 "type": "string"
             },
             "DefaultContentHeaderOutputPayload": {
+                "type": "string"
+            },
+            "EmptyStructOperationOutputPayload": {
+                "type": "string"
+            },
+            "ExplicitContentTypeHeaderInputPayload": {
+                "type": "string",
+                "format": "byte"
+            },
+            "ExplicitContentTypeHeaderOutputPayload": {
                 "type": "string"
             },
             "NoBodyOperationOutputPayload": {

--- a/modules/bootstrapped/resources/smithy4s.example.content.ContentHeaderTestService.json
+++ b/modules/bootstrapped/resources/smithy4s.example.content.ContentHeaderTestService.json
@@ -1,0 +1,219 @@
+{
+    "openapi": "3.0.2",
+    "info": {
+        "title": "ContentHeaderTestService",
+        "version": ""
+    },
+    "paths": {
+        "/blob-no-media": {
+            "post": {
+                "description": "Operation with Blob input without media type",
+                "operationId": "BlobInputNoMediaType",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/BlobInputNoMediaTypeInputPayload"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "BlobInputNoMediaType 200 response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/BlobInputNoMediaTypeOutputPayload"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/blob-with-media": {
+            "post": {
+                "description": "Operation with Blob input that has media type",
+                "operationId": "BlobInputWithMediaType",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/BlobInputWithMediaTypeInputPayload"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "BlobInputWithMediaType 200 response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/BlobInputWithMediaTypeOutputPayload"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/default": {
+            "post": {
+                "description": "Operation with no media types - should use default Content-Type header",
+                "operationId": "DefaultContentHeader",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/DefaultContentHeaderInputPayload"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "DefaultContentHeader 200 response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/DefaultContentHeaderOutputPayload"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/no-body": {
+            "get": {
+                "description": "Operation with only metadata (no body) - should not have Content-Type header",
+                "operationId": "NoBodyOperation",
+                "parameters": [
+                    {
+                        "name": "q",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "NoBodyOperation 200 response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/NoBodyOperationOutputPayload"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/xml-input": {
+            "post": {
+                "description": "Operation with XML input media type",
+                "operationId": "XmlInput",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/XmlInputInputPayload"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "XmlInput 200 response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/XmlInputOutputPayload"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/xml-json": {
+            "post": {
+                "description": "Operation with different media types for input and output",
+                "operationId": "XmlInputJsonOutput",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/XmlInputJsonOutputInputPayload"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "XmlInputJsonOutput 200 response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/XmlInputJsonOutputOutputPayload"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "BlobInputNoMediaTypeInputPayload": {
+                "type": "string",
+                "format": "byte"
+            },
+            "BlobInputNoMediaTypeOutputPayload": {
+                "type": "string"
+            },
+            "BlobInputWithMediaTypeInputPayload": {
+                "type": "string",
+                "description": "PNG image blob type",
+                "format": "byte"
+            },
+            "BlobInputWithMediaTypeOutputPayload": {
+                "type": "string"
+            },
+            "DefaultContentHeaderInputPayload": {
+                "type": "string"
+            },
+            "DefaultContentHeaderOutputPayload": {
+                "type": "string"
+            },
+            "NoBodyOperationOutputPayload": {
+                "type": "string"
+            },
+            "XmlInputInputPayload": {
+                "type": "string",
+                "description": "XML payload type"
+            },
+            "XmlInputJsonOutputInputPayload": {
+                "type": "string",
+                "description": "XML payload type"
+            },
+            "XmlInputJsonOutputOutputPayload": {
+                "type": "string",
+                "description": "JSON payload type"
+            },
+            "XmlInputOutputPayload": {
+                "type": "string"
+            }
+        }
+    }
+}

--- a/modules/bootstrapped/src/generated/smithy4s/example/content/BlobInputNoMediaTypeInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/content/BlobInputNoMediaTypeInput.scala
@@ -1,0 +1,26 @@
+package smithy4s.example.content
+
+import smithy4s.Blob
+import smithy4s.Hints
+import smithy4s.Schema
+import smithy4s.ShapeId
+import smithy4s.ShapeTag
+import smithy4s.schema.Schema.bytes
+import smithy4s.schema.Schema.struct
+
+final case class BlobInputNoMediaTypeInput(image: Blob)
+
+object BlobInputNoMediaTypeInput extends ShapeTag.Companion[BlobInputNoMediaTypeInput] {
+  val id: ShapeId = ShapeId("smithy4s.example.content", "BlobInputNoMediaTypeInput")
+
+  val hints: Hints = Hints(
+    smithy.api.Input(),
+  ).lazily
+
+  // constructor using the original order from the spec
+  private def make(image: Blob): BlobInputNoMediaTypeInput = BlobInputNoMediaTypeInput(image)
+
+  implicit val schema: Schema[BlobInputNoMediaTypeInput] = struct(
+    bytes.required[BlobInputNoMediaTypeInput]("image", _.image).addHints(smithy.api.HttpPayload()),
+  )(make).withId(id).addHints(hints)
+}

--- a/modules/bootstrapped/src/generated/smithy4s/example/content/BlobInputNoMediaTypeOutput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/content/BlobInputNoMediaTypeOutput.scala
@@ -1,0 +1,25 @@
+package smithy4s.example.content
+
+import smithy4s.Hints
+import smithy4s.Schema
+import smithy4s.ShapeId
+import smithy4s.ShapeTag
+import smithy4s.schema.Schema.string
+import smithy4s.schema.Schema.struct
+
+final case class BlobInputNoMediaTypeOutput(data: Option[String] = None)
+
+object BlobInputNoMediaTypeOutput extends ShapeTag.Companion[BlobInputNoMediaTypeOutput] {
+  val id: ShapeId = ShapeId("smithy4s.example.content", "BlobInputNoMediaTypeOutput")
+
+  val hints: Hints = Hints(
+    smithy.api.Output(),
+  ).lazily
+
+  // constructor using the original order from the spec
+  private def make(data: Option[String]): BlobInputNoMediaTypeOutput = BlobInputNoMediaTypeOutput(data)
+
+  implicit val schema: Schema[BlobInputNoMediaTypeOutput] = struct(
+    string.optional[BlobInputNoMediaTypeOutput]("data", _.data).addHints(smithy.api.HttpPayload()),
+  )(make).withId(id).addHints(hints)
+}

--- a/modules/bootstrapped/src/generated/smithy4s/example/content/BlobInputWithMediaTypeInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/content/BlobInputWithMediaTypeInput.scala
@@ -1,0 +1,27 @@
+package smithy4s.example.content
+
+import smithy4s.Hints
+import smithy4s.Schema
+import smithy4s.ShapeId
+import smithy4s.ShapeTag
+import smithy4s.schema.Schema.struct
+
+/** @param image
+  *   PNG image blob type
+  */
+final case class BlobInputWithMediaTypeInput(image: PngImage)
+
+object BlobInputWithMediaTypeInput extends ShapeTag.Companion[BlobInputWithMediaTypeInput] {
+  val id: ShapeId = ShapeId("smithy4s.example.content", "BlobInputWithMediaTypeInput")
+
+  val hints: Hints = Hints(
+    smithy.api.Input(),
+  ).lazily
+
+  // constructor using the original order from the spec
+  private def make(image: PngImage): BlobInputWithMediaTypeInput = BlobInputWithMediaTypeInput(image)
+
+  implicit val schema: Schema[BlobInputWithMediaTypeInput] = struct(
+    PngImage.schema.required[BlobInputWithMediaTypeInput]("image", _.image).addHints(smithy.api.HttpPayload()),
+  )(make).withId(id).addHints(hints)
+}

--- a/modules/bootstrapped/src/generated/smithy4s/example/content/BlobInputWithMediaTypeOutput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/content/BlobInputWithMediaTypeOutput.scala
@@ -1,0 +1,25 @@
+package smithy4s.example.content
+
+import smithy4s.Hints
+import smithy4s.Schema
+import smithy4s.ShapeId
+import smithy4s.ShapeTag
+import smithy4s.schema.Schema.string
+import smithy4s.schema.Schema.struct
+
+final case class BlobInputWithMediaTypeOutput(data: Option[String] = None)
+
+object BlobInputWithMediaTypeOutput extends ShapeTag.Companion[BlobInputWithMediaTypeOutput] {
+  val id: ShapeId = ShapeId("smithy4s.example.content", "BlobInputWithMediaTypeOutput")
+
+  val hints: Hints = Hints(
+    smithy.api.Output(),
+  ).lazily
+
+  // constructor using the original order from the spec
+  private def make(data: Option[String]): BlobInputWithMediaTypeOutput = BlobInputWithMediaTypeOutput(data)
+
+  implicit val schema: Schema[BlobInputWithMediaTypeOutput] = struct(
+    string.optional[BlobInputWithMediaTypeOutput]("data", _.data).addHints(smithy.api.HttpPayload()),
+  )(make).withId(id).addHints(hints)
+}

--- a/modules/bootstrapped/src/generated/smithy4s/example/content/ContentHeaderTestService.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/content/ContentHeaderTestService.scala
@@ -14,6 +14,11 @@ import smithy4s.schema.OperationSchema
 trait ContentHeaderTestServiceGen[F[_, _, _, _, _]] {
   self =>
 
+  /** Operation with empty struct - should have Content-Type when writeEmptyStructs=true, none when false
+    * 
+    * HTTP POST /empty-struct
+    */
+  def emptyStructOperation(): F[EmptyStructOperationInput, Nothing, EmptyStructOperationOutput, Nothing, Nothing]
   /** Operation with Blob input that has media type
     * 
     * HTTP POST /blob-with-media
@@ -53,6 +58,11 @@ trait ContentHeaderTestServiceGen[F[_, _, _, _, _]] {
     *   XML payload type
     */
   def xmlInput(data: XmlPayload): F[XmlInputInput, Nothing, XmlInputOutput, Nothing, Nothing]
+  /** Operation with explicit Content-Type header - should override default behavior
+    * 
+    * HTTP POST /explicit-content-type
+    */
+  def explicitContentTypeHeader(data: Blob, contentType: Option[String] = None): F[ExplicitContentTypeHeaderInput, Nothing, ExplicitContentTypeHeaderOutput, Nothing, Nothing]
 
   final def transform: Transformation.PartiallyApplied[ContentHeaderTestServiceGen[F]] = Transformation.of[ContentHeaderTestServiceGen[F]](this)
 }
@@ -74,12 +84,14 @@ object ContentHeaderTestServiceGen extends Service.Mixin[ContentHeaderTestServic
   }
 
   val endpoints: Vector[smithy4s.Endpoint[ContentHeaderTestServiceOperation, _, _, _, _, _]] = Vector(
+    ContentHeaderTestServiceOperation.EmptyStructOperation,
     ContentHeaderTestServiceOperation.BlobInputWithMediaType,
     ContentHeaderTestServiceOperation.DefaultContentHeader,
     ContentHeaderTestServiceOperation.BlobInputNoMediaType,
     ContentHeaderTestServiceOperation.NoBodyOperation,
     ContentHeaderTestServiceOperation.XmlInputJsonOutput,
     ContentHeaderTestServiceOperation.XmlInput,
+    ContentHeaderTestServiceOperation.ExplicitContentTypeHeader,
   )
 
   def input[I, E, O, SI, SO](op: ContentHeaderTestServiceOperation[I, E, O, SI, SO]): I = op.input
@@ -104,28 +116,44 @@ sealed trait ContentHeaderTestServiceOperation[Input, Err, Output, StreamedInput
 object ContentHeaderTestServiceOperation {
 
   object reified extends ContentHeaderTestServiceGen[ContentHeaderTestServiceOperation] {
+    def emptyStructOperation(): EmptyStructOperation = EmptyStructOperation(EmptyStructOperationInput())
     def blobInputWithMediaType(image: PngImage): BlobInputWithMediaType = BlobInputWithMediaType(BlobInputWithMediaTypeInput(image))
     def defaultContentHeader(data: String): DefaultContentHeader = DefaultContentHeader(DefaultContentHeaderInput(data))
     def blobInputNoMediaType(image: Blob): BlobInputNoMediaType = BlobInputNoMediaType(BlobInputNoMediaTypeInput(image))
     def noBodyOperation(query: Option[String] = None): NoBodyOperation = NoBodyOperation(NoBodyOperationInput(query))
     def xmlInputJsonOutput(data: XmlPayload): XmlInputJsonOutput = XmlInputJsonOutput(XmlInputJsonOutputInput(data))
     def xmlInput(data: XmlPayload): XmlInput = XmlInput(XmlInputInput(data))
+    def explicitContentTypeHeader(data: Blob, contentType: Option[String] = None): ExplicitContentTypeHeader = ExplicitContentTypeHeader(ExplicitContentTypeHeaderInput(data, contentType))
   }
   class Transformed[P[_, _, _, _, _], P1[_ ,_ ,_ ,_ ,_]](alg: ContentHeaderTestServiceGen[P], f: PolyFunction5[P, P1]) extends ContentHeaderTestServiceGen[P1] {
+    def emptyStructOperation(): P1[EmptyStructOperationInput, Nothing, EmptyStructOperationOutput, Nothing, Nothing] = f[EmptyStructOperationInput, Nothing, EmptyStructOperationOutput, Nothing, Nothing](this.alg.emptyStructOperation())
     def blobInputWithMediaType(image: PngImage): P1[BlobInputWithMediaTypeInput, Nothing, BlobInputWithMediaTypeOutput, Nothing, Nothing] = f[BlobInputWithMediaTypeInput, Nothing, BlobInputWithMediaTypeOutput, Nothing, Nothing](this.alg.blobInputWithMediaType(image))
     def defaultContentHeader(data: String): P1[DefaultContentHeaderInput, Nothing, DefaultContentHeaderOutput, Nothing, Nothing] = f[DefaultContentHeaderInput, Nothing, DefaultContentHeaderOutput, Nothing, Nothing](this.alg.defaultContentHeader(data))
     def blobInputNoMediaType(image: Blob): P1[BlobInputNoMediaTypeInput, Nothing, BlobInputNoMediaTypeOutput, Nothing, Nothing] = f[BlobInputNoMediaTypeInput, Nothing, BlobInputNoMediaTypeOutput, Nothing, Nothing](this.alg.blobInputNoMediaType(image))
     def noBodyOperation(query: Option[String] = None): P1[NoBodyOperationInput, Nothing, NoBodyOperationOutput, Nothing, Nothing] = f[NoBodyOperationInput, Nothing, NoBodyOperationOutput, Nothing, Nothing](this.alg.noBodyOperation(query))
     def xmlInputJsonOutput(data: XmlPayload): P1[XmlInputJsonOutputInput, Nothing, XmlInputJsonOutputOutput, Nothing, Nothing] = f[XmlInputJsonOutputInput, Nothing, XmlInputJsonOutputOutput, Nothing, Nothing](this.alg.xmlInputJsonOutput(data))
     def xmlInput(data: XmlPayload): P1[XmlInputInput, Nothing, XmlInputOutput, Nothing, Nothing] = f[XmlInputInput, Nothing, XmlInputOutput, Nothing, Nothing](this.alg.xmlInput(data))
+    def explicitContentTypeHeader(data: Blob, contentType: Option[String] = None): P1[ExplicitContentTypeHeaderInput, Nothing, ExplicitContentTypeHeaderOutput, Nothing, Nothing] = f[ExplicitContentTypeHeaderInput, Nothing, ExplicitContentTypeHeaderOutput, Nothing, Nothing](this.alg.explicitContentTypeHeader(data, contentType))
   }
 
   def toPolyFunction[P[_, _, _, _, _]](impl: ContentHeaderTestServiceGen[P]): PolyFunction5[ContentHeaderTestServiceOperation, P] = new PolyFunction5[ContentHeaderTestServiceOperation, P] {
     def apply[I, E, O, SI, SO](op: ContentHeaderTestServiceOperation[I, E, O, SI, SO]): P[I, E, O, SI, SO] = op.run(impl) 
   }
+  final case class EmptyStructOperation(input: EmptyStructOperationInput) extends ContentHeaderTestServiceOperation[EmptyStructOperationInput, Nothing, EmptyStructOperationOutput, Nothing, Nothing] {
+    def run[F[_, _, _, _, _]](impl: ContentHeaderTestServiceGen[F]): F[EmptyStructOperationInput, Nothing, EmptyStructOperationOutput, Nothing, Nothing] = impl.emptyStructOperation()
+    def ordinal: Int = 0
+    def endpoint: smithy4s.Endpoint[ContentHeaderTestServiceOperation,EmptyStructOperationInput, Nothing, EmptyStructOperationOutput, Nothing, Nothing] = EmptyStructOperation
+  }
+  object EmptyStructOperation extends smithy4s.Endpoint[ContentHeaderTestServiceOperation,EmptyStructOperationInput, Nothing, EmptyStructOperationOutput, Nothing, Nothing] {
+    val schema: OperationSchema[EmptyStructOperationInput, Nothing, EmptyStructOperationOutput, Nothing, Nothing] = Schema.operation(ShapeId("smithy4s.example.content", "EmptyStructOperation"))
+      .withInput(EmptyStructOperationInput.schema)
+      .withOutput(EmptyStructOperationOutput.schema)
+      .withHints(smithy.api.Documentation("Operation with empty struct - should have Content-Type when writeEmptyStructs=true, none when false"), smithy.api.Http(method = smithy.api.NonEmptyString("POST"), uri = smithy.api.NonEmptyString("/empty-struct"), code = 200))
+    def wrap(input: EmptyStructOperationInput): EmptyStructOperation = EmptyStructOperation(input)
+  }
   final case class BlobInputWithMediaType(input: BlobInputWithMediaTypeInput) extends ContentHeaderTestServiceOperation[BlobInputWithMediaTypeInput, Nothing, BlobInputWithMediaTypeOutput, Nothing, Nothing] {
     def run[F[_, _, _, _, _]](impl: ContentHeaderTestServiceGen[F]): F[BlobInputWithMediaTypeInput, Nothing, BlobInputWithMediaTypeOutput, Nothing, Nothing] = impl.blobInputWithMediaType(input.image)
-    def ordinal: Int = 0
+    def ordinal: Int = 1
     def endpoint: smithy4s.Endpoint[ContentHeaderTestServiceOperation,BlobInputWithMediaTypeInput, Nothing, BlobInputWithMediaTypeOutput, Nothing, Nothing] = BlobInputWithMediaType
   }
   object BlobInputWithMediaType extends smithy4s.Endpoint[ContentHeaderTestServiceOperation,BlobInputWithMediaTypeInput, Nothing, BlobInputWithMediaTypeOutput, Nothing, Nothing] {
@@ -137,7 +165,7 @@ object ContentHeaderTestServiceOperation {
   }
   final case class DefaultContentHeader(input: DefaultContentHeaderInput) extends ContentHeaderTestServiceOperation[DefaultContentHeaderInput, Nothing, DefaultContentHeaderOutput, Nothing, Nothing] {
     def run[F[_, _, _, _, _]](impl: ContentHeaderTestServiceGen[F]): F[DefaultContentHeaderInput, Nothing, DefaultContentHeaderOutput, Nothing, Nothing] = impl.defaultContentHeader(input.data)
-    def ordinal: Int = 1
+    def ordinal: Int = 2
     def endpoint: smithy4s.Endpoint[ContentHeaderTestServiceOperation,DefaultContentHeaderInput, Nothing, DefaultContentHeaderOutput, Nothing, Nothing] = DefaultContentHeader
   }
   object DefaultContentHeader extends smithy4s.Endpoint[ContentHeaderTestServiceOperation,DefaultContentHeaderInput, Nothing, DefaultContentHeaderOutput, Nothing, Nothing] {
@@ -149,7 +177,7 @@ object ContentHeaderTestServiceOperation {
   }
   final case class BlobInputNoMediaType(input: BlobInputNoMediaTypeInput) extends ContentHeaderTestServiceOperation[BlobInputNoMediaTypeInput, Nothing, BlobInputNoMediaTypeOutput, Nothing, Nothing] {
     def run[F[_, _, _, _, _]](impl: ContentHeaderTestServiceGen[F]): F[BlobInputNoMediaTypeInput, Nothing, BlobInputNoMediaTypeOutput, Nothing, Nothing] = impl.blobInputNoMediaType(input.image)
-    def ordinal: Int = 2
+    def ordinal: Int = 3
     def endpoint: smithy4s.Endpoint[ContentHeaderTestServiceOperation,BlobInputNoMediaTypeInput, Nothing, BlobInputNoMediaTypeOutput, Nothing, Nothing] = BlobInputNoMediaType
   }
   object BlobInputNoMediaType extends smithy4s.Endpoint[ContentHeaderTestServiceOperation,BlobInputNoMediaTypeInput, Nothing, BlobInputNoMediaTypeOutput, Nothing, Nothing] {
@@ -161,7 +189,7 @@ object ContentHeaderTestServiceOperation {
   }
   final case class NoBodyOperation(input: NoBodyOperationInput) extends ContentHeaderTestServiceOperation[NoBodyOperationInput, Nothing, NoBodyOperationOutput, Nothing, Nothing] {
     def run[F[_, _, _, _, _]](impl: ContentHeaderTestServiceGen[F]): F[NoBodyOperationInput, Nothing, NoBodyOperationOutput, Nothing, Nothing] = impl.noBodyOperation(input.query)
-    def ordinal: Int = 3
+    def ordinal: Int = 4
     def endpoint: smithy4s.Endpoint[ContentHeaderTestServiceOperation,NoBodyOperationInput, Nothing, NoBodyOperationOutput, Nothing, Nothing] = NoBodyOperation
   }
   object NoBodyOperation extends smithy4s.Endpoint[ContentHeaderTestServiceOperation,NoBodyOperationInput, Nothing, NoBodyOperationOutput, Nothing, Nothing] {
@@ -173,7 +201,7 @@ object ContentHeaderTestServiceOperation {
   }
   final case class XmlInputJsonOutput(input: XmlInputJsonOutputInput) extends ContentHeaderTestServiceOperation[XmlInputJsonOutputInput, Nothing, XmlInputJsonOutputOutput, Nothing, Nothing] {
     def run[F[_, _, _, _, _]](impl: ContentHeaderTestServiceGen[F]): F[XmlInputJsonOutputInput, Nothing, XmlInputJsonOutputOutput, Nothing, Nothing] = impl.xmlInputJsonOutput(input.data)
-    def ordinal: Int = 4
+    def ordinal: Int = 5
     def endpoint: smithy4s.Endpoint[ContentHeaderTestServiceOperation,XmlInputJsonOutputInput, Nothing, XmlInputJsonOutputOutput, Nothing, Nothing] = XmlInputJsonOutput
   }
   object XmlInputJsonOutput extends smithy4s.Endpoint[ContentHeaderTestServiceOperation,XmlInputJsonOutputInput, Nothing, XmlInputJsonOutputOutput, Nothing, Nothing] {
@@ -185,7 +213,7 @@ object ContentHeaderTestServiceOperation {
   }
   final case class XmlInput(input: XmlInputInput) extends ContentHeaderTestServiceOperation[XmlInputInput, Nothing, XmlInputOutput, Nothing, Nothing] {
     def run[F[_, _, _, _, _]](impl: ContentHeaderTestServiceGen[F]): F[XmlInputInput, Nothing, XmlInputOutput, Nothing, Nothing] = impl.xmlInput(input.data)
-    def ordinal: Int = 5
+    def ordinal: Int = 6
     def endpoint: smithy4s.Endpoint[ContentHeaderTestServiceOperation,XmlInputInput, Nothing, XmlInputOutput, Nothing, Nothing] = XmlInput
   }
   object XmlInput extends smithy4s.Endpoint[ContentHeaderTestServiceOperation,XmlInputInput, Nothing, XmlInputOutput, Nothing, Nothing] {
@@ -194,6 +222,18 @@ object ContentHeaderTestServiceOperation {
       .withOutput(XmlInputOutput.schema)
       .withHints(smithy.api.Documentation("Operation with XML input media type"), smithy.api.Http(method = smithy.api.NonEmptyString("POST"), uri = smithy.api.NonEmptyString("/xml-input"), code = 200))
     def wrap(input: XmlInputInput): XmlInput = XmlInput(input)
+  }
+  final case class ExplicitContentTypeHeader(input: ExplicitContentTypeHeaderInput) extends ContentHeaderTestServiceOperation[ExplicitContentTypeHeaderInput, Nothing, ExplicitContentTypeHeaderOutput, Nothing, Nothing] {
+    def run[F[_, _, _, _, _]](impl: ContentHeaderTestServiceGen[F]): F[ExplicitContentTypeHeaderInput, Nothing, ExplicitContentTypeHeaderOutput, Nothing, Nothing] = impl.explicitContentTypeHeader(input.data, input.contentType)
+    def ordinal: Int = 7
+    def endpoint: smithy4s.Endpoint[ContentHeaderTestServiceOperation,ExplicitContentTypeHeaderInput, Nothing, ExplicitContentTypeHeaderOutput, Nothing, Nothing] = ExplicitContentTypeHeader
+  }
+  object ExplicitContentTypeHeader extends smithy4s.Endpoint[ContentHeaderTestServiceOperation,ExplicitContentTypeHeaderInput, Nothing, ExplicitContentTypeHeaderOutput, Nothing, Nothing] {
+    val schema: OperationSchema[ExplicitContentTypeHeaderInput, Nothing, ExplicitContentTypeHeaderOutput, Nothing, Nothing] = Schema.operation(ShapeId("smithy4s.example.content", "ExplicitContentTypeHeader"))
+      .withInput(ExplicitContentTypeHeaderInput.schema)
+      .withOutput(ExplicitContentTypeHeaderOutput.schema)
+      .withHints(smithy.api.Documentation("Operation with explicit Content-Type header - should override default behavior"), smithy.api.Http(method = smithy.api.NonEmptyString("POST"), uri = smithy.api.NonEmptyString("/explicit-content-type"), code = 200))
+    def wrap(input: ExplicitContentTypeHeaderInput): ExplicitContentTypeHeader = ExplicitContentTypeHeader(input)
   }
 }
 

--- a/modules/bootstrapped/src/generated/smithy4s/example/content/ContentHeaderTestService.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/content/ContentHeaderTestService.scala
@@ -1,0 +1,199 @@
+package smithy4s.example.content
+
+import smithy4s.Blob
+import smithy4s.Endpoint
+import smithy4s.Hints
+import smithy4s.Schema
+import smithy4s.Service
+import smithy4s.ShapeId
+import smithy4s.Transformation
+import smithy4s.kinds.PolyFunction5
+import smithy4s.kinds.toPolyFunction5.const5
+import smithy4s.schema.OperationSchema
+
+trait ContentHeaderTestServiceGen[F[_, _, _, _, _]] {
+  self =>
+
+  /** Operation with Blob input that has media type
+    * 
+    * HTTP POST /blob-with-media
+    * 
+    * @param image
+    *   PNG image blob type
+    */
+  def blobInputWithMediaType(image: PngImage): F[BlobInputWithMediaTypeInput, Nothing, BlobInputWithMediaTypeOutput, Nothing, Nothing]
+  /** Operation with no media types - should use default Content-Type header
+    * 
+    * HTTP POST /default
+    */
+  def defaultContentHeader(data: String): F[DefaultContentHeaderInput, Nothing, DefaultContentHeaderOutput, Nothing, Nothing]
+  /** Operation with Blob input without media type
+    * 
+    * HTTP POST /blob-no-media
+    */
+  def blobInputNoMediaType(image: Blob): F[BlobInputNoMediaTypeInput, Nothing, BlobInputNoMediaTypeOutput, Nothing, Nothing]
+  /** Operation with only metadata (no body) - should not have Content-Type header
+    * 
+    * HTTP GET /no-body
+    */
+  def noBodyOperation(query: Option[String] = None): F[NoBodyOperationInput, Nothing, NoBodyOperationOutput, Nothing, Nothing]
+  /** Operation with different media types for input and output
+    * 
+    * HTTP POST /xml-json
+    * 
+    * @param data
+    *   XML payload type
+    */
+  def xmlInputJsonOutput(data: XmlPayload): F[XmlInputJsonOutputInput, Nothing, XmlInputJsonOutputOutput, Nothing, Nothing]
+  /** Operation with XML input media type
+    * 
+    * HTTP POST /xml-input
+    * 
+    * @param data
+    *   XML payload type
+    */
+  def xmlInput(data: XmlPayload): F[XmlInputInput, Nothing, XmlInputOutput, Nothing, Nothing]
+
+  final def transform: Transformation.PartiallyApplied[ContentHeaderTestServiceGen[F]] = Transformation.of[ContentHeaderTestServiceGen[F]](this)
+}
+
+object ContentHeaderTestServiceGen extends Service.Mixin[ContentHeaderTestServiceGen, ContentHeaderTestServiceOperation] {
+
+  val id: ShapeId = ShapeId("smithy4s.example.content", "ContentHeaderTestService")
+  val version: String = ""
+
+  val hints: Hints = Hints(
+    alloy.SimpleRestJson(),
+  ).lazily
+
+  def apply[F[_]](implicit F: Impl[F]): F.type = F
+
+  object ErrorAware {
+    def apply[F[_, _]](implicit F: ErrorAware[F]): F.type = F
+    type Default[F[+_, +_]] = Constant[smithy4s.kinds.stubs.Kind2[F]#toKind5]
+  }
+
+  val endpoints: Vector[smithy4s.Endpoint[ContentHeaderTestServiceOperation, _, _, _, _, _]] = Vector(
+    ContentHeaderTestServiceOperation.BlobInputWithMediaType,
+    ContentHeaderTestServiceOperation.DefaultContentHeader,
+    ContentHeaderTestServiceOperation.BlobInputNoMediaType,
+    ContentHeaderTestServiceOperation.NoBodyOperation,
+    ContentHeaderTestServiceOperation.XmlInputJsonOutput,
+    ContentHeaderTestServiceOperation.XmlInput,
+  )
+
+  def input[I, E, O, SI, SO](op: ContentHeaderTestServiceOperation[I, E, O, SI, SO]): I = op.input
+  def ordinal[I, E, O, SI, SO](op: ContentHeaderTestServiceOperation[I, E, O, SI, SO]): Int = op.ordinal
+  override def endpoint[I, E, O, SI, SO](op: ContentHeaderTestServiceOperation[I, E, O, SI, SO]) = op.endpoint
+  class Constant[P[-_, +_, +_, +_, +_]](value: P[Any, Nothing, Nothing, Nothing, Nothing]) extends ContentHeaderTestServiceOperation.Transformed[ContentHeaderTestServiceOperation, P](reified, const5(value))
+  type Default[F[+_]] = Constant[smithy4s.kinds.stubs.Kind1[F]#toKind5]
+  def reified: ContentHeaderTestServiceGen[ContentHeaderTestServiceOperation] = ContentHeaderTestServiceOperation.reified
+  def mapK5[P[_, _, _, _, _], P1[_, _, _, _, _]](alg: ContentHeaderTestServiceGen[P], f: PolyFunction5[P, P1]): ContentHeaderTestServiceGen[P1] = new ContentHeaderTestServiceOperation.Transformed(alg, f)
+  def fromPolyFunction[P[_, _, _, _, _]](f: PolyFunction5[ContentHeaderTestServiceOperation, P]): ContentHeaderTestServiceGen[P] = new ContentHeaderTestServiceOperation.Transformed(reified, f)
+  def toPolyFunction[P[_, _, _, _, _]](impl: ContentHeaderTestServiceGen[P]): PolyFunction5[ContentHeaderTestServiceOperation, P] = ContentHeaderTestServiceOperation.toPolyFunction(impl)
+
+}
+
+sealed trait ContentHeaderTestServiceOperation[Input, Err, Output, StreamedInput, StreamedOutput] {
+  def run[F[_, _, _, _, _]](impl: ContentHeaderTestServiceGen[F]): F[Input, Err, Output, StreamedInput, StreamedOutput]
+  def ordinal: Int
+  def input: Input
+  def endpoint: Endpoint[ContentHeaderTestServiceOperation, Input, Err, Output, StreamedInput, StreamedOutput]
+}
+
+object ContentHeaderTestServiceOperation {
+
+  object reified extends ContentHeaderTestServiceGen[ContentHeaderTestServiceOperation] {
+    def blobInputWithMediaType(image: PngImage): BlobInputWithMediaType = BlobInputWithMediaType(BlobInputWithMediaTypeInput(image))
+    def defaultContentHeader(data: String): DefaultContentHeader = DefaultContentHeader(DefaultContentHeaderInput(data))
+    def blobInputNoMediaType(image: Blob): BlobInputNoMediaType = BlobInputNoMediaType(BlobInputNoMediaTypeInput(image))
+    def noBodyOperation(query: Option[String] = None): NoBodyOperation = NoBodyOperation(NoBodyOperationInput(query))
+    def xmlInputJsonOutput(data: XmlPayload): XmlInputJsonOutput = XmlInputJsonOutput(XmlInputJsonOutputInput(data))
+    def xmlInput(data: XmlPayload): XmlInput = XmlInput(XmlInputInput(data))
+  }
+  class Transformed[P[_, _, _, _, _], P1[_ ,_ ,_ ,_ ,_]](alg: ContentHeaderTestServiceGen[P], f: PolyFunction5[P, P1]) extends ContentHeaderTestServiceGen[P1] {
+    def blobInputWithMediaType(image: PngImage): P1[BlobInputWithMediaTypeInput, Nothing, BlobInputWithMediaTypeOutput, Nothing, Nothing] = f[BlobInputWithMediaTypeInput, Nothing, BlobInputWithMediaTypeOutput, Nothing, Nothing](this.alg.blobInputWithMediaType(image))
+    def defaultContentHeader(data: String): P1[DefaultContentHeaderInput, Nothing, DefaultContentHeaderOutput, Nothing, Nothing] = f[DefaultContentHeaderInput, Nothing, DefaultContentHeaderOutput, Nothing, Nothing](this.alg.defaultContentHeader(data))
+    def blobInputNoMediaType(image: Blob): P1[BlobInputNoMediaTypeInput, Nothing, BlobInputNoMediaTypeOutput, Nothing, Nothing] = f[BlobInputNoMediaTypeInput, Nothing, BlobInputNoMediaTypeOutput, Nothing, Nothing](this.alg.blobInputNoMediaType(image))
+    def noBodyOperation(query: Option[String] = None): P1[NoBodyOperationInput, Nothing, NoBodyOperationOutput, Nothing, Nothing] = f[NoBodyOperationInput, Nothing, NoBodyOperationOutput, Nothing, Nothing](this.alg.noBodyOperation(query))
+    def xmlInputJsonOutput(data: XmlPayload): P1[XmlInputJsonOutputInput, Nothing, XmlInputJsonOutputOutput, Nothing, Nothing] = f[XmlInputJsonOutputInput, Nothing, XmlInputJsonOutputOutput, Nothing, Nothing](this.alg.xmlInputJsonOutput(data))
+    def xmlInput(data: XmlPayload): P1[XmlInputInput, Nothing, XmlInputOutput, Nothing, Nothing] = f[XmlInputInput, Nothing, XmlInputOutput, Nothing, Nothing](this.alg.xmlInput(data))
+  }
+
+  def toPolyFunction[P[_, _, _, _, _]](impl: ContentHeaderTestServiceGen[P]): PolyFunction5[ContentHeaderTestServiceOperation, P] = new PolyFunction5[ContentHeaderTestServiceOperation, P] {
+    def apply[I, E, O, SI, SO](op: ContentHeaderTestServiceOperation[I, E, O, SI, SO]): P[I, E, O, SI, SO] = op.run(impl) 
+  }
+  final case class BlobInputWithMediaType(input: BlobInputWithMediaTypeInput) extends ContentHeaderTestServiceOperation[BlobInputWithMediaTypeInput, Nothing, BlobInputWithMediaTypeOutput, Nothing, Nothing] {
+    def run[F[_, _, _, _, _]](impl: ContentHeaderTestServiceGen[F]): F[BlobInputWithMediaTypeInput, Nothing, BlobInputWithMediaTypeOutput, Nothing, Nothing] = impl.blobInputWithMediaType(input.image)
+    def ordinal: Int = 0
+    def endpoint: smithy4s.Endpoint[ContentHeaderTestServiceOperation,BlobInputWithMediaTypeInput, Nothing, BlobInputWithMediaTypeOutput, Nothing, Nothing] = BlobInputWithMediaType
+  }
+  object BlobInputWithMediaType extends smithy4s.Endpoint[ContentHeaderTestServiceOperation,BlobInputWithMediaTypeInput, Nothing, BlobInputWithMediaTypeOutput, Nothing, Nothing] {
+    val schema: OperationSchema[BlobInputWithMediaTypeInput, Nothing, BlobInputWithMediaTypeOutput, Nothing, Nothing] = Schema.operation(ShapeId("smithy4s.example.content", "BlobInputWithMediaType"))
+      .withInput(BlobInputWithMediaTypeInput.schema)
+      .withOutput(BlobInputWithMediaTypeOutput.schema)
+      .withHints(smithy.api.Documentation("Operation with Blob input that has media type"), smithy.api.Http(method = smithy.api.NonEmptyString("POST"), uri = smithy.api.NonEmptyString("/blob-with-media"), code = 200))
+    def wrap(input: BlobInputWithMediaTypeInput): BlobInputWithMediaType = BlobInputWithMediaType(input)
+  }
+  final case class DefaultContentHeader(input: DefaultContentHeaderInput) extends ContentHeaderTestServiceOperation[DefaultContentHeaderInput, Nothing, DefaultContentHeaderOutput, Nothing, Nothing] {
+    def run[F[_, _, _, _, _]](impl: ContentHeaderTestServiceGen[F]): F[DefaultContentHeaderInput, Nothing, DefaultContentHeaderOutput, Nothing, Nothing] = impl.defaultContentHeader(input.data)
+    def ordinal: Int = 1
+    def endpoint: smithy4s.Endpoint[ContentHeaderTestServiceOperation,DefaultContentHeaderInput, Nothing, DefaultContentHeaderOutput, Nothing, Nothing] = DefaultContentHeader
+  }
+  object DefaultContentHeader extends smithy4s.Endpoint[ContentHeaderTestServiceOperation,DefaultContentHeaderInput, Nothing, DefaultContentHeaderOutput, Nothing, Nothing] {
+    val schema: OperationSchema[DefaultContentHeaderInput, Nothing, DefaultContentHeaderOutput, Nothing, Nothing] = Schema.operation(ShapeId("smithy4s.example.content", "DefaultContentHeader"))
+      .withInput(DefaultContentHeaderInput.schema)
+      .withOutput(DefaultContentHeaderOutput.schema)
+      .withHints(smithy.api.Documentation("Operation with no media types - should use default Content-Type header"), smithy.api.Http(method = smithy.api.NonEmptyString("POST"), uri = smithy.api.NonEmptyString("/default"), code = 200))
+    def wrap(input: DefaultContentHeaderInput): DefaultContentHeader = DefaultContentHeader(input)
+  }
+  final case class BlobInputNoMediaType(input: BlobInputNoMediaTypeInput) extends ContentHeaderTestServiceOperation[BlobInputNoMediaTypeInput, Nothing, BlobInputNoMediaTypeOutput, Nothing, Nothing] {
+    def run[F[_, _, _, _, _]](impl: ContentHeaderTestServiceGen[F]): F[BlobInputNoMediaTypeInput, Nothing, BlobInputNoMediaTypeOutput, Nothing, Nothing] = impl.blobInputNoMediaType(input.image)
+    def ordinal: Int = 2
+    def endpoint: smithy4s.Endpoint[ContentHeaderTestServiceOperation,BlobInputNoMediaTypeInput, Nothing, BlobInputNoMediaTypeOutput, Nothing, Nothing] = BlobInputNoMediaType
+  }
+  object BlobInputNoMediaType extends smithy4s.Endpoint[ContentHeaderTestServiceOperation,BlobInputNoMediaTypeInput, Nothing, BlobInputNoMediaTypeOutput, Nothing, Nothing] {
+    val schema: OperationSchema[BlobInputNoMediaTypeInput, Nothing, BlobInputNoMediaTypeOutput, Nothing, Nothing] = Schema.operation(ShapeId("smithy4s.example.content", "BlobInputNoMediaType"))
+      .withInput(BlobInputNoMediaTypeInput.schema)
+      .withOutput(BlobInputNoMediaTypeOutput.schema)
+      .withHints(smithy.api.Documentation("Operation with Blob input without media type"), smithy.api.Http(method = smithy.api.NonEmptyString("POST"), uri = smithy.api.NonEmptyString("/blob-no-media"), code = 200))
+    def wrap(input: BlobInputNoMediaTypeInput): BlobInputNoMediaType = BlobInputNoMediaType(input)
+  }
+  final case class NoBodyOperation(input: NoBodyOperationInput) extends ContentHeaderTestServiceOperation[NoBodyOperationInput, Nothing, NoBodyOperationOutput, Nothing, Nothing] {
+    def run[F[_, _, _, _, _]](impl: ContentHeaderTestServiceGen[F]): F[NoBodyOperationInput, Nothing, NoBodyOperationOutput, Nothing, Nothing] = impl.noBodyOperation(input.query)
+    def ordinal: Int = 3
+    def endpoint: smithy4s.Endpoint[ContentHeaderTestServiceOperation,NoBodyOperationInput, Nothing, NoBodyOperationOutput, Nothing, Nothing] = NoBodyOperation
+  }
+  object NoBodyOperation extends smithy4s.Endpoint[ContentHeaderTestServiceOperation,NoBodyOperationInput, Nothing, NoBodyOperationOutput, Nothing, Nothing] {
+    val schema: OperationSchema[NoBodyOperationInput, Nothing, NoBodyOperationOutput, Nothing, Nothing] = Schema.operation(ShapeId("smithy4s.example.content", "NoBodyOperation"))
+      .withInput(NoBodyOperationInput.schema)
+      .withOutput(NoBodyOperationOutput.schema)
+      .withHints(smithy.api.Documentation("Operation with only metadata (no body) - should not have Content-Type header"), smithy.api.Http(method = smithy.api.NonEmptyString("GET"), uri = smithy.api.NonEmptyString("/no-body"), code = 200))
+    def wrap(input: NoBodyOperationInput): NoBodyOperation = NoBodyOperation(input)
+  }
+  final case class XmlInputJsonOutput(input: XmlInputJsonOutputInput) extends ContentHeaderTestServiceOperation[XmlInputJsonOutputInput, Nothing, XmlInputJsonOutputOutput, Nothing, Nothing] {
+    def run[F[_, _, _, _, _]](impl: ContentHeaderTestServiceGen[F]): F[XmlInputJsonOutputInput, Nothing, XmlInputJsonOutputOutput, Nothing, Nothing] = impl.xmlInputJsonOutput(input.data)
+    def ordinal: Int = 4
+    def endpoint: smithy4s.Endpoint[ContentHeaderTestServiceOperation,XmlInputJsonOutputInput, Nothing, XmlInputJsonOutputOutput, Nothing, Nothing] = XmlInputJsonOutput
+  }
+  object XmlInputJsonOutput extends smithy4s.Endpoint[ContentHeaderTestServiceOperation,XmlInputJsonOutputInput, Nothing, XmlInputJsonOutputOutput, Nothing, Nothing] {
+    val schema: OperationSchema[XmlInputJsonOutputInput, Nothing, XmlInputJsonOutputOutput, Nothing, Nothing] = Schema.operation(ShapeId("smithy4s.example.content", "XmlInputJsonOutput"))
+      .withInput(XmlInputJsonOutputInput.schema)
+      .withOutput(XmlInputJsonOutputOutput.schema)
+      .withHints(smithy.api.Documentation("Operation with different media types for input and output"), smithy.api.Http(method = smithy.api.NonEmptyString("POST"), uri = smithy.api.NonEmptyString("/xml-json"), code = 200))
+    def wrap(input: XmlInputJsonOutputInput): XmlInputJsonOutput = XmlInputJsonOutput(input)
+  }
+  final case class XmlInput(input: XmlInputInput) extends ContentHeaderTestServiceOperation[XmlInputInput, Nothing, XmlInputOutput, Nothing, Nothing] {
+    def run[F[_, _, _, _, _]](impl: ContentHeaderTestServiceGen[F]): F[XmlInputInput, Nothing, XmlInputOutput, Nothing, Nothing] = impl.xmlInput(input.data)
+    def ordinal: Int = 5
+    def endpoint: smithy4s.Endpoint[ContentHeaderTestServiceOperation,XmlInputInput, Nothing, XmlInputOutput, Nothing, Nothing] = XmlInput
+  }
+  object XmlInput extends smithy4s.Endpoint[ContentHeaderTestServiceOperation,XmlInputInput, Nothing, XmlInputOutput, Nothing, Nothing] {
+    val schema: OperationSchema[XmlInputInput, Nothing, XmlInputOutput, Nothing, Nothing] = Schema.operation(ShapeId("smithy4s.example.content", "XmlInput"))
+      .withInput(XmlInputInput.schema)
+      .withOutput(XmlInputOutput.schema)
+      .withHints(smithy.api.Documentation("Operation with XML input media type"), smithy.api.Http(method = smithy.api.NonEmptyString("POST"), uri = smithy.api.NonEmptyString("/xml-input"), code = 200))
+    def wrap(input: XmlInputInput): XmlInput = XmlInput(input)
+  }
+}
+

--- a/modules/bootstrapped/src/generated/smithy4s/example/content/DefaultContentHeaderInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/content/DefaultContentHeaderInput.scala
@@ -1,0 +1,25 @@
+package smithy4s.example.content
+
+import smithy4s.Hints
+import smithy4s.Schema
+import smithy4s.ShapeId
+import smithy4s.ShapeTag
+import smithy4s.schema.Schema.string
+import smithy4s.schema.Schema.struct
+
+final case class DefaultContentHeaderInput(data: String)
+
+object DefaultContentHeaderInput extends ShapeTag.Companion[DefaultContentHeaderInput] {
+  val id: ShapeId = ShapeId("smithy4s.example.content", "DefaultContentHeaderInput")
+
+  val hints: Hints = Hints(
+    smithy.api.Input(),
+  ).lazily
+
+  // constructor using the original order from the spec
+  private def make(data: String): DefaultContentHeaderInput = DefaultContentHeaderInput(data)
+
+  implicit val schema: Schema[DefaultContentHeaderInput] = struct(
+    string.required[DefaultContentHeaderInput]("data", _.data).addHints(smithy.api.HttpPayload()),
+  )(make).withId(id).addHints(hints)
+}

--- a/modules/bootstrapped/src/generated/smithy4s/example/content/DefaultContentHeaderOutput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/content/DefaultContentHeaderOutput.scala
@@ -1,0 +1,25 @@
+package smithy4s.example.content
+
+import smithy4s.Hints
+import smithy4s.Schema
+import smithy4s.ShapeId
+import smithy4s.ShapeTag
+import smithy4s.schema.Schema.string
+import smithy4s.schema.Schema.struct
+
+final case class DefaultContentHeaderOutput(result: Option[String] = None)
+
+object DefaultContentHeaderOutput extends ShapeTag.Companion[DefaultContentHeaderOutput] {
+  val id: ShapeId = ShapeId("smithy4s.example.content", "DefaultContentHeaderOutput")
+
+  val hints: Hints = Hints(
+    smithy.api.Output(),
+  ).lazily
+
+  // constructor using the original order from the spec
+  private def make(result: Option[String]): DefaultContentHeaderOutput = DefaultContentHeaderOutput(result)
+
+  implicit val schema: Schema[DefaultContentHeaderOutput] = struct(
+    string.optional[DefaultContentHeaderOutput]("result", _.result).addHints(smithy.api.HttpPayload()),
+  )(make).withId(id).addHints(hints)
+}

--- a/modules/bootstrapped/src/generated/smithy4s/example/content/JsonPayload.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/content/JsonPayload.scala
@@ -1,0 +1,19 @@
+package smithy4s.example.content
+
+import smithy4s.Hints
+import smithy4s.Newtype
+import smithy4s.Schema
+import smithy4s.ShapeId
+import smithy4s.schema.Schema.bijection
+import smithy4s.schema.Schema.string
+
+/** JSON payload type */
+object JsonPayload extends Newtype[String] {
+  val id: ShapeId = ShapeId("smithy4s.example.content", "JsonPayload")
+  val hints: Hints = Hints(
+    smithy.api.Documentation("JSON payload type"),
+    smithy.api.MediaType("application/json"),
+  ).lazily
+  val underlyingSchema: Schema[String] = string.withId(id).addHints(hints)
+  implicit val schema: Schema[JsonPayload] = bijection(underlyingSchema, asBijection)
+}

--- a/modules/bootstrapped/src/generated/smithy4s/example/content/NoBodyOperationInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/content/NoBodyOperationInput.scala
@@ -1,0 +1,25 @@
+package smithy4s.example.content
+
+import smithy4s.Hints
+import smithy4s.Schema
+import smithy4s.ShapeId
+import smithy4s.ShapeTag
+import smithy4s.schema.Schema.string
+import smithy4s.schema.Schema.struct
+
+final case class NoBodyOperationInput(query: Option[String] = None)
+
+object NoBodyOperationInput extends ShapeTag.Companion[NoBodyOperationInput] {
+  val id: ShapeId = ShapeId("smithy4s.example.content", "NoBodyOperationInput")
+
+  val hints: Hints = Hints(
+    smithy.api.Input(),
+  ).lazily
+
+  // constructor using the original order from the spec
+  private def make(query: Option[String]): NoBodyOperationInput = NoBodyOperationInput(query)
+
+  implicit val schema: Schema[NoBodyOperationInput] = struct(
+    string.optional[NoBodyOperationInput]("query", _.query).addHints(smithy.api.HttpQuery("q")),
+  )(make).withId(id).addHints(hints)
+}

--- a/modules/bootstrapped/src/generated/smithy4s/example/content/NoBodyOperationOutput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/content/NoBodyOperationOutput.scala
@@ -1,0 +1,25 @@
+package smithy4s.example.content
+
+import smithy4s.Hints
+import smithy4s.Schema
+import smithy4s.ShapeId
+import smithy4s.ShapeTag
+import smithy4s.schema.Schema.string
+import smithy4s.schema.Schema.struct
+
+final case class NoBodyOperationOutput(data: Option[String] = None)
+
+object NoBodyOperationOutput extends ShapeTag.Companion[NoBodyOperationOutput] {
+  val id: ShapeId = ShapeId("smithy4s.example.content", "NoBodyOperationOutput")
+
+  val hints: Hints = Hints(
+    smithy.api.Output(),
+  ).lazily
+
+  // constructor using the original order from the spec
+  private def make(data: Option[String]): NoBodyOperationOutput = NoBodyOperationOutput(data)
+
+  implicit val schema: Schema[NoBodyOperationOutput] = struct(
+    string.optional[NoBodyOperationOutput]("data", _.data).addHints(smithy.api.HttpPayload()),
+  )(make).withId(id).addHints(hints)
+}

--- a/modules/bootstrapped/src/generated/smithy4s/example/content/PlainTextPayload.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/content/PlainTextPayload.scala
@@ -1,0 +1,19 @@
+package smithy4s.example.content
+
+import smithy4s.Hints
+import smithy4s.Newtype
+import smithy4s.Schema
+import smithy4s.ShapeId
+import smithy4s.schema.Schema.bijection
+import smithy4s.schema.Schema.string
+
+/** Plain text payload type */
+object PlainTextPayload extends Newtype[String] {
+  val id: ShapeId = ShapeId("smithy4s.example.content", "PlainTextPayload")
+  val hints: Hints = Hints(
+    smithy.api.Documentation("Plain text payload type"),
+    smithy.api.MediaType("text/plain"),
+  ).lazily
+  val underlyingSchema: Schema[String] = string.withId(id).addHints(hints)
+  implicit val schema: Schema[PlainTextPayload] = bijection(underlyingSchema, asBijection)
+}

--- a/modules/bootstrapped/src/generated/smithy4s/example/content/PngImage.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/content/PngImage.scala
@@ -1,0 +1,20 @@
+package smithy4s.example.content
+
+import smithy4s.Blob
+import smithy4s.Hints
+import smithy4s.Newtype
+import smithy4s.Schema
+import smithy4s.ShapeId
+import smithy4s.schema.Schema.bijection
+import smithy4s.schema.Schema.bytes
+
+/** PNG image blob type */
+object PngImage extends Newtype[Blob] {
+  val id: ShapeId = ShapeId("smithy4s.example.content", "PngImage")
+  val hints: Hints = Hints(
+    smithy.api.Documentation("PNG image blob type"),
+    smithy.api.MediaType("image/png"),
+  ).lazily
+  val underlyingSchema: Schema[Blob] = bytes.withId(id).addHints(hints)
+  implicit val schema: Schema[PngImage] = bijection(underlyingSchema, asBijection)
+}

--- a/modules/bootstrapped/src/generated/smithy4s/example/content/XmlInputInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/content/XmlInputInput.scala
@@ -1,0 +1,27 @@
+package smithy4s.example.content
+
+import smithy4s.Hints
+import smithy4s.Schema
+import smithy4s.ShapeId
+import smithy4s.ShapeTag
+import smithy4s.schema.Schema.struct
+
+/** @param data
+  *   XML payload type
+  */
+final case class XmlInputInput(data: XmlPayload)
+
+object XmlInputInput extends ShapeTag.Companion[XmlInputInput] {
+  val id: ShapeId = ShapeId("smithy4s.example.content", "XmlInputInput")
+
+  val hints: Hints = Hints(
+    smithy.api.Input(),
+  ).lazily
+
+  // constructor using the original order from the spec
+  private def make(data: XmlPayload): XmlInputInput = XmlInputInput(data)
+
+  implicit val schema: Schema[XmlInputInput] = struct(
+    XmlPayload.schema.required[XmlInputInput]("data", _.data).addHints(smithy.api.HttpPayload()),
+  )(make).withId(id).addHints(hints)
+}

--- a/modules/bootstrapped/src/generated/smithy4s/example/content/XmlInputJsonOutputInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/content/XmlInputJsonOutputInput.scala
@@ -1,0 +1,27 @@
+package smithy4s.example.content
+
+import smithy4s.Hints
+import smithy4s.Schema
+import smithy4s.ShapeId
+import smithy4s.ShapeTag
+import smithy4s.schema.Schema.struct
+
+/** @param data
+  *   XML payload type
+  */
+final case class XmlInputJsonOutputInput(data: XmlPayload)
+
+object XmlInputJsonOutputInput extends ShapeTag.Companion[XmlInputJsonOutputInput] {
+  val id: ShapeId = ShapeId("smithy4s.example.content", "XmlInputJsonOutputInput")
+
+  val hints: Hints = Hints(
+    smithy.api.Input(),
+  ).lazily
+
+  // constructor using the original order from the spec
+  private def make(data: XmlPayload): XmlInputJsonOutputInput = XmlInputJsonOutputInput(data)
+
+  implicit val schema: Schema[XmlInputJsonOutputInput] = struct(
+    XmlPayload.schema.required[XmlInputJsonOutputInput]("data", _.data).addHints(smithy.api.HttpPayload()),
+  )(make).withId(id).addHints(hints)
+}

--- a/modules/bootstrapped/src/generated/smithy4s/example/content/XmlInputJsonOutputOutput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/content/XmlInputJsonOutputOutput.scala
@@ -1,0 +1,27 @@
+package smithy4s.example.content
+
+import smithy4s.Hints
+import smithy4s.Schema
+import smithy4s.ShapeId
+import smithy4s.ShapeTag
+import smithy4s.schema.Schema.struct
+
+/** @param result
+  *   JSON payload type
+  */
+final case class XmlInputJsonOutputOutput(result: Option[JsonPayload] = None)
+
+object XmlInputJsonOutputOutput extends ShapeTag.Companion[XmlInputJsonOutputOutput] {
+  val id: ShapeId = ShapeId("smithy4s.example.content", "XmlInputJsonOutputOutput")
+
+  val hints: Hints = Hints(
+    smithy.api.Output(),
+  ).lazily
+
+  // constructor using the original order from the spec
+  private def make(result: Option[JsonPayload]): XmlInputJsonOutputOutput = XmlInputJsonOutputOutput(result)
+
+  implicit val schema: Schema[XmlInputJsonOutputOutput] = struct(
+    JsonPayload.schema.optional[XmlInputJsonOutputOutput]("result", _.result).addHints(smithy.api.HttpPayload()),
+  )(make).withId(id).addHints(hints)
+}

--- a/modules/bootstrapped/src/generated/smithy4s/example/content/XmlInputOutput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/content/XmlInputOutput.scala
@@ -1,0 +1,25 @@
+package smithy4s.example.content
+
+import smithy4s.Hints
+import smithy4s.Schema
+import smithy4s.ShapeId
+import smithy4s.ShapeTag
+import smithy4s.schema.Schema.string
+import smithy4s.schema.Schema.struct
+
+final case class XmlInputOutput(result: Option[String] = None)
+
+object XmlInputOutput extends ShapeTag.Companion[XmlInputOutput] {
+  val id: ShapeId = ShapeId("smithy4s.example.content", "XmlInputOutput")
+
+  val hints: Hints = Hints(
+    smithy.api.Output(),
+  ).lazily
+
+  // constructor using the original order from the spec
+  private def make(result: Option[String]): XmlInputOutput = XmlInputOutput(result)
+
+  implicit val schema: Schema[XmlInputOutput] = struct(
+    string.optional[XmlInputOutput]("result", _.result).addHints(smithy.api.HttpPayload()),
+  )(make).withId(id).addHints(hints)
+}

--- a/modules/bootstrapped/src/generated/smithy4s/example/content/XmlPayload.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/content/XmlPayload.scala
@@ -1,0 +1,19 @@
+package smithy4s.example.content
+
+import smithy4s.Hints
+import smithy4s.Newtype
+import smithy4s.Schema
+import smithy4s.ShapeId
+import smithy4s.schema.Schema.bijection
+import smithy4s.schema.Schema.string
+
+/** XML payload type */
+object XmlPayload extends Newtype[String] {
+  val id: ShapeId = ShapeId("smithy4s.example.content", "XmlPayload")
+  val hints: Hints = Hints(
+    smithy.api.Documentation("XML payload type"),
+    smithy.api.MediaType("application/xml"),
+  ).lazily
+  val underlyingSchema: Schema[String] = string.withId(id).addHints(hints)
+  implicit val schema: Schema[XmlPayload] = bijection(underlyingSchema, asBijection)
+}

--- a/modules/bootstrapped/src/generated/smithy4s/example/content/package.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/content/package.scala
@@ -1,0 +1,16 @@
+package smithy4s.example
+
+package object content {
+  type ContentHeaderTestService[F[_]] = smithy4s.kinds.FunctorAlgebra[ContentHeaderTestServiceGen, F]
+  val ContentHeaderTestService = ContentHeaderTestServiceGen
+
+  /** JSON payload type */
+  type JsonPayload = smithy4s.example.content.JsonPayload.Type
+  /** Plain text payload type */
+  type PlainTextPayload = smithy4s.example.content.PlainTextPayload.Type
+  /** PNG image blob type */
+  type PngImage = smithy4s.example.content.PngImage.Type
+  /** XML payload type */
+  type XmlPayload = smithy4s.example.content.XmlPayload.Type
+
+}

--- a/modules/bootstrapped/test/src/smithy4s/http/AcceptHeaderSpec.scala
+++ b/modules/bootstrapped/test/src/smithy4s/http/AcceptHeaderSpec.scala
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2021-2025 Disney Streaming
+ *  Copyright 2021-2026 Disney Streaming
  *
  *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/modules/bootstrapped/test/src/smithy4s/http/ContentHeaderSpec.scala
+++ b/modules/bootstrapped/test/src/smithy4s/http/ContentHeaderSpec.scala
@@ -42,6 +42,7 @@ final class ContentHeaderSpec extends FunSuite {
   ], HttpResponse[Blob]] =
     HttpUnaryClientCodecs
       .builder[Id]
+      .withMetadataEncoders(Metadata.Encoder)
       .withBaseRequest(_ =>
         HttpRequest(
           HttpMethod.POST,
@@ -86,7 +87,7 @@ final class ContentHeaderSpec extends FunSuite {
   }
 
   test(
-    "Content-Type header uses default requestMediaType (text/plain) when no specific media type is set"
+    "Content-Type header is NOT set when body encoders are not configured (body is empty)"
   ) {
     val codecsMake = baseBuilder.build()
 
@@ -102,7 +103,8 @@ final class ContentHeaderSpec extends FunSuite {
     val request = codec.inputEncoder(DefaultContentHeaderInput("hello"))
 
     val contentTypeHeader = extractContentTypeHeader(request)
-    assertEquals(contentTypeHeader, Some("text/plain"))
+    // Without body encoders, the body stays empty, so no Content-Type
+    assertEquals(contentTypeHeader, None)
   }
 
   test(
@@ -133,7 +135,8 @@ final class ContentHeaderSpec extends FunSuite {
     ](
       ContentHeaderTestServiceOperation.BlobInputNoMediaType.schema
     )
-    val request = codec.inputEncoder(BlobInputNoMediaTypeInput(Blob.empty))
+    val request =
+      codec.inputEncoder(BlobInputNoMediaTypeInput(Blob("some data")))
 
     val contentTypeHeader = extractContentTypeHeader(request)
     // Blob without @mediaType defaults to "application/octet-stream"
@@ -173,10 +176,56 @@ final class ContentHeaderSpec extends FunSuite {
       ContentHeaderTestServiceOperation.BlobInputWithMediaType.schema
     )
     val request =
-      codec.inputEncoder(BlobInputWithMediaTypeInput(PngImage(Blob.empty)))
+      codec.inputEncoder(
+        BlobInputWithMediaTypeInput(PngImage(Blob("fake png data")))
+      )
 
     val contentTypeHeader = extractContentTypeHeader(request)
     assertEquals(contentTypeHeader, Some("image/png"))
+  }
+
+  test(
+    "Content-Type header is NOT set for Blob input with @mediaType when body is empty"
+  ) {
+    val codec = codecWithRawStringsAndBlobsPayloads.apply[
+      BlobInputWithMediaTypeInput,
+      Nothing,
+      BlobInputWithMediaTypeOutput,
+      Nothing,
+      Nothing
+    ](
+      ContentHeaderTestServiceOperation.BlobInputWithMediaType.schema
+    )
+    val request =
+      codec.inputEncoder(BlobInputWithMediaTypeInput(PngImage(Blob.empty)))
+
+    val contentTypeHeader = extractContentTypeHeader(request)
+    // Even though schema specifies @mediaType("image/png"), no Content-Type when body is empty
+    assertEquals(contentTypeHeader, None)
+  }
+
+  test(
+    "Content-Type header respects explicit @httpHeader(\"Content-Type\") over defaults"
+  ) {
+    val codec = codecWithRawStringsAndBlobsPayloads.apply[
+      ExplicitContentTypeHeaderInput,
+      Nothing,
+      ExplicitContentTypeHeaderOutput,
+      Nothing,
+      Nothing
+    ](
+      ContentHeaderTestServiceOperation.ExplicitContentTypeHeader.schema
+    )
+    val request = codec.inputEncoder(
+      ExplicitContentTypeHeaderInput(
+        contentType = Some("application/custom-type"),
+        data = Blob("test data")
+      )
+    )
+
+    val contentTypeHeader = extractContentTypeHeader(request)
+    // Explicit Content-Type from @httpHeader should override default behavior
+    assertEquals(contentTypeHeader, Some("application/custom-type"))
   }
 
   test(
@@ -197,6 +246,56 @@ final class ContentHeaderSpec extends FunSuite {
 
     val contentTypeHeader = extractContentTypeHeader(request)
     // No body content, so no Content-Type header should be set
+    assertEquals(contentTypeHeader, None)
+  }
+
+  test(
+    "Content-Type header is NOT set for empty struct with writeEmptyStructs=true but no JSON encoders"
+  ) {
+    val codecsMake =
+      baseBuilder.withRawStringsAndBlobsPayloads // Provides String/Blob encoders, but not struct encoders
+        .withWriteEmptyStructs(_ => true) // Enable writing empty structs
+        .build()
+
+    val codec = codecsMake.apply[
+      EmptyStructOperationInput,
+      Nothing,
+      EmptyStructOperationOutput,
+      Nothing,
+      Nothing
+    ](
+      ContentHeaderTestServiceOperation.EmptyStructOperation.schema
+    )
+    val request = codec.inputEncoder(EmptyStructOperationInput())
+
+    val contentTypeHeader = extractContentTypeHeader(request)
+    // Without JSON encoders, empty struct writes empty Blob (not {}), so Content-Type is NOT set
+    assertEquals(contentTypeHeader, None)
+  }
+
+  test(
+    "Content-Type header is NOT set for empty struct when writeEmptyStructs is false"
+  ) {
+    val codecsMake =
+      baseBuilder.withRawStringsAndBlobsPayloads // Same encoders as the true case
+        .withWriteEmptyStructs(_ =>
+          false
+        ) // Explicitly disable (though this is the default)
+        .build()
+
+    val codec = codecsMake.apply[
+      EmptyStructOperationInput,
+      Nothing,
+      EmptyStructOperationOutput,
+      Nothing,
+      Nothing
+    ](
+      ContentHeaderTestServiceOperation.EmptyStructOperation.schema
+    )
+    val request = codec.inputEncoder(EmptyStructOperationInput())
+
+    val contentTypeHeader = extractContentTypeHeader(request)
+    // Empty struct will NOT be serialized (no body), so Content-Type should NOT be set
     assertEquals(contentTypeHeader, None)
   }
 }

--- a/modules/bootstrapped/test/src/smithy4s/http/ContentHeaderSpec.scala
+++ b/modules/bootstrapped/test/src/smithy4s/http/ContentHeaderSpec.scala
@@ -1,0 +1,205 @@
+/*
+ *  Copyright 2021-2026 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package smithy4s.http
+
+import munit._
+import smithy4s._
+import smithy4s.capability.MonadThrowLike
+import smithy4s.example.content._
+import cats.Id
+import smithy4s.client.UnaryClientCodecs
+import smithy4s.http.Metadata
+
+final class ContentHeaderSpec extends FunSuite {
+
+  implicit val F: MonadThrowLike[Id] = new MonadThrowLike[Id] {
+    override def map[A, B](fa: Id[A])(f: A => B): Id[B] = f(fa)
+    def flatMap[A, B](fa: Id[A])(f: A => Id[B]): Id[B] = f(fa)
+    def raiseError[A](e: Throwable): Id[A] = throw e
+    def handleErrorWith[A](fa: Id[A])(f: Throwable => Id[A]): Id[A] =
+      try fa
+      catch { case e: Throwable => f(e) }
+    def pure[A](a: A): Id[A] = a
+    def zipMapAll[A](seq: IndexedSeq[Id[Any]])(f: IndexedSeq[Any] => A): Id[A] =
+      f(seq)
+  }
+
+  def baseBuilder: HttpUnaryClientCodecs.Builder[Id, HttpRequest[
+    Blob
+  ], HttpResponse[Blob]] =
+    HttpUnaryClientCodecs
+      .builder[Id]
+      .withMetadataEncoders(Metadata.Encoder)
+      .withBaseRequest(_ =>
+        HttpRequest(
+          HttpMethod.POST,
+          HttpUri.fromURI(new java.net.URI("/")),
+          Map.empty,
+          Blob.empty
+        )
+      )
+
+  val codecWithRawStringsAndBlobsPayloads
+      : UnaryClientCodecs.Make[Id, HttpRequest[Blob], HttpResponse[Blob]] =
+    baseBuilder.withRawStringsAndBlobsPayloads.build()
+
+  def extractContentTypeHeader(request: HttpRequest[Blob]): Option[String] = {
+    request.headers
+      .get(CaseInsensitive("Content-Type"))
+      .flatMap(_.headOption)
+  }
+
+  test(
+    "Content-Type header uses provided requestMediaType when rawStringsAndBlobPayloads is true"
+  ) {
+    val codecsMake = baseBuilder
+      .withRequestMediaType("application/json")
+      .withRawStringsAndBlobsPayloads
+      .build()
+
+    val codec = codecsMake.apply[
+      DefaultContentHeaderInput,
+      Nothing,
+      DefaultContentHeaderOutput,
+      Nothing,
+      Nothing
+    ](
+      ContentHeaderTestServiceOperation.DefaultContentHeader.schema
+    )
+    val request = codec.inputEncoder(DefaultContentHeaderInput("test data"))
+
+    val contentTypeHeader = extractContentTypeHeader(request)
+    // Note: The builder chain doesn't properly override requestMediaType, so it uses the default "text/plain"
+    // In production (http4s), the codec is configured directly with the desired requestMediaType
+    assertEquals(contentTypeHeader, Some("text/plain"))
+  }
+
+  test(
+    "Content-Type header uses default requestMediaType (text/plain) when no specific media type is set"
+  ) {
+    val codecsMake = baseBuilder.withRawStringsAndBlobsPayloads.build()
+
+    val codec = codecsMake.apply[
+      DefaultContentHeaderInput,
+      Nothing,
+      DefaultContentHeaderOutput,
+      Nothing,
+      Nothing
+    ](
+      ContentHeaderTestServiceOperation.DefaultContentHeader.schema
+    )
+    val request = codec.inputEncoder(DefaultContentHeaderInput("hello"))
+
+    val contentTypeHeader = extractContentTypeHeader(request)
+    assertEquals(contentTypeHeader, Some("text/plain"))
+  }
+
+  test(
+    "Content-Type header derives from input schema and uses the value from @mediaType, when rawStringsAndBlobPayloads is true and input has @mediaType applied"
+  ) {
+
+    val codec = codecWithRawStringsAndBlobsPayloads
+      .apply[XmlInputInput, Nothing, XmlInputOutput, Nothing, Nothing](
+        ContentHeaderTestServiceOperation.XmlInput.schema
+      )
+    val request = codec.inputEncoder(XmlInputInput(XmlPayload("test")))
+
+    val contentTypeHeader = extractContentTypeHeader(request)
+    assertEquals(contentTypeHeader, Some("application/xml"))
+  }
+
+  test(
+    "Content-Type header uses the default media type provided by the protocol, when rawStringsAndBlobPayloads is true but input has no @mediaType"
+  ) {
+    val codecsMake = codecWithRawStringsAndBlobsPayloads
+
+    val codec = codecsMake.apply[
+      BlobInputNoMediaTypeInput,
+      Nothing,
+      BlobInputNoMediaTypeOutput,
+      Nothing,
+      Nothing
+    ](
+      ContentHeaderTestServiceOperation.BlobInputNoMediaType.schema
+    )
+    val request = codec.inputEncoder(BlobInputNoMediaTypeInput(Blob.empty))
+
+    val contentTypeHeader = extractContentTypeHeader(request)
+    // Blob without @mediaType defaults to "application/octet-stream"
+    assertEquals(contentTypeHeader, Some("application/octet-stream"))
+  }
+
+  test(
+    "Content-Type header correctly derives from input when input and output have different media types"
+  ) {
+
+    val codec = codecWithRawStringsAndBlobsPayloads.apply[
+      XmlInputJsonOutputInput,
+      Nothing,
+      XmlInputJsonOutputOutput,
+      Nothing,
+      Nothing
+    ](
+      ContentHeaderTestServiceOperation.XmlInputJsonOutput.schema
+    )
+    val request =
+      codec.inputEncoder(XmlInputJsonOutputInput(XmlPayload("test")))
+
+    val contentTypeHeader = extractContentTypeHeader(request)
+    // Content-Type header should be derived from input (XmlPayload), not output (JsonPayload)
+    assertEquals(contentTypeHeader, Some("application/xml"))
+  }
+
+  test("Content-Type header for Blob input with @mediaType") {
+
+    val codec = codecWithRawStringsAndBlobsPayloads.apply[
+      BlobInputWithMediaTypeInput,
+      Nothing,
+      BlobInputWithMediaTypeOutput,
+      Nothing,
+      Nothing
+    ](
+      ContentHeaderTestServiceOperation.BlobInputWithMediaType.schema
+    )
+    val request =
+      codec.inputEncoder(BlobInputWithMediaTypeInput(PngImage(Blob.empty)))
+
+    val contentTypeHeader = extractContentTypeHeader(request)
+    assertEquals(contentTypeHeader, Some("image/png"))
+  }
+
+  test(
+    "Content-Type header is not set when there is no body content (only metadata)"
+  ) {
+    val codecsMake = baseBuilder.withRawStringsAndBlobsPayloads.build()
+
+    val codec = codecsMake.apply[
+      NoBodyOperationInput,
+      Nothing,
+      NoBodyOperationOutput,
+      Nothing,
+      Nothing
+    ](
+      ContentHeaderTestServiceOperation.NoBodyOperation.schema
+    )
+    val request = codec.inputEncoder(NoBodyOperationInput(Some("test query")))
+
+    val contentTypeHeader = extractContentTypeHeader(request)
+    // No body content, so no Content-Type header should be set
+    assertEquals(contentTypeHeader, None)
+  }
+}

--- a/modules/bootstrapped/test/src/smithy4s/http/ContentHeaderSpec.scala
+++ b/modules/bootstrapped/test/src/smithy4s/http/ContentHeaderSpec.scala
@@ -22,7 +22,6 @@ import smithy4s.capability.MonadThrowLike
 import smithy4s.example.content._
 import cats.Id
 import smithy4s.client.UnaryClientCodecs
-import smithy4s.http.Metadata
 
 final class ContentHeaderSpec extends FunSuite {
 
@@ -43,7 +42,6 @@ final class ContentHeaderSpec extends FunSuite {
   ], HttpResponse[Blob]] =
     HttpUnaryClientCodecs
       .builder[Id]
-      .withMetadataEncoders(Metadata.Encoder)
       .withBaseRequest(_ =>
         HttpRequest(
           HttpMethod.POST,

--- a/modules/bootstrapped/test/src/smithy4s/http/ContentHeaderSpec.scala
+++ b/modules/bootstrapped/test/src/smithy4s/http/ContentHeaderSpec.scala
@@ -62,7 +62,7 @@ final class ContentHeaderSpec extends FunSuite {
   }
 
   test(
-    "Content-Type header uses provided requestMediaType when rawStringsAndBlobPayloads is true"
+    "Content-Type header ignores provided requestMediaType when rawStringsAndBlobPayloads is true, rather header is derived from the input schema"
   ) {
     val codecsMake = baseBuilder
       .withRequestMediaType("application/json")
@@ -81,15 +81,14 @@ final class ContentHeaderSpec extends FunSuite {
     val request = codec.inputEncoder(DefaultContentHeaderInput("test data"))
 
     val contentTypeHeader = extractContentTypeHeader(request)
-    // Note: The builder chain doesn't properly override requestMediaType, so it uses the default "text/plain"
-    // In production (http4s), the codec is configured directly with the desired requestMediaType
+
     assertEquals(contentTypeHeader, Some("text/plain"))
   }
 
   test(
     "Content-Type header uses default requestMediaType (text/plain) when no specific media type is set"
   ) {
-    val codecsMake = baseBuilder.withRawStringsAndBlobsPayloads.build()
+    val codecsMake = baseBuilder.build()
 
     val codec = codecsMake.apply[
       DefaultContentHeaderInput,

--- a/modules/core/src/smithy4s/http/HttpUnaryClientCodecs.scala
+++ b/modules/core/src/smithy4s/http/HttpUnaryClientCodecs.scala
@@ -195,8 +195,15 @@ object HttpUnaryClientCodecs {
             }
 
           val contentTypeHeaderWriter: HttpRequest.Writer[Blob, I] = {
+            val restSchema = HttpRestSchema(endpoint.input)
+            val hasBodyInSchema = restSchema match {
+              case HttpRestSchema.OnlyBody(_)           => true
+              case HttpRestSchema.MetadataAndBody(_, _) => true
+              case _                                    => false
+            }
+
             if (rawStringsAndBlobPayloads) {
-              val maybeMediaType: Option[HttpMediaType] = HttpRestSchema(endpoint.input) match {
+              val maybeMediaType: Option[HttpMediaType] = restSchema match {
                 case HttpRestSchema.OnlyBody(schema)               => HttpMediaType.fromSchema(schema)
                 case HttpRestSchema.MetadataAndBody(_, bodySchema) => HttpMediaType.fromSchema(bodySchema)
                 case _                                             => None
@@ -216,10 +223,12 @@ object HttpUnaryClientCodecs {
                   )
               }
             } else {
+              // When rawStringsAndBlobPayloads = false, we're using a structured protocol (e.g., JSON).
+              // Set Content-Type if the schema has a body OR if the body was actually written.
               Writer.lift((req: HttpRequest[Blob], _: I) =>
                 if (req.headers.contains(CaseInsensitive("Content-Type"))) req
-                else if (req.body.isEmpty) req
-                else req.withContentType(requestMediaType)
+                else if (hasBodyInSchema || !req.body.isEmpty) req.withContentType(requestMediaType)
+                else req
               )
             }
           }

--- a/modules/core/src/smithy4s/http/HttpUnaryClientCodecs.scala
+++ b/modules/core/src/smithy4s/http/HttpUnaryClientCodecs.scala
@@ -136,33 +136,11 @@ object HttpUnaryClientCodecs {
       val setBody: HttpRequest.Writer[Blob, Blob] = Writer.lift((req, blob) => req.copy(body = blob))
       val setBodyK = smithy4s.codecs.Encoder.pipeToWriterK[HttpRequest[Blob], Blob](setBody)
 
-      val mediaTypeWriters = new CachedSchemaCompiler.Uncached[HttpRequest.Writer[Blob, *]] {
-        def fromSchema[A](schema: Schema[A]): HttpRequest.Writer[Blob, A] = {
-          val maybeRawMediaType = if (rawStringsAndBlobPayloads) HttpMediaType.fromSchema(schema).map(_.value) else None
-          maybeRawMediaType match {
-            case Some(mt) =>
-              new HttpRequest.Writer[Blob, A] {
-                def write(request: HttpRequest[Blob], value: A): HttpRequest[Blob] =
-                  request.withContentType(mt)
-              }
-            case None =>
-              new HttpRequest.Writer[Blob, A] {
-                def write(request: HttpRequest[Blob], value: A): HttpRequest[Blob] =
-                  if (request.body.isEmpty) request
-                  else request.withContentType(requestMediaType)
-              }
-          }
-        }
-      }
-
       val httpBodyWriters: CachedSchemaCompiler[HttpRequest.Writer[Blob, *]] = if (rawStringsAndBlobPayloads) {
         val finalBodyEncoders = CachedSchemaCompiler
           .getOrElse(smithy4s.codecs.StringAndBlobCodecs.encoders, requestBodyEncoders)
         finalBodyEncoders.mapK(setBodyK)
       } else requestBodyEncoders.mapK(setBodyK)
-
-      val httpMediaWriter: CachedSchemaCompiler[HttpRequest.Writer[Blob, *]] =
-        Writer.combineCompilers(httpBodyWriters, mediaTypeWriters)
 
       def responseDecoders(blobDecoders: BlobDecoder.Compiler) = {
         val httpBodyDecoders: CachedSchemaCompiler[Decoder[F, Blob, *]] = {
@@ -188,8 +166,8 @@ object HttpUnaryClientCodecs {
 
       val inputEncoders = metadataEncoders match {
         case Some(mEncoders) =>
-          HttpRequest.Writer.restSchemaCompiler(mEncoders, httpMediaWriter, writeEmptyStructs)
-        case None => httpMediaWriter
+          HttpRequest.Writer.restSchemaCompiler(mEncoders, httpBodyWriters, writeEmptyStructs)
+        case None => httpBodyWriters
       }
       val outputDecoders = responseDecoders(successResponseBodyDecoders)
       val errorDecoders = responseDecoders(errorResponseBodyDecoders)
@@ -216,6 +194,31 @@ object HttpUnaryClientCodecs {
               case None => inputEncoders.fromSchema(endpoint.input, inputEncoderCache)
             }
 
+          val contentTypeHeaderWriter: HttpRequest.Writer[Blob, I] = {
+            if (rawStringsAndBlobPayloads) {
+              val maybeMediaType: Option[HttpMediaType] = HttpRestSchema(endpoint.input) match {
+                case HttpRestSchema.OnlyBody(schema)               => HttpMediaType.fromSchema(schema)
+                case HttpRestSchema.MetadataAndBody(_, bodySchema) => HttpMediaType.fromSchema(bodySchema)
+                case _                                             => None
+              }
+
+              maybeMediaType match {
+                case Some(mediaType) =>
+                  Writer.lift((req: HttpRequest[Blob], _: I) => req.withContentType(mediaType.value))
+                case None =>
+                  Writer.lift((req: HttpRequest[Blob], _: I) =>
+                    if (req.body.isEmpty) req
+                    else req.withContentType(requestMediaType)
+                  )
+              }
+            } else {
+              Writer.lift((req: HttpRequest[Blob], _: I) =>
+                if (req.body.isEmpty) req
+                else req.withContentType(requestMediaType)
+              )
+            }
+          }
+
           val acceptHeaderWriter: HttpRequest.Writer[Blob, I] = {
             if (rawStringsAndBlobPayloads) {
               val maybeMediaType: Option[HttpMediaType] = HttpRestSchema(endpoint.output) match {
@@ -235,7 +238,9 @@ object HttpUnaryClientCodecs {
             }
           }
 
-          val inputWriterWithAccept: HttpRequest.Writer[Blob, I] = inputWriter.combine(acceptHeaderWriter)
+          val inputWriterWithContentType: HttpRequest.Writer[Blob, I] = inputWriter.combine(contentTypeHeaderWriter)
+          val inputWriterWithAccept: HttpRequest.Writer[Blob, I] =
+            inputWriterWithContentType.combine(acceptHeaderWriter)
 
           val prefixedInputWriter: HttpRequest.Writer[Blob, I] =
             if (hostPrefixInjection) inputWriterWithAccept.combine(HttpRequest.Writer.hostPrefix(endpoint))

--- a/modules/core/src/smithy4s/http/HttpUnaryClientCodecs.scala
+++ b/modules/core/src/smithy4s/http/HttpUnaryClientCodecs.scala
@@ -204,16 +204,21 @@ object HttpUnaryClientCodecs {
 
               maybeMediaType match {
                 case Some(mediaType) =>
-                  Writer.lift((req: HttpRequest[Blob], _: I) => req.withContentType(mediaType.value))
+                  Writer.lift((req: HttpRequest[Blob], _: I) =>
+                    if (req.headers.contains(CaseInsensitive("Content-Type"))) req
+                    else req.withContentType(mediaType.value)
+                  )
                 case None =>
                   Writer.lift((req: HttpRequest[Blob], _: I) =>
-                    if (req.body.isEmpty) req
+                    if (req.headers.contains(CaseInsensitive("Content-Type"))) req
+                    else if (req.body.isEmpty) req
                     else req.withContentType(requestMediaType)
                   )
               }
             } else {
               Writer.lift((req: HttpRequest[Blob], _: I) =>
-                if (req.body.isEmpty) req
+                if (req.headers.contains(CaseInsensitive("Content-Type"))) req
+                else if (req.body.isEmpty) req
                 else req.withContentType(requestMediaType)
               )
             }

--- a/modules/core/src/smithy4s/http/HttpUnaryClientCodecs.scala
+++ b/modules/core/src/smithy4s/http/HttpUnaryClientCodecs.scala
@@ -196,41 +196,30 @@ object HttpUnaryClientCodecs {
 
           val contentTypeHeaderWriter: HttpRequest.Writer[Blob, I] = {
             val restSchema = HttpRestSchema(endpoint.input)
-            val hasBodyInSchema = restSchema match {
-              case HttpRestSchema.OnlyBody(_)           => true
-              case HttpRestSchema.MetadataAndBody(_, _) => true
-              case _                                    => false
-            }
 
-            if (rawStringsAndBlobPayloads) {
-              val maybeMediaType: Option[HttpMediaType] = restSchema match {
-                case HttpRestSchema.OnlyBody(schema)               => HttpMediaType.fromSchema(schema)
-                case HttpRestSchema.MetadataAndBody(_, bodySchema) => HttpMediaType.fromSchema(bodySchema)
-                case _                                             => None
+            Writer.lift((req: HttpRequest[Blob], _: I) =>
+              if (req.headers.contains(CaseInsensitive("Content-Type"))) {
+                // Respect explicitly-set Content-Type headers
+                req
+              } else if (req.body.isEmpty) {
+                // No content = no Content-Type header
+                req
+              } else {
+                // Body has content, determine which Content-Type to use
+                if (rawStringsAndBlobPayloads) {
+                  // For raw mode, check if schema has @mediaType annotation
+                  val maybeMediaType: Option[HttpMediaType] = restSchema match {
+                    case HttpRestSchema.OnlyBody(schema)               => HttpMediaType.fromSchema(schema)
+                    case HttpRestSchema.MetadataAndBody(_, bodySchema) => HttpMediaType.fromSchema(bodySchema)
+                    case _                                             => None
+                  }
+                  req.withContentType(maybeMediaType.map(_.value).getOrElse(requestMediaType))
+                } else {
+                  // For structured protocols, use requestMediaType
+                  req.withContentType(requestMediaType)
+                }
               }
-
-              maybeMediaType match {
-                case Some(mediaType) =>
-                  Writer.lift((req: HttpRequest[Blob], _: I) =>
-                    if (req.headers.contains(CaseInsensitive("Content-Type"))) req
-                    else req.withContentType(mediaType.value)
-                  )
-                case None =>
-                  Writer.lift((req: HttpRequest[Blob], _: I) =>
-                    if (req.headers.contains(CaseInsensitive("Content-Type"))) req
-                    else if (req.body.isEmpty) req
-                    else req.withContentType(requestMediaType)
-                  )
-              }
-            } else {
-              // When rawStringsAndBlobPayloads = false, we're using a structured protocol (e.g., JSON).
-              // Set Content-Type if the schema has a body OR if the body was actually written.
-              Writer.lift((req: HttpRequest[Blob], _: I) =>
-                if (req.headers.contains(CaseInsensitive("Content-Type"))) req
-                else if (hasBodyInSchema || !req.body.isEmpty) req.withContentType(requestMediaType)
-                else req
-              )
-            }
+            )
           }
 
           val acceptHeaderWriter: HttpRequest.Writer[Blob, I] = {

--- a/sampleSpecs/contentHeader.smithy
+++ b/sampleSpecs/contentHeader.smithy
@@ -1,0 +1,121 @@
+$version: "2"
+
+namespace smithy4s.example.content
+
+use smithy.api#mediaType
+use smithy.api#http
+
+/// Service to test Content-Type header behavior
+use alloy#simpleRestJson
+
+@simpleRestJson
+service ContentHeaderTestService {
+    operations: [
+        DefaultContentHeader,
+        XmlInput,
+        XmlInputJsonOutput,
+        BlobInputWithMediaType,
+        BlobInputNoMediaType,
+        NoBodyOperation
+    ]
+}
+
+/// JSON payload type
+@mediaType("application/json")
+string JsonPayload
+
+/// XML payload type
+@mediaType("application/xml")
+string XmlPayload
+
+/// Plain text payload type
+@mediaType("text/plain")
+string PlainTextPayload
+
+/// PNG image blob type
+@mediaType("image/png")
+blob PngImage
+
+/// Operation with no media types - should use default Content-Type header
+@http(method: "POST", uri: "/default")
+operation DefaultContentHeader {
+    input := {
+        @httpPayload
+        @required
+        data: String
+    }
+    output := {
+        @httpPayload
+        result: String
+    }
+}
+
+/// Operation with XML input media type
+@http(method: "POST", uri: "/xml-input")
+operation XmlInput {
+    input := {
+        @httpPayload
+        @required
+        data: XmlPayload
+    }
+    output := {
+        @httpPayload
+        result: String
+    }
+}
+
+/// Operation with different media types for input and output
+@http(method: "POST", uri: "/xml-json")
+operation XmlInputJsonOutput {
+    input := {
+        @httpPayload
+        @required
+        data: XmlPayload
+    }
+    output := {
+        @httpPayload
+        result: JsonPayload
+    }
+}
+
+/// Operation with Blob input that has media type
+@http(method: "POST", uri: "/blob-with-media")
+operation BlobInputWithMediaType {
+    input := {
+        @httpPayload
+        @required
+        image: PngImage
+    }
+    output := {
+        @httpPayload
+        data: String
+    }
+}
+
+/// Operation with Blob input without media type
+@http(method: "POST", uri: "/blob-no-media")
+operation BlobInputNoMediaType {
+    input := {
+        @httpPayload
+        @required
+        image: Blob
+    }
+    output := {
+        @httpPayload
+        data: String
+    }
+}
+
+/// Operation with only metadata (no body) - should not have Content-Type header
+@http(method: "GET", uri: "/no-body")
+operation NoBodyOperation {
+    input := {
+        @httpQuery("q")
+        query: String
+    }
+    output := {
+        @httpPayload
+        data: String
+    }
+}
+

--- a/sampleSpecs/contentHeader.smithy
+++ b/sampleSpecs/contentHeader.smithy
@@ -16,7 +16,9 @@ service ContentHeaderTestService {
         XmlInputJsonOutput,
         BlobInputWithMediaType,
         BlobInputNoMediaType,
-        NoBodyOperation
+        NoBodyOperation,
+        EmptyStructOperation,
+        ExplicitContentTypeHeader
     ]
 }
 
@@ -116,6 +118,33 @@ operation NoBodyOperation {
     output := {
         @httpPayload
         data: String
+    }
+}
+
+/// Operation with empty struct - should have Content-Type when writeEmptyStructs=true, none when false
+@http(method: "POST", uri: "/empty-struct")
+operation EmptyStructOperation {
+    input := {}
+    output := {
+        @httpPayload
+        data: String
+    }
+}
+
+/// Operation with explicit Content-Type header - should override default behavior
+@http(method: "POST", uri: "/explicit-content-type")
+operation ExplicitContentTypeHeader {
+    input := {
+        @httpHeader("Content-Type")
+        contentType: String
+
+        @httpPayload
+        @required
+        data: Blob
+    }
+    output := {
+        @httpPayload
+        result: String
     }
 }
 


### PR DESCRIPTION
This PR changes how the content-type header is added to an outbound request in the Client codecs.

Currently , the mediaTypeWriters is invoked only when the MetadataEncoders are set .
The default for the UnaryClientCodecs is to have the Metadata Encoders set to None . ( I assume this is because some protocols dont have metadata ) . I observed when creating a test for the Content-Type header , if I did not set the metadata encoder a content type header would not be added . This is a hidden dependency and is incorrect behavior . The source for this logic is [here](https://github.com/disneystreaming/smithy4s/blob/3a9eea61df19d145164b6a41974ed5b6c5775561/modules/core/src/smithy4s/http/HttpUnaryClientCodecs.scala#L189) , where if the metadata encoders field is `None` , we just return the mediaTypeWriters , which does not know how to decompose a schema and partition out the body part 

The logic for setting content-type header is ,
-  there must be content i.e. it should not be set if the body is empty 
- if rawStringsAndBlobs is set and no mediaType is set , content-type is set according to the default media-type , otherwise use the mediaType value
- default to the protocol configured by the requestedMediaType setting

## PR Checklist (not all items are relevant to all PRs)

- [x] Added unit-tests (for runtime code)
- [x] Added bootstrapped code + smoke tests (when the rendering logic is modified)
- [ ] Updated changelog
