### PR TITLE
Update Dependency Versions

### DIFF
--- a/modules/bootstrapped/src/generated/smithy4s/example/ErrorHandlingService.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/ErrorHandlingService.scala
@@ -91,23 +91,23 @@ object ErrorHandlingServiceOperation {
     object project {
       def eHFallbackClientError: Option[EHFallbackClientError] = ErrorHandlingOperationError.EHFallbackClientErrorCase.alt.project.lift(self).map(_.eHFallbackClientError)
       def eHServiceUnavailable: Option[EHServiceUnavailable] = ErrorHandlingOperationError.EHServiceUnavailableCase.alt.project.lift(self).map(_.eHServiceUnavailable)
-      def eHNotFound: Option[EHNotFound] = ErrorHandlingOperationError.EHNotFoundCase.alt.project.lift(self).map(_.eHNotFound)
       def eHFallbackServerError: Option[EHFallbackServerError] = ErrorHandlingOperationError.EHFallbackServerErrorCase.alt.project.lift(self).map(_.eHFallbackServerError)
+      def eHNotFound: Option[EHNotFound] = ErrorHandlingOperationError.EHNotFoundCase.alt.project.lift(self).map(_.eHNotFound)
     }
 
     def accept[A](visitor: ErrorHandlingOperationError.Visitor[A]): A = this match {
       case value: ErrorHandlingOperationError.EHFallbackClientErrorCase => visitor.eHFallbackClientError(value.eHFallbackClientError)
       case value: ErrorHandlingOperationError.EHServiceUnavailableCase => visitor.eHServiceUnavailable(value.eHServiceUnavailable)
-      case value: ErrorHandlingOperationError.EHNotFoundCase => visitor.eHNotFound(value.eHNotFound)
       case value: ErrorHandlingOperationError.EHFallbackServerErrorCase => visitor.eHFallbackServerError(value.eHFallbackServerError)
+      case value: ErrorHandlingOperationError.EHNotFoundCase => visitor.eHNotFound(value.eHNotFound)
     }
   }
   object ErrorHandlingOperationError extends ErrorSchema.Companion[ErrorHandlingOperationError] {
 
     def eHFallbackClientError(eHFallbackClientError: EHFallbackClientError): ErrorHandlingOperationError = EHFallbackClientErrorCase(eHFallbackClientError)
     def eHServiceUnavailable(eHServiceUnavailable: EHServiceUnavailable): ErrorHandlingOperationError = EHServiceUnavailableCase(eHServiceUnavailable)
-    def eHNotFound(eHNotFound: EHNotFound): ErrorHandlingOperationError = EHNotFoundCase(eHNotFound)
     def eHFallbackServerError(eHFallbackServerError: EHFallbackServerError): ErrorHandlingOperationError = EHFallbackServerErrorCase(eHFallbackServerError)
+    def eHNotFound(eHNotFound: EHNotFound): ErrorHandlingOperationError = EHNotFoundCase(eHNotFound)
 
     val id: ShapeId = ShapeId("smithy4s.example", "ErrorHandlingOperationError")
 
@@ -115,8 +115,8 @@ object ErrorHandlingServiceOperation {
 
     final case class EHFallbackClientErrorCase(eHFallbackClientError: EHFallbackClientError) extends ErrorHandlingOperationError { final def $ordinal: Int = 0 }
     final case class EHServiceUnavailableCase(eHServiceUnavailable: EHServiceUnavailable) extends ErrorHandlingOperationError { final def $ordinal: Int = 1 }
-    final case class EHNotFoundCase(eHNotFound: EHNotFound) extends ErrorHandlingOperationError { final def $ordinal: Int = 2 }
-    final case class EHFallbackServerErrorCase(eHFallbackServerError: EHFallbackServerError) extends ErrorHandlingOperationError { final def $ordinal: Int = 3 }
+    final case class EHFallbackServerErrorCase(eHFallbackServerError: EHFallbackServerError) extends ErrorHandlingOperationError { final def $ordinal: Int = 2 }
+    final case class EHNotFoundCase(eHNotFound: EHNotFound) extends ErrorHandlingOperationError { final def $ordinal: Int = 3 }
 
     object EHFallbackClientErrorCase {
       val hints: Hints = Hints.empty
@@ -128,22 +128,22 @@ object ErrorHandlingServiceOperation {
       val schema: Schema[ErrorHandlingOperationError.EHServiceUnavailableCase] = bijection(EHServiceUnavailable.schema.addHints(hints), ErrorHandlingOperationError.EHServiceUnavailableCase(_), _.eHServiceUnavailable)
       val alt = schema.oneOf[ErrorHandlingOperationError]("EHServiceUnavailable")
     }
-    object EHNotFoundCase {
-      val hints: Hints = Hints.empty
-      val schema: Schema[ErrorHandlingOperationError.EHNotFoundCase] = bijection(EHNotFound.schema.addHints(hints), ErrorHandlingOperationError.EHNotFoundCase(_), _.eHNotFound)
-      val alt = schema.oneOf[ErrorHandlingOperationError]("EHNotFound")
-    }
     object EHFallbackServerErrorCase {
       val hints: Hints = Hints.empty
       val schema: Schema[ErrorHandlingOperationError.EHFallbackServerErrorCase] = bijection(EHFallbackServerError.schema.addHints(hints), ErrorHandlingOperationError.EHFallbackServerErrorCase(_), _.eHFallbackServerError)
       val alt = schema.oneOf[ErrorHandlingOperationError]("EHFallbackServerError")
     }
+    object EHNotFoundCase {
+      val hints: Hints = Hints.empty
+      val schema: Schema[ErrorHandlingOperationError.EHNotFoundCase] = bijection(EHNotFound.schema.addHints(hints), ErrorHandlingOperationError.EHNotFoundCase(_), _.eHNotFound)
+      val alt = schema.oneOf[ErrorHandlingOperationError]("EHNotFound")
+    }
 
     trait Visitor[A] {
       def eHFallbackClientError(value: EHFallbackClientError): A
       def eHServiceUnavailable(value: EHServiceUnavailable): A
-      def eHNotFound(value: EHNotFound): A
       def eHFallbackServerError(value: EHFallbackServerError): A
+      def eHNotFound(value: EHNotFound): A
     }
 
     object Visitor {
@@ -151,31 +151,31 @@ object ErrorHandlingServiceOperation {
         def default: A
         def eHFallbackClientError(value: EHFallbackClientError): A = default
         def eHServiceUnavailable(value: EHServiceUnavailable): A = default
-        def eHNotFound(value: EHNotFound): A = default
         def eHFallbackServerError(value: EHFallbackServerError): A = default
+        def eHNotFound(value: EHNotFound): A = default
       }
     }
 
     implicit val schema: Schema[ErrorHandlingOperationError] = union(
       ErrorHandlingOperationError.EHFallbackClientErrorCase.alt,
       ErrorHandlingOperationError.EHServiceUnavailableCase.alt,
-      ErrorHandlingOperationError.EHNotFoundCase.alt,
       ErrorHandlingOperationError.EHFallbackServerErrorCase.alt,
+      ErrorHandlingOperationError.EHNotFoundCase.alt,
     ){
       _.$ordinal
     }
     def liftError(throwable: Throwable): Option[ErrorHandlingOperationError] = throwable match {
       case e: EHFallbackClientError => Some(ErrorHandlingOperationError.EHFallbackClientErrorCase(e))
       case e: EHServiceUnavailable => Some(ErrorHandlingOperationError.EHServiceUnavailableCase(e))
-      case e: EHNotFound => Some(ErrorHandlingOperationError.EHNotFoundCase(e))
       case e: EHFallbackServerError => Some(ErrorHandlingOperationError.EHFallbackServerErrorCase(e))
+      case e: EHNotFound => Some(ErrorHandlingOperationError.EHNotFoundCase(e))
       case _ => None
     }
     def unliftError(e: ErrorHandlingOperationError): Throwable = e match {
       case ErrorHandlingOperationError.EHFallbackClientErrorCase(e) => e
       case ErrorHandlingOperationError.EHServiceUnavailableCase(e) => e
-      case ErrorHandlingOperationError.EHNotFoundCase(e) => e
       case ErrorHandlingOperationError.EHFallbackServerErrorCase(e) => e
+      case ErrorHandlingOperationError.EHNotFoundCase(e) => e
     }
   }
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/ErrorHandlingServiceExtraErrors.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/ErrorHandlingServiceExtraErrors.scala
@@ -91,23 +91,23 @@ object ErrorHandlingServiceExtraErrorsOperation {
 
     object project {
       def randomOtherClientError: Option[RandomOtherClientError] = ExtraErrorOperationError.RandomOtherClientErrorCase.alt.project.lift(self).map(_.randomOtherClientError)
-      def randomOtherServerError: Option[RandomOtherServerError] = ExtraErrorOperationError.RandomOtherServerErrorCase.alt.project.lift(self).map(_.randomOtherServerError)
       def randomOtherClientErrorWithCode: Option[RandomOtherClientErrorWithCode] = ExtraErrorOperationError.RandomOtherClientErrorWithCodeCase.alt.project.lift(self).map(_.randomOtherClientErrorWithCode)
+      def randomOtherServerError: Option[RandomOtherServerError] = ExtraErrorOperationError.RandomOtherServerErrorCase.alt.project.lift(self).map(_.randomOtherServerError)
       def randomOtherServerErrorWithCode: Option[RandomOtherServerErrorWithCode] = ExtraErrorOperationError.RandomOtherServerErrorWithCodeCase.alt.project.lift(self).map(_.randomOtherServerErrorWithCode)
     }
 
     def accept[A](visitor: ExtraErrorOperationError.Visitor[A]): A = this match {
       case value: ExtraErrorOperationError.RandomOtherClientErrorCase => visitor.randomOtherClientError(value.randomOtherClientError)
-      case value: ExtraErrorOperationError.RandomOtherServerErrorCase => visitor.randomOtherServerError(value.randomOtherServerError)
       case value: ExtraErrorOperationError.RandomOtherClientErrorWithCodeCase => visitor.randomOtherClientErrorWithCode(value.randomOtherClientErrorWithCode)
+      case value: ExtraErrorOperationError.RandomOtherServerErrorCase => visitor.randomOtherServerError(value.randomOtherServerError)
       case value: ExtraErrorOperationError.RandomOtherServerErrorWithCodeCase => visitor.randomOtherServerErrorWithCode(value.randomOtherServerErrorWithCode)
     }
   }
   object ExtraErrorOperationError extends ErrorSchema.Companion[ExtraErrorOperationError] {
 
     def randomOtherClientError(randomOtherClientError: RandomOtherClientError): ExtraErrorOperationError = RandomOtherClientErrorCase(randomOtherClientError)
-    def randomOtherServerError(randomOtherServerError: RandomOtherServerError): ExtraErrorOperationError = RandomOtherServerErrorCase(randomOtherServerError)
     def randomOtherClientErrorWithCode(randomOtherClientErrorWithCode: RandomOtherClientErrorWithCode): ExtraErrorOperationError = RandomOtherClientErrorWithCodeCase(randomOtherClientErrorWithCode)
+    def randomOtherServerError(randomOtherServerError: RandomOtherServerError): ExtraErrorOperationError = RandomOtherServerErrorCase(randomOtherServerError)
     def randomOtherServerErrorWithCode(randomOtherServerErrorWithCode: RandomOtherServerErrorWithCode): ExtraErrorOperationError = RandomOtherServerErrorWithCodeCase(randomOtherServerErrorWithCode)
 
     val id: ShapeId = ShapeId("smithy4s.example", "ExtraErrorOperationError")
@@ -115,8 +115,8 @@ object ErrorHandlingServiceExtraErrorsOperation {
     val hints: Hints = Hints.empty
 
     final case class RandomOtherClientErrorCase(randomOtherClientError: RandomOtherClientError) extends ExtraErrorOperationError { final def $ordinal: Int = 0 }
-    final case class RandomOtherServerErrorCase(randomOtherServerError: RandomOtherServerError) extends ExtraErrorOperationError { final def $ordinal: Int = 1 }
-    final case class RandomOtherClientErrorWithCodeCase(randomOtherClientErrorWithCode: RandomOtherClientErrorWithCode) extends ExtraErrorOperationError { final def $ordinal: Int = 2 }
+    final case class RandomOtherClientErrorWithCodeCase(randomOtherClientErrorWithCode: RandomOtherClientErrorWithCode) extends ExtraErrorOperationError { final def $ordinal: Int = 1 }
+    final case class RandomOtherServerErrorCase(randomOtherServerError: RandomOtherServerError) extends ExtraErrorOperationError { final def $ordinal: Int = 2 }
     final case class RandomOtherServerErrorWithCodeCase(randomOtherServerErrorWithCode: RandomOtherServerErrorWithCode) extends ExtraErrorOperationError { final def $ordinal: Int = 3 }
 
     object RandomOtherClientErrorCase {
@@ -124,15 +124,15 @@ object ErrorHandlingServiceExtraErrorsOperation {
       val schema: Schema[ExtraErrorOperationError.RandomOtherClientErrorCase] = bijection(RandomOtherClientError.schema.addHints(hints), ExtraErrorOperationError.RandomOtherClientErrorCase(_), _.randomOtherClientError)
       val alt = schema.oneOf[ExtraErrorOperationError]("RandomOtherClientError")
     }
-    object RandomOtherServerErrorCase {
-      val hints: Hints = Hints.empty
-      val schema: Schema[ExtraErrorOperationError.RandomOtherServerErrorCase] = bijection(RandomOtherServerError.schema.addHints(hints), ExtraErrorOperationError.RandomOtherServerErrorCase(_), _.randomOtherServerError)
-      val alt = schema.oneOf[ExtraErrorOperationError]("RandomOtherServerError")
-    }
     object RandomOtherClientErrorWithCodeCase {
       val hints: Hints = Hints.empty
       val schema: Schema[ExtraErrorOperationError.RandomOtherClientErrorWithCodeCase] = bijection(RandomOtherClientErrorWithCode.schema.addHints(hints), ExtraErrorOperationError.RandomOtherClientErrorWithCodeCase(_), _.randomOtherClientErrorWithCode)
       val alt = schema.oneOf[ExtraErrorOperationError]("RandomOtherClientErrorWithCode")
+    }
+    object RandomOtherServerErrorCase {
+      val hints: Hints = Hints.empty
+      val schema: Schema[ExtraErrorOperationError.RandomOtherServerErrorCase] = bijection(RandomOtherServerError.schema.addHints(hints), ExtraErrorOperationError.RandomOtherServerErrorCase(_), _.randomOtherServerError)
+      val alt = schema.oneOf[ExtraErrorOperationError]("RandomOtherServerError")
     }
     object RandomOtherServerErrorWithCodeCase {
       val hints: Hints = Hints.empty
@@ -142,8 +142,8 @@ object ErrorHandlingServiceExtraErrorsOperation {
 
     trait Visitor[A] {
       def randomOtherClientError(value: RandomOtherClientError): A
-      def randomOtherServerError(value: RandomOtherServerError): A
       def randomOtherClientErrorWithCode(value: RandomOtherClientErrorWithCode): A
+      def randomOtherServerError(value: RandomOtherServerError): A
       def randomOtherServerErrorWithCode(value: RandomOtherServerErrorWithCode): A
     }
 
@@ -151,31 +151,31 @@ object ErrorHandlingServiceExtraErrorsOperation {
       trait Default[A] extends Visitor[A] {
         def default: A
         def randomOtherClientError(value: RandomOtherClientError): A = default
-        def randomOtherServerError(value: RandomOtherServerError): A = default
         def randomOtherClientErrorWithCode(value: RandomOtherClientErrorWithCode): A = default
+        def randomOtherServerError(value: RandomOtherServerError): A = default
         def randomOtherServerErrorWithCode(value: RandomOtherServerErrorWithCode): A = default
       }
     }
 
     implicit val schema: Schema[ExtraErrorOperationError] = union(
       ExtraErrorOperationError.RandomOtherClientErrorCase.alt,
-      ExtraErrorOperationError.RandomOtherServerErrorCase.alt,
       ExtraErrorOperationError.RandomOtherClientErrorWithCodeCase.alt,
+      ExtraErrorOperationError.RandomOtherServerErrorCase.alt,
       ExtraErrorOperationError.RandomOtherServerErrorWithCodeCase.alt,
     ){
       _.$ordinal
     }
     def liftError(throwable: Throwable): Option[ExtraErrorOperationError] = throwable match {
       case e: RandomOtherClientError => Some(ExtraErrorOperationError.RandomOtherClientErrorCase(e))
-      case e: RandomOtherServerError => Some(ExtraErrorOperationError.RandomOtherServerErrorCase(e))
       case e: RandomOtherClientErrorWithCode => Some(ExtraErrorOperationError.RandomOtherClientErrorWithCodeCase(e))
+      case e: RandomOtherServerError => Some(ExtraErrorOperationError.RandomOtherServerErrorCase(e))
       case e: RandomOtherServerErrorWithCode => Some(ExtraErrorOperationError.RandomOtherServerErrorWithCodeCase(e))
       case _ => None
     }
     def unliftError(e: ExtraErrorOperationError): Throwable = e match {
       case ExtraErrorOperationError.RandomOtherClientErrorCase(e) => e
-      case ExtraErrorOperationError.RandomOtherServerErrorCase(e) => e
       case ExtraErrorOperationError.RandomOtherClientErrorWithCodeCase(e) => e
+      case ExtraErrorOperationError.RandomOtherServerErrorCase(e) => e
       case ExtraErrorOperationError.RandomOtherServerErrorWithCodeCase(e) => e
     }
   }

--- a/modules/bootstrapped/src/generated/smithy4s/example/LeftRight.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/LeftRight.scala
@@ -20,7 +20,9 @@ sealed abstract class LeftRight(_value: String, _name: String, _intValue: Int, _
 object LeftRight extends Enumeration[LeftRight] with ShapeTag.Companion[LeftRight] {
   val id: ShapeId = ShapeId("smithy4s.example", "leftRight")
 
-  val hints: Hints = Hints.empty
+  val hints: Hints = Hints(
+    smithy.api.Trait(selector = None, structurallyExclusive = None, conflicts = None, breakingChanges = None),
+  ).lazily
 
   case object LEFT extends LeftRight("left", "LEFT", 0, Hints.empty)
   case object RIGHT extends LeftRight("right", "RIGHT", 1, Hints.empty)

--- a/modules/bootstrapped/src/generated/smithy4s/example/ObjectService.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/ObjectService.scala
@@ -109,65 +109,65 @@ object ObjectServiceOperation {
     def $ordinal: Int
 
     object project {
-      def serverError: Option[ServerError] = GetObjectError.ServerErrorCase.alt.project.lift(self).map(_.serverError)
       def clientError: Option[ClientError] = GetObjectError.ClientErrorCase.alt.project.lift(self).map(_.clientError)
+      def serverError: Option[ServerError] = GetObjectError.ServerErrorCase.alt.project.lift(self).map(_.serverError)
     }
 
     def accept[A](visitor: GetObjectError.Visitor[A]): A = this match {
-      case value: GetObjectError.ServerErrorCase => visitor.serverError(value.serverError)
       case value: GetObjectError.ClientErrorCase => visitor.clientError(value.clientError)
+      case value: GetObjectError.ServerErrorCase => visitor.serverError(value.serverError)
     }
   }
   object GetObjectError extends ErrorSchema.Companion[GetObjectError] {
 
-    def serverError(serverError: ServerError): GetObjectError = ServerErrorCase(serverError)
     def clientError(clientError: ClientError): GetObjectError = ClientErrorCase(clientError)
+    def serverError(serverError: ServerError): GetObjectError = ServerErrorCase(serverError)
 
     val id: ShapeId = ShapeId("smithy4s.example", "GetObjectError")
 
     val hints: Hints = Hints.empty
 
-    final case class ServerErrorCase(serverError: ServerError) extends GetObjectError { final def $ordinal: Int = 0 }
-    final case class ClientErrorCase(clientError: ClientError) extends GetObjectError { final def $ordinal: Int = 1 }
+    final case class ClientErrorCase(clientError: ClientError) extends GetObjectError { final def $ordinal: Int = 0 }
+    final case class ServerErrorCase(serverError: ServerError) extends GetObjectError { final def $ordinal: Int = 1 }
 
-    object ServerErrorCase {
-      val hints: Hints = Hints.empty
-      val schema: Schema[GetObjectError.ServerErrorCase] = bijection(ServerError.schema.addHints(hints), GetObjectError.ServerErrorCase(_), _.serverError)
-      val alt = schema.oneOf[GetObjectError]("ServerError")
-    }
     object ClientErrorCase {
       val hints: Hints = Hints.empty
       val schema: Schema[GetObjectError.ClientErrorCase] = bijection(ClientError.schema.addHints(hints), GetObjectError.ClientErrorCase(_), _.clientError)
       val alt = schema.oneOf[GetObjectError]("ClientError")
     }
+    object ServerErrorCase {
+      val hints: Hints = Hints.empty
+      val schema: Schema[GetObjectError.ServerErrorCase] = bijection(ServerError.schema.addHints(hints), GetObjectError.ServerErrorCase(_), _.serverError)
+      val alt = schema.oneOf[GetObjectError]("ServerError")
+    }
 
     trait Visitor[A] {
-      def serverError(value: ServerError): A
       def clientError(value: ClientError): A
+      def serverError(value: ServerError): A
     }
 
     object Visitor {
       trait Default[A] extends Visitor[A] {
         def default: A
-        def serverError(value: ServerError): A = default
         def clientError(value: ClientError): A = default
+        def serverError(value: ServerError): A = default
       }
     }
 
     implicit val schema: Schema[GetObjectError] = union(
-      GetObjectError.ServerErrorCase.alt,
       GetObjectError.ClientErrorCase.alt,
+      GetObjectError.ServerErrorCase.alt,
     ){
       _.$ordinal
     }
     def liftError(throwable: Throwable): Option[GetObjectError] = throwable match {
-      case e: ServerError => Some(GetObjectError.ServerErrorCase(e))
       case e: ClientError => Some(GetObjectError.ClientErrorCase(e))
+      case e: ServerError => Some(GetObjectError.ServerErrorCase(e))
       case _ => None
     }
     def unliftError(e: GetObjectError): Throwable = e match {
-      case GetObjectError.ServerErrorCase(e) => e
       case GetObjectError.ClientErrorCase(e) => e
+      case GetObjectError.ServerErrorCase(e) => e
     }
   }
   final case class PutObject(input: PutObjectInput) extends ObjectServiceOperation[PutObjectInput, ObjectServiceOperation.PutObjectError, Unit, Nothing, Nothing] {
@@ -188,40 +188,40 @@ object ObjectServiceOperation {
     def $ordinal: Int
 
     object project {
-      def serverError: Option[ServerError] = PutObjectError.ServerErrorCase.alt.project.lift(self).map(_.serverError)
       def clientError: Option[ClientError] = PutObjectError.ClientErrorCase.alt.project.lift(self).map(_.clientError)
+      def serverError: Option[ServerError] = PutObjectError.ServerErrorCase.alt.project.lift(self).map(_.serverError)
       def noMoreSpace: Option[NoMoreSpace] = PutObjectError.NoMoreSpaceCase.alt.project.lift(self).map(_.noMoreSpace)
     }
 
     def accept[A](visitor: PutObjectError.Visitor[A]): A = this match {
-      case value: PutObjectError.ServerErrorCase => visitor.serverError(value.serverError)
       case value: PutObjectError.ClientErrorCase => visitor.clientError(value.clientError)
+      case value: PutObjectError.ServerErrorCase => visitor.serverError(value.serverError)
       case value: PutObjectError.NoMoreSpaceCase => visitor.noMoreSpace(value.noMoreSpace)
     }
   }
   object PutObjectError extends ErrorSchema.Companion[PutObjectError] {
 
-    def serverError(serverError: ServerError): PutObjectError = ServerErrorCase(serverError)
     def clientError(clientError: ClientError): PutObjectError = ClientErrorCase(clientError)
+    def serverError(serverError: ServerError): PutObjectError = ServerErrorCase(serverError)
     def noMoreSpace(noMoreSpace: NoMoreSpace): PutObjectError = NoMoreSpaceCase(noMoreSpace)
 
     val id: ShapeId = ShapeId("smithy4s.example", "PutObjectError")
 
     val hints: Hints = Hints.empty
 
-    final case class ServerErrorCase(serverError: ServerError) extends PutObjectError { final def $ordinal: Int = 0 }
-    final case class ClientErrorCase(clientError: ClientError) extends PutObjectError { final def $ordinal: Int = 1 }
+    final case class ClientErrorCase(clientError: ClientError) extends PutObjectError { final def $ordinal: Int = 0 }
+    final case class ServerErrorCase(serverError: ServerError) extends PutObjectError { final def $ordinal: Int = 1 }
     final case class NoMoreSpaceCase(noMoreSpace: NoMoreSpace) extends PutObjectError { final def $ordinal: Int = 2 }
 
-    object ServerErrorCase {
-      val hints: Hints = Hints.empty
-      val schema: Schema[PutObjectError.ServerErrorCase] = bijection(ServerError.schema.addHints(hints), PutObjectError.ServerErrorCase(_), _.serverError)
-      val alt = schema.oneOf[PutObjectError]("ServerError")
-    }
     object ClientErrorCase {
       val hints: Hints = Hints.empty
       val schema: Schema[PutObjectError.ClientErrorCase] = bijection(ClientError.schema.addHints(hints), PutObjectError.ClientErrorCase(_), _.clientError)
       val alt = schema.oneOf[PutObjectError]("ClientError")
+    }
+    object ServerErrorCase {
+      val hints: Hints = Hints.empty
+      val schema: Schema[PutObjectError.ServerErrorCase] = bijection(ServerError.schema.addHints(hints), PutObjectError.ServerErrorCase(_), _.serverError)
+      val alt = schema.oneOf[PutObjectError]("ServerError")
     }
     object NoMoreSpaceCase {
       val hints: Hints = Hints.empty
@@ -230,36 +230,36 @@ object ObjectServiceOperation {
     }
 
     trait Visitor[A] {
-      def serverError(value: ServerError): A
       def clientError(value: ClientError): A
+      def serverError(value: ServerError): A
       def noMoreSpace(value: NoMoreSpace): A
     }
 
     object Visitor {
       trait Default[A] extends Visitor[A] {
         def default: A
-        def serverError(value: ServerError): A = default
         def clientError(value: ClientError): A = default
+        def serverError(value: ServerError): A = default
         def noMoreSpace(value: NoMoreSpace): A = default
       }
     }
 
     implicit val schema: Schema[PutObjectError] = union(
-      PutObjectError.ServerErrorCase.alt,
       PutObjectError.ClientErrorCase.alt,
+      PutObjectError.ServerErrorCase.alt,
       PutObjectError.NoMoreSpaceCase.alt,
     ){
       _.$ordinal
     }
     def liftError(throwable: Throwable): Option[PutObjectError] = throwable match {
-      case e: ServerError => Some(PutObjectError.ServerErrorCase(e))
       case e: ClientError => Some(PutObjectError.ClientErrorCase(e))
+      case e: ServerError => Some(PutObjectError.ServerErrorCase(e))
       case e: NoMoreSpace => Some(PutObjectError.NoMoreSpaceCase(e))
       case _ => None
     }
     def unliftError(e: PutObjectError): Throwable = e match {
-      case PutObjectError.ServerErrorCase(e) => e
       case PutObjectError.ClientErrorCase(e) => e
+      case PutObjectError.ServerErrorCase(e) => e
       case PutObjectError.NoMoreSpaceCase(e) => e
     }
   }

--- a/modules/bootstrapped/src/generated/smithy4s/example/OldStyleLeftRight.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/OldStyleLeftRight.scala
@@ -20,7 +20,9 @@ sealed abstract class OldStyleLeftRight(_value: String, _name: String, _intValue
 object OldStyleLeftRight extends Enumeration[OldStyleLeftRight] with ShapeTag.Companion[OldStyleLeftRight] {
   val id: ShapeId = ShapeId("smithy4s.example", "oldStyleLeftRight")
 
-  val hints: Hints = Hints.empty
+  val hints: Hints = Hints(
+    smithy.api.Trait(selector = None, structurallyExclusive = None, conflicts = None, breakingChanges = None),
+  ).lazily
 
   case object LEFT extends OldStyleLeftRight("left", "LEFT", 0, Hints.empty)
   case object RIGHT extends OldStyleLeftRight("right", "RIGHT", 1, Hints.empty)

--- a/modules/bootstrapped/src/generated/smithy4s/example/OneTwo.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/OneTwo.scala
@@ -20,7 +20,9 @@ sealed abstract class OneTwo(_value: String, _name: String, _intValue: Int, _hin
 object OneTwo extends Enumeration[OneTwo] with ShapeTag.Companion[OneTwo] {
   val id: ShapeId = ShapeId("smithy4s.example", "oneTwo")
 
-  val hints: Hints = Hints.empty
+  val hints: Hints = Hints(
+    smithy.api.Trait(selector = None, structurallyExclusive = None, conflicts = None, breakingChanges = None),
+  ).lazily
 
   case object ONE extends OneTwo("ONE", "ONE", 1, Hints.empty)
   case object TWO extends OneTwo("TWO", "TWO", 2, Hints.empty)

--- a/modules/bootstrapped/src/generated/smithy4s/example/PizzaAdminService.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/PizzaAdminService.scala
@@ -547,79 +547,79 @@ object PizzaAdminServiceOperation {
     def $ordinal: Int
 
     object project {
-      def priceError: Option[PriceError] = AddMenuItemError.PriceErrorCase.alt.project.lift(self).map(_.priceError)
-      def genericServerError: Option[GenericServerError] = AddMenuItemError.GenericServerErrorCase.alt.project.lift(self).map(_.genericServerError)
       def genericClientError: Option[GenericClientError] = AddMenuItemError.GenericClientErrorCase.alt.project.lift(self).map(_.genericClientError)
+      def genericServerError: Option[GenericServerError] = AddMenuItemError.GenericServerErrorCase.alt.project.lift(self).map(_.genericServerError)
+      def priceError: Option[PriceError] = AddMenuItemError.PriceErrorCase.alt.project.lift(self).map(_.priceError)
     }
 
     def accept[A](visitor: AddMenuItemError.Visitor[A]): A = this match {
-      case value: AddMenuItemError.PriceErrorCase => visitor.priceError(value.priceError)
-      case value: AddMenuItemError.GenericServerErrorCase => visitor.genericServerError(value.genericServerError)
       case value: AddMenuItemError.GenericClientErrorCase => visitor.genericClientError(value.genericClientError)
+      case value: AddMenuItemError.GenericServerErrorCase => visitor.genericServerError(value.genericServerError)
+      case value: AddMenuItemError.PriceErrorCase => visitor.priceError(value.priceError)
     }
   }
   object AddMenuItemError extends ErrorSchema.Companion[AddMenuItemError] {
 
-    def priceError(priceError: PriceError): AddMenuItemError = PriceErrorCase(priceError)
-    def genericServerError(genericServerError: GenericServerError): AddMenuItemError = GenericServerErrorCase(genericServerError)
     def genericClientError(genericClientError: GenericClientError): AddMenuItemError = GenericClientErrorCase(genericClientError)
+    def genericServerError(genericServerError: GenericServerError): AddMenuItemError = GenericServerErrorCase(genericServerError)
+    def priceError(priceError: PriceError): AddMenuItemError = PriceErrorCase(priceError)
 
     val id: ShapeId = ShapeId("smithy4s.example", "AddMenuItemError")
 
     val hints: Hints = Hints.empty
 
-    final case class PriceErrorCase(priceError: PriceError) extends AddMenuItemError { final def $ordinal: Int = 0 }
+    final case class GenericClientErrorCase(genericClientError: GenericClientError) extends AddMenuItemError { final def $ordinal: Int = 0 }
     final case class GenericServerErrorCase(genericServerError: GenericServerError) extends AddMenuItemError { final def $ordinal: Int = 1 }
-    final case class GenericClientErrorCase(genericClientError: GenericClientError) extends AddMenuItemError { final def $ordinal: Int = 2 }
+    final case class PriceErrorCase(priceError: PriceError) extends AddMenuItemError { final def $ordinal: Int = 2 }
 
-    object PriceErrorCase {
+    object GenericClientErrorCase {
       val hints: Hints = Hints.empty
-      val schema: Schema[AddMenuItemError.PriceErrorCase] = bijection(PriceError.schema.addHints(hints), AddMenuItemError.PriceErrorCase(_), _.priceError)
-      val alt = schema.oneOf[AddMenuItemError]("PriceError")
+      val schema: Schema[AddMenuItemError.GenericClientErrorCase] = bijection(GenericClientError.schema.addHints(hints), AddMenuItemError.GenericClientErrorCase(_), _.genericClientError)
+      val alt = schema.oneOf[AddMenuItemError]("GenericClientError")
     }
     object GenericServerErrorCase {
       val hints: Hints = Hints.empty
       val schema: Schema[AddMenuItemError.GenericServerErrorCase] = bijection(GenericServerError.schema.addHints(hints), AddMenuItemError.GenericServerErrorCase(_), _.genericServerError)
       val alt = schema.oneOf[AddMenuItemError]("GenericServerError")
     }
-    object GenericClientErrorCase {
+    object PriceErrorCase {
       val hints: Hints = Hints.empty
-      val schema: Schema[AddMenuItemError.GenericClientErrorCase] = bijection(GenericClientError.schema.addHints(hints), AddMenuItemError.GenericClientErrorCase(_), _.genericClientError)
-      val alt = schema.oneOf[AddMenuItemError]("GenericClientError")
+      val schema: Schema[AddMenuItemError.PriceErrorCase] = bijection(PriceError.schema.addHints(hints), AddMenuItemError.PriceErrorCase(_), _.priceError)
+      val alt = schema.oneOf[AddMenuItemError]("PriceError")
     }
 
     trait Visitor[A] {
-      def priceError(value: PriceError): A
-      def genericServerError(value: GenericServerError): A
       def genericClientError(value: GenericClientError): A
+      def genericServerError(value: GenericServerError): A
+      def priceError(value: PriceError): A
     }
 
     object Visitor {
       trait Default[A] extends Visitor[A] {
         def default: A
-        def priceError(value: PriceError): A = default
-        def genericServerError(value: GenericServerError): A = default
         def genericClientError(value: GenericClientError): A = default
+        def genericServerError(value: GenericServerError): A = default
+        def priceError(value: PriceError): A = default
       }
     }
 
     implicit val schema: Schema[AddMenuItemError] = union(
-      AddMenuItemError.PriceErrorCase.alt,
-      AddMenuItemError.GenericServerErrorCase.alt,
       AddMenuItemError.GenericClientErrorCase.alt,
+      AddMenuItemError.GenericServerErrorCase.alt,
+      AddMenuItemError.PriceErrorCase.alt,
     ){
       _.$ordinal
     }
     def liftError(throwable: Throwable): Option[AddMenuItemError] = throwable match {
-      case e: PriceError => Some(AddMenuItemError.PriceErrorCase(e))
-      case e: GenericServerError => Some(AddMenuItemError.GenericServerErrorCase(e))
       case e: GenericClientError => Some(AddMenuItemError.GenericClientErrorCase(e))
+      case e: GenericServerError => Some(AddMenuItemError.GenericServerErrorCase(e))
+      case e: PriceError => Some(AddMenuItemError.PriceErrorCase(e))
       case _ => None
     }
     def unliftError(e: AddMenuItemError): Throwable = e match {
-      case AddMenuItemError.PriceErrorCase(e) => e
-      case AddMenuItemError.GenericServerErrorCase(e) => e
       case AddMenuItemError.GenericClientErrorCase(e) => e
+      case AddMenuItemError.GenericServerErrorCase(e) => e
+      case AddMenuItemError.PriceErrorCase(e) => e
     }
   }
   final case class CheckQueryKindZ(input: CheckQueryInput) extends PizzaAdminServiceOperation[CheckQueryInput, Nothing, CheckQueryOutput, Nothing, Nothing] {
@@ -729,40 +729,35 @@ object PizzaAdminServiceOperation {
     def $ordinal: Int
 
     object project {
-      def notFoundError: Option[NotFoundError] = GetMenuError.NotFoundErrorCase.alt.project.lift(self).map(_.notFoundError)
       def fallbackError: Option[FallbackError] = GetMenuError.FallbackErrorCase.alt.project.lift(self).map(_.fallbackError)
       def fallbackError2: Option[FallbackError2] = GetMenuError.FallbackError2Case.alt.project.lift(self).map(_.fallbackError2)
       def genericClientError: Option[GenericClientError] = GetMenuError.GenericClientErrorCase.alt.project.lift(self).map(_.genericClientError)
+      def notFoundError: Option[NotFoundError] = GetMenuError.NotFoundErrorCase.alt.project.lift(self).map(_.notFoundError)
     }
 
     def accept[A](visitor: GetMenuError.Visitor[A]): A = this match {
-      case value: GetMenuError.NotFoundErrorCase => visitor.notFoundError(value.notFoundError)
       case value: GetMenuError.FallbackErrorCase => visitor.fallbackError(value.fallbackError)
       case value: GetMenuError.FallbackError2Case => visitor.fallbackError2(value.fallbackError2)
       case value: GetMenuError.GenericClientErrorCase => visitor.genericClientError(value.genericClientError)
+      case value: GetMenuError.NotFoundErrorCase => visitor.notFoundError(value.notFoundError)
     }
   }
   object GetMenuError extends ErrorSchema.Companion[GetMenuError] {
 
-    def notFoundError(notFoundError: NotFoundError): GetMenuError = NotFoundErrorCase(notFoundError)
     def fallbackError(fallbackError: FallbackError): GetMenuError = FallbackErrorCase(fallbackError)
     def fallbackError2(fallbackError2: FallbackError2): GetMenuError = FallbackError2Case(fallbackError2)
     def genericClientError(genericClientError: GenericClientError): GetMenuError = GenericClientErrorCase(genericClientError)
+    def notFoundError(notFoundError: NotFoundError): GetMenuError = NotFoundErrorCase(notFoundError)
 
     val id: ShapeId = ShapeId("smithy4s.example", "GetMenuError")
 
     val hints: Hints = Hints.empty
 
-    final case class NotFoundErrorCase(notFoundError: NotFoundError) extends GetMenuError { final def $ordinal: Int = 0 }
-    final case class FallbackErrorCase(fallbackError: FallbackError) extends GetMenuError { final def $ordinal: Int = 1 }
-    final case class FallbackError2Case(fallbackError2: FallbackError2) extends GetMenuError { final def $ordinal: Int = 2 }
-    final case class GenericClientErrorCase(genericClientError: GenericClientError) extends GetMenuError { final def $ordinal: Int = 3 }
+    final case class FallbackErrorCase(fallbackError: FallbackError) extends GetMenuError { final def $ordinal: Int = 0 }
+    final case class FallbackError2Case(fallbackError2: FallbackError2) extends GetMenuError { final def $ordinal: Int = 1 }
+    final case class GenericClientErrorCase(genericClientError: GenericClientError) extends GetMenuError { final def $ordinal: Int = 2 }
+    final case class NotFoundErrorCase(notFoundError: NotFoundError) extends GetMenuError { final def $ordinal: Int = 3 }
 
-    object NotFoundErrorCase {
-      val hints: Hints = Hints.empty
-      val schema: Schema[GetMenuError.NotFoundErrorCase] = bijection(NotFoundError.schema.addHints(hints), GetMenuError.NotFoundErrorCase(_), _.notFoundError)
-      val alt = schema.oneOf[GetMenuError]("NotFoundError")
-    }
     object FallbackErrorCase {
       val hints: Hints = Hints.empty
       val schema: Schema[GetMenuError.FallbackErrorCase] = bijection(FallbackError.schema.addHints(hints), GetMenuError.FallbackErrorCase(_), _.fallbackError)
@@ -778,44 +773,49 @@ object PizzaAdminServiceOperation {
       val schema: Schema[GetMenuError.GenericClientErrorCase] = bijection(GenericClientError.schema.addHints(hints), GetMenuError.GenericClientErrorCase(_), _.genericClientError)
       val alt = schema.oneOf[GetMenuError]("GenericClientError")
     }
+    object NotFoundErrorCase {
+      val hints: Hints = Hints.empty
+      val schema: Schema[GetMenuError.NotFoundErrorCase] = bijection(NotFoundError.schema.addHints(hints), GetMenuError.NotFoundErrorCase(_), _.notFoundError)
+      val alt = schema.oneOf[GetMenuError]("NotFoundError")
+    }
 
     trait Visitor[A] {
-      def notFoundError(value: NotFoundError): A
       def fallbackError(value: FallbackError): A
       def fallbackError2(value: FallbackError2): A
       def genericClientError(value: GenericClientError): A
+      def notFoundError(value: NotFoundError): A
     }
 
     object Visitor {
       trait Default[A] extends Visitor[A] {
         def default: A
-        def notFoundError(value: NotFoundError): A = default
         def fallbackError(value: FallbackError): A = default
         def fallbackError2(value: FallbackError2): A = default
         def genericClientError(value: GenericClientError): A = default
+        def notFoundError(value: NotFoundError): A = default
       }
     }
 
     implicit val schema: Schema[GetMenuError] = union(
-      GetMenuError.NotFoundErrorCase.alt,
       GetMenuError.FallbackErrorCase.alt,
       GetMenuError.FallbackError2Case.alt,
       GetMenuError.GenericClientErrorCase.alt,
+      GetMenuError.NotFoundErrorCase.alt,
     ){
       _.$ordinal
     }
     def liftError(throwable: Throwable): Option[GetMenuError] = throwable match {
-      case e: NotFoundError => Some(GetMenuError.NotFoundErrorCase(e))
       case e: FallbackError => Some(GetMenuError.FallbackErrorCase(e))
       case e: FallbackError2 => Some(GetMenuError.FallbackError2Case(e))
       case e: GenericClientError => Some(GetMenuError.GenericClientErrorCase(e))
+      case e: NotFoundError => Some(GetMenuError.NotFoundErrorCase(e))
       case _ => None
     }
     def unliftError(e: GetMenuError): Throwable = e match {
-      case GetMenuError.NotFoundErrorCase(e) => e
       case GetMenuError.FallbackErrorCase(e) => e
       case GetMenuError.FallbackError2Case(e) => e
       case GetMenuError.GenericClientErrorCase(e) => e
+      case GetMenuError.NotFoundErrorCase(e) => e
     }
   }
   final case class CheckQueryVariantB(input: CheckQueryInput) extends PizzaAdminServiceOperation[CheckQueryInput, Nothing, CheckQueryOutput, Nothing, Nothing] {

--- a/modules/bootstrapped/src/generated/smithy4s/example/test/HelloService.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/test/HelloService.scala
@@ -129,65 +129,65 @@ object HelloServiceOperation {
     def $ordinal: Int
 
     object project {
-      def simpleError: Option[SimpleError] = SayHelloError.SimpleErrorCase.alt.project.lift(self).map(_.simpleError)
       def complexError: Option[ComplexError] = SayHelloError.ComplexErrorCase.alt.project.lift(self).map(_.complexError)
+      def simpleError: Option[SimpleError] = SayHelloError.SimpleErrorCase.alt.project.lift(self).map(_.simpleError)
     }
 
     def accept[A](visitor: SayHelloError.Visitor[A]): A = this match {
-      case value: SayHelloError.SimpleErrorCase => visitor.simpleError(value.simpleError)
       case value: SayHelloError.ComplexErrorCase => visitor.complexError(value.complexError)
+      case value: SayHelloError.SimpleErrorCase => visitor.simpleError(value.simpleError)
     }
   }
   object SayHelloError extends ErrorSchema.Companion[SayHelloError] {
 
-    def simpleError(simpleError: SimpleError): SayHelloError = SimpleErrorCase(simpleError)
     def complexError(complexError: ComplexError): SayHelloError = ComplexErrorCase(complexError)
+    def simpleError(simpleError: SimpleError): SayHelloError = SimpleErrorCase(simpleError)
 
     val id: ShapeId = ShapeId("smithy4s.example.test", "SayHelloError")
 
     val hints: Hints = Hints.empty
 
-    final case class SimpleErrorCase(simpleError: SimpleError) extends SayHelloError { final def $ordinal: Int = 0 }
-    final case class ComplexErrorCase(complexError: ComplexError) extends SayHelloError { final def $ordinal: Int = 1 }
+    final case class ComplexErrorCase(complexError: ComplexError) extends SayHelloError { final def $ordinal: Int = 0 }
+    final case class SimpleErrorCase(simpleError: SimpleError) extends SayHelloError { final def $ordinal: Int = 1 }
 
-    object SimpleErrorCase {
-      val hints: Hints = Hints.empty
-      val schema: Schema[SayHelloError.SimpleErrorCase] = bijection(SimpleError.schema.addHints(hints), SayHelloError.SimpleErrorCase(_), _.simpleError)
-      val alt = schema.oneOf[SayHelloError]("SimpleError")
-    }
     object ComplexErrorCase {
       val hints: Hints = Hints.empty
       val schema: Schema[SayHelloError.ComplexErrorCase] = bijection(ComplexError.schema.addHints(hints), SayHelloError.ComplexErrorCase(_), _.complexError)
       val alt = schema.oneOf[SayHelloError]("ComplexError")
     }
+    object SimpleErrorCase {
+      val hints: Hints = Hints.empty
+      val schema: Schema[SayHelloError.SimpleErrorCase] = bijection(SimpleError.schema.addHints(hints), SayHelloError.SimpleErrorCase(_), _.simpleError)
+      val alt = schema.oneOf[SayHelloError]("SimpleError")
+    }
 
     trait Visitor[A] {
-      def simpleError(value: SimpleError): A
       def complexError(value: ComplexError): A
+      def simpleError(value: SimpleError): A
     }
 
     object Visitor {
       trait Default[A] extends Visitor[A] {
         def default: A
-        def simpleError(value: SimpleError): A = default
         def complexError(value: ComplexError): A = default
+        def simpleError(value: SimpleError): A = default
       }
     }
 
     implicit val schema: Schema[SayHelloError] = union(
-      SayHelloError.SimpleErrorCase.alt,
       SayHelloError.ComplexErrorCase.alt,
+      SayHelloError.SimpleErrorCase.alt,
     ){
       _.$ordinal
     }
     def liftError(throwable: Throwable): Option[SayHelloError] = throwable match {
-      case e: SimpleError => Some(SayHelloError.SimpleErrorCase(e))
       case e: ComplexError => Some(SayHelloError.ComplexErrorCase(e))
+      case e: SimpleError => Some(SayHelloError.SimpleErrorCase(e))
       case _ => None
     }
     def unliftError(e: SayHelloError): Throwable = e match {
-      case SayHelloError.SimpleErrorCase(e) => e
       case SayHelloError.ComplexErrorCase(e) => e
+      case SayHelloError.SimpleErrorCase(e) => e
     }
   }
 }

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/aws-newtype-flatten/build.sbt
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/aws-newtype-flatten/build.sbt
@@ -1,7 +1,7 @@
 lazy val root = (project in file("."))
   .enablePlugins(Smithy4sCodegenPlugin)
   .settings(
-    scalaVersion := "2.13.16",
+    scalaVersion := "2.13.18",
     libraryDependencies ++= Seq(
       "com.disneystreaming.smithy4s" %% "smithy4s-aws-kernel" % smithy4sVersion.value
     ),

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/aws-open-enums/build.sbt
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/aws-open-enums/build.sbt
@@ -1,7 +1,7 @@
 lazy val root = (project in file("."))
   .enablePlugins(Smithy4sCodegenPlugin)
   .settings(
-    scalaVersion := "2.13.16",
+    scalaVersion := "2.13.18",
     libraryDependencies ++= Seq(
       "com.disneystreaming.smithy4s" %% "smithy4s-aws-kernel" % smithy4sVersion.value
     )

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/aws-specs/build.sbt
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/aws-specs/build.sbt
@@ -1,6 +1,6 @@
 lazy val root = (project in file("."))
   .enablePlugins(Smithy4sCodegenPlugin)
   .settings(
-    scalaVersion := "2.13.16",
+    scalaVersion := "2.13.18",
     smithy4sAwsSpecs ++= Seq(AWS.dynamodb)
   )

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/cross-builds/build.sbt
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/cross-builds/build.sbt
@@ -1,7 +1,7 @@
 lazy val root = (project in file("."))
   .enablePlugins(Smithy4sCodegenPlugin)
   .settings(
-    crossScalaVersions := Seq("2.13.16", "3.3.3"),
+    crossScalaVersions := Seq("2.13.18", "3.3.3"),
     libraryDependencies ++= Seq(
       "com.disneystreaming.smithy4s" %% "smithy4s-core" % smithy4sVersion.value
     )

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/custom-settings/build.sbt
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/custom-settings/build.sbt
@@ -1,5 +1,5 @@
 lazy val commonSettings = Def.settings(
-  scalaVersion := "2.13.16",
+  scalaVersion := "2.13.18",
   Compile / smithy4sInputDirs := Seq(
     (ThisBuild / baseDirectory).value / "smithy_input"
   ),

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/defaults/build.sbt
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/defaults/build.sbt
@@ -1,7 +1,7 @@
 lazy val root = (project in file("."))
   .enablePlugins(Smithy4sCodegenPlugin)
   .settings(
-    scalaVersion := "2.13.16",
+    scalaVersion := "2.13.18",
     libraryDependencies ++= Seq(
       "com.disneystreaming.smithy4s" %% "smithy4s-core" % smithy4sVersion.value,
       "com.disneystreaming.smithy4s" %% "smithy4s-dynamic" % smithy4sVersion.value

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/dependencies-only/build.sbt
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/dependencies-only/build.sbt
@@ -1,7 +1,7 @@
 lazy val p1 = project
   .enablePlugins(Smithy4sCodegenPlugin)
   .settings(
-    scalaVersion := "2.13.16",
+    scalaVersion := "2.13.18",
     Compile / smithy4sAllowedNamespaces := List(
       "aws.iam"
     ),

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/extra-configs/build.sbt
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/extra-configs/build.sbt
@@ -1,7 +1,7 @@
 lazy val root = (project in file("."))
   .enablePlugins(Smithy4sCodegenPlugin)
   .settings(
-    scalaVersion := "2.13.16",
+    scalaVersion := "2.13.18",
     libraryDependencies += "com.disneystreaming.smithy4s" %% "smithy4s-core" % smithy4sVersion.value,
     Smithy4sCodegenPlugin.defaultSettings(Test)
   )

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/multimodule-aws/build.sbt
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/multimodule-aws/build.sbt
@@ -1,6 +1,6 @@
 import smithy4s.codegen.BuildInfo._
 
-ThisBuild / scalaVersion := "2.13.16"
+ThisBuild / scalaVersion := "2.13.18"
 
 lazy val foo = (project in file("foo"))
   .enablePlugins(Smithy4sCodegenPlugin)

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/multimodule-no-compile/build.sbt
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/multimodule-no-compile/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / scalaVersion := "2.13.16"
+ThisBuild / scalaVersion := "2.13.18"
 
 lazy val foo = (project in file("foo"))
 

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/multimodule-staged/build.sbt
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/multimodule-staged/build.sbt
@@ -1,6 +1,6 @@
 import smithy4s.codegen.BuildInfo.smithyVersion
 
-ThisBuild / scalaVersion := "2.13.16"
+ThisBuild / scalaVersion := "2.13.18"
 ThisBuild / version := "0.0.1-SNAPSHOT"
 ThisBuild / organization := "foobar"
 

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/multimodule/build.sbt
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/multimodule/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / scalaVersion := "2.13.16"
+ThisBuild / scalaVersion := "2.13.18"
 
 lazy val root = project
   .in(file("."))

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/multiple-artifacts-same-namespace/build.sbt
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/multiple-artifacts-same-namespace/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / scalaVersion := "2.13.16"
+ThisBuild / scalaVersion := "2.13.18"
 
 lazy val a = project
   .enablePlugins(Smithy4sCodegenPlugin)

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/optics-generate/build.sbt
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/optics-generate/build.sbt
@@ -1,7 +1,7 @@
 lazy val root = (project in file("."))
   .enablePlugins(Smithy4sCodegenPlugin)
   .settings(
-    scalaVersion := "2.13.16",
+    scalaVersion := "2.13.18",
     Compile / smithy4sRenderOptics := true,
     libraryDependencies ++= Seq(
       "com.disneystreaming.smithy4s" %% "smithy4s-core" % smithy4sVersion.value,

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/protobuf/build.sbt
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/protobuf/build.sbt
@@ -1,7 +1,7 @@
 lazy val root = (project in file("."))
   .enablePlugins(Smithy4sCodegenPlugin)
   .settings(
-    scalaVersion := "2.13.16",
+    scalaVersion := "2.13.18",
     libraryDependencies ++= Seq(
       "com.disneystreaming.smithy4s" %% "smithy4s-core" % smithy4sVersion.value
     )

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/refinements/build.sbt
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/refinements/build.sbt
@@ -1,10 +1,8 @@
-
 lazy val root = (project in file("."))
   .enablePlugins(Smithy4sCodegenPlugin)
   .settings(
-    scalaVersion := "2.13.16",
+    scalaVersion := "2.13.18",
     libraryDependencies ++= Seq(
-        "com.disneystreaming.smithy4s" %% "smithy4s-core" % smithy4sVersion.value
-      )
+      "com.disneystreaming.smithy4s" %% "smithy4s-core" % smithy4sVersion.value
     )
-
+  )

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/render-validated-newtypes/build.sbt
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/render-validated-newtypes/build.sbt
@@ -1,7 +1,7 @@
 lazy val root = (project in file("."))
   .enablePlugins(Smithy4sCodegenPlugin)
   .settings(
-    scalaVersion := "2.13.16",
+    scalaVersion := "2.13.18",
     libraryDependencies ++= Seq(
       "com.disneystreaming.smithy4s" %% "smithy4s-core" % smithy4sVersion.value,
       "com.disneystreaming.smithy4s" %% "smithy4s-dynamic" % smithy4sVersion.value,

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/smithy-build-kind-projector/build.sbt
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/smithy-build-kind-projector/build.sbt
@@ -1,13 +1,16 @@
 lazy val root = (project in file("."))
   .enablePlugins(Smithy4sCodegenPlugin)
   .settings(
-    scalaVersion := "2.13.16",
-    addCompilerPlugin("org.typelevel" % "kind-projector" % "0.13.3" cross CrossVersion.full),
+    scalaVersion := "2.13.18",
+    addCompilerPlugin(
+      "org.typelevel" % "kind-projector" % "0.13.4" cross CrossVersion.full
+    ),
     libraryDependencies ++= Seq(
       "com.disneystreaming.smithy4s" %% "smithy4s-core" % smithy4sVersion.value
     ),
     Compile / scalacOptions ++= Seq(
-      "-Xsource:3", "-P:kind-projector:underscore-placeholders"
+      "-Xsource:3",
+      "-P:kind-projector:underscore-placeholders"
     ),
     Compile / smithyBuild := Some(baseDirectory.value / "smithy-build.json"),
     TaskKey[Unit]("checkOpenApi") := {

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/smithy-build/build.sbt
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/smithy-build/build.sbt
@@ -1,7 +1,7 @@
 lazy val root = (project in file("."))
   .enablePlugins(Smithy4sCodegenPlugin)
   .settings(
-    scalaVersion := "2.13.16",
+    scalaVersion := "2.13.18",
     libraryDependencies ++= Seq(
       "com.disneystreaming.smithy4s" %% "smithy4s-core" % smithy4sVersion.value
     ),

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/smithy-rules/build.sbt
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/smithy-rules/build.sbt
@@ -1,7 +1,7 @@
 lazy val root = (project in file("."))
   .enablePlugins(Smithy4sCodegenPlugin)
   .settings(
-    scalaVersion := "2.13.16",
+    scalaVersion := "2.13.18",
     libraryDependencies ++= Seq(
       "com.disneystreaming.smithy4s" %% "smithy4s-core" % smithy4sVersion.value,
       "software.amazon.smithy" % "smithy-rules-engine" % smithy4s.codegen.BuildInfo.smithyVersion % Smithy4s

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/wildcard-config/build.sbt
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/wildcard-config/build.sbt
@@ -1,4 +1,4 @@
-val scala213 = "2.13.16"
+val scala213 = "2.13.18"
 val scala3 = "3.3.0"
 
 val expectedWildcardArgument =

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/wildcard-config/test
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/wildcard-config/test
@@ -1,7 +1,7 @@
 # use "_" if major version is not 3
-> check _ 2.13.16
-> check _ 2.13.16 -source future
-> check _ 2.13.16 -source:future
+> check _ 2.13.18
+> check _ 2.13.18 -source future
+> check _ 2.13.18 -source:future
 
 # use "?" if major version >= 3.1 or using -source:future or -source future
 > check ? 3.1.foobar
@@ -12,7 +12,7 @@
 > check _ 3.0.foobar
 > check _ 3.foobar.foobar
 
-> ++2.13.16
+> ++2.13.18
 > root/compile
 $ exists target/scala-2.13/src_managed/main/smithy/generated-metadata.smithy
 $ exists target/scala-2.13/resource_managed/main/META-INF/smithy/generated-metadata.smithy

--- a/modules/codegen/src/smithy4s/codegen/internals/SmithyToIR.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/SmithyToIR.scala
@@ -462,9 +462,10 @@ private[codegen] class SmithyToIR(
       override def serviceShape(shape: ServiceShape): Option[Decl] = {
         val generalErrors: List[Type] =
           shape
-            .getErrors()
+            .getErrorsSet()
             .asScala
             .toList
+            .sortBy(_.toShapeId)
             .map(_.tpe)
             .collect { case Some(tpe) => tpe }
 
@@ -501,10 +502,11 @@ private[codegen] class SmithyToIR(
 
             val errorTypes = {
               generalErrors ++ op
-                .getErrors()
+                .getErrorsSet()
                 .asScala
-                .flatMap(_.tpe)
                 .toList
+                .sortBy(_.toShapeId)
+                .flatMap(_.tpe)
             }.distinct
 
             val outputType =

--- a/modules/docs/resources/markdown/01-overview/02-quickstart.md
+++ b/modules/docs/resources/markdown/01-overview/02-quickstart.md
@@ -50,7 +50,7 @@ import smithy4s.codegen.mill._
 
 import mill._, mill.scalalib._
 object example extends ScalaModule with Smithy4sModule {
-  def scalaVersion = "2.13.16"
+  def scalaVersion = "2.13.18"
   override def ivyDeps = Agg(
     ivy"com.disneystreaming.smithy4s::smithy4s-core:${smithy4sVersion()}",
     ivy"com.disneystreaming.smithy4s::smithy4s-http4s-swagger:${smithy4sVersion()}",

--- a/modules/docs/resources/markdown/01-overview/03-installation.md
+++ b/modules/docs/resources/markdown/01-overview/03-installation.md
@@ -59,7 +59,7 @@ import smithy4s.codegen.mill._
 
 import mill._, mill.scalalib._
 object example extends ScalaModule with Smithy4sModule {
-  def scalaVersion = "2.13.16"
+  def scalaVersion = "2.13.18"
   override def ivyDeps = Agg(
     ivy"com.disneystreaming.smithy4s::smithy4s-core:${smithy4sVersion()}"
   )
@@ -86,7 +86,7 @@ import smithy4s.codegen.mill._
 
 import mill._, mill.scalalib._
 object example extends ScalaModule with Smithy4sModule {
-  def scalaVersion = "2.13.16"
+  def scalaVersion = "2.13.18"
   override def ivyDeps = Agg(
     ivy"com.disneystreaming.smithy4s::smithy4s-core:${smithy4sVersion()}"
   )

--- a/modules/docs/resources/markdown/03-protocols/03-aws/01-aws.md
+++ b/modules/docs/resources/markdown/03-protocols/03-aws/01-aws.md
@@ -53,7 +53,7 @@ import $ivy.`com.disneystreaming.smithy4s::smithy4s-mill-codegen-plugin::@VERSIO
 import smithy4s.codegen.mill._
 
 object foo extends Smithy4sModule {
-  override def scalaVersion = "2.13.16"
+  override def scalaVersion = "2.13.18"
   override def ivyDeps = Agg(
     ivy"com.disneystreaming.smithy4s::smithy4s-aws-http4s:${smithy4sVersion()}",
   )

--- a/modules/docs/resources/markdown/06-guides/model-preprocessing.md
+++ b/modules/docs/resources/markdown/06-guides/model-preprocessing.md
@@ -76,7 +76,7 @@ import mill._
 import scalalib._
 
 object preprocessors extends ScalaModule {
-  def scalaVersion = "2.13.16" // 2.13 to match what Mill uses
+  def scalaVersion = "2.13.18" // 2.13 to match what Mill uses
   def ivyDeps = Agg(
     s"software.amazon.smithy:smithy-build:${smithy4s.codegen.BuildInfo.smithyVersion}"
   )

--- a/modules/mill-codegen-plugin/test/src-mill-0_11/smithy4s/codegen/mill/Smithy4sModuleSpec.scala
+++ b/modules/mill-codegen-plugin/test/src-mill-0_11/smithy4s/codegen/mill/Smithy4sModuleSpec.scala
@@ -41,7 +41,7 @@ class Smithy4sModuleSpec extends munit.FunSuite {
 
   test("basic codegen runs") {
     object foo extends testKit.BaseModule with Smithy4sModule {
-      override def scalaVersion = "2.13.16"
+      override def scalaVersion = "2.13.18"
       override def ivyDeps = Agg(coreDep)
       override def millSourcePath = resourcePath / "basic"
     }
@@ -90,9 +90,9 @@ class Smithy4sModuleSpec extends munit.FunSuite {
     }
 
     val msg1 = """use "_" if major version is not 3"""
-    assertEquals(getArg("2.13.16", Seq()), "_", msg1)
-    assertEquals(getArg("2.13.16", Seq("-source", "future")), "_", msg1)
-    assertEquals(getArg("2.13.16", Seq("-source:future")), "_", msg1)
+    assertEquals(getArg("2.13.18", Seq()), "_", msg1)
+    assertEquals(getArg("2.13.18", Seq("-source", "future")), "_", msg1)
+    assertEquals(getArg("2.13.18", Seq("-source:future")), "_", msg1)
 
     val msg2 =
       """use "?" if major version >= 3.1 or using -source:future or -source future"""
@@ -128,10 +128,10 @@ class Smithy4sModuleSpec extends munit.FunSuite {
 
   test("2.13 codegen with placeholder wildcards") {
     object foo extends testKit.BaseModule with Smithy4sModule {
-      override def scalaVersion = "2.13.16"
+      override def scalaVersion = "2.13.18"
       override def ivyDeps = Agg(coreDep)
       override def scalacPluginIvyDeps =
-        Agg(ivy"org.typelevel:::kind-projector:0.13.3")
+        Agg(ivy"org.typelevel:::kind-projector:0.13.4")
       override def scalacOptions =
         Seq("-Xsource:3", "-P:kind-projector:underscore-placeholders")
       override def millSourcePath = resourcePath / "service"
@@ -151,7 +151,7 @@ class Smithy4sModuleSpec extends munit.FunSuite {
 
   test("codegen with dependencies") {
     object foo extends testKit.BaseModule with Smithy4sModule {
-      override def scalaVersion = "2.13.16"
+      override def scalaVersion = "2.13.18"
       override def ivyDeps = Agg(coreDep)
       override def millSourcePath = resourcePath / "basic"
       override def smithy4sAllowedNamespaces = T(Some(Set("aws.iam")))
@@ -171,7 +171,7 @@ class Smithy4sModuleSpec extends munit.FunSuite {
 
   test("codegen with custom smithy-build.json works") {
     object foo extends testKit.BaseModule with Smithy4sModule {
-      override def scalaVersion = "2.13.16"
+      override def scalaVersion = "2.13.18"
       override def ivyDeps = Agg(coreDep)
       override def millSourcePath = resourcePath / "smithy-build"
       override def smithyBuild =
@@ -194,14 +194,14 @@ class Smithy4sModuleSpec extends munit.FunSuite {
   test("multi-module codegen works") {
 
     object foo extends testKit.BaseModule with Smithy4sModule {
-      override def scalaVersion = "2.13.16"
+      override def scalaVersion = "2.13.18"
       override def ivyDeps = Agg(coreDep)
       override def millSourcePath = resourcePath / "multi-module" / "foo"
     }
 
     object bar extends testKit.BaseModule with Smithy4sModule {
       override def moduleDeps = Seq(foo)
-      override def scalaVersion = "2.13.16"
+      override def scalaVersion = "2.13.18"
       override def ivyDeps = Agg(coreDep)
       override def millSourcePath = resourcePath / "multi-module" / "bar"
     }
@@ -243,7 +243,7 @@ class Smithy4sModuleSpec extends munit.FunSuite {
   test("multi-module codegen works with AWS specs upstream") {
 
     object foo extends testKit.BaseModule with Smithy4sModule {
-      override def scalaVersion = "2.13.16"
+      override def scalaVersion = "2.13.18"
       override def ivyDeps = Agg(
         ivy"com.disneystreaming.smithy4s::smithy4s-aws-kernel:${smithy4s.codegen.BuildInfo.version}"
       )
@@ -255,7 +255,7 @@ class Smithy4sModuleSpec extends munit.FunSuite {
 
     object bar extends testKit.BaseModule with Smithy4sModule {
       override def moduleDeps = Seq(foo)
-      override def scalaVersion = "2.13.16"
+      override def scalaVersion = "2.13.18"
       override def millSourcePath = resourcePath / "multi-module-aws" / "bar"
     }
 
@@ -297,14 +297,14 @@ class Smithy4sModuleSpec extends munit.FunSuite {
   ) {
 
     object foo extends testKit.BaseModule with ScalaModule {
-      override def scalaVersion = "2.13.16"
+      override def scalaVersion = "2.13.18"
       override def millSourcePath =
         resourcePath / "multi-module-no-compile" / "foo"
     }
 
     object bar extends testKit.BaseModule with Smithy4sModule {
       override def moduleDeps = Seq(foo)
-      override def scalaVersion = "2.13.16"
+      override def scalaVersion = "2.13.18"
       override def ivyDeps = Agg(coreDep)
       override def millSourcePath =
         resourcePath / "multi-module-no-compile" / "bar"
@@ -326,7 +326,7 @@ class Smithy4sModuleSpec extends munit.FunSuite {
         with SbtModule
         with Smithy4sModule
         with PublishModule {
-      override def scalaVersion = "2.13.16"
+      override def scalaVersion = "2.13.18"
       override def repositoriesTask: Task[Seq[Repository]] = T.task {
         val ivy2Local = IvyRepository.fromPattern(
           (localIvyRepo.toNIO.toUri.toString + "/") +: coursier.ivy.Pattern.default,
@@ -348,7 +348,7 @@ class Smithy4sModuleSpec extends munit.FunSuite {
 
     object foo extends Base {
       override def artifactName: T[String] = "foo-mill"
-      override def scalaVersion = "2.13.16"
+      override def scalaVersion = "2.13.18"
       override def ivyDeps = Agg(coreDep)
       override def smithy4sAllowedNamespaces: T[Option[Set[String]]] =
         Some(Set("aws.api", "foo"))
@@ -362,7 +362,7 @@ class Smithy4sModuleSpec extends munit.FunSuite {
 
     object bar extends Base {
       override def artifactName: T[String] = "bar-mill"
-      override def scalaVersion = "2.13.16"
+      override def scalaVersion = "2.13.18"
       // bar depend on foo as a library, and an assumption is made that bar may depend on the same smithy models
       // that foo depended on for its own codegen. Therefore, these are retrieved from foo's manifest,
       // resolved and added to the list of jars to seek smithy models from during code generation
@@ -395,7 +395,7 @@ class Smithy4sModuleSpec extends munit.FunSuite {
 
   test("codegen with aws specs") {
     object foo extends testKit.BaseModule with Smithy4sModule {
-      override def scalaVersion = "2.13.16"
+      override def scalaVersion = "2.13.18"
       override def ivyDeps = Agg(coreDep)
       override def smithy4sAwsSpecs: T[Seq[String]] = T(
         Seq(AWS.dynamodb)

--- a/modules/mill-codegen-plugin/test/src-mill-0_11/smithy4s/codegen/mill/SmithyLSPConfigSpec.scala
+++ b/modules/mill-codegen-plugin/test/src-mill-0_11/smithy4s/codegen/mill/SmithyLSPConfigSpec.scala
@@ -36,7 +36,7 @@ class SmithyLSPConfigSpec extends munit.FunSuite {
               )
             )
         }
-        override def scalaVersion = "2.13.16"
+        override def scalaVersion = "2.13.18"
         override def smithy4sAllowedNamespaces = T(Some(Set("aws.iam")))
         override def smithy4sIvyDeps = Agg(
           ivy"software.amazon.smithy:smithy-aws-iam-traits:${smithy4s.codegen.BuildInfo.smithyVersion}"

--- a/modules/mill-codegen-plugin/test/src-mill-0_12/smithy4s/codegen/mill/Smithy4sModuleSpec.scala
+++ b/modules/mill-codegen-plugin/test/src-mill-0_12/smithy4s/codegen/mill/Smithy4sModuleSpec.scala
@@ -37,7 +37,7 @@ class Smithy4sModuleSpec extends munit.FunSuite {
 
   test("basic codegen runs") {
     object foo extends TestBaseModule with Smithy4sModule {
-      override def scalaVersion = "2.13.16"
+      override def scalaVersion = "2.13.18"
       override def ivyDeps = Agg(coreDep)
     }
 
@@ -99,9 +99,9 @@ class Smithy4sModuleSpec extends munit.FunSuite {
     }
 
     val msg1 = """use "_" if major version is not 3"""
-    assertEquals(getArg("2.13.16", Seq()), "_", msg1)
-    assertEquals(getArg("2.13.16", Seq("-source", "future")), "_", msg1)
-    assertEquals(getArg("2.13.16", Seq("-source:future")), "_", msg1)
+    assertEquals(getArg("2.13.18", Seq()), "_", msg1)
+    assertEquals(getArg("2.13.18", Seq("-source", "future")), "_", msg1)
+    assertEquals(getArg("2.13.18", Seq("-source:future")), "_", msg1)
 
     val msg2 =
       """use "?" if major version >= 3.1 or using -source:future or -source future"""
@@ -146,10 +146,10 @@ class Smithy4sModuleSpec extends munit.FunSuite {
 
   test("2.13 codegen with placeholder wildcards") {
     object foo extends TestBaseModule with Smithy4sModule {
-      override def scalaVersion = "2.13.16"
+      override def scalaVersion = "2.13.18"
       override def ivyDeps = Agg(coreDep)
       override def scalacPluginIvyDeps =
-        Agg(ivy"org.typelevel:::kind-projector:0.13.3")
+        Agg(ivy"org.typelevel:::kind-projector:0.13.4")
       override def scalacOptions =
         Seq("-Xsource:3", "-P:kind-projector:underscore-placeholders")
 
@@ -179,7 +179,7 @@ class Smithy4sModuleSpec extends munit.FunSuite {
 
   test("codegen with dependencies") {
     object foo extends TestBaseModule with Smithy4sModule {
-      override def scalaVersion = "2.13.16"
+      override def scalaVersion = "2.13.18"
       override def ivyDeps = Agg(coreDep)
       override def smithy4sAllowedNamespaces = T(Some(Set("aws.iam")))
       override def smithy4sIvyDeps = Agg(
@@ -206,7 +206,7 @@ class Smithy4sModuleSpec extends munit.FunSuite {
 
   test("codegen with custom smithy-build.json works") {
     object foo extends TestBaseModule with Smithy4sModule {
-      override def scalaVersion = "2.13.16"
+      override def scalaVersion = "2.13.18"
       override def ivyDeps = Agg(coreDep)
 
       override def smithyBuild =
@@ -239,12 +239,12 @@ class Smithy4sModuleSpec extends munit.FunSuite {
   test("multi-module codegen works") {
     object base extends TestBaseModule {
       object foo extends Smithy4sModule {
-        override def scalaVersion = "2.13.16"
+        override def scalaVersion = "2.13.18"
         override def ivyDeps = Agg(coreDep)
       }
 
       object bar extends Smithy4sModule {
-        override def scalaVersion = "2.13.16"
+        override def scalaVersion = "2.13.18"
         override def ivyDeps = Agg(coreDep)
         override def moduleDeps = Seq(foo)
       }
@@ -291,7 +291,7 @@ class Smithy4sModuleSpec extends munit.FunSuite {
   test("multi-module codegen works with AWS specs upstream") {
     object base extends TestBaseModule {
       object foo extends Smithy4sModule {
-        override def scalaVersion = "2.13.16"
+        override def scalaVersion = "2.13.18"
         override def ivyDeps = Agg(
           ivy"com.disneystreaming.smithy4s::smithy4s-aws-kernel:${smithy4s.codegen.BuildInfo.version}"
         )
@@ -301,7 +301,7 @@ class Smithy4sModuleSpec extends munit.FunSuite {
       }
 
       object bar extends Smithy4sModule {
-        override def scalaVersion = "2.13.16"
+        override def scalaVersion = "2.13.18"
         override def moduleDeps = Seq(foo)
       }
     }
@@ -345,11 +345,11 @@ class Smithy4sModuleSpec extends munit.FunSuite {
   ) {
     object base extends TestBaseModule {
       object foo extends ScalaModule {
-        override def scalaVersion = "2.13.16"
+        override def scalaVersion = "2.13.18"
       }
 
       object bar extends Smithy4sModule {
-        override def scalaVersion = "2.13.16"
+        override def scalaVersion = "2.13.18"
         override def moduleDeps = Seq(foo)
         override def ivyDeps = Agg(coreDep)
 
@@ -373,7 +373,7 @@ class Smithy4sModuleSpec extends munit.FunSuite {
     val localIvyRepo = os.temp.dir() / ".ivy2" / "local"
 
     trait Common extends SbtModule with Smithy4sModule with PublishModule {
-      override def scalaVersion = "2.13.16"
+      override def scalaVersion = "2.13.18"
       override def repositoriesTask: Task[Seq[Repository]] = T.task {
         val ivy2Local = IvyRepository.fromPattern(
           (localIvyRepo.toNIO.toUri.toString + "/") +: coursier.ivy.Pattern.default,
@@ -396,7 +396,7 @@ class Smithy4sModuleSpec extends munit.FunSuite {
     object base extends TestBaseModule {
       object foo extends Common {
         override def artifactName: T[String] = "foo-mill"
-        override def scalaVersion = "2.13.16"
+        override def scalaVersion = "2.13.18"
         override def ivyDeps = Agg(coreDep)
         override def smithy4sAllowedNamespaces: T[Option[Set[String]]] =
           Some(Set("aws.api", "foo"))
@@ -411,7 +411,7 @@ class Smithy4sModuleSpec extends munit.FunSuite {
 
       object bar extends Common {
         override def artifactName: T[String] = "bar-mill"
-        override def scalaVersion = "2.13.16"
+        override def scalaVersion = "2.13.18"
         // bar depend on foo as a library, and an assumption is made that bar may depend on the same smithy models
         // that foo depended on for its own codegen. Therefore, these are retrieved from foo's manifest,
         // resolved and added to the list of jars to seek smithy models from during code generation
@@ -455,7 +455,7 @@ class Smithy4sModuleSpec extends munit.FunSuite {
 
   test("codegen with aws specs") {
     object foo extends TestBaseModule with Smithy4sModule {
-      override def scalaVersion = "2.13.16"
+      override def scalaVersion = "2.13.18"
       override def ivyDeps = Agg(coreDep)
       override def smithy4sAwsSpecs: T[Seq[String]] = T(Seq(AWS.dynamodb))
     }

--- a/modules/mill-codegen-plugin/test/src-mill-0_12/smithy4s/codegen/mill/SmithyLSPConfigSpec.scala
+++ b/modules/mill-codegen-plugin/test/src-mill-0_12/smithy4s/codegen/mill/SmithyLSPConfigSpec.scala
@@ -37,7 +37,7 @@ class SmithyLSPConfigSpec extends munit.FunSuite {
               )
             )
         }
-        override def scalaVersion = "2.13.16"
+        override def scalaVersion = "2.13.18"
         override def smithy4sAllowedNamespaces = T(Some(Set("aws.iam")))
         override def smithy4sIvyDeps = Agg(
           ivy"software.amazon.smithy:smithy-aws-iam-traits:${smithy4s.codegen.BuildInfo.smithyVersion}"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -46,7 +46,8 @@ object Dependencies {
 
   val Cats = new {
     val core: Def.Initialize[ModuleID] =
-      Def.setting("org.typelevel" %%% "cats-core" % "2.13.0")
+      // must remain on 2.11 until we update scala-native version
+      Def.setting("org.typelevel" %%% "cats-core" % "2.11.0")
   }
 
   val Monocle = new {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,7 +10,8 @@ object Dependencies {
 
   val Jsoniter = new {
     val org = "com.github.plokhotnyuk.jsoniter-scala"
-    val jsoniterScalaVersion = "2.38.8"
+    // must keep 2.30.2 until upgrade to scala native 0.5
+    val jsoniterScalaVersion = "2.30.2"
     val core = Def.setting(org %%% "jsoniter-scala-core" % jsoniterScalaVersion)
     val macros = Def.setting(
       org %%% "jsoniter-scala-macros" % jsoniterScalaVersion % "compile-internal"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -55,7 +55,8 @@ object Dependencies {
   }
 
   object Circe {
-    val circeVersion = "0.14.14"
+    // we have to stay on 0.14.8 until we move to scala-native 0.5.x
+    val circeVersion = "0.14.8"
     val core = Def.setting("io.circe" %%% "circe-core" % circeVersion)
     val parser = Def.setting("io.circe" %%% "circe-parser" % circeVersion)
     val generic = Def.setting("io.circe" %%% "circe-generic" % circeVersion)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,7 +10,7 @@ object Dependencies {
 
   val Jsoniter = new {
     val org = "com.github.plokhotnyuk.jsoniter-scala"
-    val jsoniterScalaVersion = "2.30.2"
+    val jsoniterScalaVersion = "2.38.8"
     val core = Def.setting(org %%% "jsoniter-scala-core" % jsoniterScalaVersion)
     val macros = Def.setting(
       org %%% "jsoniter-scala-macros" % jsoniterScalaVersion % "compile-internal"
@@ -19,7 +19,7 @@ object Dependencies {
 
   val Smithy = new {
     val org = "software.amazon.smithy"
-    val smithyVersion = "1.57.1"
+    val smithyVersion = "1.63.0"
     val model = org % "smithy-model" % smithyVersion
     val testTraits = org % "smithy-protocol-test-traits" % smithyVersion
     val build = org % "smithy-build" % smithyVersion
@@ -31,7 +31,7 @@ object Dependencies {
 
   val Alloy = new {
     val org = "com.disneystreaming.alloy"
-    val alloyVersion = "0.3.33"
+    val alloyVersion = "0.3.35"
     val core = org % "alloy-core" % alloyVersion
     val openapi = org %% "alloy-openapi" % alloyVersion
     val protobuf = org % "alloy-protobuf" % alloyVersion
@@ -40,13 +40,13 @@ object Dependencies {
 
   val Smithytranslate = new {
     val org = "com.disneystreaming.smithy"
-    val smithyTranslateVersion = "0.5.10"
+    val smithyTranslateVersion = "0.7.5"
     val proto = org %% "smithytranslate-proto" % smithyTranslateVersion
   }
 
   val Cats = new {
     val core: Def.Initialize[ModuleID] =
-      Def.setting("org.typelevel" %%% "cats-core" % "2.11.0")
+      Def.setting("org.typelevel" %%% "cats-core" % "2.13.0")
   }
 
   val Monocle = new {
@@ -55,21 +55,21 @@ object Dependencies {
   }
 
   object Circe {
-    val circeVersion = "0.14.8"
+    val circeVersion = "0.14.14"
     val core = Def.setting("io.circe" %%% "circe-core" % circeVersion)
     val parser = Def.setting("io.circe" %%% "circe-parser" % circeVersion)
     val generic = Def.setting("io.circe" %%% "circe-generic" % circeVersion)
   }
 
   object Decline {
-    val declineVersion = "2.4.1"
+    val declineVersion = "2.5.0"
 
     val core = Def.setting("com.monovore" %%% "decline" % declineVersion)
     val effect =
       Def.setting("com.monovore" %%% "decline-effect" % declineVersion)
   }
   object Fs2 {
-    val fs2Version = "3.12.0"
+    val fs2Version = "3.12.2"
 
     val core: Def.Initialize[ModuleID] =
       Def.setting("co.fs2" %%% "fs2-core" % fs2Version)
@@ -104,7 +104,7 @@ object Dependencies {
     Def.setting("org.typelevel" %%% "cats-effect" % "3.6.0")
 
   object Http4s {
-    val http4sVersion = "0.23.30"
+    val http4sVersion = "0.23.33"
 
     val emberServer: Def.Initialize[ModuleID] =
       Def.setting("org.http4s" %%% "http4s-ember-server" % http4sVersion)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -65,7 +65,8 @@ object Dependencies {
   }
 
   object Decline {
-    val declineVersion = "2.5.0"
+    // must be kept at 2.4.1 until upgrade to scala-native 0.5
+    val declineVersion = "2.4.1"
 
     val core = Def.setting("com.monovore" %%% "decline" % declineVersion)
     val effect =

--- a/project/Smithy4sBuildPlugin.scala
+++ b/project/Smithy4sBuildPlugin.scala
@@ -71,7 +71,7 @@ case class MillCustomRow(mv: String) extends CustomRow {
 object Smithy4sBuildPlugin extends AutoPlugin {
 
   val Scala212 = "2.12.20"
-  val Scala213 = "2.13.16"
+  val Scala213 = "2.13.18"
   val Scala3 = "3.3.6"
 
   object autoImport {
@@ -239,7 +239,7 @@ object Smithy4sBuildPlugin extends AutoPlugin {
         Seq(
           compilerPlugin("com.olegpy" %% "better-monadic-for" % "0.3.1"),
           compilerPlugin(
-            "org.typelevel" % "kind-projector" % "0.13.3" cross CrossVersion.full
+            "org.typelevel" % "kind-projector" % "0.13.4" cross CrossVersion.full
           )
         )
       else Seq.empty

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 // format: off
-addSbtPlugin("ch.epfl.scala"        % "sbt-scalafix"                  % "0.14.3")
+addSbtPlugin("ch.epfl.scala"        % "sbt-scalafix"                  % "0.14.5")
 addSbtPlugin("org.scala-js"         % "sbt-scalajs"                   % "1.18.2")
 addSbtPlugin("com.github.sbt"       % "sbt-pgp"                       % "2.3.1")
 addSbtPlugin("com.github.sbt"       % "sbt-dynver"                    % "5.1.0")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 // format: off
 addSbtPlugin("ch.epfl.scala"        % "sbt-scalafix"                  % "0.14.5")
-addSbtPlugin("org.scala-js"         % "sbt-scalajs"                   % "1.18.2")
+addSbtPlugin("org.scala-js"         % "sbt-scalajs"                   % "1.20.2")
 addSbtPlugin("com.github.sbt"       % "sbt-pgp"                       % "2.3.1")
 addSbtPlugin("com.github.sbt"       % "sbt-dynver"                    % "5.1.0")
 addSbtPlugin("org.xerial.sbt"       % "sbt-sonatype"                  % "3.12.2")

--- a/sampleSpecs/enumTraits.smithy
+++ b/sampleSpecs/enumTraits.smithy
@@ -2,16 +2,19 @@ $version: "2.0"
 
 namespace smithy4s.example
 
+@trait
 intEnum oneTwo {
     ONE = 1
     TWO = 2
 }
 
+@trait
 enum leftRight {
     LEFT = "left"
     RIGHT = "right"
 }
 
+@trait
 @enum([
     {
         name: "LEFT"


### PR DESCRIPTION
It seems scala-steward is not updating dependencies in our repo at the moment, I went ahead and updated some dependencies that have fallen behind. Will work on getting smithy-model all the way up to date, I think I need to update it in smithy-translate and alloy first so going to try that.

Note that this is not an exhaustive update of everything, I just manually went through and updated ones that seemed higher priority to keep up to date for the moment. We can be more exhaustive, especially with things like sbt plugins in another PR.

# Included Updates

- Scala 2.13.16 -> 2.13.18
- Smithy-translate 0.5.x -> 0.7.x
- Smithy (all libs, like smithy-model) 1.57.x -> 1.63.x (latest is 1.65, but having issues with it at the moment, going to look at this in another PR)
- Http4s 0.23.30 -> 0.23.33
- Alloy 0.3.33 -> 0.3.35
- Fs2 3.12.0 -> 3.12.2
- sbt-scalajs 1.18.2 -> 1.20.2
- sbt-scalafix 0.14.3 -> 0.14.5
- Kind Projector 0.13.3 -> 0.13.4

## PR Checklist (not all items are relevant to all PRs)

- [ ] Added unit-tests (for runtime code)
- [ ] Added bootstrapped code + smoke tests (when the rendering logic is modified)
- [ ] Added build-plugins integration tests (when reflection loading is required at codegen-time)
- [ ] Added alloy compliance tests (when simpleRestJson protocol behaviour is expanded/updated)
- [ ] Updated dynamic module to match generated-code behaviour
- [ ] Added documentation
- [ ] Updated changelog
