### PR TITLE
Query params refactor

### DIFF
--- a/modules/aws-http4s/src/smithy4s/aws/AwsClient.scala
+++ b/modules/aws-http4s/src/smithy4s/aws/AwsClient.scala
@@ -78,7 +78,7 @@ object AwsClient {
             host = s"$endpointPrefix.$region.amazonaws.com",
             port = None,
             path = IndexedSeq.empty,
-            queryParams = Map.empty,
+            queryParams = IndexedSeq.empty,
             pathParams = None
           )
           // Uri.unsafeFromString(s"https://$endpointPrefix.$region.amazonaws.com/")

--- a/modules/bootstrapped/test/src/smithy4s/http/HttpRequestSpec.scala
+++ b/modules/bootstrapped/test/src/smithy4s/http/HttpRequestSpec.scala
@@ -47,7 +47,7 @@ final class HttpRequestSpec extends FunSuite {
       "example.com",
       None,
       IndexedSeq.empty,
-      Map.empty,
+      IndexedSeq.empty,
       None
     )
     val request = HttpRequest(HttpMethod.GET, uri, Map.empty, "")

--- a/modules/bootstrapped/test/src/smithy4s/http/HttpUriSpec.scala
+++ b/modules/bootstrapped/test/src/smithy4s/http/HttpUriSpec.scala
@@ -37,11 +37,11 @@ final class HttpUriSpec extends FunSuite {
         )
       ),
       path = IndexedSeq("foo"),
-      queryParams = Map(
+      queryParams = HttpUri.queryParamsFromMap(Map(
         "bar" -> List("2"),
         "baz" -> List("a==2"),
         "qux" -> List("a&b&c")
-      ),
+      )),
       pathParams = Option.empty
     )
 
@@ -58,11 +58,11 @@ final class HttpUriSpec extends FunSuite {
     val httpUri = HttpUri(
       origin = None,
       path = IndexedSeq("foo"),
-      queryParams = Map(
+      queryParams = HttpUri.queryParamsFromMap(Map(
         "bar" -> List("2"),
         "baz" -> List("a==2"),
         "qux" -> List("a&b&c")
-      ),
+      )),
       pathParams = Option.empty
     )
 
@@ -87,7 +87,7 @@ final class HttpUriSpec extends FunSuite {
       val httpUri = HttpUri.fromURI(uri)
       assertEquals(uri, httpUri.toURI)
       assert(httpUri.path == IndexedSeq("foo bar"))
-      assert(httpUri.queryParams == Map("baz" -> List("qux quux")))
+      assert(httpUri.queryParamsAsMap == Map("baz" -> List("qux quux")))
     }
   }
 
@@ -108,7 +108,7 @@ final class HttpUriSpec extends FunSuite {
           )
         ),
         path = IndexedSeq("foo bar"),
-        queryParams = Map("baz" -> List("qux quux")),
+        queryParams = HttpUri.queryParamsFromMap(Map("baz" -> List("qux quux"))),
         pathParams = Option.empty
       )
       val uri = httpUri.toURI

--- a/modules/bootstrapped/test/src/smithy4s/http/HttpUriSpec.scala
+++ b/modules/bootstrapped/test/src/smithy4s/http/HttpUriSpec.scala
@@ -123,4 +123,76 @@ final class HttpUriSpec extends FunSuite {
     }
   }
 
+  test("Parse URI with valueless query parameter") {
+    val uri = URI.create("http://example.com/foo?bar&baz=value")
+    val httpUri = HttpUri.fromURI(uri)
+    assertEquals(
+      httpUri.queryParams,
+      IndexedSeq("bar" -> None, "baz" -> Some("value"))
+    )
+  }
+
+  test("HttpUri with valueless param converts to URI correctly") {
+    val httpUri = HttpUri(
+      origin = Some(
+        HttpUriOrigin.absolute(
+          HttpUriScheme.Http,
+          "example.com"
+        )
+      ),
+      path = IndexedSeq("foo"),
+      queryParams = IndexedSeq("bar" -> None, "baz" -> Some("value")),
+      pathParams = Option.empty
+    )
+    val uri = httpUri.toURI
+    assertEquals(uri.toString, "http://example.com/foo?bar&baz=value")
+  }
+
+  test("Roundtrip with valueless query parameters") {
+    val uri = URI.create("http://example.com/foo?flag&key=value")
+    val httpUri = HttpUri.fromURI(uri)
+    assertEquals(uri, httpUri.toURI)
+  }
+
+  test("queryParamsAsMap preserves None values") {
+    val httpUri = HttpUri(
+      origin = None,
+      path = IndexedSeq("foo"),
+      queryParams = IndexedSeq(
+        "a" -> None,
+        "b" -> Some(""),
+        "c" -> Some("value")
+      ),
+      pathParams = Option.empty
+    )
+    assertEquals(
+      httpUri.queryParamsAsMap,
+      Map("a" -> Seq(None), "b" -> Seq(Some("")), "c" -> Seq(Some("value")))
+    )
+  }
+
+  test("Distinguish between empty value and valueless params") {
+    val uriEmpty = URI.create("http://example.com/foo?param=")
+    val uriValueless = URI.create("http://example.com/foo?param")
+
+    val httpUriEmpty = HttpUri.fromURI(uriEmpty)
+    val httpUriValueless = HttpUri.fromURI(uriValueless)
+
+    assertEquals(httpUriEmpty.queryParams, IndexedSeq("param" -> Some("")))
+    assertEquals(httpUriValueless.queryParams, IndexedSeq("param" -> None))
+  }
+
+  test("Multiple valueless query parameters") {
+    val uri = URI.create("http://example.com/foo?flag1&flag2&key=value")
+    val httpUri = HttpUri.fromURI(uri)
+    assertEquals(
+      httpUri.queryParams,
+      IndexedSeq(
+        "flag1" -> None,
+        "flag2" -> None,
+        "key" -> Some("value")
+      )
+    )
+  }
+
 }

--- a/modules/bootstrapped/test/src/smithy4s/http/HttpUriSpec.scala
+++ b/modules/bootstrapped/test/src/smithy4s/http/HttpUriSpec.scala
@@ -37,11 +37,13 @@ final class HttpUriSpec extends FunSuite {
         )
       ),
       path = IndexedSeq("foo"),
-      queryParams = HttpUri.queryParamsFromMap(Map(
-        "bar" -> List("2"),
-        "baz" -> List("a==2"),
-        "qux" -> List("a&b&c")
-      )),
+      queryParams = HttpUri.queryParamsFromMap(
+        Map(
+          "bar" -> List("2"),
+          "baz" -> List("a==2"),
+          "qux" -> List("a&b&c")
+        )
+      ),
       pathParams = Option.empty
     )
 
@@ -58,11 +60,13 @@ final class HttpUriSpec extends FunSuite {
     val httpUri = HttpUri(
       origin = None,
       path = IndexedSeq("foo"),
-      queryParams = HttpUri.queryParamsFromMap(Map(
-        "bar" -> List("2"),
-        "baz" -> List("a==2"),
-        "qux" -> List("a&b&c")
-      )),
+      queryParams = HttpUri.queryParamsFromMap(
+        Map(
+          "bar" -> List("2"),
+          "baz" -> List("a==2"),
+          "qux" -> List("a&b&c")
+        )
+      ),
       pathParams = Option.empty
     )
 
@@ -108,7 +112,8 @@ final class HttpUriSpec extends FunSuite {
           )
         ),
         path = IndexedSeq("foo bar"),
-        queryParams = HttpUri.queryParamsFromMap(Map("baz" -> List("qux quux"))),
+        queryParams =
+          HttpUri.queryParamsFromMap(Map("baz" -> List("qux quux"))),
         pathParams = Option.empty
       )
       val uri = httpUri.toURI

--- a/modules/bootstrapped/test/src/smithy4s/http/HttpUriSpec.scala
+++ b/modules/bootstrapped/test/src/smithy4s/http/HttpUriSpec.scala
@@ -37,7 +37,7 @@ final class HttpUriSpec extends FunSuite {
         )
       ),
       path = IndexedSeq("foo"),
-      queryParams = HttpUri.queryParamsFromMap(
+      queryParams = HttpUri.queryParamsFromStringMap(
         Map(
           "bar" -> List("2"),
           "baz" -> List("a==2"),
@@ -60,7 +60,7 @@ final class HttpUriSpec extends FunSuite {
     val httpUri = HttpUri(
       origin = None,
       path = IndexedSeq("foo"),
-      queryParams = HttpUri.queryParamsFromMap(
+      queryParams = HttpUri.queryParamsFromStringMap(
         Map(
           "bar" -> List("2"),
           "baz" -> List("a==2"),
@@ -91,7 +91,7 @@ final class HttpUriSpec extends FunSuite {
       val httpUri = HttpUri.fromURI(uri)
       assertEquals(uri, httpUri.toURI)
       assert(httpUri.path == IndexedSeq("foo bar"))
-      assert(httpUri.queryParamsAsMap == Map("baz" -> List("qux quux")))
+      assert(httpUri.queryParamsAsMap == Map("baz" -> List(Some("qux quux"))))
     }
   }
 
@@ -113,7 +113,7 @@ final class HttpUriSpec extends FunSuite {
         ),
         path = IndexedSeq("foo bar"),
         queryParams =
-          HttpUri.queryParamsFromMap(Map("baz" -> List("qux quux"))),
+          HttpUri.queryParamsFromStringMap(Map("baz" -> List("qux quux"))),
         pathParams = Option.empty
       )
       val uri = httpUri.toURI

--- a/modules/bootstrapped/test/src/smithy4s/http/internals/MetadataSpec.scala
+++ b/modules/bootstrapped/test/src/smithy4s/http/internals/MetadataSpec.scala
@@ -17,7 +17,6 @@
 package smithy4s
 package http.internals
 
-import cats.syntax.all._
 import smithy4s.Schema
 import smithy4s.time.Timestamp
 import smithy4s.example.HeadersStruct
@@ -26,7 +25,6 @@ import smithy4s.example.PathParams
 import smithy4s.example.Queries
 import smithy4s.example.QueriesWithDefaults
 import smithy4s.example.ValidationChecks
-import smithy4s.http.CaseInsensitive
 import smithy4s.http.HttpBinding
 import smithy4s.http.Metadata
 import smithy4s.http.MetadataError
@@ -140,7 +138,7 @@ class MetadataSpec() extends FunSuite {
     val queries = Queries(str = Some("hello"))
     val finished =
       Queries(str = Some("hello"), slm = Some(Map("str" -> "hello")))
-    val expected = Metadata(query = Map("str" -> List("hello")))
+    val expected = Metadata.empty.addQueryParam("str", "hello")
     checkQueryRoundTrip(queries, expected, finished)
   }
 
@@ -149,7 +147,7 @@ class MetadataSpec() extends FunSuite {
   // which it uses
   test("Double NaN query parameter - allow NaN in decoder") {
     val queries = Queries(dbl = Some(Double.NaN))
-    val expected = Metadata(query = Map("dbl" -> List("NaN")))
+    val expected = Metadata.empty.addQueryParam("dbl", "NaN")
     val errorMessage =
       "Field dbl, found in Query parameter dbl, failed constraint checks with message: Numeric values must not be NaN or pos/neg infinity. Found NaN"
     checkQueryRoundTripError(queries, expected, errorMessage, allowNaN = true)
@@ -159,7 +157,7 @@ class MetadataSpec() extends FunSuite {
   // As such the RefinementProvider for Range will not be called in this test
   test("Double NaN query parameter - disallow NaN in decoder") {
     val queries = Queries(dbl = Some(Double.NaN))
-    val expected = Metadata(query = Map("dbl" -> List("NaN")))
+    val expected = Metadata.empty.addQueryParam("dbl", "NaN")
     val errorMessage =
       "NaN or pos/neg infinity are not allowed for inputs of type Double"
     checkQueryRoundTripError(queries, expected, errorMessage, allowNaN = false)
@@ -173,7 +171,7 @@ class MetadataSpec() extends FunSuite {
   test("String length constraint violation") {
     val string = "1" * 11
     val queries = ValidationChecks(str = Some(string))
-    val expected = Metadata(query = Map("str" -> List(string)))
+    val expected = Metadata.empty.addQueryParam("str", string)
     checkRoundTripError(
       queries,
       expected,
@@ -184,7 +182,7 @@ class MetadataSpec() extends FunSuite {
   test("List length constraint violation") {
     val list = List.fill(11)("str")
     val queries = ValidationChecks(lst = Some(list))
-    val expected = Metadata(query = Map("lst" -> list))
+    val expected = Metadata.empty.addMultipleQueryParams("lst", list)
     checkRoundTripError(
       queries,
       expected,
@@ -195,7 +193,7 @@ class MetadataSpec() extends FunSuite {
   test("Integer range constraint violation") {
     val i = 11
     val queries = ValidationChecks(int = Some(i))
-    val expected = Metadata(query = Map("int" -> List(i.toString)))
+    val expected = Metadata.empty.addQueryParam("int", i.toString)
     checkRoundTripError(
       queries,
       expected,
@@ -206,14 +204,14 @@ class MetadataSpec() extends FunSuite {
   test("Integer query parameter") {
     val queries = Queries(int = Some(123))
     val finished = Queries(int = Some(123), slm = Some(Map("int" -> "123")))
-    val expected = Metadata(query = Map("int" -> List("123")))
+    val expected = Metadata.empty.addQueryParam("int", "123")
     checkQueryRoundTrip(queries, expected, finished)
   }
 
   test("Boolean query parameter") {
     val queries = Queries(b = Some(true))
     val finished = Queries(b = Some(true), slm = Some(Map("b" -> "true")))
-    val expected = Metadata(query = Map("b" -> List("true")))
+    val expected = Metadata.empty.addQueryParam("b", "true")
     checkQueryRoundTrip(queries, expected, finished)
   }
 
@@ -222,7 +220,7 @@ class MetadataSpec() extends FunSuite {
     val queries = Queries(ts1 = Some(ts))
     val finished =
       Queries(ts1 = Some(ts), slm = Some(Map("ts1" -> epochString)))
-    val expected = Metadata(query = Map("ts1" -> List(epochString)))
+    val expected = Metadata.empty.addQueryParam("ts1", epochString)
     checkQueryRoundTrip(queries, expected, finished)
   }
 
@@ -231,7 +229,7 @@ class MetadataSpec() extends FunSuite {
     val queries = Queries(ts2 = Some(ts))
     val finished =
       Queries(ts2 = Some(ts), slm = Some(Map("ts2" -> epochString)))
-    val expected = Metadata(query = Map("ts2" -> List(epochString)))
+    val expected = Metadata.empty.addQueryParam("ts2", epochString)
     checkQueryRoundTrip(queries, expected, finished)
   }
 
@@ -240,7 +238,7 @@ class MetadataSpec() extends FunSuite {
     val queries = Queries(ts3 = Some(ts))
     val finished =
       Queries(ts3 = Some(ts), slm = Some(Map("ts3" -> "1234567890")))
-    val expected = Metadata(query = Map("ts3" -> List("1234567890")))
+    val expected = Metadata.empty.addQueryParam("ts3", "1234567890")
     checkQueryRoundTrip(queries, expected, finished)
   }
 
@@ -252,7 +250,7 @@ class MetadataSpec() extends FunSuite {
       slm = Some(Map("ts4" -> "Thu, 01 Jan 1970 00:00:00 GMT"))
     )
     val expected =
-      Metadata(query = Map("ts4" -> List("Thu, 01 Jan 1970 00:00:00 GMT")))
+      Metadata.empty.addQueryParam("ts4", "Thu, 01 Jan 1970 00:00:00 GMT")
     checkQueryRoundTrip(queries, expected, finished)
   }
 
@@ -260,7 +258,9 @@ class MetadataSpec() extends FunSuite {
     val map =
       Map("hello" -> "a", "world" -> "b")
     val queries = Queries(slm = Some(map))
-    val expected = Metadata(query = map.fmap(Seq(_)))
+    val expected = map.foldLeft(Metadata.empty) { case (md, (k, v)) =>
+      md.addQueryParam(k, v)
+    }
     checkRoundTrip(queries, expected)
   }
 
@@ -268,7 +268,7 @@ class MetadataSpec() extends FunSuite {
     val list = List("hello", "world")
     val queries = Queries(sl = Some(list))
     val finished = Queries(sl = Some(list), slm = Some(Map("sl" -> "hello")))
-    val expected = Metadata(query = Map("sl" -> list))
+    val expected = Metadata.empty.addMultipleQueryParams("sl", list)
     checkQueryRoundTrip(queries, expected, finished)
   }
 
@@ -279,7 +279,7 @@ class MetadataSpec() extends FunSuite {
       ie = Some(smithy4s.example.Numbers.ONE),
       slm = Some(Map("nums" -> "1"))
     )
-    val expected = Metadata(query = Map("nums" -> List("1")))
+    val expected = Metadata.empty.addQueryParam("nums", "1")
     checkQueryRoundTrip(queries, expected, finished)
   }
 
@@ -290,7 +290,7 @@ class MetadataSpec() extends FunSuite {
       on = Some(smithy4s.example.OpenNums.$Unknown(101)),
       slm = Some(Map("openNums" -> "101"))
     )
-    val expected = Metadata(query = Map("openNums" -> List("101")))
+    val expected = Metadata.empty.addQueryParam("openNums", "101")
     checkQueryRoundTrip(queries, expected, finished)
   }
 
@@ -301,7 +301,7 @@ class MetadataSpec() extends FunSuite {
       on = Some(smithy4s.example.OpenNums.ONE),
       slm = Some(Map("openNums" -> "1"))
     )
-    val expected = Metadata(query = Map("openNums" -> List("1")))
+    val expected = Metadata.empty.addQueryParam("openNums", "1")
     checkQueryRoundTrip(queries, expected, finished)
   }
 
@@ -313,7 +313,7 @@ class MetadataSpec() extends FunSuite {
       ons = Some(smithy4s.example.OpenNumsStr.$Unknown("test")),
       slm = Some(Map("openNumsStr" -> "test"))
     )
-    val expected = Metadata(query = Map("openNumsStr" -> List("test")))
+    val expected = Metadata.empty.addQueryParam("openNumsStr", "test")
     checkQueryRoundTrip(queries, expected, finished)
   }
 
@@ -324,7 +324,7 @@ class MetadataSpec() extends FunSuite {
       ons = Some(smithy4s.example.OpenNumsStr.ONE),
       slm = Some(Map("openNumsStr" -> "ONE"))
     )
-    val expected = Metadata(query = Map("openNumsStr" -> List("ONE")))
+    val expected = Metadata.empty.addQueryParam("openNumsStr", "ONE")
     checkQueryRoundTrip(queries, expected, finished)
   }
 
@@ -390,12 +390,9 @@ class MetadataSpec() extends FunSuite {
         "hello" -> "a",
         "world" -> "b"
       )
-    val expectedHeaders =
-      Map(
-        CaseInsensitive("foo-hello") -> List("a"),
-        CaseInsensitive("foo-world") -> List("b")
-      )
-    val expected = Metadata(headers = expectedHeaders)
+    val expected = map.foldLeft(Metadata.empty) { case (md, (k, v)) =>
+      md.addHeader(s"foo-$k", v)
+    }
     val headers = HeadersStruct(slm = Some(map))
     checkRoundTrip(headers, expected)
   }
@@ -481,7 +478,7 @@ class MetadataSpec() extends FunSuite {
 
   test("bad data gets caught") {
     val metadata =
-      Metadata(query = Map("ts3" -> List("Thu, 01 Jan 1970 00:00:00 GMT")))
+      Metadata.empty.addQueryParam("ts3", "Thu, 01 Jan 1970 00:00:00 GMT")
     val result = Metadata.decode[Queries](metadata)
     val expected = MetadataError.WrongType(
       "ts3",
@@ -504,7 +501,7 @@ class MetadataSpec() extends FunSuite {
 
   test("too many parameters get caught") {
     val metadata =
-      Metadata(query = Map("ts3" -> List("1", "2", "3")))
+      Metadata.empty.addMultipleQueryParams("ts3", List("1", "2", "3"))
     val result = Metadata.decode[Queries](metadata)
     val expected = MetadataError.ArityError(
       "ts3",

--- a/modules/bootstrapped/test/src/smithy4s/http/internals/MetadataSpec.scala
+++ b/modules/bootstrapped/test/src/smithy4s/http/internals/MetadataSpec.scala
@@ -142,6 +142,26 @@ class MetadataSpec() extends FunSuite {
     checkQueryRoundTrip(queries, expected, finished)
   }
 
+  test("Valueless query parameter decodes as empty string for required field") {
+    val metadata = Metadata(query = Map("str" -> Seq(None)))
+    val decoded = Metadata.Decoder[Queries].decode(metadata)
+    expect(decoded.isRight)
+    expect(decoded.map(_.str) == Right(Some("")))
+  }
+
+  test("Empty value query parameter decodes as empty string") {
+    val metadata = Metadata(query = Map("str" -> Seq(Some(""))))
+    val decoded = Metadata.Decoder[Queries].decode(metadata)
+    expect(decoded.isRight)
+    expect(decoded.map(_.str) == Right(Some("")))
+  }
+
+  test("Distinguish valueless and empty value in Metadata representation") {
+    val metadataValueless = Metadata(query = Map("param" -> Seq(None)))
+    val metadataEmpty = Metadata(query = Map("param" -> Seq(Some(""))))
+    expect(metadataValueless != metadataEmpty)
+  }
+
   // In this test the Metadata Decoder will allow NaN by creating a `Double.NaN` value.
   // The Range RefinementProvider will reject this since `NaN` is not a valid `BigDecimal`
   // which it uses

--- a/modules/bootstrapped/test/src/smithy4s/http/internals/PathSpec.scala
+++ b/modules/bootstrapped/test/src/smithy4s/http/internals/PathSpec.scala
@@ -83,7 +83,8 @@ class PathSpec() extends munit.FunSuite {
     val sqp = httpEndpoint.staticQueryParams
     val path = httpEndpoint.path
 
-    val expectedQueryMap = Map("value" -> Seq("foo"), "baz" -> Seq("bar"))
+    val expectedQueryMap =
+      Map("value" -> Seq(Some("foo")), "baz" -> Seq(Some("bar")))
     expect(sqp == expectedQueryMap)
     expect(
       path ==

--- a/modules/bootstrapped/test/src/smithy4s/http/internals/PathSpec.scala
+++ b/modules/bootstrapped/test/src/smithy4s/http/internals/PathSpec.scala
@@ -102,6 +102,35 @@ class PathSpec() extends munit.FunSuite {
     )
   }
 
+  test("parse static query params with valueless parameters") {
+    import smithy4s.http.internals.staticQueryParams
+    val params = staticQueryParams("/path?foo&bar&baz=value")
+    val expected =
+      Map("foo" -> Seq(None), "bar" -> Seq(None), "baz" -> Seq(Some("value")))
+    expect(params == expected)
+  }
+
+  test("distinguish between empty value and valueless in static query params") {
+    import smithy4s.http.internals.staticQueryParams
+    val paramsEmpty = staticQueryParams("/path?foo=")
+    val paramsValueless = staticQueryParams("/path?foo")
+
+    expect(paramsEmpty == Map("foo" -> Seq(Some(""))))
+    expect(paramsValueless == Map("foo" -> Seq(None)))
+  }
+
+  test("parse static query params with mixed valueless and valued params") {
+    import smithy4s.http.internals.staticQueryParams
+    val params = staticQueryParams("/path?flag1&key1=a&flag2&key2=b")
+    val expected = Map(
+      "flag1" -> Seq(None),
+      "key1" -> Seq(Some("a")),
+      "flag2" -> Seq(None),
+      "key2" -> Seq(Some("b"))
+    )
+    expect(params == expected)
+  }
+
   test("Write PathParams for DummyPath") {
     val result = HttpEndpoint
       .cast(

--- a/modules/compliance-tests/src/smithy4s/compliancetests/internals/Assertions.scala
+++ b/modules/compliance-tests/src/smithy4s/compliancetests/internals/Assertions.scala
@@ -148,7 +148,7 @@ private[internals] object assert {
   }
 
   private def queryParamsExistenceCheck(
-      queryParameters: Map[String, Seq[String]],
+      queryParameters: Map[String, Seq[Option[String]]],
       requiredParameters: Option[List[String]],
       forbiddenParameters: Option[List[String]]
   ) = {
@@ -174,7 +174,7 @@ private[internals] object assert {
   }
 
   private def queryParamValuesCheck(
-      queryParameters: Map[String, Seq[String]],
+      queryParameters: Map[String, Seq[Option[String]]],
       testCase: Option[List[String]]
   ) = {
     testCase.toList.flatten
@@ -244,7 +244,7 @@ private[internals] object assert {
 
     def checkQueryParameters(
         tc: HttpRequestTestCase,
-        queryParameters: Map[String, Seq[String]]
+        queryParameters: Map[String, Seq[Option[String]]]
     ): ComplianceResult = {
       val existenceChecks = assert.queryParamsExistenceCheck(
         queryParameters = queryParameters,

--- a/modules/compliance-tests/src/smithy4s/compliancetests/internals/ClientHttpComplianceTestCase.scala
+++ b/modules/compliance-tests/src/smithy4s/compliancetests/internals/ClientHttpComplianceTestCase.scala
@@ -24,6 +24,7 @@ import cats.implicits._
 import org.http4s.Headers
 import org.http4s.HttpApp
 import org.http4s.Request
+import org.http4s.Query
 import org.http4s.Response
 import org.http4s.Status
 import org.http4s.Uri
@@ -81,9 +82,8 @@ private[compliancetests] class ClientHttpComplianceTestCase[
 
     val expectedUri = baseUri
       .withPath(Uri.Path.unsafeFromString(testCase.uri))
-      .withMultiValueQueryParams(
-        parseQueryParams(testCase.queryParams)
-      )
+      .copy(query = Query.fromVector(parseQueryParams(testCase.queryParams)))
+
     val pathAssert =
       assert.eql(
         receivedPathSegments,
@@ -92,7 +92,9 @@ private[compliancetests] class ClientHttpComplianceTestCase[
       )
     val queryAssert = assert.testCase.checkQueryParameters(
       testCase,
-      expectedUri.query.multiParams
+      expectedUri.query.pairs.groupBy(_._1).map { case (k, v) =>
+        k -> v.map(_._2).toList
+      }
     )
     val methodAssert = assert.eql(
       request.method.name.toLowerCase(),

--- a/modules/compliance-tests/src/smithy4s/compliancetests/internals/ClientHttpComplianceTestCase.scala
+++ b/modules/compliance-tests/src/smithy4s/compliancetests/internals/ClientHttpComplianceTestCase.scala
@@ -23,8 +23,8 @@ import cats.effect.syntax.all._
 import cats.implicits._
 import org.http4s.Headers
 import org.http4s.HttpApp
-import org.http4s.Request
 import org.http4s.Query
+import org.http4s.Request
 import org.http4s.Response
 import org.http4s.Status
 import org.http4s.Uri

--- a/modules/compliance-tests/src/smithy4s/compliancetests/internals/ServerHttpComplianceTestCase.scala
+++ b/modules/compliance-tests/src/smithy4s/compliancetests/internals/ServerHttpComplianceTestCase.scala
@@ -73,8 +73,8 @@ private[compliancetests] class ServerHttpComplianceTestCase[
       .withPath(
         Uri.Path.unsafeFromString(testCase.uri).addEndsWithSlash
       )
-      .withMultiValueQueryParams(
-        parseQueryParams(testCase.queryParams)
+      .copy(
+        query = Query.fromVector(parseQueryParams(testCase.queryParams))
       )
 
     val body =

--- a/modules/compliance-tests/src/smithy4s/compliancetests/internals/package.scala
+++ b/modules/compliance-tests/src/smithy4s/compliancetests/internals/package.scala
@@ -17,46 +17,37 @@
 package smithy4s
 package compliancetests
 
-import cats.implicits._
 import org.http4s.Header
 import org.http4s.Headers
 import org.http4s.Uri
 import org.typelevel.ci.CIString
 
 import java.nio.charset.StandardCharsets
-import scala.collection.immutable.ListMap
 
 package object internals {
 
   private[compliancetests] def splitQuery(
       queryString: String
-  ): (String, String) = {
+  ): (String, Option[String]) = {
     queryString.split("=", 2) match {
       case Array(k, v) =>
         (
           k,
-          Uri.decode(
+          Some(Uri.decode(
             toDecode = v,
             charset = StandardCharsets.UTF_8,
             plusIsSpace = true
-          )
+          ))
         )
-      case Array(k) => (k, "")
+      case Array(k) => (k, None)
     }
   }
 
   private[compliancetests] def parseQueryParams(
       queryParams: Option[List[String]]
-  ): ListMap[String, List[String]] = {
-    queryParams.combineAll
+  ): Vector[(String, Option[String])] = {
+    queryParams.toVector.flatten
       .map(splitQuery)
-      .foldLeft[ListMap[String, List[String]]](ListMap.empty) {
-        case (acc, (k, v)) =>
-          acc.get(k) match {
-            case Some(value) => acc + (k -> (value :+ v))
-            case None        => acc + (k -> List(v))
-          }
-      }
   }
 
   private def escape(str: String): String = {

--- a/modules/compliance-tests/src/smithy4s/compliancetests/internals/package.scala
+++ b/modules/compliance-tests/src/smithy4s/compliancetests/internals/package.scala
@@ -33,11 +33,13 @@ package object internals {
       case Array(k, v) =>
         (
           k,
-          Some(Uri.decode(
-            toDecode = v,
-            charset = StandardCharsets.UTF_8,
-            plusIsSpace = true
-          ))
+          Some(
+            Uri.decode(
+              toDecode = v,
+              charset = StandardCharsets.UTF_8,
+              plusIsSpace = true
+            )
+          )
         )
       case Array(k) => (k, None)
     }

--- a/modules/core/src/smithy4s/http/HttpEndpoint.scala
+++ b/modules/core/src/smithy4s/http/HttpEndpoint.scala
@@ -37,7 +37,7 @@ trait HttpEndpoint[I] {
   def path: List[PathSegment]
 
   // Returns a map of static query parameters that are found in the uri of Http hint.
-  def staticQueryParams: Map[String, Seq[String]]
+  def staticQueryParams: Map[String, Seq[Option[String]]]
   def method: HttpMethod
   def code: Int
 
@@ -89,7 +89,7 @@ object HttpEndpoint {
 
         def encodedPath(input: I): List[String] =
           labelEncodingEncoder.encode(input)
-        val staticQueryParams: Map[String, Seq[String]] = queryParams
+        val staticQueryParams: Map[String, Seq[Option[String]]] = queryParams
         val path: List[PathSegment] = httpPath.toList
         val method: HttpMethod = httpMethod
         val code: Int = http.code

--- a/modules/core/src/smithy4s/http/HttpRequest.scala
+++ b/modules/core/src/smithy4s/http/HttpRequest.scala
@@ -33,7 +33,7 @@ final case class HttpRequest[+A](
 
   def toMetadata: Metadata = Metadata(
     path = uri.pathParams.getOrElse(Map.empty),
-    query = uri.queryParams,
+    query = uri.queryParamsAsMap,
     headers = headers
   )
 
@@ -87,7 +87,8 @@ object HttpRequest {
         val path =
           if (smithyPathEncoding) httpEndpoint.encodedPath(input)
           else httpEndpoint.path(input)
-        val staticQueries = httpEndpoint.staticQueryParams
+        val staticQueries =
+          HttpUri.queryParamsFromMap(httpEndpoint.staticQueryParams)
         val oldUri = request.uri
         val newUri = oldUri
           .withQueryParams(staticQueries)
@@ -103,7 +104,9 @@ object HttpRequest {
       (req: HttpRequest[Body], meta: Metadata) =>
         val oldUri = req.uri
         val newUri =
-          oldUri.transformQueryParams(_ ++ meta.query)
+          oldUri.transformQueryParams(
+            _ ++ HttpUri.queryParamsFromMap(meta.query)
+          )
         req.addHeaders(meta.headers).copy(uri = newUri)
     }
 

--- a/modules/core/src/smithy4s/http/HttpRequest.scala
+++ b/modules/core/src/smithy4s/http/HttpRequest.scala
@@ -87,8 +87,7 @@ object HttpRequest {
         val path =
           if (smithyPathEncoding) httpEndpoint.encodedPath(input)
           else httpEndpoint.path(input)
-        val staticQueries =
-          HttpUri.queryParamsFromStringMap(httpEndpoint.staticQueryParams)
+        val staticQueries = mapToIndexedSeq(httpEndpoint.staticQueryParams)
         val oldUri = request.uri
         val newUri = oldUri
           .withQueryParams(staticQueries)
@@ -105,7 +104,7 @@ object HttpRequest {
         val oldUri = req.uri
         val newUri =
           oldUri.transformQueryParams(
-            _ ++ HttpUri.queryParamsFromMap(meta.query)
+            _ ++ mapToIndexedSeq(meta.query)
           )
         req.addHeaders(meta.headers).copy(uri = newUri)
     }
@@ -179,4 +178,6 @@ object HttpRequest {
       : PolyFunction[GenericDecoder[F, Body, *], Decoder[F, Body, *]] =
     GenericDecoder.in[F].composeK(_.body)
 
+  private def mapToIndexedSeq[A, B](m: Map[A, Seq[B]]): IndexedSeq[(A, B)] =
+    m.toIndexedSeq.flatMap { case (k, v) => v.map(k -> _) }
 }

--- a/modules/core/src/smithy4s/http/HttpRequest.scala
+++ b/modules/core/src/smithy4s/http/HttpRequest.scala
@@ -88,7 +88,7 @@ object HttpRequest {
           if (smithyPathEncoding) httpEndpoint.encodedPath(input)
           else httpEndpoint.path(input)
         val staticQueries =
-          HttpUri.queryParamsFromMap(httpEndpoint.staticQueryParams)
+          HttpUri.queryParamsFromStringMap(httpEndpoint.staticQueryParams)
         val oldUri = request.uri
         val newUri = oldUri
           .withQueryParams(staticQueries)

--- a/modules/core/src/smithy4s/http/HttpUnaryServerRouter.scala
+++ b/modules/core/src/smithy4s/http/HttpUnaryServerRouter.scala
@@ -305,28 +305,28 @@ object HttpUnaryServerRouter {
 
   }
 
-  /** Checks if `larger` multimap is a subset of the `smaller` */
-  private def isSubset[K, V](larger: Map[K, Seq[V]], smaller: Map[K, Seq[V]]): Boolean =
-    smaller.forall { case (k, vRequired) =>
-      larger
-        .get(k)
-        .exists(vs =>
-          vRequired.forall { required =>
-            // Direct match
-            vs.contains(required) || {
-              // Special case: treat valueless query params (None) as matching empty values (Some(""))
-              // This only applies when V is Option[String]
-              required match {
-                case None =>
-                  vs.exists {
-                    case Some("") => true
-                    case _        => false
-                  }
-                case _ => false
-              }
-            }
-          }
-        )
+  /** Checks if `smaller` multimap is a subset of the `larger` */
+  private def isSubset(
+      larger: Map[String, Seq[Option[String]]],
+      smaller: Map[String, Seq[Option[String]]]
+  ): Boolean =
+    smaller.forall { case (key, requiredValues) =>
+      larger.get(key).exists { actualValues =>
+        val normalizedActual = normalizeQueryValues(actualValues)
+        requiredValues.forall(normalizedActual.contains)
+      }
     }
 
+  private def normalizeQueryValues(
+      values: Seq[Option[String]]
+  ): Set[Option[String]] = {
+    val asSet = values.toSet
+
+    // HTTP semantics: treat valueless (?foo) and empty (?foo=) as equivalent
+    if (asSet.contains(None) || asSet.contains(Some("")))
+      // this facilitates O(1) lookups for both None and Some("") when either is present
+      asSet + None + Some("")
+    else
+      asSet
+  }
 }

--- a/modules/core/src/smithy4s/http/HttpUnaryServerRouter.scala
+++ b/modules/core/src/smithy4s/http/HttpUnaryServerRouter.scala
@@ -308,7 +308,25 @@ object HttpUnaryServerRouter {
   /** Checks if `larger` multimap is a subset of the `smaller` */
   private def isSubset[K, V](larger: Map[K, Seq[V]], smaller: Map[K, Seq[V]]): Boolean =
     smaller.forall { case (k, vRequired) =>
-      larger.get(k).exists(vs => vRequired.forall(vs.contains))
+      larger
+        .get(k)
+        .exists(vs =>
+          vRequired.forall { required =>
+            // Direct match
+            vs.contains(required) || {
+              // Special case: treat valueless query params (None) as matching empty values (Some(""))
+              // This only applies when V is Option[String]
+              required match {
+                case None =>
+                  vs.exists {
+                    case Some("") => true
+                    case _        => false
+                  }
+                case _ => false
+              }
+            }
+          }
+        )
     }
 
 }

--- a/modules/core/src/smithy4s/http/HttpUnaryServerRouter.scala
+++ b/modules/core/src/smithy4s/http/HttpUnaryServerRouter.scala
@@ -197,12 +197,12 @@ object HttpUnaryServerRouter {
       val method = getMethod(request)
       val uri = getUri(request)
       val path = uri.path
-      val query = uri.queryParams
+      val queryMap = uri.queryParamsAsMap
       perMethodEndpoint.get(method).flatMap { httpUnaryEndpoints =>
         httpUnaryEndpoints.iterator
           .flatMap(ep => ep.httpEndpoint.matches(path).map(ep -> _))
           .collectFirst {
-            case (ep, pathParams) if isSubset(larger = query, smaller = ep.httpEndpoint.staticQueryParams) =>
+            case (ep, pathParams) if isSubset(larger = queryMap, smaller = ep.httpEndpoint.staticQueryParams) =>
               val amendedRequest = addDecodedPathParams(request, pathParams)
               ep.handler(amendedRequest)
           }

--- a/modules/core/src/smithy4s/http/HttpUri.scala
+++ b/modules/core/src/smithy4s/http/HttpUri.scala
@@ -168,13 +168,13 @@ final case class HttpUri private (
 
   /**
    * Converts query parameters to Map format, grouping multiple values for the same key.
-   * Keys without values are represented as empty sequences.
+   * Preserves None values to distinguish between valueless parameters and parameters with empty values.
    */
-  def queryParamsAsMap: Map[String, Seq[String]] = {
+  def queryParamsAsMap: Map[String, Seq[Option[String]]] = {
     queryParams
       .groupBy(_._1)
       .map { case (k, vs) =>
-        k -> vs.flatMap(_._2).toSeq
+        k -> vs.map(_._2).toSeq
       }
   }
 
@@ -303,12 +303,22 @@ object HttpUri {
    * Keys with empty sequences become keys without values.
    */
   def queryParamsFromMap(
-      queryParams: Map[String, Seq[String]]
+      queryParams: Map[String, Seq[Option[String]]]
   ): IndexedSeq[(String, Option[String])] = {
     queryParams.toIndexedSeq.flatMap { case (k, vs) =>
       if (vs.isEmpty) IndexedSeq(k -> None)
-      else vs.map(v => k -> Some(v))
+      else vs.map(v => k -> v)
     }
+  }
+
+  /**
+   * Converts Map format query parameters with String values to IndexedSeq format.
+   * This is a convenience method that wraps String values in Some().
+   */
+  def queryParamsFromStringMap(
+      queryParams: Map[String, Seq[String]]
+  ): IndexedSeq[(String, Option[String])] = {
+    queryParamsFromMap(queryParams.map { case (k, vs) => k -> vs.map(Some(_)) })
   }
 
   private def uriDecode(v: String): String =

--- a/modules/core/src/smithy4s/http/HttpUri.scala
+++ b/modules/core/src/smithy4s/http/HttpUri.scala
@@ -220,11 +220,16 @@ object HttpUri {
           query
             .split("&")
             .map { pair =>
-              pair.split("=").map(uriDecode) match {
-                case Array(k: String, v: String) => k -> Some(v)
-                case Array(k: String)            => k -> None
-                // cases where you have q1=v1=v2 => q1 -> "v1=v2"
-                case v @ Array(k: String, _*) => k -> Some(v.tail.mkString("="))
+              // Check if the pair contains '=' to distinguish between
+              // valueless params (?foo) and empty-value params (?foo=)
+              if (pair.contains("=")) {
+                pair.split("=", -1).map(uriDecode) match {
+                  case Array(k: String, v: String) => k -> Some(v)
+                  // cases where you have q1=v1=v2 => q1 -> "v1=v2"
+                  case v @ Array(k: String, _*) => k -> Some(v.tail.mkString("="))
+                }
+              } else {
+                uriDecode(pair) -> None
               }
             }
             .toIndexedSeq

--- a/modules/core/src/smithy4s/http/HttpUri.scala
+++ b/modules/core/src/smithy4s/http/HttpUri.scala
@@ -28,7 +28,7 @@ import java.nio.charset.StandardCharsets
 final case class HttpUri private (
     origin: Option[HttpUriOrigin],
     path: IndexedSeq[String],
-    queryParams: Map[String, Seq[String]],
+    queryParams: IndexedSeq[(String, Option[String])],
     pathParams: Option[Map[String, String]]
 ) {
   def toURI: URI = {
@@ -37,10 +37,13 @@ final case class HttpUri private (
     val queryStr = queryParams
       .map { case (k, v) =>
         val encodedKey = HttpUri.uriEncode(k)
-        v.map(vv => {
-          val encodedValue = HttpUri.uriEncode(vv)
-          s"$encodedKey=$encodedValue"
-        }).mkString("&")
+        v match {
+          case Some(vv) =>
+            val encodedValue = HttpUri.uriEncode(vv)
+            s"$encodedKey=$encodedValue"
+          case None =>
+            encodedKey
+        }
       }
       .mkString("&")
 
@@ -132,15 +135,17 @@ final case class HttpUri private (
     copy(path = path)
   }
   def withQueryParams(
-      queryParams: Map[String, Seq[String]]
+      queryParams: IndexedSeq[(String, Option[String])]
   ): HttpUri = {
     copy(queryParams = queryParams)
   }
   def withoutQueryParams: HttpUri = {
-    copy(queryParams = Map.empty)
+    copy(queryParams = IndexedSeq.empty)
   }
   def transformQueryParams(
-      f: Map[String, Seq[String]] => Map[String, Seq[String]]
+      f: IndexedSeq[(String, Option[String])] => IndexedSeq[
+        (String, Option[String])
+      ]
   ): HttpUri = {
     copy(queryParams = f(queryParams))
   }
@@ -161,6 +166,18 @@ final case class HttpUri private (
     }
   }
 
+  /**
+   * Converts query parameters to Map format, grouping multiple values for the same key.
+   * Keys without values are represented as empty sequences.
+   */
+  def queryParamsAsMap: Map[String, Seq[String]] = {
+    queryParams
+      .groupBy(_._1)
+      .map { case (k, vs) =>
+        k -> vs.flatMap(_._2).toSeq
+      }
+  }
+
 }
 
 object HttpUri {
@@ -174,7 +191,7 @@ object HttpUri {
     (
         Option[HttpUriOrigin],
         IndexedSeq[String],
-        Map[String, Seq[String]],
+        IndexedSeq[(String, Option[String])],
         Option[Map[String, String]]
     )
   ] = {
@@ -184,7 +201,7 @@ object HttpUri {
   def apply(
       origin: Option[HttpUriOrigin],
       path: IndexedSeq[String],
-      queryParams: Map[String, Seq[String]],
+      queryParams: IndexedSeq[(String, Option[String])],
       pathParams: Option[Map[String, String]]
   ): HttpUri = {
     new HttpUri(origin, path, queryParams, pathParams)
@@ -197,22 +214,22 @@ object HttpUri {
     val host = Option(uri.getHost())
     val port = Option(uri.getPort()).filter(_ >= 0)
     val path = uri.getPath.split('/').filter(_.nonEmpty).toIndexedSeq
-    val queryParams: Map[String, Seq[String]] = Option(uri.getRawQuery())
-      .map { query =>
-        query
-          .split("&")
-          .map { pair =>
-            pair.split("=").map(uriDecode) match {
-              case Array(k: String, v: String) => k -> Seq(v)
-              case Array(k: String)            => k -> Seq.empty[String]
-              // cases where you have q1=v1=v2 => q1 -> "v1=v2"
-              case v @ Array(k: String, _*) => k -> Seq(v.tail.mkString("="))
+    val queryParams: IndexedSeq[(String, Option[String])] =
+      Option(uri.getRawQuery())
+        .map { query =>
+          query
+            .split("&")
+            .map { pair =>
+              pair.split("=").map(uriDecode) match {
+                case Array(k: String, v: String) => k -> Some(v)
+                case Array(k: String)            => k -> None
+                // cases where you have q1=v1=v2 => q1 -> "v1=v2"
+                case v @ Array(k: String, _*) => k -> Some(v.tail.mkString("="))
+              }
             }
-          }
-          .groupBy(_._1)
-          .map { case (k, vs) => k -> vs.map(_._2).flatten.toSeq }
-      }
-      .getOrElse(Map.empty)
+            .toIndexedSeq
+        }
+        .getOrElse(IndexedSeq.empty)
     val origin = host.map(hn => {
       HttpUriOrigin(
         scheme = scheme,
@@ -232,7 +249,7 @@ object HttpUri {
    */
   def relative(
       path: IndexedSeq[String],
-      queryParams: Map[String, Seq[String]],
+      queryParams: IndexedSeq[(String, Option[String])] = IndexedSeq.empty,
       pathParams: Option[Map[String, String]] = None
   ): HttpUri = {
     HttpUri(
@@ -250,7 +267,7 @@ object HttpUri {
       host: String,
       port: Option[Int],
       path: IndexedSeq[String],
-      queryParams: Map[String, Seq[String]] = Map.empty,
+      queryParams: IndexedSeq[(String, Option[String])] = IndexedSeq.empty,
       pathParams: Option[Map[String, String]] = None
   ): HttpUri = {
     HttpUri(
@@ -269,7 +286,7 @@ object HttpUri {
       host: String,
       port: Option[Int],
       path: IndexedSeq[String],
-      queryParams: Map[String, Seq[String]] = Map.empty,
+      queryParams: IndexedSeq[(String, Option[String])] = IndexedSeq.empty,
       pathParams: Option[Map[String, String]] = None
   ): HttpUri = {
 
@@ -279,6 +296,19 @@ object HttpUri {
       queryParams = queryParams,
       pathParams = pathParams
     )
+  }
+
+  /**
+   * Converts Map format query parameters to IndexedSeq format.
+   * Keys with empty sequences become keys without values.
+   */
+  def queryParamsFromMap(
+      queryParams: Map[String, Seq[String]]
+  ): IndexedSeq[(String, Option[String])] = {
+    queryParams.toIndexedSeq.flatMap { case (k, vs) =>
+      if (vs.isEmpty) IndexedSeq(k -> None)
+      else vs.map(v => k -> Some(v))
+    }
   }
 
   private def uriDecode(v: String): String =

--- a/modules/core/src/smithy4s/http/HttpUri.scala
+++ b/modules/core/src/smithy4s/http/HttpUri.scala
@@ -226,7 +226,8 @@ object HttpUri {
                 pair.split("=", -1).map(uriDecode) match {
                   case Array(k: String, v: String) => k -> Some(v)
                   // cases where you have q1=v1=v2 => q1 -> "v1=v2"
-                  case v @ Array(k: String, _*) => k -> Some(v.tail.mkString("="))
+                  case v @ Array(k: String, _*) =>
+                    k -> Some(v.tail.mkString("="))
                 }
               } else {
                 uriDecode(pair) -> None

--- a/modules/core/src/smithy4s/http/Metadata.scala
+++ b/modules/core/src/smithy4s/http/Metadata.scala
@@ -186,10 +186,17 @@ object Metadata {
    * @param tail Additional values for multi-valued parameters. Each value is wrapped in Option
    *             to support valueless query parameters in lists.
    */
-  final case class BindingValues(
+  final class BindingValues(
       head: Option[String],
       tail: List[Option[String]]
   )
+
+  object BindingValues {
+    def apply(
+        head: Option[String],
+        tail: List[Option[String]]
+    ): BindingValues = new BindingValues(head, tail)
+  }
 
   trait Access {
     def metadata: Metadata

--- a/modules/core/src/smithy4s/http/Metadata.scala
+++ b/modules/core/src/smithy4s/http/Metadata.scala
@@ -135,22 +135,33 @@ case class Metadata(
     )
   }
 
+  /**
+   * Finds metadata values for a given HTTP binding location.
+   *
+   * Returns BindingValues if the binding exists:
+   * - For query parameters: head can be None (valueless param like ?foo) or Some(value) (like ?foo=bar)
+   * - For headers: head is always Some(value) since headers cannot be valueless
+   * - For path parameters: returns a single value with empty tail list
+   *
+   * @param location The HTTP binding location to look up (header, query, or path)
+   * @return None if binding not found, otherwise Some(BindingValues)
+   */
   def find(
       location: HttpBinding
-  ): Option[(Option[String], List[Option[String]])] =
+  ): Option[Metadata.BindingValues] =
     location match {
       case HttpBinding.HeaderBinding(httpName) =>
         headers.get(httpName).flatMap {
-          case head :: tl => Some((Some(head), tl.map(Some(_))))
+          case head :: tl => Some(Metadata.BindingValues(Some(head), tl.map(Some(_))))
           case Nil        => None
         }
       case HttpBinding.QueryBinding(httpName) =>
         query.get(httpName).flatMap {
-          case head :: tl => Some((head, tl))
+          case head :: tl => Some(Metadata.BindingValues(head, tl))
           case Nil        => None
         }
       case HttpBinding.PathBinding(httpName) =>
-        path.get(httpName).map(v => Some(v) -> Nil)
+        path.get(httpName).map(v => Metadata.BindingValues(Some(v), Nil))
       case _ => None
     }
 }
@@ -161,6 +172,20 @@ object Metadata {
     i.foldLeft(empty)((acc, a) => acc ++ f(a))
 
   val empty = Metadata(Map.empty, Map.empty, Map.empty)
+
+  /**
+   * Represents values found for a specific HTTP binding location.
+   *
+   * @param head The first value. Can be None for valueless query parameters (e.g., ?foo),
+   *             or Some(value) for parameters with values (e.g., ?foo=bar).
+   *             Always Some for headers and path parameters.
+   * @param tail Additional values for multi-valued parameters. Each value is wrapped in Option
+   *             to support valueless query parameters in lists.
+   */
+  final case class BindingValues(
+      head: Option[String],
+      tail: List[Option[String]]
+  )
 
   trait Access {
     def metadata: Metadata

--- a/modules/core/src/smithy4s/http/Metadata.scala
+++ b/modules/core/src/smithy4s/http/Metadata.scala
@@ -40,7 +40,7 @@ import smithy4s.schema.FieldFilter
   */
 case class Metadata(
     path: Map[String, String] = Map.empty,
-    query: Map[String, Seq[String]] = Map.empty,
+    query: Map[String, Seq[Option[String]]] = Map.empty,
     headers: Map[CaseInsensitive, Seq[String]] = Map.empty,
     statusCode: Option[Int] = None
 ) { self =>
@@ -50,9 +50,10 @@ case class Metadata(
       v.map(k -> _)
     }
 
-  def queryFlattened: Vector[(String, String)] = query.toVector.flatMap {
-    case (k, v) => v.map(k -> _)
-  }
+  def queryFlattened: Vector[(String, Option[String])] =
+    query.toVector.flatMap { case (k, v) =>
+      v.map(k -> _)
+    }
 
   def addHeader(ciKey: CaseInsensitive, value: String): Metadata = {
     headers.get(ciKey) match {
@@ -67,17 +68,26 @@ case class Metadata(
   }
   def addPathParam(key: String, value: String): Metadata =
     copy(path = path + (key -> value))
-  def addQueryParam(key: String, value: String): Metadata =
+
+  def addQueryParamOpt(key: String, value: Option[String]): Metadata =
     query.get(key) match {
       case Some(existing) =>
         copy(query = query + (key -> (existing :+ value)))
       case None => copy(query = query + (key -> List(value)))
     }
+  def addQueryParam(key: String, value: String): Metadata =
+    addQueryParamOpt(key, Some(value))
+
+
   def addQueryParamsIfNoExist(key: String, values: String*): Metadata =
+    addQueryParamsIfNotExist(key, values.map(Some(_)): _*)
+
+  def addQueryParamsIfNotExist(key: String, values: Option[String]*): Metadata =
     query.get(key) match {
       case Some(_) => self
       case None    => copy(query = query + (key -> values.toList))
     }
+
   def addMultipleHeaders(
       ciKey: CaseInsensitive,
       value: List[String]
@@ -92,6 +102,12 @@ case class Metadata(
     addMultipleHeaders(CaseInsensitive(key), value)
 
   def addMultipleQueryParams(key: String, value: List[String]): Metadata =
+    addMultipleQueryParamsOpt(key, value.map(Some(_)))
+
+  def addMultipleQueryParamsOpt(
+      key: String,
+      value: List[Option[String]]
+  ): Metadata =
     query.get(key) match {
       case Some(existing) =>
         copy(query = query + (key -> (existing ++ value)))
@@ -128,9 +144,12 @@ case class Metadata(
           case Nil        => None
         }
       case HttpBinding.QueryBinding(httpName) =>
-        query.get(httpName).flatMap {
-          case head :: tl => Some((head, tl))
-          case Nil        => None
+        query.get(httpName).flatMap { values =>
+          val flattenedValues = values.flatMap(opt => opt).toList
+          flattenedValues match {
+            case head :: tl => Some((head, tl))
+            case Nil        => None
+          }
         }
       case HttpBinding.PathBinding(httpName) => path.get(httpName).map(_ -> Nil)
       case _                                 => None

--- a/modules/core/src/smithy4s/http/Metadata.scala
+++ b/modules/core/src/smithy4s/http/Metadata.scala
@@ -78,7 +78,6 @@ case class Metadata(
   def addQueryParam(key: String, value: String): Metadata =
     addQueryParamOpt(key, Some(value))
 
-
   def addQueryParamsIfNoExist(key: String, values: String*): Metadata =
     addQueryParamsIfNotExist(key, values.map(Some(_)): _*)
 

--- a/modules/core/src/smithy4s/http/Metadata.scala
+++ b/modules/core/src/smithy4s/http/Metadata.scala
@@ -187,8 +187,8 @@ object Metadata {
    *             to support valueless query parameters in lists.
    */
   final class BindingValues(
-      head: Option[String],
-      tail: List[Option[String]]
+      val head: Option[String],
+      val tail: List[Option[String]]
   )
 
   object BindingValues {
@@ -196,6 +196,11 @@ object Metadata {
         head: Option[String],
         tail: List[Option[String]]
     ): BindingValues = new BindingValues(head, tail)
+
+    def unapply(
+        bv: BindingValues
+    ): Option[(Option[String], List[Option[String]])] =
+      Some((bv.head, bv.tail))
   }
 
   trait Access {

--- a/modules/core/src/smithy4s/http/Metadata.scala
+++ b/modules/core/src/smithy4s/http/Metadata.scala
@@ -79,9 +79,9 @@ case class Metadata(
     addQueryParamOpt(key, Some(value))
 
   def addQueryParamsIfNoExist(key: String, values: String*): Metadata =
-    addQueryParamsIfNotExist(key, values.map(Some(_)): _*)
+    addQueryParamsIfNotExistOpt(key, values.map(Some(_)): _*)
 
-  def addQueryParamsIfNotExist(key: String, values: Option[String]*): Metadata =
+  def addQueryParamsIfNotExistOpt(key: String, values: Option[String]*): Metadata =
     query.get(key) match {
       case Some(_) => self
       case None    => copy(query = query + (key -> values.toList))

--- a/modules/core/src/smithy4s/http/Metadata.scala
+++ b/modules/core/src/smithy4s/http/Metadata.scala
@@ -135,20 +135,23 @@ case class Metadata(
     )
   }
 
-  def find(location: HttpBinding): Option[(Option[String], List[Option[String]])] =
+  def find(
+      location: HttpBinding
+  ): Option[(Option[String], List[Option[String]])] =
     location match {
       case HttpBinding.HeaderBinding(httpName) =>
         headers.get(httpName).flatMap {
           case head :: tl => Some((Some(head), tl.map(Some(_))))
-                    case Nil        => None
+          case Nil        => None
         }
       case HttpBinding.QueryBinding(httpName) =>
-      query.get(httpName).flatMap {
+        query.get(httpName).flatMap {
           case head :: tl => Some((head, tl))
           case Nil        => None
-      } 
-      case HttpBinding.PathBinding(httpName) =>         path.get(httpName).map(v => Some(v) -> Nil)
-      case _                                 => None
+        }
+      case HttpBinding.PathBinding(httpName) =>
+        path.get(httpName).map(v => Some(v) -> Nil)
+      case _ => None
     }
 }
 

--- a/modules/core/src/smithy4s/http/Metadata.scala
+++ b/modules/core/src/smithy4s/http/Metadata.scala
@@ -81,7 +81,10 @@ case class Metadata(
   def addQueryParamsIfNoExist(key: String, values: String*): Metadata =
     addQueryParamsIfNotExistOpt(key, values.map(Some(_)): _*)
 
-  def addQueryParamsIfNotExistOpt(key: String, values: Option[String]*): Metadata =
+  def addQueryParamsIfNotExistOpt(
+      key: String,
+      values: Option[String]*
+  ): Metadata =
     query.get(key) match {
       case Some(_) => self
       case None    => copy(query = query + (key -> values.toList))
@@ -152,8 +155,9 @@ case class Metadata(
     location match {
       case HttpBinding.HeaderBinding(httpName) =>
         headers.get(httpName).flatMap {
-          case head :: tl => Some(Metadata.BindingValues(Some(head), tl.map(Some(_))))
-          case Nil        => None
+          case head :: tl =>
+            Some(Metadata.BindingValues(Some(head), tl.map(Some(_))))
+          case Nil => None
         }
       case HttpBinding.QueryBinding(httpName) =>
         query.get(httpName).flatMap {

--- a/modules/core/src/smithy4s/http/Metadata.scala
+++ b/modules/core/src/smithy4s/http/Metadata.scala
@@ -135,22 +135,19 @@ case class Metadata(
     )
   }
 
-  def find(location: HttpBinding): Option[(String, List[String])] =
+  def find(location: HttpBinding): Option[(Option[String], List[Option[String]])] =
     location match {
       case HttpBinding.HeaderBinding(httpName) =>
         headers.get(httpName).flatMap {
-          case head :: tl => Some((head, tl))
-          case Nil        => None
+          case head :: tl => Some((Some(head), tl.map(Some(_))))
+                    case Nil        => None
         }
       case HttpBinding.QueryBinding(httpName) =>
-        query.get(httpName).flatMap { values =>
-          val flattenedValues = values.flatMap(opt => opt).toList
-          flattenedValues match {
-            case head :: tl => Some((head, tl))
-            case Nil        => None
-          }
-        }
-      case HttpBinding.PathBinding(httpName) => path.get(httpName).map(_ -> Nil)
+      query.get(httpName).flatMap {
+          case head :: tl => Some((head, tl))
+          case Nil        => None
+      } 
+      case HttpBinding.PathBinding(httpName) =>         path.get(httpName).map(v => Some(v) -> Nil)
       case _                                 => None
     }
 }

--- a/modules/core/src/smithy4s/http/internals/MetaDecode.scala
+++ b/modules/core/src/smithy4s/http/internals/MetaDecode.scala
@@ -80,7 +80,8 @@ private[http] sealed abstract class MetaDecode[+A] {
           if (values.size == 1) {
             values.head match {
               case Some(value) => putField(f(value))
-              case None => throw MetadataError.NotFound(fieldName, binding)
+              // Treat valueless query params as empty strings (AWS protocol behavior)
+              case None => putField(f(""))
             }
           } else throw MetadataError.ArityError(fieldName, binding)
         }

--- a/modules/core/src/smithy4s/http/internals/MetaDecode.scala
+++ b/modules/core/src/smithy4s/http/internals/MetaDecode.scala
@@ -78,12 +78,15 @@ private[http] sealed abstract class MetaDecode[+A] {
       case (QueryBinding(h), StringValueMetaDecode(f)) =>
         lookupAndProcess(_.query, h) { (values, fieldName, putField) =>
           if (values.size == 1) {
-            putField(f(values.head))
+            values.head match {
+              case Some(value) => putField(f(value))
+              case None => throw MetadataError.NotFound(fieldName, binding)
+            }
           } else throw MetadataError.ArityError(fieldName, binding)
         }
       case (QueryBinding(q), StringCollectionMetaDecode(f)) =>
         lookupAndProcess(_.query, q) { (values, fieldName, putField) =>
-          putField(f(values.iterator))
+          putField(f(values.iterator.flatMap(opt => opt)))
         }
       // see https://smithy.io/2.0/spec/http-bindings.html#httpqueryparams-trait
       // when targeting Map[String,String] we take the first value encountered
@@ -92,7 +95,11 @@ private[http] sealed abstract class MetaDecode[+A] {
           val iter: Iterator[(FieldName, FieldName)] = metadata.query.iterator
             .map { case (k, values) =>
               if (values.nonEmpty) {
-                k -> values.head
+                values.head match {
+                  case Some(value) => k -> value
+                  case None =>
+                    throw MetadataError.NotFound(fieldName, QueryParamsBinding)
+                }
               } else throw MetadataError.NotFound(fieldName, QueryParamsBinding)
             }
           if (iter.nonEmpty) putField(f(iter))
@@ -102,7 +109,7 @@ private[http] sealed abstract class MetaDecode[+A] {
         (metadata, putField) =>
           val iter = metadata.query.iterator
             .map { case (k, values) =>
-              k -> values.iterator
+              k -> values.iterator.flatMap(opt => opt)
             }
           if (iter.nonEmpty) putField(f(iter))
           else putDefault(putField)

--- a/modules/core/src/smithy4s/http/internals/MetaDecode.scala
+++ b/modules/core/src/smithy4s/http/internals/MetaDecode.scala
@@ -98,8 +98,8 @@ private[http] sealed abstract class MetaDecode[+A] {
               if (values.nonEmpty) {
                 values.head match {
                   case Some(value) => k -> value
-                  case None =>
-                    throw MetadataError.NotFound(fieldName, QueryParamsBinding)
+                  // Treat valueless query params as empty strings (AWS protocol behavior)
+                  case None => k -> ""
                 }
               } else throw MetadataError.NotFound(fieldName, QueryParamsBinding)
             }

--- a/modules/core/src/smithy4s/http/internals/package.scala
+++ b/modules/core/src/smithy4s/http/internals/package.scala
@@ -75,18 +75,21 @@ package object internals {
 
   private[http] def staticQueryParams(
       uri: String
-  ): Map[String, Seq[String]] = {
+  ): Map[String, Seq[Option[String]]] = {
     uri.split("\\?", 2) match {
       case Array(_) => Map.empty
       case Array(_, query) =>
-        query.split("&").toList.foldLeft(Map.empty[String, Seq[String]]) {
-          case (acc, param) =>
-            val (k, v) = param.split("=", 2) match {
-              case Array(key)        => (key, "")
-              case Array(key, value) => (key, value)
-            }
-            acc.updated(k, acc.getOrElse(k, Seq.empty) :+ v)
-        }
+        query
+          .split("&")
+          .toList
+          .foldLeft(Map.empty[String, Seq[Option[String]]]) {
+            case (acc, param) =>
+              val (k, v) = param.split("=", 2) match {
+                case Array(key)        => (key, None)
+                case Array(key, value) => (key, Some(value))
+              }
+              acc.updated(k, acc.getOrElse(k, Seq.empty) :+ v)
+          }
     }
   }
 

--- a/modules/http4s-kernel/src/smithy4s/http4s/kernel/package.scala
+++ b/modules/http4s-kernel/src/smithy4s/http4s/kernel/package.scala
@@ -138,12 +138,6 @@ package object kernel {
     val path = Uri.Path.Root.addSegments(uri.path.map(mkSegment))
     val authority =
       uri.host.map(h => Uri.Authority(host = Uri.RegName(h), port = uri.port))
-    val queryMap = uri.queryParamsAsMap.map { case (k, vs) =>
-      k -> vs.flatMap {
-        case Some(v) => Seq(v)
-        case None    => Seq("true")
-      }
-    }
     Uri(
       path = path,
       authority = authority,
@@ -152,7 +146,7 @@ package object kernel {
         case Smithy4sHttpUriScheme.Https => Uri.Scheme.https
 
       }
-    ).withMultiValueQueryParams(queryMap)
+    ).copy(query = Query.fromVector(uri.queryParams.toVector))
   }
 
   /**

--- a/modules/http4s-kernel/src/smithy4s/http4s/kernel/package.scala
+++ b/modules/http4s-kernel/src/smithy4s/http4s/kernel/package.scala
@@ -146,7 +146,7 @@ package object kernel {
         case Smithy4sHttpUriScheme.Https => Uri.Scheme.https
 
       }
-    ).withMultiValueQueryParams(uri.queryParams)
+    ).withMultiValueQueryParams(uri.queryParamsAsMap)
   }
 
   /**
@@ -224,14 +224,10 @@ package object kernel {
 
   private[smithy4s] def getQueryParams[F[_]](
       uri: Uri
-  ): Map[String, List[String]] =
-    uri.query.pairs
-      .collect {
-        case (name, None)        => name -> "true"
-        case (name, Some(value)) => name -> value
-      }
-      .groupBy(_._1)
-      .map { case (k, v) => k -> v.map(_._2).toList }
+  ): IndexedSeq[(String, Option[String])] =
+    uri.query.pairs.map {
+      case (name, value) => name -> value
+    }.toIndexedSeq
 
   private def collectBytes[F[_]: Concurrent](
       stream: fs2.Stream[F, Byte]

--- a/modules/http4s-kernel/src/smithy4s/http4s/kernel/package.scala
+++ b/modules/http4s-kernel/src/smithy4s/http4s/kernel/package.scala
@@ -138,6 +138,12 @@ package object kernel {
     val path = Uri.Path.Root.addSegments(uri.path.map(mkSegment))
     val authority =
       uri.host.map(h => Uri.Authority(host = Uri.RegName(h), port = uri.port))
+    val queryMap = uri.queryParamsAsMap.map { case (k, vs) =>
+      k -> vs.flatMap {
+        case Some(v) => Seq(v)
+        case None    => Seq("true")
+      }
+    }
     Uri(
       path = path,
       authority = authority,
@@ -146,7 +152,7 @@ package object kernel {
         case Smithy4sHttpUriScheme.Https => Uri.Scheme.https
 
       }
-    ).withMultiValueQueryParams(uri.queryParamsAsMap)
+    ).withMultiValueQueryParams(queryMap)
   }
 
   /**
@@ -221,13 +227,6 @@ package object kernel {
     req.headers.headers.groupBy(_.name).map { case (k, v) =>
       (CaseInsensitive(k.toString), v.map(_.value))
     }
-
-  private[smithy4s] def getQueryParams[F[_]](
-      uri: Uri
-  ): IndexedSeq[(String, Option[String])] =
-    uri.query.pairs.map { case (name, value) =>
-      name -> value
-    }.toIndexedSeq
 
   private def collectBytes[F[_]: Concurrent](
       stream: fs2.Stream[F, Byte]

--- a/modules/http4s-kernel/src/smithy4s/http4s/kernel/package.scala
+++ b/modules/http4s-kernel/src/smithy4s/http4s/kernel/package.scala
@@ -95,7 +95,7 @@ package object kernel {
     Smithy4sHttpUri(
       origin,
       uri.path.segments.map(_.decoded()),
-      getQueryParams(uri),
+      uri.query.pairs,
       pathParams
     )
   }
@@ -225,8 +225,8 @@ package object kernel {
   private[smithy4s] def getQueryParams[F[_]](
       uri: Uri
   ): IndexedSeq[(String, Option[String])] =
-    uri.query.pairs.map {
-      case (name, value) => name -> value
+    uri.query.pairs.map { case (name, value) =>
+      name -> value
     }.toIndexedSeq
 
   private def collectBytes[F[_]: Concurrent](

--- a/modules/http4s-kernel/test/src/smithy4s/http4s/kernel/Http4sConversionSpec.scala
+++ b/modules/http4s-kernel/test/src/smithy4s/http4s/kernel/Http4sConversionSpec.scala
@@ -123,7 +123,7 @@ object Http4sConversionSpec extends SimpleIOSuite {
       host = "example.com",
       port = None,
       path = IndexedSeq.empty,
-      queryParams = Map.empty,
+      queryParams = IndexedSeq.empty,
       pathParams = None
     )
 }


### PR DESCRIPTION
This PR is based off [this](https://github.com/disneystreaming/smithy4s/pull/1513) PR, focusing on remodeling the http query params to an RFC compliant model 


Adds additional tests , plus relies on existing tests to confirm conformance.

- the isSubset method was refactored to not be abstract as its coupled to http implementation and we specifically want to handle Strings
- 
