### PR TITLE
enable xsource 3 for scala 2.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,8 @@ The behavior of `@default(null)` has changed to better align with Smithy semanti
 ## `Bijection` does no longer extends `Function` in [#1794](https://github.com/disneystreaming/smithy4s/pull/1794)
 Prevents using it as an implicit conversion in Scala 2
 
+## Enable `-Xsource:3` for scala 2.13 in [#1878](https://github.com/disneystreaming/smithy4s/pull/1878)
+
 # 0.18.46
 
 * core: Set the Accept header via the HttpUnaryClientCodecs  (see [#1864](https://github.com/disneystreaming/smithy4s/pull/1864))

--- a/build.sbt
+++ b/build.sbt
@@ -101,6 +101,8 @@ lazy val docsRendering =
       docs
     )
     .settings(
+      // mdoc is ignoring wconf flags which makes using -Xsource:3 difficult
+      scalacOptions := scalacOptions.value.filterNot(_ == "-Xsource:3"),
       mdocIn := (ThisBuild / baseDirectory).value / "modules" / "docs" / "resources" / "markdown",
       mdocVariables := Map(
         "VERSION" -> {

--- a/modules/aws-kernel/src/smithy4s/aws/AwsInstanceMetadata.scala
+++ b/modules/aws-kernel/src/smithy4s/aws/AwsInstanceMetadata.scala
@@ -26,7 +26,7 @@ case class AwsInstanceMetadata(
     secretAccessKey: String,
     token: String
 ) extends AwsTemporaryCredentials {
-  def sessionToken = Some(token)
+  def sessionToken: Option[String] = Some(token)
 }
 
 object AwsInstanceMetadata {

--- a/modules/codegen-cli/src/smithy4s/codegen/cli/CodegenCommand.scala
+++ b/modules/codegen-cli/src/smithy4s/codegen/cli/CodegenCommand.scala
@@ -143,6 +143,6 @@ object CodegenCommand {
   val command = Command(
     "generate",
     "Generates scala code and openapi-specs from smithy specs"
-  )(options.map(Smithy4sCommand.Generate))
+  )(options.map(Smithy4sCommand.Generate.apply))
 
 }

--- a/modules/core/src/smithy4s/codecs/package.scala
+++ b/modules/core/src/smithy4s/codecs/package.scala
@@ -24,7 +24,8 @@ package object codecs {
   object BlobEncoder {
     type Compiler = CachedSchemaCompiler[BlobEncoder]
     val noop: Compiler = new CachedSchemaCompiler.Uncached[BlobEncoder] {
-      def fromSchema[A](schema: Schema[A]) = Encoder.static(Blob.empty)
+      def fromSchema[A](schema: Schema[A]): BlobEncoder[A] =
+        Encoder.static(Blob.empty)
     }
   }
 

--- a/modules/http4s-protocol-tests/test/src-jvm/smithy4s/http4s/Http4sDynamicPizzaClientSpec.scala
+++ b/modules/http4s-protocol-tests/test/src-jvm/smithy4s/http4s/Http4sDynamicPizzaClientSpec.scala
@@ -70,7 +70,10 @@ class DynamicHttpProxy(client: Client[IO]) {
 
 object Http4sDynamicPizzaClientSpec extends smithy4s.tests.PizzaClientSpec {
 
-  def makeClient = Left { (httpApp: HttpApp[IO]) =>
+  def makeClient: Either[
+    HttpApp[IO] => Resource[IO, PizzaAdminService[IO]],
+    Int => Resource[IO, PizzaAdminService[IO]]
+  ] = Left { (httpApp: HttpApp[IO]) =>
     Resource.eval(
       new DynamicHttpProxy(Client.fromHttpApp(httpApp)).dynamicPizza
     )

--- a/modules/http4s-protocol-tests/test/src/smithy4s/http4s/SimpleRestJsonComplianceSuite.scala
+++ b/modules/http4s-protocol-tests/test/src/smithy4s/http4s/SimpleRestJsonComplianceSuite.scala
@@ -73,7 +73,9 @@ object SimpleRestJsonComplianceSuite extends ProtocolComplianceSuite {
 
   object SimpleRestJsonIntegration extends Router[IO] with ReverseRouter[IO] {
     type Protocol = SimpleRestJson
-    val protocolTag = alloy.SimpleRestJson
+    val protocolTag: smithy4s.ShapeTag[
+      smithy4s.http4s.SimpleRestJsonComplianceSuite.SimpleRestJsonIntegration.Protocol
+    ] = alloy.SimpleRestJson
 
     def expectedResponseType(schema: Schema[_]): HttpMediaType = HttpMediaType(
       "application/json"

--- a/modules/json/src/smithy4s/json/internals/SchemaVisitorJCodec.scala
+++ b/modules/json/src/smithy4s/json/internals/SchemaVisitorJCodec.scala
@@ -1445,14 +1445,14 @@ private[smithy4s] class SchemaVisitorJCodec(
     val label = field.label
 
     val decodeFn: (Cursor, JCodec[A], JsonReader) => A = {
-      val allowExplicitNulls = !{
-          // required fields can't accept explicit nulls
-          field.hints.has(Required) ||
-          // if there was no default, we'd allow explicit nulls by virtue of having an OptionSchema
-          default == null ||
-          // nullables have separate handling in OptionSchema
-          field.hints.has(alloy.Nullable)
-        }
+      val allowExplicitNulls = ! {
+        // required fields can't accept explicit nulls
+        field.hints.has(Required) ||
+        // if there was no default, we'd allow explicit nulls by virtue of having an OptionSchema
+        default == null ||
+        // nullables have separate handling in OptionSchema
+        field.hints.has(alloy.Nullable)
+      }
 
       if (allowExplicitNulls)
         (cursor, codec, in) =>

--- a/modules/json/src/smithy4s/json/internals/SchemaVisitorJCodec.scala
+++ b/modules/json/src/smithy4s/json/internals/SchemaVisitorJCodec.scala
@@ -1445,8 +1445,7 @@ private[smithy4s] class SchemaVisitorJCodec(
     val label = field.label
 
     val decodeFn: (Cursor, JCodec[A], JsonReader) => A = {
-      val allowExplicitNulls =
-        ! {
+      val allowExplicitNulls = !{
           // required fields can't accept explicit nulls
           field.hints.has(Required) ||
           // if there was no default, we'd allow explicit nulls by virtue of having an OptionSchema

--- a/modules/mill-codegen-plugin/src-mill-0_11/smithy4s/codegen/mill/LSPCompat.scala
+++ b/modules/mill-codegen-plugin/src-mill-0_11/smithy4s/codegen/mill/LSPCompat.scala
@@ -1,0 +1,19 @@
+/*
+ *  Copyright 2021-2026 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package smithy4s.codegen.mill
+
+trait LSPCompat {}

--- a/modules/mill-codegen-plugin/src-mill-0_12/smithy4s/codegen/mill/LSPCompat.scala
+++ b/modules/mill-codegen-plugin/src-mill-0_12/smithy4s/codegen/mill/LSPCompat.scala
@@ -18,5 +18,4 @@ package smithy4s.codegen.mill
 
 import _root_.{mill => mmill}
 
-trait LSPCompat extends mmill.main.TokenReaders0 {
-}
+trait LSPCompat extends mmill.main.TokenReaders0 {}

--- a/modules/mill-codegen-plugin/src-mill-0_12/smithy4s/codegen/mill/LSPCompat.scala
+++ b/modules/mill-codegen-plugin/src-mill-0_12/smithy4s/codegen/mill/LSPCompat.scala
@@ -1,0 +1,22 @@
+/*
+ *  Copyright 2021-2026 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package smithy4s.codegen.mill
+
+import _root_.{mill => mmill}
+
+trait LSPCompat extends mmill.main.TokenReaders0 {
+}

--- a/modules/mill-codegen-plugin/src-mill-shared/smithy4s/codegen/LSP.scala
+++ b/modules/mill-codegen-plugin/src-mill-shared/smithy4s/codegen/LSP.scala
@@ -28,6 +28,7 @@ import smithy4s.codegen.mill.Smithy4sModule
 
 import scala.annotation.nowarn
 import scala.collection.immutable.ListSet
+import mmill.main.TokenReaders.millEvaluatorTokenReader
 
 object LSP extends ExternalModule {
   lazy val millDiscover = mmill.define.Discover[this.type]

--- a/modules/mill-codegen-plugin/src-mill-shared/smithy4s/codegen/LSP.scala
+++ b/modules/mill-codegen-plugin/src-mill-shared/smithy4s/codegen/LSP.scala
@@ -24,11 +24,11 @@ import mmill.define.ExternalModule
 import mmill.define.Target
 import mmill.eval.Evaluator
 import smithy4s.codegen.SmithyBuildJson
+import smithy4s.codegen.mill.LSPCompat
 import smithy4s.codegen.mill.Smithy4sModule
 
 import scala.annotation.nowarn
 import scala.collection.immutable.ListSet
-import smithy4s.codegen.mill.LSPCompat
 
 object LSP extends ExternalModule with LSPCompat {
   lazy val millDiscover = mmill.define.Discover[this.type]

--- a/modules/mill-codegen-plugin/src-mill-shared/smithy4s/codegen/LSP.scala
+++ b/modules/mill-codegen-plugin/src-mill-shared/smithy4s/codegen/LSP.scala
@@ -28,9 +28,9 @@ import smithy4s.codegen.mill.Smithy4sModule
 
 import scala.annotation.nowarn
 import scala.collection.immutable.ListSet
-import mmill.main.TokenReaders.millEvaluatorTokenReader
+import smithy4s.codegen.mill.LSPCompat
 
-object LSP extends ExternalModule {
+object LSP extends ExternalModule with LSPCompat {
   lazy val millDiscover = mmill.define.Discover[this.type]
 
   @nowarn("cat=deprecation")

--- a/modules/mill-codegen-plugin/test/src-mill-0_11/smithy4s/codegen/mill/Smithy4sModuleSpec.scala
+++ b/modules/mill-codegen-plugin/test/src-mill-0_11/smithy4s/codegen/mill/Smithy4sModuleSpec.scala
@@ -155,7 +155,8 @@ class Smithy4sModuleSpec extends munit.FunSuite {
       override def scalaVersion = "2.13.18"
       override def ivyDeps = Agg(coreDep)
       override def millSourcePath = resourcePath / "basic"
-      override def smithy4sAllowedNamespaces: T[Option[Set[String]]] = T(Some(Set("aws.iam")))
+      override def smithy4sAllowedNamespaces: T[Option[Set[String]]] =
+        T(Some(Set("aws.iam")))
       override def smithy4sIvyDeps = Agg(
         ivy"software.amazon.smithy:smithy-aws-iam-traits:${smithy4s.codegen.BuildInfo.smithyVersion}"
       )

--- a/modules/mill-codegen-plugin/test/src-mill-0_11/smithy4s/codegen/mill/Smithy4sModuleSpec.scala
+++ b/modules/mill-codegen-plugin/test/src-mill-0_11/smithy4s/codegen/mill/Smithy4sModuleSpec.scala
@@ -155,7 +155,7 @@ class Smithy4sModuleSpec extends munit.FunSuite {
       override def scalaVersion = "2.13.18"
       override def ivyDeps = Agg(coreDep)
       override def millSourcePath = resourcePath / "basic"
-      override def smithy4sAllowedNamespaces = T(Some(Set("aws.iam")))
+      override def smithy4sAllowedNamespaces: T[Option[Set[String]]] = T(Some(Set("aws.iam")))
       override def smithy4sIvyDeps = Agg(
         ivy"software.amazon.smithy:smithy-aws-iam-traits:${smithy4s.codegen.BuildInfo.smithyVersion}"
       )
@@ -175,7 +175,7 @@ class Smithy4sModuleSpec extends munit.FunSuite {
       override def scalaVersion = "2.13.18"
       override def ivyDeps = Agg(coreDep)
       override def millSourcePath = resourcePath / "smithy-build"
-      override def smithyBuild =
+      override def smithyBuild: T[Option[PathRef]] =
         Some(PathRef(millSourcePath / "smithy-build.json"))
     }
     val ev =
@@ -201,7 +201,7 @@ class Smithy4sModuleSpec extends munit.FunSuite {
     }
 
     object bar extends testKit.BaseModule with Smithy4sModule {
-      override def moduleDeps = Seq(foo)
+      override def moduleDeps: Seq[JavaModule] = Seq(foo)
       override def scalaVersion = "2.13.18"
       override def ivyDeps = Agg(coreDep)
       override def millSourcePath = resourcePath / "multi-module" / "bar"
@@ -255,7 +255,7 @@ class Smithy4sModuleSpec extends munit.FunSuite {
     }
 
     object bar extends testKit.BaseModule with Smithy4sModule {
-      override def moduleDeps = Seq(foo)
+      override def moduleDeps: Seq[JavaModule] = Seq(foo)
       override def scalaVersion = "2.13.18"
       override def millSourcePath = resourcePath / "multi-module-aws" / "bar"
     }
@@ -304,7 +304,7 @@ class Smithy4sModuleSpec extends munit.FunSuite {
     }
 
     object bar extends testKit.BaseModule with Smithy4sModule {
-      override def moduleDeps = Seq(foo)
+      override def moduleDeps: Seq[JavaModule] = Seq(foo)
       override def scalaVersion = "2.13.18"
       override def ivyDeps = Agg(coreDep)
       override def millSourcePath =

--- a/modules/mill-codegen-plugin/test/src-mill-0_11/smithy4s/codegen/mill/SmithyLSPConfigSpec.scala
+++ b/modules/mill-codegen-plugin/test/src-mill-0_11/smithy4s/codegen/mill/SmithyLSPConfigSpec.scala
@@ -37,7 +37,8 @@ class SmithyLSPConfigSpec extends munit.FunSuite {
             )
         }
         override def scalaVersion = "2.13.18"
-        override def smithy4sAllowedNamespaces: T[Option[Set[String]]] = T(Some(Set("aws.iam")))
+        override def smithy4sAllowedNamespaces: T[Option[Set[String]]] =
+          T(Some(Set("aws.iam")))
         override def smithy4sIvyDeps = Agg(
           ivy"software.amazon.smithy:smithy-aws-iam-traits:${smithy4s.codegen.BuildInfo.smithyVersion}"
         )

--- a/modules/mill-codegen-plugin/test/src-mill-0_11/smithy4s/codegen/mill/SmithyLSPConfigSpec.scala
+++ b/modules/mill-codegen-plugin/test/src-mill-0_11/smithy4s/codegen/mill/SmithyLSPConfigSpec.scala
@@ -37,7 +37,7 @@ class SmithyLSPConfigSpec extends munit.FunSuite {
             )
         }
         override def scalaVersion = "2.13.18"
-        override def smithy4sAllowedNamespaces = T(Some(Set("aws.iam")))
+        override def smithy4sAllowedNamespaces: T[Option[Set[String]]] = T(Some(Set("aws.iam")))
         override def smithy4sIvyDeps = Agg(
           ivy"software.amazon.smithy:smithy-aws-iam-traits:${smithy4s.codegen.BuildInfo.smithyVersion}"
         )

--- a/modules/mill-codegen-plugin/test/src-mill-0_12/smithy4s/codegen/mill/Smithy4sModuleSpec.scala
+++ b/modules/mill-codegen-plugin/test/src-mill-0_12/smithy4s/codegen/mill/Smithy4sModuleSpec.scala
@@ -183,7 +183,7 @@ class Smithy4sModuleSpec extends munit.FunSuite {
     object foo extends TestBaseModule with Smithy4sModule {
       override def scalaVersion = "2.13.18"
       override def ivyDeps = Agg(coreDep)
-      override def smithy4sAllowedNamespaces = T(Some(Set("aws.iam")))
+      override def smithy4sAllowedNamespaces: T[Option[Set[String]]] = T(Some(Set("aws.iam")))
       override def smithy4sIvyDeps = Agg(
         ivy"software.amazon.smithy:smithy-aws-iam-traits:${smithy4s.codegen.BuildInfo.smithyVersion}"
       )
@@ -211,7 +211,7 @@ class Smithy4sModuleSpec extends munit.FunSuite {
       override def scalaVersion = "2.13.18"
       override def ivyDeps = Agg(coreDep)
 
-      override def smithyBuild =
+      override def smithyBuild: T[Option[PathRef]] =
         Some(PathRef(millSourcePath / "smithy-build.json"))
     }
 
@@ -248,7 +248,7 @@ class Smithy4sModuleSpec extends munit.FunSuite {
       object bar extends Smithy4sModule {
         override def scalaVersion = "2.13.18"
         override def ivyDeps = Agg(coreDep)
-        override def moduleDeps = Seq(foo)
+        override def moduleDeps: Seq[JavaModule] = Seq(foo)
       }
     }
 
@@ -304,7 +304,7 @@ class Smithy4sModuleSpec extends munit.FunSuite {
 
       object bar extends Smithy4sModule {
         override def scalaVersion = "2.13.18"
-        override def moduleDeps = Seq(foo)
+        override def moduleDeps: Seq[JavaModule] = Seq(foo)
       }
     }
 
@@ -352,7 +352,7 @@ class Smithy4sModuleSpec extends munit.FunSuite {
 
       object bar extends Smithy4sModule {
         override def scalaVersion = "2.13.18"
-        override def moduleDeps = Seq(foo)
+        override def moduleDeps: Seq[JavaModule] = Seq(foo)
         override def ivyDeps = Agg(coreDep)
 
         override def smithy4sInternalDependenciesAsJars = List.empty[PathRef]

--- a/modules/mill-codegen-plugin/test/src-mill-0_12/smithy4s/codegen/mill/Smithy4sModuleSpec.scala
+++ b/modules/mill-codegen-plugin/test/src-mill-0_12/smithy4s/codegen/mill/Smithy4sModuleSpec.scala
@@ -183,7 +183,8 @@ class Smithy4sModuleSpec extends munit.FunSuite {
     object foo extends TestBaseModule with Smithy4sModule {
       override def scalaVersion = "2.13.18"
       override def ivyDeps = Agg(coreDep)
-      override def smithy4sAllowedNamespaces: T[Option[Set[String]]] = T(Some(Set("aws.iam")))
+      override def smithy4sAllowedNamespaces: T[Option[Set[String]]] =
+        T(Some(Set("aws.iam")))
       override def smithy4sIvyDeps = Agg(
         ivy"software.amazon.smithy:smithy-aws-iam-traits:${smithy4s.codegen.BuildInfo.smithyVersion}"
       )

--- a/modules/mill-codegen-plugin/test/src-mill-0_12/smithy4s/codegen/mill/SmithyLSPConfigSpec.scala
+++ b/modules/mill-codegen-plugin/test/src-mill-0_12/smithy4s/codegen/mill/SmithyLSPConfigSpec.scala
@@ -39,7 +39,7 @@ class SmithyLSPConfigSpec extends munit.FunSuite {
             )
         }
         override def scalaVersion = "2.13.18"
-        override def smithy4sAllowedNamespaces = T(Some(Set("aws.iam")))
+        override def smithy4sAllowedNamespaces: T[Option[Set[String]]] = T(Some(Set("aws.iam")))
         override def smithy4sIvyDeps = Agg(
           ivy"software.amazon.smithy:smithy-aws-iam-traits:${smithy4s.codegen.BuildInfo.smithyVersion}"
         )

--- a/modules/mill-codegen-plugin/test/src-mill-0_12/smithy4s/codegen/mill/SmithyLSPConfigSpec.scala
+++ b/modules/mill-codegen-plugin/test/src-mill-0_12/smithy4s/codegen/mill/SmithyLSPConfigSpec.scala
@@ -39,7 +39,8 @@ class SmithyLSPConfigSpec extends munit.FunSuite {
             )
         }
         override def scalaVersion = "2.13.18"
-        override def smithy4sAllowedNamespaces: T[Option[Set[String]]] = T(Some(Set("aws.iam")))
+        override def smithy4sAllowedNamespaces: T[Option[Set[String]]] =
+          T(Some(Set("aws.iam")))
         override def smithy4sIvyDeps = Agg(
           ivy"software.amazon.smithy:smithy-aws-iam-traits:${smithy4s.codegen.BuildInfo.smithyVersion}"
         )

--- a/modules/xml/test/src/smithy4s/xml/XmlCodecSpec.scala
+++ b/modules/xml/test/src/smithy4s/xml/XmlCodecSpec.scala
@@ -434,7 +434,7 @@ object XmlCodecSpec extends SimpleIOSuite {
       val value = stringValue
       val hints = Hints.empty
       type EnumType = FooBar
-      def enumeration = FooBar
+      def enumeration: smithy4s.Enumeration[FooBar.this.EnumType] = FooBar
     }
     object FooBar extends smithy4s.Enumeration[FooBar] {
       case object Foo extends FooBar("foo", 0)

--- a/project/Smithy4sBuildPlugin.scala
+++ b/project/Smithy4sBuildPlugin.scala
@@ -299,7 +299,7 @@ object Smithy4sBuildPlugin extends AutoPlugin {
         filterScala2_12Options(commonCompilerOptions)
       else
         commonCompilerOptions ++ Seq(
-          "-Xsource:3",
+          "-Xsource:3"
         )
 
     base ++ targetScalacOptions(scalaVersion) ++ {

--- a/project/Smithy4sBuildPlugin.scala
+++ b/project/Smithy4sBuildPlugin.scala
@@ -214,7 +214,8 @@ object Smithy4sBuildPlugin extends AutoPlugin {
       "-Wconf:msg=type Enum in package smithy.api is deprecated:silent",
       // silencing -XSource:3 warnings for case class copy methods since they are just informing of
       // a difference between scala 2.x and 3.x
-      "-Wconf:msg=.*method are copied from the case class constructor under Scala 3.*:silent"
+      "-Wconf:msg=access modifiers for `apply` method are copied:silent",
+      "-Wconf:msg=access modifiers for `copy` method are copied:silent"
     ),
     ThisScope / bloopEnabled := {
       virtualAxes.?.value match {

--- a/project/Smithy4sBuildPlugin.scala
+++ b/project/Smithy4sBuildPlugin.scala
@@ -211,7 +211,10 @@ object Smithy4sBuildPlugin extends AutoPlugin {
       "-Wconf:msg=type Enum in package api is deprecated:silent",
       // for Scala 3
       "-Wconf:msg=object Enum in package smithy.api is deprecated:silent",
-      "-Wconf:msg=type Enum in package smithy.api is deprecated:silent"
+      "-Wconf:msg=type Enum in package smithy.api is deprecated:silent",
+      // silencing -XSource:3 warnings for case class copy methods since they are just informing of
+      // a difference between scala 2.x and 3.x
+      "-Wconf:msg=.*method are copied from the case class constructor under Scala 3.*:silent"
     ),
     ThisScope / bloopEnabled := {
       virtualAxes.?.value match {
@@ -294,11 +297,9 @@ object Smithy4sBuildPlugin extends AutoPlugin {
       else if (priorTo2_13(scalaVersion))
         filterScala2_12Options(commonCompilerOptions)
       else
-        commonCompilerOptions
-    // ++ Seq(
-    //   "-Xsource:3",
-    //   "-P:kind-projector:underscore-placeholders"
-    // )
+        commonCompilerOptions ++ Seq(
+          "-Xsource:3",
+        )
 
     base ++ targetScalacOptions(scalaVersion) ++ {
       if (priorTo2_13(scalaVersion)) compilerOptions2_12_Only


### PR DESCRIPTION
## PR Checklist (not all items are relevant to all PRs)

- [ ] Added unit-tests (for runtime code)
- [ ] Added bootstrapped code + smoke tests (when the rendering logic is modified)
- [ ] Added build-plugins integration tests (when reflection loading is required at codegen-time)
- [ ] Added alloy compliance tests (when simpleRestJson protocol behaviour is expanded/updated)
- [ ] Updated dynamic module to match generated-code behaviour
- [ ] Added documentation
- [ ] Updated changelog

closes #1584 
