### PR TITLE
Remove function surjection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,10 @@ Prevents using it as an implicit conversion in Scala 2
 
 ## Enable `-Xsource:3` for scala 2.13 in [#1878](https://github.com/disneystreaming/smithy4s/pull/1878)
 
+## Surjection no longer extends `Function` in [#1887](https://github.com/disneystreaming/smithy4s/pull/1887)
+
+Prevents using it as an implicit conversion in Scala 2
+
 # 0.18.47
 
 * core: Add `asSurjection` method to `ValidatedNewtype` class (see [#1873](https://github.com/disneystreaming/smithy4s/pull/1873))

--- a/modules/core/src/smithy4s/Surjection.scala
+++ b/modules/core/src/smithy4s/Surjection.scala
@@ -26,11 +26,13 @@ import scala.util.control.NonFatal
   *
   * surjection(input).map(surjection.from) == Right(input)
   */
-trait Surjection[A, B] extends Function[A, Either[String, B]] { outer =>
+trait Surjection[A, B] { outer =>
   def to(a: A): Either[String, B]
   def from(b: B): A
 
   final def apply(a: A): Either[String, B] = to(a)
+
+  def toFunction: A => Either[String, B] = apply
 
   final def imapFull[A0, B0](
       sourceBijection: Bijection[A, A0],
@@ -61,7 +63,7 @@ object Surjection {
     )
 
   private class Impl[A, B](
-      toFunction: A => Either[String, B],
+      override val toFunction: A => Either[String, B],
       fromFunction: B => A
   ) extends Surjection[A, B] {
     def to(a: A): Either[String, B] = toFunction(a)


### PR DESCRIPTION
This avoids issues where it is used as an implicit conversion in Scala 2. Closes #1884.
## PR Checklist (not all items are relevant to all PRs)

- [ ] Added unit-tests (for runtime code)
- [ ] Added bootstrapped code + smoke tests (when the rendering logic is modified)
- [ ] Added build-plugins integration tests (when reflection loading is required at codegen-time)
- [ ] Added alloy compliance tests (when simpleRestJson protocol behaviour is expanded/updated)
- [ ] Updated dynamic module to match generated-code behaviour
- [ ] Added documentation
- [x] Updated changelog
