### PR TITLE
Add type params to `struct` and `union` in codegen schemas

### DIFF
--- a/modules/bootstrapped/src/generated/com/amazonaws/dynamodb/DescribeEndpointsResponse.scala
+++ b/modules/bootstrapped/src/generated/com/amazonaws/dynamodb/DescribeEndpointsResponse.scala
@@ -19,7 +19,7 @@ object DescribeEndpointsResponse extends ShapeTag.Companion[DescribeEndpointsRes
   // constructor using the original order from the spec
   private def make(endpoints: List[Endpoint]): DescribeEndpointsResponse = DescribeEndpointsResponse(endpoints)
 
-  implicit val schema: Schema[DescribeEndpointsResponse] = struct(
+  implicit val schema: Schema[DescribeEndpointsResponse] = struct[DescribeEndpointsResponse](
     Endpoints.underlyingSchema.required[DescribeEndpointsResponse]("Endpoints", _.endpoints).addHints(smithy.api.Documentation("<p>List of endpoints.</p>")),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/com/amazonaws/dynamodb/DynamoDB.scala
+++ b/modules/bootstrapped/src/generated/com/amazonaws/dynamodb/DynamoDB.scala
@@ -178,7 +178,7 @@ object DynamoDBOperation {
       }
     }
 
-    implicit val schema: Schema[ListTablesError] = union(
+    implicit val schema: Schema[ListTablesError] = union[ListTablesError](
       ListTablesError.InternalServerErrorCase.alt,
       ListTablesError.InvalidEndpointExceptionCase.alt,
     ){

--- a/modules/bootstrapped/src/generated/com/amazonaws/dynamodb/Endpoint.scala
+++ b/modules/bootstrapped/src/generated/com/amazonaws/dynamodb/Endpoint.scala
@@ -27,7 +27,7 @@ object Endpoint extends ShapeTag.Companion[Endpoint] {
   // constructor using the original order from the spec
   private def make(address: String, cachePeriodInMinutes: Long): Endpoint = Endpoint(address, cachePeriodInMinutes)
 
-  implicit val schema: Schema[Endpoint] = struct(
+  implicit val schema: Schema[Endpoint] = struct[Endpoint](
     string.required[Endpoint]("Address", _.address).addHints(smithy.api.Documentation("<p>IP address of the endpoint.</p>")),
     long.required[Endpoint]("CachePeriodInMinutes", _.cachePeriodInMinutes).addHints(smithy.api.Default(smithy4s.Document.fromLong(0)), smithy.api.Documentation("<p>Endpoint cache time to live (TTL) value.</p>")),
   )(make).withId(id).addHints(hints)

--- a/modules/bootstrapped/src/generated/com/amazonaws/dynamodb/InternalServerError.scala
+++ b/modules/bootstrapped/src/generated/com/amazonaws/dynamodb/InternalServerError.scala
@@ -27,7 +27,7 @@ object InternalServerError extends ShapeTag.Companion[InternalServerError] {
   // constructor using the original order from the spec
   private def make(message: Option[ErrorMessage]): InternalServerError = InternalServerError(message)
 
-  implicit val schema: Schema[InternalServerError] = struct(
+  implicit val schema: Schema[InternalServerError] = struct[InternalServerError](
     ErrorMessage.schema.optional[InternalServerError]("message", _.message).addHints(smithy.api.Documentation("<p>The server encountered an internal error trying to fulfill the request.</p>")),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/com/amazonaws/dynamodb/InvalidEndpointException.scala
+++ b/modules/bootstrapped/src/generated/com/amazonaws/dynamodb/InvalidEndpointException.scala
@@ -23,7 +23,7 @@ object InvalidEndpointException extends ShapeTag.Companion[InvalidEndpointExcept
   // constructor using the original order from the spec
   private def make(message: Option[String]): InvalidEndpointException = InvalidEndpointException(message)
 
-  implicit val schema: Schema[InvalidEndpointException] = struct(
+  implicit val schema: Schema[InvalidEndpointException] = struct[InvalidEndpointException](
     string.optional[InvalidEndpointException]("Message", _.message),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/com/amazonaws/dynamodb/ListTablesInput.scala
+++ b/modules/bootstrapped/src/generated/com/amazonaws/dynamodb/ListTablesInput.scala
@@ -27,7 +27,7 @@ object ListTablesInput extends ShapeTag.Companion[ListTablesInput] {
   // constructor using the original order from the spec
   private def make(exclusiveStartTableName: Option[TableName], limit: Option[ListTablesInputLimit]): ListTablesInput = ListTablesInput(exclusiveStartTableName, limit)
 
-  implicit val schema: Schema[ListTablesInput] = struct(
+  implicit val schema: Schema[ListTablesInput] = struct[ListTablesInput](
     TableName.schema.optional[ListTablesInput]("ExclusiveStartTableName", _.exclusiveStartTableName).addHints(smithy.api.Documentation("<p>The first table name that this operation will evaluate. Use the value that was returned for\n        <code>LastEvaluatedTableName</code> in a previous operation, so that you can obtain the next page\n      of results.</p>")),
     ListTablesInputLimit.schema.optional[ListTablesInput]("Limit", _.limit).addHints(smithy.api.Documentation("<p>A maximum number of table names to return. If this parameter is not specified, the limit is 100.</p>")),
   )(make).withId(id).addHints(hints)

--- a/modules/bootstrapped/src/generated/com/amazonaws/dynamodb/ListTablesOutput.scala
+++ b/modules/bootstrapped/src/generated/com/amazonaws/dynamodb/ListTablesOutput.scala
@@ -32,7 +32,7 @@ object ListTablesOutput extends ShapeTag.Companion[ListTablesOutput] {
   // constructor using the original order from the spec
   private def make(tableNames: Option[List[TableName]], lastEvaluatedTableName: Option[TableName]): ListTablesOutput = ListTablesOutput(tableNames, lastEvaluatedTableName)
 
-  implicit val schema: Schema[ListTablesOutput] = struct(
+  implicit val schema: Schema[ListTablesOutput] = struct[ListTablesOutput](
     TableNameList.underlyingSchema.optional[ListTablesOutput]("TableNames", _.tableNames).addHints(smithy.api.Documentation("<p>The names of the tables associated with the current account at the current endpoint. The maximum size of this array is 100.</p>\n         <p>If <code>LastEvaluatedTableName</code> also appears in the output, you can use this value as the\n        <code>ExclusiveStartTableName</code> parameter in a subsequent <code>ListTables</code> request and\n      obtain the next page of results.</p>")),
     TableName.schema.optional[ListTablesOutput]("LastEvaluatedTableName", _.lastEvaluatedTableName).addHints(smithy.api.Documentation("<p>The name of the last table in the current page of results. Use this value as the\n        <code>ExclusiveStartTableName</code> in a new request to obtain the next page of results, until\n      all the table names are returned.</p>\n         <p>If you do not receive a <code>LastEvaluatedTableName</code> value in the response, this means that\n      there are no more table names to be retrieved.</p>")),
   )(make).withId(id).addHints(hints)

--- a/modules/bootstrapped/src/generated/smithy4s/benchmark/Attributes.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/benchmark/Attributes.scala
@@ -21,7 +21,7 @@ object Attributes extends ShapeTag.Companion[Attributes] {
   // constructor using the original order from the spec
   private def make(user: String, public: Boolean, size: Long, creationDate: Timestamp, region: String, queryable: Option[Boolean], queryableLastChange: Option[Timestamp], blockPublicAccess: Option[Boolean], permissions: Option[List[Permission]], tags: Option[List[String]], backedUp: Option[Boolean], metadata: Option[List[Metadata]], encryption: Option[Encryption]): Attributes = Attributes(user, public, size, creationDate, region, queryable, queryableLastChange, blockPublicAccess, permissions, tags, backedUp, metadata, encryption)
 
-  implicit val schema: Schema[Attributes] = struct(
+  implicit val schema: Schema[Attributes] = struct[Attributes](
     string.required[Attributes]("user", _.user),
     boolean.required[Attributes]("public", _.public),
     long.required[Attributes]("size", _.size),

--- a/modules/bootstrapped/src/generated/smithy4s/benchmark/CreateObjectInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/benchmark/CreateObjectInput.scala
@@ -17,7 +17,7 @@ object CreateObjectInput extends ShapeTag.Companion[CreateObjectInput] {
   // constructor using the original order from the spec
   private def make(key: String, bucketName: String, payload: S3Object): CreateObjectInput = CreateObjectInput(key, bucketName, payload)
 
-  implicit val schema: Schema[CreateObjectInput] = struct(
+  implicit val schema: Schema[CreateObjectInput] = struct[CreateObjectInput](
     string.required[CreateObjectInput]("key", _.key).addHints(smithy.api.HttpLabel()),
     string.required[CreateObjectInput]("bucketName", _.bucketName).addHints(smithy.api.HttpLabel()),
     S3Object.schema.required[CreateObjectInput]("payload", _.payload).addHints(smithy.api.HttpPayload()),

--- a/modules/bootstrapped/src/generated/smithy4s/benchmark/Creds.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/benchmark/Creds.scala
@@ -17,7 +17,7 @@ object Creds extends ShapeTag.Companion[Creds] {
   // constructor using the original order from the spec
   private def make(user: Option[String], key: Option[String]): Creds = Creds(user, key)
 
-  implicit val schema: Schema[Creds] = struct(
+  implicit val schema: Schema[Creds] = struct[Creds](
     string.optional[Creds]("user", _.user),
     string.optional[Creds]("key", _.key),
   )(make).withId(id).addHints(hints)

--- a/modules/bootstrapped/src/generated/smithy4s/benchmark/Encryption.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/benchmark/Encryption.scala
@@ -19,7 +19,7 @@ object Encryption extends ShapeTag.Companion[Encryption] {
   // constructor using the original order from the spec
   private def make(user: Option[String], date: Option[Timestamp], metadata: Option[EncryptionMetadata]): Encryption = Encryption(user, date, metadata)
 
-  implicit val schema: Schema[Encryption] = struct(
+  implicit val schema: Schema[Encryption] = struct[Encryption](
     string.optional[Encryption]("user", _.user),
     timestamp.optional[Encryption]("date", _.date).addHints(smithy.api.TimestampFormat.EPOCH_SECONDS.widen),
     EncryptionMetadata.schema.optional[Encryption]("metadata", _.metadata),

--- a/modules/bootstrapped/src/generated/smithy4s/benchmark/EncryptionMetadata.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/benchmark/EncryptionMetadata.scala
@@ -18,7 +18,7 @@ object EncryptionMetadata extends ShapeTag.Companion[EncryptionMetadata] {
   // constructor using the original order from the spec
   private def make(system: Option[String], credentials: Option[Creds], partial: Option[Boolean]): EncryptionMetadata = EncryptionMetadata(system, credentials, partial)
 
-  implicit val schema: Schema[EncryptionMetadata] = struct(
+  implicit val schema: Schema[EncryptionMetadata] = struct[EncryptionMetadata](
     string.optional[EncryptionMetadata]("system", _.system),
     Creds.schema.optional[EncryptionMetadata]("credentials", _.credentials),
     boolean.optional[EncryptionMetadata]("partial", _.partial),

--- a/modules/bootstrapped/src/generated/smithy4s/benchmark/Metadata.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/benchmark/Metadata.scala
@@ -20,7 +20,7 @@ object Metadata extends ShapeTag.Companion[Metadata] {
   // constructor using the original order from the spec
   private def make(contentType: Option[String], lastModified: Option[Timestamp], checkSum: Option[String], pendingDeletion: Option[Boolean], etag: Option[String]): Metadata = Metadata(contentType, lastModified, checkSum, pendingDeletion, etag)
 
-  implicit val schema: Schema[Metadata] = struct(
+  implicit val schema: Schema[Metadata] = struct[Metadata](
     string.optional[Metadata]("contentType", _.contentType),
     timestamp.optional[Metadata]("lastModified", _.lastModified).addHints(smithy.api.TimestampFormat.EPOCH_SECONDS.widen),
     string.optional[Metadata]("checkSum", _.checkSum),

--- a/modules/bootstrapped/src/generated/smithy4s/benchmark/Permission.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/benchmark/Permission.scala
@@ -17,7 +17,7 @@ object Permission extends ShapeTag.Companion[Permission] {
   // constructor using the original order from the spec
   private def make(read: Option[Boolean], write: Option[Boolean], directory: Option[Boolean]): Permission = Permission(read, write, directory)
 
-  implicit val schema: Schema[Permission] = struct(
+  implicit val schema: Schema[Permission] = struct[Permission](
     boolean.optional[Permission]("read", _.read),
     boolean.optional[Permission]("write", _.write),
     boolean.optional[Permission]("directory", _.directory),

--- a/modules/bootstrapped/src/generated/smithy4s/benchmark/S3Object.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/benchmark/S3Object.scala
@@ -19,7 +19,7 @@ object S3Object extends ShapeTag.Companion[S3Object] {
   // constructor using the original order from the spec
   private def make(id: String, owner: String, attributes: Attributes, data: Blob): S3Object = S3Object(id, owner, attributes, data)
 
-  implicit val schema: Schema[S3Object] = struct(
+  implicit val schema: Schema[S3Object] = struct[S3Object](
     string.required[S3Object]("id", _.id),
     string.required[S3Object]("owner", _.owner),
     Attributes.schema.required[S3Object]("attributes", _.attributes),

--- a/modules/bootstrapped/src/generated/smithy4s/benchmark/SendStringInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/benchmark/SendStringInput.scala
@@ -17,7 +17,7 @@ object SendStringInput extends ShapeTag.Companion[SendStringInput] {
   // constructor using the original order from the spec
   private def make(key: String, bucketName: String, body: String): SendStringInput = SendStringInput(key, bucketName, body)
 
-  implicit val schema: Schema[SendStringInput] = struct(
+  implicit val schema: Schema[SendStringInput] = struct[SendStringInput](
     string.required[SendStringInput]("key", _.key).addHints(smithy.api.HttpLabel()),
     string.required[SendStringInput]("bucketName", _.bucketName).addHints(smithy.api.HttpLabel()),
     string.required[SendStringInput]("body", _.body).addHints(smithy.api.HttpPayload()),

--- a/modules/bootstrapped/src/generated/smithy4s/example/AStructure.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/AStructure.scala
@@ -19,7 +19,7 @@ object AStructure extends ShapeTag.Companion[AStructure] {
   // constructor using the original order from the spec
   private def make(astring: AString): AStructure = AStructure(astring)
 
-  implicit val schema: Schema[AStructure] = struct(
+  implicit val schema: Schema[AStructure] = struct[AStructure](
     AString.schema.field[AStructure]("astring", _.astring).addHints(smithy.api.Default(smithy4s.Document.fromString("\"Hello World\" with \"quotes\""))),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/AddBrandsInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/AddBrandsInput.scala
@@ -17,7 +17,7 @@ object AddBrandsInput extends ShapeTag.Companion[AddBrandsInput] {
   // constructor using the original order from the spec
   private def make(brands: Option[List[String]]): AddBrandsInput = AddBrandsInput(brands)
 
-  implicit val schema: Schema[AddBrandsInput] = struct(
+  implicit val schema: Schema[AddBrandsInput] = struct[AddBrandsInput](
     BrandList.underlyingSchema.optional[AddBrandsInput]("brands", _.brands),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/AddMenuItemRequest.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/AddMenuItemRequest.scala
@@ -17,7 +17,7 @@ object AddMenuItemRequest extends ShapeTag.Companion[AddMenuItemRequest] {
   // constructor using the original order from the spec
   private def make(restaurant: String, menuItem: MenuItem): AddMenuItemRequest = AddMenuItemRequest(restaurant, menuItem)
 
-  implicit val schema: Schema[AddMenuItemRequest] = struct(
+  implicit val schema: Schema[AddMenuItemRequest] = struct[AddMenuItemRequest](
     string.required[AddMenuItemRequest]("restaurant", _.restaurant).addHints(smithy.api.HttpLabel()),
     MenuItem.schema.required[AddMenuItemRequest]("menuItem", _.menuItem).addHints(smithy.api.HttpPayload()),
   )(make).withId(id).addHints(hints)

--- a/modules/bootstrapped/src/generated/smithy4s/example/AddMenuItemResult.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/AddMenuItemResult.scala
@@ -19,7 +19,7 @@ object AddMenuItemResult extends ShapeTag.Companion[AddMenuItemResult] {
   // constructor using the original order from the spec
   private def make(itemId: String, added: Timestamp): AddMenuItemResult = AddMenuItemResult(itemId, added)
 
-  implicit val schema: Schema[AddMenuItemResult] = struct(
+  implicit val schema: Schema[AddMenuItemResult] = struct[AddMenuItemResult](
     string.required[AddMenuItemResult]("itemId", _.itemId).addHints(smithy.api.HttpPayload()),
     timestamp.required[AddMenuItemResult]("added", _.added).addHints(smithy.api.HttpHeader("X-ADDED-AT"), smithy.api.TimestampFormat.EPOCH_SECONDS.widen),
   )(make).withId(id).addHints(hints)

--- a/modules/bootstrapped/src/generated/smithy4s/example/AdtUnionWithSomeTransitiveMixins.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/AdtUnionWithSomeTransitiveMixins.scala
@@ -43,7 +43,7 @@ object AdtUnionWithSomeTransitiveMixins extends ShapeTag.Companion[AdtUnionWithS
     // constructor using the original order from the spec
     private def make(lng: Option[Long]): AdtMemberWithTransitiveMixin1 = AdtMemberWithTransitiveMixin1(lng)
 
-    val schema: Schema[AdtMemberWithTransitiveMixin1] = struct(
+    val schema: Schema[AdtMemberWithTransitiveMixin1] = struct[AdtMemberWithTransitiveMixin1](
       long.optional[AdtMemberWithTransitiveMixin1]("lng", _.lng),
     )(make).withId(id).addHints(hints)
 
@@ -61,7 +61,7 @@ object AdtUnionWithSomeTransitiveMixins extends ShapeTag.Companion[AdtUnionWithS
     // constructor using the original order from the spec
     private def make(lng: Option[Long]): AdtMemberWithDirectMixin = AdtMemberWithDirectMixin(lng)
 
-    val schema: Schema[AdtMemberWithDirectMixin] = struct(
+    val schema: Schema[AdtMemberWithDirectMixin] = struct[AdtMemberWithDirectMixin](
       long.optional[AdtMemberWithDirectMixin]("lng", _.lng),
     )(make).withId(id).addHints(hints)
 
@@ -82,7 +82,7 @@ object AdtUnionWithSomeTransitiveMixins extends ShapeTag.Companion[AdtUnionWithS
     }
   }
 
-  implicit val schema: Schema[AdtUnionWithSomeTransitiveMixins] = union(
+  implicit val schema: Schema[AdtUnionWithSomeTransitiveMixins] = union[AdtUnionWithSomeTransitiveMixins](
     AdtUnionWithSomeTransitiveMixins.AdtMemberWithTransitiveMixin1.alt,
     AdtUnionWithSomeTransitiveMixins.AdtMemberWithDirectMixin.alt,
   ){

--- a/modules/bootstrapped/src/generated/smithy4s/example/AdtUnionWithTransitiveAndDirectMixins.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/AdtUnionWithTransitiveAndDirectMixins.scala
@@ -43,7 +43,7 @@ object AdtUnionWithTransitiveAndDirectMixins extends ShapeTag.Companion[AdtUnion
     // constructor using the original order from the spec
     private def make(lng: Option[Long]): AdtMemberWithTransitiveMixin2 = AdtMemberWithTransitiveMixin2(lng)
 
-    val schema: Schema[AdtMemberWithTransitiveMixin2] = struct(
+    val schema: Schema[AdtMemberWithTransitiveMixin2] = struct[AdtMemberWithTransitiveMixin2](
       long.optional[AdtMemberWithTransitiveMixin2]("lng", _.lng),
     )(make).withId(id).addHints(hints)
 
@@ -61,7 +61,7 @@ object AdtUnionWithTransitiveAndDirectMixins extends ShapeTag.Companion[AdtUnion
     // constructor using the original order from the spec
     private def make(lng: Option[Long]): AdtMemberWithTransitiveMixin3 = AdtMemberWithTransitiveMixin3(lng)
 
-    val schema: Schema[AdtMemberWithTransitiveMixin3] = struct(
+    val schema: Schema[AdtMemberWithTransitiveMixin3] = struct[AdtMemberWithTransitiveMixin3](
       long.optional[AdtMemberWithTransitiveMixin3]("lng", _.lng),
     )(make).withId(id).addHints(hints)
 
@@ -82,7 +82,7 @@ object AdtUnionWithTransitiveAndDirectMixins extends ShapeTag.Companion[AdtUnion
     }
   }
 
-  implicit val schema: Schema[AdtUnionWithTransitiveAndDirectMixins] = union(
+  implicit val schema: Schema[AdtUnionWithTransitiveAndDirectMixins] = union[AdtUnionWithTransitiveAndDirectMixins](
     AdtUnionWithTransitiveAndDirectMixins.AdtMemberWithTransitiveMixin2.alt,
     AdtUnionWithTransitiveAndDirectMixins.AdtMemberWithTransitiveMixin3.alt,
   ){

--- a/modules/bootstrapped/src/generated/smithy4s/example/BigStruct.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/BigStruct.scala
@@ -18,7 +18,7 @@ object BigStruct extends ShapeTag.Companion[BigStruct] {
   // constructor using the original order from the spec
   private def make(a1: Int, a2: Int, a3: Int, a4: Int, a5: Int, a6: Int, a7: Int, a8: Int, a9: Int, a10: Int, a11: Int, a12: Int, a13: Int, a14: Int, a15: Int, a16: Int, a17: Int, a18: Int, a19: Int, a20: Int, a21: Int, a22: Int, a23: Option[String], a24: Int): BigStruct = BigStruct(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a24, a23)
 
-  implicit val schema: Schema[BigStruct] = struct.genericArity(
+  implicit val schema: Schema[BigStruct] = struct[BigStruct].genericArity(
     int.required[BigStruct]("a1", _.a1),
     int.required[BigStruct]("a2", _.a2),
     int.required[BigStruct]("a3", _.a3),

--- a/modules/bootstrapped/src/generated/smithy4s/example/Candy.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/Candy.scala
@@ -17,7 +17,7 @@ object Candy extends ShapeTag.Companion[Candy] {
   // constructor using the original order from the spec
   private def make(name: Option[String]): Candy = Candy(name)
 
-  implicit val schema: Schema[Candy] = struct(
+  implicit val schema: Schema[Candy] = struct[Candy](
     string.optional[Candy]("name", _.name),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/CheckQueryInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/CheckQueryInput.scala
@@ -16,7 +16,7 @@ object CheckQueryInput extends ShapeTag.Companion[CheckQueryInput] {
   // constructor using the original order from the spec
   private def make(inp: Map[String, List[String]]): CheckQueryInput = CheckQueryInput(inp)
 
-  implicit val schema: Schema[CheckQueryInput] = struct(
+  implicit val schema: Schema[CheckQueryInput] = struct[CheckQueryInput](
     QParams.underlyingSchema.field[CheckQueryInput]("inp", _.inp).addHints(smithy.api.Default(smithy4s.Document.obj()), smithy.api.HttpQueryParams()),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/CheckQueryOutput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/CheckQueryOutput.scala
@@ -16,7 +16,7 @@ object CheckQueryOutput extends ShapeTag.Companion[CheckQueryOutput] {
   // constructor using the original order from the spec
   private def make(variants: List[String], staticVariants: List[String], kinds: List[String], staticKinds: List[String]): CheckQueryOutput = CheckQueryOutput(variants, staticVariants, kinds, staticKinds)
 
-  implicit val schema: Schema[CheckQueryOutput] = struct(
+  implicit val schema: Schema[CheckQueryOutput] = struct[CheckQueryOutput](
     QueryVariants.underlyingSchema.field[CheckQueryOutput]("variants", _.variants).addHints(smithy.api.Default(smithy4s.Document.array())),
     QueryVariants.underlyingSchema.field[CheckQueryOutput]("staticVariants", _.staticVariants).addHints(smithy.api.Default(smithy4s.Document.array())),
     QueryKinds.underlyingSchema.field[CheckQueryOutput]("kinds", _.kinds).addHints(smithy.api.Default(smithy4s.Document.array())),

--- a/modules/bootstrapped/src/generated/smithy4s/example/CheckedOrUnchecked.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/CheckedOrUnchecked.scala
@@ -58,7 +58,7 @@ object CheckedOrUnchecked extends ShapeTag.Companion[CheckedOrUnchecked] {
     }
   }
 
-  implicit val schema: Schema[CheckedOrUnchecked] = union(
+  implicit val schema: Schema[CheckedOrUnchecked] = union[CheckedOrUnchecked](
     CheckedOrUnchecked.CheckedCase.alt,
     CheckedOrUnchecked.RawCase.alt,
   ){

--- a/modules/bootstrapped/src/generated/smithy4s/example/CheckedOrUnchecked2.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/CheckedOrUnchecked2.scala
@@ -60,7 +60,7 @@ object CheckedOrUnchecked2 extends ShapeTag.Companion[CheckedOrUnchecked2] {
     }
   }
 
-  implicit val schema: Schema[CheckedOrUnchecked2] = union(
+  implicit val schema: Schema[CheckedOrUnchecked2] = union[CheckedOrUnchecked2](
     CheckedOrUnchecked2.CheckedCase.alt,
     CheckedOrUnchecked2.RawCase.alt,
   ){

--- a/modules/bootstrapped/src/generated/smithy4s/example/CityCoordinates.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/CityCoordinates.scala
@@ -17,7 +17,7 @@ object CityCoordinates extends ShapeTag.Companion[CityCoordinates] {
   // constructor using the original order from the spec
   private def make(latitude: Float, longitude: Float): CityCoordinates = CityCoordinates(latitude, longitude)
 
-  implicit val schema: Schema[CityCoordinates] = struct(
+  implicit val schema: Schema[CityCoordinates] = struct[CityCoordinates](
     float.required[CityCoordinates]("latitude", _.latitude),
     float.required[CityCoordinates]("longitude", _.longitude),
   )(make).withId(id).addHints(hints)

--- a/modules/bootstrapped/src/generated/smithy4s/example/CitySummary.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/CitySummary.scala
@@ -19,7 +19,7 @@ object CitySummary extends ShapeTag.Companion[CitySummary] {
   // constructor using the original order from the spec
   private def make(cityId: CityId, name: String): CitySummary = CitySummary(cityId, name)
 
-  implicit val schema: Schema[CitySummary] = struct(
+  implicit val schema: Schema[CitySummary] = struct[CitySummary](
     CityId.schema.required[CitySummary]("cityId", _.cityId),
     string.required[CitySummary]("name", _.name),
   )(make).withId(id).addHints(hints)

--- a/modules/bootstrapped/src/generated/smithy4s/example/ClientError.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/ClientError.scala
@@ -21,7 +21,7 @@ object ClientError extends ShapeTag.Companion[ClientError] {
   // constructor using the original order from the spec
   private def make(code: Int, details: String): ClientError = ClientError(code, details)
 
-  implicit val schema: Schema[ClientError] = struct(
+  implicit val schema: Schema[ClientError] = struct[ClientError](
     int.required[ClientError]("code", _.code),
     string.required[ClientError]("details", _.details),
   )(make).withId(id).addHints(hints)

--- a/modules/bootstrapped/src/generated/smithy4s/example/CustomCodeInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/CustomCodeInput.scala
@@ -17,7 +17,7 @@ object CustomCodeInput extends ShapeTag.Companion[CustomCodeInput] {
   // constructor using the original order from the spec
   private def make(code: Int): CustomCodeInput = CustomCodeInput(code)
 
-  implicit val schema: Schema[CustomCodeInput] = struct(
+  implicit val schema: Schema[CustomCodeInput] = struct[CustomCodeInput](
     int.required[CustomCodeInput]("code", _.code).addHints(smithy.api.HttpLabel()),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/CustomCodeOutput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/CustomCodeOutput.scala
@@ -17,7 +17,7 @@ object CustomCodeOutput extends ShapeTag.Companion[CustomCodeOutput] {
   // constructor using the original order from the spec
   private def make(code: Option[Int]): CustomCodeOutput = CustomCodeOutput(code)
 
-  implicit val schema: Schema[CustomCodeOutput] = struct(
+  implicit val schema: Schema[CustomCodeOutput] = struct[CustomCodeOutput](
     int.optional[CustomCodeOutput]("code", _.code).addHints(smithy.api.HttpResponseCode()),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/DefaultInMixinUsageTest.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/DefaultInMixinUsageTest.scala
@@ -17,7 +17,7 @@ object DefaultInMixinUsageTest extends ShapeTag.Companion[DefaultInMixinUsageTes
   // constructor using the original order from the spec
   private def make(one: String): DefaultInMixinUsageTest = DefaultInMixinUsageTest(one)
 
-  implicit val schema: Schema[DefaultInMixinUsageTest] = struct(
+  implicit val schema: Schema[DefaultInMixinUsageTest] = struct[DefaultInMixinUsageTest](
     string.field[DefaultInMixinUsageTest]("one", _.one).addHints(smithy.api.Default(smithy4s.Document.fromString("test"))),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/DefaultNotCapitalized.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/DefaultNotCapitalized.scala
@@ -16,7 +16,7 @@ object DefaultNotCapitalized extends ShapeTag.Companion[DefaultNotCapitalized] {
   // constructor using the original order from the spec
   private def make(name: Username): DefaultNotCapitalized = DefaultNotCapitalized(name)
 
-  implicit val schema: Schema[DefaultNotCapitalized] = struct(
+  implicit val schema: Schema[DefaultNotCapitalized] = struct[DefaultNotCapitalized](
     Username.schema.required[DefaultNotCapitalized]("name", _.name).addHints(smithy.api.Default(smithy4s.Document.fromString("hello"))),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/DefaultNullsOperationInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/DefaultNullsOperationInput.scala
@@ -19,7 +19,7 @@ object DefaultNullsOperationInput extends ShapeTag.Companion[DefaultNullsOperati
   // constructor using the original order from the spec
   private def make(optional: Option[String], optionalWithDefault: String, requiredLabel: String, requiredWithDefault: String, optionalHeader: Option[String], optionalHeaderWithDefault: String, requiredHeaderWithDefault: String, optionalQuery: Option[String], optionalQueryWithDefault: String, requiredQueryWithDefault: String): DefaultNullsOperationInput = DefaultNullsOperationInput(optionalWithDefault, requiredLabel, requiredWithDefault, optionalHeaderWithDefault, requiredHeaderWithDefault, optionalQueryWithDefault, requiredQueryWithDefault, optional, optionalHeader, optionalQuery)
 
-  implicit val schema: Schema[DefaultNullsOperationInput] = struct(
+  implicit val schema: Schema[DefaultNullsOperationInput] = struct[DefaultNullsOperationInput](
     string.optional[DefaultNullsOperationInput]("optional", _.optional),
     string.field[DefaultNullsOperationInput]("optionalWithDefault", _.optionalWithDefault).addHints(smithy.api.Default(smithy4s.Document.fromString("optional-default"))),
     string.required[DefaultNullsOperationInput]("requiredLabel", _.requiredLabel).addHints(smithy.api.Default(smithy4s.Document.fromString("required-label-with-default")), smithy.api.HttpLabel()),

--- a/modules/bootstrapped/src/generated/smithy4s/example/DefaultNullsOperationOutput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/DefaultNullsOperationOutput.scala
@@ -19,7 +19,7 @@ object DefaultNullsOperationOutput extends ShapeTag.Companion[DefaultNullsOperat
   // constructor using the original order from the spec
   private def make(optional: Option[String], optionalWithDefault: String, requiredWithDefault: String, optionalHeader: Option[String], optionalHeaderWithDefault: String, requiredHeaderWithDefault: String): DefaultNullsOperationOutput = DefaultNullsOperationOutput(optionalWithDefault, requiredWithDefault, optionalHeaderWithDefault, requiredHeaderWithDefault, optional, optionalHeader)
 
-  implicit val schema: Schema[DefaultNullsOperationOutput] = struct(
+  implicit val schema: Schema[DefaultNullsOperationOutput] = struct[DefaultNullsOperationOutput](
     string.optional[DefaultNullsOperationOutput]("optional", _.optional),
     string.field[DefaultNullsOperationOutput]("optionalWithDefault", _.optionalWithDefault).addHints(smithy.api.Default(smithy4s.Document.fromString("optional-default"))),
     string.required[DefaultNullsOperationOutput]("requiredWithDefault", _.requiredWithDefault).addHints(smithy.api.Default(smithy4s.Document.fromString("required-default"))),

--- a/modules/bootstrapped/src/generated/smithy4s/example/DefaultOrderingTest.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/DefaultOrderingTest.scala
@@ -18,7 +18,7 @@ object DefaultOrderingTest extends ShapeTag.Companion[DefaultOrderingTest] {
   // constructor using the original order from the spec
   private def make(one: Int, two: Option[String], three: String): DefaultOrderingTest = DefaultOrderingTest(three, one, two)
 
-  implicit val schema: Schema[DefaultOrderingTest] = struct(
+  implicit val schema: Schema[DefaultOrderingTest] = struct[DefaultOrderingTest](
     int.field[DefaultOrderingTest]("one", _.one).addHints(smithy.api.Default(smithy4s.Document.fromLong(1))),
     string.optional[DefaultOrderingTest]("two", _.two),
     string.required[DefaultOrderingTest]("three", _.three),

--- a/modules/bootstrapped/src/generated/smithy4s/example/DefaultTest.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/DefaultTest.scala
@@ -30,7 +30,7 @@ object DefaultTest extends ShapeTag.Companion[DefaultTest] {
   // constructor using the original order from the spec
   private def make(one: Int, two: String, three: List[String], four: List[String], five: String, six: Int, seven: Document, eight: Map[String, String], nine: Short, ten: Double, eleven: Float, twelve: Long, thirteen: Timestamp, fourteen: Timestamp, fifteen: Timestamp, sixteen: Byte, seventeen: Blob, eighteen: Boolean): DefaultTest = DefaultTest(one, two, three, four, five, six, seven, eight, nine, ten, eleven, twelve, thirteen, fourteen, fifteen, sixteen, seventeen, eighteen)
 
-  implicit val schema: Schema[DefaultTest] = struct(
+  implicit val schema: Schema[DefaultTest] = struct[DefaultTest](
     int.field[DefaultTest]("one", _.one).addHints(smithy.api.Default(smithy4s.Document.fromLong(1))),
     string.field[DefaultTest]("two", _.two).addHints(smithy.api.Default(smithy4s.Document.fromString("test"))),
     StringList.underlyingSchema.field[DefaultTest]("three", _.three).addHints(smithy.api.Default(smithy4s.Document.array())),

--- a/modules/bootstrapped/src/generated/smithy4s/example/DefaultVariants.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/DefaultVariants.scala
@@ -17,7 +17,7 @@ object DefaultVariants extends ShapeTag.Companion[DefaultVariants] {
   // constructor using the original order from the spec
   private def make(req: String, reqDef: String, opt: Option[String], optDef: String): DefaultVariants = DefaultVariants(req, reqDef, optDef, opt)
 
-  implicit val schema: Schema[DefaultVariants] = struct(
+  implicit val schema: Schema[DefaultVariants] = struct[DefaultVariants](
     string.required[DefaultVariants]("req", _.req),
     string.required[DefaultVariants]("reqDef", _.reqDef).addHints(smithy.api.Default(smithy4s.Document.fromString("default"))),
     string.optional[DefaultVariants]("opt", _.opt),

--- a/modules/bootstrapped/src/generated/smithy4s/example/DeprecatedStructure.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/DeprecatedStructure.scala
@@ -20,7 +20,7 @@ object DeprecatedStructure extends ShapeTag.Companion[DeprecatedStructure] {
   // constructor using the original order from the spec
   private def make(strings: Option[List[String]], other: Option[List[String]], name: Option[String], nameV2: Option[String]): DeprecatedStructure = DeprecatedStructure(strings, other, name, nameV2)
 
-  implicit val schema: Schema[DeprecatedStructure] = struct(
+  implicit val schema: Schema[DeprecatedStructure] = struct[DeprecatedStructure](
     Strings.underlyingSchema.optional[DeprecatedStructure]("strings", _.strings).addHints(smithy.api.Deprecated(message = None, since = None)),
     Strings.underlyingSchema.optional[DeprecatedStructure]("other", _.other),
     string.optional[DeprecatedStructure]("name", _.name).addHints(smithy.api.Deprecated(message = None, since = None)),

--- a/modules/bootstrapped/src/generated/smithy4s/example/DeprecatedUnion.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/DeprecatedUnion.scala
@@ -111,7 +111,7 @@ object DeprecatedUnion extends ShapeTag.Companion[DeprecatedUnion] {
     }
   }
 
-  implicit val schema: Schema[DeprecatedUnion] = union(
+  implicit val schema: Schema[DeprecatedUnion] = union[DeprecatedUnion](
     DeprecatedUnion.SCase.alt,
     DeprecatedUnion.S_V2Case.alt,
     DeprecatedUnion.DeprecatedUnionProductCase.alt,

--- a/modules/bootstrapped/src/generated/smithy4s/example/DocumentationComment.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/DocumentationComment.scala
@@ -24,7 +24,7 @@ object DocumentationComment extends ShapeTag.Companion[DocumentationComment] {
   // constructor using the original order from the spec
   private def make(member: Option[String]): DocumentationComment = DocumentationComment(member)
 
-  implicit val schema: Schema[DocumentationComment] = struct(
+  implicit val schema: Schema[DocumentationComment] = struct[DocumentationComment](
     string.optional[DocumentationComment]("member", _.member).addHints(smithy.api.Documentation("/*")),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/EHFallbackClientError.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/EHFallbackClientError.scala
@@ -22,7 +22,7 @@ object EHFallbackClientError extends ShapeTag.Companion[EHFallbackClientError] {
   // constructor using the original order from the spec
   private def make(message: Option[String]): EHFallbackClientError = EHFallbackClientError(message)
 
-  implicit val schema: Schema[EHFallbackClientError] = struct(
+  implicit val schema: Schema[EHFallbackClientError] = struct[EHFallbackClientError](
     string.optional[EHFallbackClientError]("message", _.message),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/EHFallbackServerError.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/EHFallbackServerError.scala
@@ -22,7 +22,7 @@ object EHFallbackServerError extends ShapeTag.Companion[EHFallbackServerError] {
   // constructor using the original order from the spec
   private def make(message: Option[String]): EHFallbackServerError = EHFallbackServerError(message)
 
-  implicit val schema: Schema[EHFallbackServerError] = struct(
+  implicit val schema: Schema[EHFallbackServerError] = struct[EHFallbackServerError](
     string.optional[EHFallbackServerError]("message", _.message),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/EHNotFound.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/EHNotFound.scala
@@ -23,7 +23,7 @@ object EHNotFound extends ShapeTag.Companion[EHNotFound] {
   // constructor using the original order from the spec
   private def make(message: Option[String]): EHNotFound = EHNotFound(message)
 
-  implicit val schema: Schema[EHNotFound] = struct(
+  implicit val schema: Schema[EHNotFound] = struct[EHNotFound](
     string.optional[EHNotFound]("message", _.message),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/EHServiceUnavailable.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/EHServiceUnavailable.scala
@@ -23,7 +23,7 @@ object EHServiceUnavailable extends ShapeTag.Companion[EHServiceUnavailable] {
   // constructor using the original order from the spec
   private def make(message: Option[String]): EHServiceUnavailable = EHServiceUnavailable(message)
 
-  implicit val schema: Schema[EHServiceUnavailable] = struct(
+  implicit val schema: Schema[EHServiceUnavailable] = struct[EHServiceUnavailable](
     string.optional[EHServiceUnavailable]("message", _.message),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/EchoBody.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/EchoBody.scala
@@ -17,7 +17,7 @@ object EchoBody extends ShapeTag.Companion[EchoBody] {
   // constructor using the original order from the spec
   private def make(data: Option[String]): EchoBody = EchoBody(data)
 
-  implicit val schema: Schema[EchoBody] = struct(
+  implicit val schema: Schema[EchoBody] = struct[EchoBody](
     string.validated(smithy.api.Length(min = Some(10L), max = None)).optional[EchoBody]("data", _.data),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/EchoInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/EchoInput.scala
@@ -17,7 +17,7 @@ object EchoInput extends ShapeTag.Companion[EchoInput] {
   // constructor using the original order from the spec
   private def make(pathParam: String, queryParam: Option[String], body: EchoBody): EchoInput = EchoInput(pathParam, body, queryParam)
 
-  implicit val schema: Schema[EchoInput] = struct(
+  implicit val schema: Schema[EchoInput] = struct[EchoInput](
     string.validated(smithy.api.Length(min = Some(10L), max = None)).required[EchoInput]("pathParam", _.pathParam).addHints(smithy.api.HttpLabel()),
     string.validated(smithy.api.Length(min = Some(10L), max = None)).optional[EchoInput]("queryParam", _.queryParam).addHints(smithy.api.HttpQuery("queryParam")),
     EchoBody.schema.required[EchoInput]("body", _.body).addHints(smithy.api.HttpPayload()),

--- a/modules/bootstrapped/src/generated/smithy4s/example/EnvVarString.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/EnvVarString.scala
@@ -24,7 +24,7 @@ object EnvVarString extends ShapeTag.Companion[EnvVarString] {
   // constructor using the original order from the spec
   private def make(member: Option[String]): EnvVarString = EnvVarString(member)
 
-  implicit val schema: Schema[EnvVarString] = struct(
+  implicit val schema: Schema[EnvVarString] = struct[EnvVarString](
     string.optional[EnvVarString]("member", _.member).addHints(smithy.api.Documentation(s"This is meant to be used with $$ENV_VAR")),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/ErrorCustomTypeMessage.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/ErrorCustomTypeMessage.scala
@@ -21,7 +21,7 @@ object ErrorCustomTypeMessage extends ShapeTag.Companion[ErrorCustomTypeMessage]
   // constructor using the original order from the spec
   private def make(message: Option[CustomErrorMessageType]): ErrorCustomTypeMessage = ErrorCustomTypeMessage(message)
 
-  implicit val schema: Schema[ErrorCustomTypeMessage] = struct(
+  implicit val schema: Schema[ErrorCustomTypeMessage] = struct[ErrorCustomTypeMessage](
     CustomErrorMessageType.schema.optional[ErrorCustomTypeMessage]("message", _.message),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/ErrorCustomTypeRequiredMessage.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/ErrorCustomTypeRequiredMessage.scala
@@ -21,7 +21,7 @@ object ErrorCustomTypeRequiredMessage extends ShapeTag.Companion[ErrorCustomType
   // constructor using the original order from the spec
   private def make(message: CustomErrorMessageType): ErrorCustomTypeRequiredMessage = ErrorCustomTypeRequiredMessage(message)
 
-  implicit val schema: Schema[ErrorCustomTypeRequiredMessage] = struct(
+  implicit val schema: Schema[ErrorCustomTypeRequiredMessage] = struct[ErrorCustomTypeRequiredMessage](
     CustomErrorMessageType.schema.required[ErrorCustomTypeRequiredMessage]("message", _.message),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/ErrorHandlingOperationInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/ErrorHandlingOperationInput.scala
@@ -19,7 +19,7 @@ object ErrorHandlingOperationInput extends ShapeTag.Companion[ErrorHandlingOpera
   // constructor using the original order from the spec
   private def make(in: Option[String]): ErrorHandlingOperationInput = ErrorHandlingOperationInput(in)
 
-  implicit val schema: Schema[ErrorHandlingOperationInput] = struct(
+  implicit val schema: Schema[ErrorHandlingOperationInput] = struct[ErrorHandlingOperationInput](
     string.optional[ErrorHandlingOperationInput]("in", _.in),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/ErrorHandlingOperationOutput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/ErrorHandlingOperationOutput.scala
@@ -19,7 +19,7 @@ object ErrorHandlingOperationOutput extends ShapeTag.Companion[ErrorHandlingOper
   // constructor using the original order from the spec
   private def make(out: Option[String]): ErrorHandlingOperationOutput = ErrorHandlingOperationOutput(out)
 
-  implicit val schema: Schema[ErrorHandlingOperationOutput] = struct(
+  implicit val schema: Schema[ErrorHandlingOperationOutput] = struct[ErrorHandlingOperationOutput](
     string.optional[ErrorHandlingOperationOutput]("out", _.out),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/ErrorHandlingService.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/ErrorHandlingService.scala
@@ -156,7 +156,7 @@ object ErrorHandlingServiceOperation {
       }
     }
 
-    implicit val schema: Schema[ErrorHandlingOperationError] = union(
+    implicit val schema: Schema[ErrorHandlingOperationError] = union[ErrorHandlingOperationError](
       ErrorHandlingOperationError.EHFallbackClientErrorCase.alt,
       ErrorHandlingOperationError.EHServiceUnavailableCase.alt,
       ErrorHandlingOperationError.EHFallbackServerErrorCase.alt,

--- a/modules/bootstrapped/src/generated/smithy4s/example/ErrorHandlingServiceExtraErrors.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/ErrorHandlingServiceExtraErrors.scala
@@ -157,7 +157,7 @@ object ErrorHandlingServiceExtraErrorsOperation {
       }
     }
 
-    implicit val schema: Schema[ExtraErrorOperationError] = union(
+    implicit val schema: Schema[ExtraErrorOperationError] = union[ExtraErrorOperationError](
       ExtraErrorOperationError.RandomOtherClientErrorCase.alt,
       ExtraErrorOperationError.RandomOtherClientErrorWithCodeCase.alt,
       ExtraErrorOperationError.RandomOtherServerErrorCase.alt,

--- a/modules/bootstrapped/src/generated/smithy4s/example/ErrorNullableCustomTypeMessage.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/ErrorNullableCustomTypeMessage.scala
@@ -22,7 +22,7 @@ object ErrorNullableCustomTypeMessage extends ShapeTag.Companion[ErrorNullableCu
   // constructor using the original order from the spec
   private def make(message: Option[Nullable[CustomErrorMessageType]]): ErrorNullableCustomTypeMessage = ErrorNullableCustomTypeMessage(message)
 
-  implicit val schema: Schema[ErrorNullableCustomTypeMessage] = struct(
+  implicit val schema: Schema[ErrorNullableCustomTypeMessage] = struct[ErrorNullableCustomTypeMessage](
     CustomErrorMessageType.schema.nullable.optional[ErrorNullableCustomTypeMessage]("message", _.message),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/ErrorNullableCustomTypeRequiredMessage.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/ErrorNullableCustomTypeRequiredMessage.scala
@@ -22,7 +22,7 @@ object ErrorNullableCustomTypeRequiredMessage extends ShapeTag.Companion[ErrorNu
   // constructor using the original order from the spec
   private def make(message: Nullable[CustomErrorMessageType]): ErrorNullableCustomTypeRequiredMessage = ErrorNullableCustomTypeRequiredMessage(message)
 
-  implicit val schema: Schema[ErrorNullableCustomTypeRequiredMessage] = struct(
+  implicit val schema: Schema[ErrorNullableCustomTypeRequiredMessage] = struct[ErrorNullableCustomTypeRequiredMessage](
     CustomErrorMessageType.schema.nullable.required[ErrorNullableCustomTypeRequiredMessage]("message", _.message),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/ErrorNullableMessage.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/ErrorNullableMessage.scala
@@ -23,7 +23,7 @@ object ErrorNullableMessage extends ShapeTag.Companion[ErrorNullableMessage] {
   // constructor using the original order from the spec
   private def make(message: Option[Nullable[String]]): ErrorNullableMessage = ErrorNullableMessage(message)
 
-  implicit val schema: Schema[ErrorNullableMessage] = struct(
+  implicit val schema: Schema[ErrorNullableMessage] = struct[ErrorNullableMessage](
     string.nullable.optional[ErrorNullableMessage]("message", _.message),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/ErrorNullableRequiredMessage.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/ErrorNullableRequiredMessage.scala
@@ -23,7 +23,7 @@ object ErrorNullableRequiredMessage extends ShapeTag.Companion[ErrorNullableRequ
   // constructor using the original order from the spec
   private def make(message: Nullable[String]): ErrorNullableRequiredMessage = ErrorNullableRequiredMessage(message)
 
-  implicit val schema: Schema[ErrorNullableRequiredMessage] = struct(
+  implicit val schema: Schema[ErrorNullableRequiredMessage] = struct[ErrorNullableRequiredMessage](
     string.nullable.required[ErrorNullableRequiredMessage]("message", _.message),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/ErrorRequiredMessage.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/ErrorRequiredMessage.scala
@@ -22,7 +22,7 @@ object ErrorRequiredMessage extends ShapeTag.Companion[ErrorRequiredMessage] {
   // constructor using the original order from the spec
   private def make(message: String): ErrorRequiredMessage = ErrorRequiredMessage(message)
 
-  implicit val schema: Schema[ErrorRequiredMessage] = struct(
+  implicit val schema: Schema[ErrorRequiredMessage] = struct[ErrorRequiredMessage](
     string.required[ErrorRequiredMessage]("message", _.message),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/ExtraErrorOperationInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/ExtraErrorOperationInput.scala
@@ -19,7 +19,7 @@ object ExtraErrorOperationInput extends ShapeTag.Companion[ExtraErrorOperationIn
   // constructor using the original order from the spec
   private def make(in: Option[String]): ExtraErrorOperationInput = ExtraErrorOperationInput(in)
 
-  implicit val schema: Schema[ExtraErrorOperationInput] = struct(
+  implicit val schema: Schema[ExtraErrorOperationInput] = struct[ExtraErrorOperationInput](
     string.optional[ExtraErrorOperationInput]("in", _.in),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/FallbackError.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/FallbackError.scala
@@ -20,7 +20,7 @@ object FallbackError extends ShapeTag.Companion[FallbackError] {
   // constructor using the original order from the spec
   private def make(error: String): FallbackError = FallbackError(error)
 
-  implicit val schema: Schema[FallbackError] = struct(
+  implicit val schema: Schema[FallbackError] = struct[FallbackError](
     string.required[FallbackError]("error", _.error),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/FallbackError2.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/FallbackError2.scala
@@ -20,7 +20,7 @@ object FallbackError2 extends ShapeTag.Companion[FallbackError2] {
   // constructor using the original order from the spec
   private def make(error: String): FallbackError2 = FallbackError2(error)
 
-  implicit val schema: Schema[FallbackError2] = struct(
+  implicit val schema: Schema[FallbackError2] = struct[FallbackError2](
     string.required[FallbackError2]("error", _.error),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/Foo.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/Foo.scala
@@ -96,7 +96,7 @@ object Foo extends ShapeTag.Companion[Foo] {
     }
   }
 
-  implicit val schema: Schema[Foo] = union(
+  implicit val schema: Schema[Foo] = union[Foo](
     Foo.IntCase.alt,
     Foo.StrCase.alt,
     Foo.BIntCase.alt,

--- a/modules/bootstrapped/src/generated/smithy4s/example/Food.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/Food.scala
@@ -57,7 +57,7 @@ object Food extends ShapeTag.Companion[Food] {
     }
   }
 
-  implicit val schema: Schema[Food] = union(
+  implicit val schema: Schema[Food] = union[Food](
     Food.PizzaCase.alt,
     Food.SaladCase.alt,
   ){

--- a/modules/bootstrapped/src/generated/smithy4s/example/ForecastResult.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/ForecastResult.scala
@@ -63,7 +63,7 @@ object ForecastResult extends ShapeTag.Companion[ForecastResult] {
     }
   }
 
-  implicit val schema: Schema[ForecastResult] = union(
+  implicit val schema: Schema[ForecastResult] = union[ForecastResult](
     ForecastResult.RainCase.alt,
     ForecastResult.SunCase.alt,
   ){

--- a/modules/bootstrapped/src/generated/smithy4s/example/Four.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/Four.scala
@@ -17,7 +17,7 @@ object Four extends ShapeTag.Companion[Four] {
   // constructor using the original order from the spec
   private def make(four: Int): Four = Four(four)
 
-  implicit val schema: Schema[Four] = struct(
+  implicit val schema: Schema[Four] = struct[Four](
     int.required[Four]("four", _.four),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/GenericClientError.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/GenericClientError.scala
@@ -23,7 +23,7 @@ object GenericClientError extends ShapeTag.Companion[GenericClientError] {
   // constructor using the original order from the spec
   private def make(message: String): GenericClientError = GenericClientError(message)
 
-  implicit val schema: Schema[GenericClientError] = struct(
+  implicit val schema: Schema[GenericClientError] = struct[GenericClientError](
     string.required[GenericClientError]("message", _.message),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/GenericServerError.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/GenericServerError.scala
@@ -23,7 +23,7 @@ object GenericServerError extends ShapeTag.Companion[GenericServerError] {
   // constructor using the original order from the spec
   private def make(message: String): GenericServerError = GenericServerError(message)
 
-  implicit val schema: Schema[GenericServerError] = struct(
+  implicit val schema: Schema[GenericServerError] = struct[GenericServerError](
     string.required[GenericServerError]("message", _.message),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/GetCityInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/GetCityInput.scala
@@ -21,7 +21,7 @@ object GetCityInput extends ShapeTag.Companion[GetCityInput] {
   // constructor using the original order from the spec
   private def make(cityId: CityId): GetCityInput = GetCityInput(cityId)
 
-  implicit val schema: Schema[GetCityInput] = struct(
+  implicit val schema: Schema[GetCityInput] = struct[GetCityInput](
     CityId.schema.required[GetCityInput]("cityId", _.cityId),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/GetCityOutput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/GetCityOutput.scala
@@ -17,7 +17,7 @@ object GetCityOutput extends ShapeTag.Companion[GetCityOutput] {
   // constructor using the original order from the spec
   private def make(name: String, coordinates: CityCoordinates): GetCityOutput = GetCityOutput(name, coordinates)
 
-  implicit val schema: Schema[GetCityOutput] = struct(
+  implicit val schema: Schema[GetCityOutput] = struct[GetCityOutput](
     string.required[GetCityOutput]("name", _.name),
     CityCoordinates.schema.required[GetCityOutput]("coordinates", _.coordinates),
   )(make).withId(id).addHints(hints)

--- a/modules/bootstrapped/src/generated/smithy4s/example/GetCurrentTimeOutput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/GetCurrentTimeOutput.scala
@@ -18,7 +18,7 @@ object GetCurrentTimeOutput extends ShapeTag.Companion[GetCurrentTimeOutput] {
   // constructor using the original order from the spec
   private def make(time: Timestamp): GetCurrentTimeOutput = GetCurrentTimeOutput(time)
 
-  implicit val schema: Schema[GetCurrentTimeOutput] = struct(
+  implicit val schema: Schema[GetCurrentTimeOutput] = struct[GetCurrentTimeOutput](
     timestamp.required[GetCurrentTimeOutput]("time", _.time),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/GetEnumInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/GetEnumInput.scala
@@ -16,7 +16,7 @@ object GetEnumInput extends ShapeTag.Companion[GetEnumInput] {
   // constructor using the original order from the spec
   private def make(aa: TheEnum): GetEnumInput = GetEnumInput(aa)
 
-  implicit val schema: Schema[GetEnumInput] = struct(
+  implicit val schema: Schema[GetEnumInput] = struct[GetEnumInput](
     TheEnum.schema.required[GetEnumInput]("aa", _.aa).addHints(smithy.api.HttpLabel()),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/GetEnumOutput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/GetEnumOutput.scala
@@ -17,7 +17,7 @@ object GetEnumOutput extends ShapeTag.Companion[GetEnumOutput] {
   // constructor using the original order from the spec
   private def make(result: Option[String]): GetEnumOutput = GetEnumOutput(result)
 
-  implicit val schema: Schema[GetEnumOutput] = struct(
+  implicit val schema: Schema[GetEnumOutput] = struct[GetEnumOutput](
     string.optional[GetEnumOutput]("result", _.result),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/GetFooOutput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/GetFooOutput.scala
@@ -21,7 +21,7 @@ object GetFooOutput extends ShapeTag.Companion[GetFooOutput] {
   // constructor using the original order from the spec
   private def make(foo: Option[Foo]): GetFooOutput = GetFooOutput(foo)
 
-  implicit val schema: Schema[GetFooOutput] = struct(
+  implicit val schema: Schema[GetFooOutput] = struct[GetFooOutput](
     Foo.schema.optional[GetFooOutput]("foo", _.foo),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/GetForecastInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/GetForecastInput.scala
@@ -16,7 +16,7 @@ object GetForecastInput extends ShapeTag.Companion[GetForecastInput] {
   // constructor using the original order from the spec
   private def make(cityId: CityId): GetForecastInput = GetForecastInput(cityId)
 
-  implicit val schema: Schema[GetForecastInput] = struct(
+  implicit val schema: Schema[GetForecastInput] = struct[GetForecastInput](
     CityId.schema.required[GetForecastInput]("cityId", _.cityId),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/GetForecastOutput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/GetForecastOutput.scala
@@ -21,7 +21,7 @@ object GetForecastOutput extends ShapeTag.Companion[GetForecastOutput] {
   // constructor using the original order from the spec
   private def make(forecast: Option[ForecastResult]): GetForecastOutput = GetForecastOutput(forecast)
 
-  implicit val schema: Schema[GetForecastOutput] = struct(
+  implicit val schema: Schema[GetForecastOutput] = struct[GetForecastOutput](
     ForecastResult.schema.optional[GetForecastOutput]("forecast", _.forecast),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/GetIntEnumInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/GetIntEnumInput.scala
@@ -18,7 +18,7 @@ object GetIntEnumInput extends ShapeTag.Companion[GetIntEnumInput] {
   // constructor using the original order from the spec
   private def make(aa: EnumResult): GetIntEnumInput = GetIntEnumInput(aa)
 
-  implicit val schema: Schema[GetIntEnumInput] = struct(
+  implicit val schema: Schema[GetIntEnumInput] = struct[GetIntEnumInput](
     EnumResult.schema.required[GetIntEnumInput]("aa", _.aa).addHints(smithy.api.HttpLabel()),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/GetIntEnumOutput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/GetIntEnumOutput.scala
@@ -18,7 +18,7 @@ object GetIntEnumOutput extends ShapeTag.Companion[GetIntEnumOutput] {
   // constructor using the original order from the spec
   private def make(result: EnumResult): GetIntEnumOutput = GetIntEnumOutput(result)
 
-  implicit val schema: Schema[GetIntEnumOutput] = struct(
+  implicit val schema: Schema[GetIntEnumOutput] = struct[GetIntEnumOutput](
     EnumResult.schema.required[GetIntEnumOutput]("result", _.result),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/GetMenuRequest.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/GetMenuRequest.scala
@@ -17,7 +17,7 @@ object GetMenuRequest extends ShapeTag.Companion[GetMenuRequest] {
   // constructor using the original order from the spec
   private def make(restaurant: String): GetMenuRequest = GetMenuRequest(restaurant)
 
-  implicit val schema: Schema[GetMenuRequest] = struct(
+  implicit val schema: Schema[GetMenuRequest] = struct[GetMenuRequest](
     string.required[GetMenuRequest]("restaurant", _.restaurant).addHints(smithy.api.HttpLabel()),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/GetMenuResult.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/GetMenuResult.scala
@@ -16,7 +16,7 @@ object GetMenuResult extends ShapeTag.Companion[GetMenuResult] {
   // constructor using the original order from the spec
   private def make(menu: Map[String, MenuItem]): GetMenuResult = GetMenuResult(menu)
 
-  implicit val schema: Schema[GetMenuResult] = struct(
+  implicit val schema: Schema[GetMenuResult] = struct[GetMenuResult](
     Menu.underlyingSchema.required[GetMenuResult]("menu", _.menu).addHints(smithy.api.HttpPayload()),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/GetObjectInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/GetObjectInput.scala
@@ -30,7 +30,7 @@ object GetObjectInput extends ShapeTag.Companion[GetObjectInput] {
   // constructor using the original order from the spec
   private def make(key: ObjectKey, bucketName: BucketName): GetObjectInput = GetObjectInput(key, bucketName)
 
-  implicit val schema: Schema[GetObjectInput] = struct(
+  implicit val schema: Schema[GetObjectInput] = struct[GetObjectInput](
     ObjectKey.schema.required[GetObjectInput]("key", _.key).addHints(smithy.api.Documentation("Sent in the URI label named \"key\".\nKey can also be seen as the filename\nIt is always required for a GET operation"), smithy.api.HttpLabel()),
     BucketName.schema.required[GetObjectInput]("bucketName", _.bucketName).addHints(smithy.api.Documentation("Sent in the URI label named \"bucketName\"."), smithy.api.HttpLabel()),
   )(make).withId(id).addHints(hints)

--- a/modules/bootstrapped/src/generated/smithy4s/example/GetObjectOutput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/GetObjectOutput.scala
@@ -17,7 +17,7 @@ object GetObjectOutput extends ShapeTag.Companion[GetObjectOutput] {
   // constructor using the original order from the spec
   private def make(size: ObjectSize, data: Option[String]): GetObjectOutput = GetObjectOutput(size, data)
 
-  implicit val schema: Schema[GetObjectOutput] = struct(
+  implicit val schema: Schema[GetObjectOutput] = struct[GetObjectOutput](
     ObjectSize.schema.required[GetObjectOutput]("size", _.size).addHints(smithy.api.HttpHeader("X-Size")),
     string.optional[GetObjectOutput]("data", _.data).addHints(smithy.api.HttpPayload()),
   )(make).withId(id).addHints(hints)

--- a/modules/bootstrapped/src/generated/smithy4s/example/GetStreamedObjectInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/GetStreamedObjectInput.scala
@@ -17,7 +17,7 @@ object GetStreamedObjectInput extends ShapeTag.Companion[GetStreamedObjectInput]
   // constructor using the original order from the spec
   private def make(key: String): GetStreamedObjectInput = GetStreamedObjectInput(key)
 
-  implicit val schema: Schema[GetStreamedObjectInput] = struct(
+  implicit val schema: Schema[GetStreamedObjectInput] = struct[GetStreamedObjectInput](
     string.required[GetStreamedObjectInput]("key", _.key),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/HasConstrainedNewtypes.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/HasConstrainedNewtypes.scala
@@ -16,7 +16,7 @@ object HasConstrainedNewtypes extends ShapeTag.Companion[HasConstrainedNewtypes]
   // constructor using the original order from the spec
   private def make(a: BucketName, b: CityId, c: Option[ObjectSize], d: Option[IndexedSeq[String]], e: Option[PNG]): HasConstrainedNewtypes = HasConstrainedNewtypes(a, b, c, d, e)
 
-  implicit val schema: Schema[HasConstrainedNewtypes] = struct(
+  implicit val schema: Schema[HasConstrainedNewtypes] = struct[HasConstrainedNewtypes](
     BucketName.schema.validated(smithy.api.Length(min = Some(1L), max = None)).required[HasConstrainedNewtypes]("a", _.a),
     CityId.schema.validated(smithy.api.Length(min = Some(1L), max = None)).required[HasConstrainedNewtypes]("b", _.b),
     ObjectSize.schema.validated(smithy.api.Range(min = Some(scala.math.BigDecimal(1.0)), max = None)).optional[HasConstrainedNewtypes]("c", _.c),

--- a/modules/bootstrapped/src/generated/smithy4s/example/HasRecursiveDiscriminatedOpenUnion.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/HasRecursiveDiscriminatedOpenUnion.scala
@@ -17,7 +17,7 @@ object HasRecursiveDiscriminatedOpenUnion extends ShapeTag.Companion[HasRecursiv
   // constructor using the original order from the spec
   private def make(rec: RecursiveDiscriminatedOpenUnion): HasRecursiveDiscriminatedOpenUnion = HasRecursiveDiscriminatedOpenUnion(rec)
 
-  implicit val schema: Schema[HasRecursiveDiscriminatedOpenUnion] = recursive(struct(
+  implicit val schema: Schema[HasRecursiveDiscriminatedOpenUnion] = recursive(struct[HasRecursiveDiscriminatedOpenUnion](
     RecursiveDiscriminatedOpenUnion.schema.required[HasRecursiveDiscriminatedOpenUnion]("rec", _.rec),
   )(make).withId(id).addHints(hints))
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/HeadRequestOutput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/HeadRequestOutput.scala
@@ -17,7 +17,7 @@ object HeadRequestOutput extends ShapeTag.Companion[HeadRequestOutput] {
   // constructor using the original order from the spec
   private def make(test: String): HeadRequestOutput = HeadRequestOutput(test)
 
-  implicit val schema: Schema[HeadRequestOutput] = struct(
+  implicit val schema: Schema[HeadRequestOutput] = struct[HeadRequestOutput](
     string.required[HeadRequestOutput]("test", _.test).addHints(smithy.api.HttpHeader("Test")),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/HeaderEndpointData.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/HeaderEndpointData.scala
@@ -17,7 +17,7 @@ object HeaderEndpointData extends ShapeTag.Companion[HeaderEndpointData] {
   // constructor using the original order from the spec
   private def make(uppercaseHeader: Option[String], capitalizedHeader: Option[String], lowercaseHeader: Option[String], mixedHeader: Option[String]): HeaderEndpointData = HeaderEndpointData(uppercaseHeader, capitalizedHeader, lowercaseHeader, mixedHeader)
 
-  implicit val schema: Schema[HeaderEndpointData] = struct(
+  implicit val schema: Schema[HeaderEndpointData] = struct[HeaderEndpointData](
     string.optional[HeaderEndpointData]("uppercaseHeader", _.uppercaseHeader).addHints(smithy.api.HttpHeader("X-UPPERCASE-HEADER")),
     string.optional[HeaderEndpointData]("capitalizedHeader", _.capitalizedHeader).addHints(smithy.api.HttpHeader("X-Capitalized-Header")),
     string.optional[HeaderEndpointData]("lowercaseHeader", _.lowercaseHeader).addHints(smithy.api.HttpHeader("x-lowercase-header")),

--- a/modules/bootstrapped/src/generated/smithy4s/example/HeadersStruct.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/HeadersStruct.scala
@@ -21,7 +21,7 @@ object HeadersStruct extends ShapeTag.Companion[HeadersStruct] {
   // constructor using the original order from the spec
   private def make(str: Option[String], int: Option[Int], ts1: Option[Timestamp], ts2: Option[Timestamp], ts3: Option[Timestamp], ts4: Option[Timestamp], b: Option[Boolean], sl: Option[List[String]], ie: Option[Numbers], on: Option[OpenNums], ons: Option[OpenNumsStr], slm: Option[Map[String, String]]): HeadersStruct = HeadersStruct(str, int, ts1, ts2, ts3, ts4, b, sl, ie, on, ons, slm)
 
-  implicit val schema: Schema[HeadersStruct] = struct(
+  implicit val schema: Schema[HeadersStruct] = struct[HeadersStruct](
     string.optional[HeadersStruct]("str", _.str).addHints(smithy.api.HttpHeader("str")),
     int.optional[HeadersStruct]("int", _.int).addHints(smithy.api.HttpHeader("int")),
     timestamp.optional[HeadersStruct]("ts1", _.ts1).addHints(smithy.api.HttpHeader("ts1")),

--- a/modules/bootstrapped/src/generated/smithy4s/example/HeadersWithDefaults.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/HeadersWithDefaults.scala
@@ -17,7 +17,7 @@ object HeadersWithDefaults extends ShapeTag.Companion[HeadersWithDefaults] {
   // constructor using the original order from the spec
   private def make(dflt: String): HeadersWithDefaults = HeadersWithDefaults(dflt)
 
-  implicit val schema: Schema[HeadersWithDefaults] = struct(
+  implicit val schema: Schema[HeadersWithDefaults] = struct[HeadersWithDefaults](
     string.field[HeadersWithDefaults]("dflt", _.dflt).addHints(smithy.api.Default(smithy4s.Document.fromString("test")), smithy.api.HttpHeader("dflt")),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/HealthRequest.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/HealthRequest.scala
@@ -17,7 +17,7 @@ object HealthRequest extends ShapeTag.Companion[HealthRequest] {
   // constructor using the original order from the spec
   private def make(query: Option[String]): HealthRequest = HealthRequest(query)
 
-  implicit val schema: Schema[HealthRequest] = struct(
+  implicit val schema: Schema[HealthRequest] = struct[HealthRequest](
     string.validated(smithy.api.Length(min = Some(0L), max = Some(5L))).optional[HealthRequest]("query", _.query).addHints(smithy.api.HttpQuery("query")),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/HealthResponse.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/HealthResponse.scala
@@ -19,7 +19,7 @@ object HealthResponse extends ShapeTag.Companion[HealthResponse] {
   // constructor using the original order from the spec
   private def make(status: String): HealthResponse = HealthResponse(status)
 
-  implicit val schema: Schema[HealthResponse] = struct(
+  implicit val schema: Schema[HealthResponse] = struct[HealthResponse](
     string.required[HealthResponse]("status", _.status),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/HostLabelInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/HostLabelInput.scala
@@ -17,7 +17,7 @@ object HostLabelInput extends ShapeTag.Companion[HostLabelInput] {
   // constructor using the original order from the spec
   private def make(label1: String, label2: String, label3: HostLabelEnum): HostLabelInput = HostLabelInput(label1, label2, label3)
 
-  implicit val schema: Schema[HostLabelInput] = struct(
+  implicit val schema: Schema[HostLabelInput] = struct[HostLabelInput](
     string.required[HostLabelInput]("label1", _.label1).addHints(smithy.api.HostLabel()),
     string.required[HostLabelInput]("label2", _.label2).addHints(smithy.api.HostLabel()),
     HostLabelEnum.schema.required[HostLabelInput]("label3", _.label3).addHints(smithy.api.HostLabel()),

--- a/modules/bootstrapped/src/generated/smithy4s/example/IntList.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/IntList.scala
@@ -18,7 +18,7 @@ object IntList extends ShapeTag.Companion[IntList] {
   // constructor using the original order from the spec
   private def make(head: Int, tail: Option[smithy4s.example.IntList]): IntList = IntList(head, tail)
 
-  implicit val schema: Schema[IntList] = recursive(struct(
+  implicit val schema: Schema[IntList] = recursive(struct[IntList](
     int.required[IntList]("head", _.head),
     smithy4s.example.IntList.schema.optional[IntList]("tail", _.tail),
   )(make).withId(id).addHints(hints))

--- a/modules/bootstrapped/src/generated/smithy4s/example/JsonUnknownExample.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/JsonUnknownExample.scala
@@ -19,7 +19,7 @@ object JsonUnknownExample extends ShapeTag.Companion[JsonUnknownExample] {
   // constructor using the original order from the spec
   private def make(s: Option[String], i: Option[Int], additionalProperties: Option[Map[String, Document]]): JsonUnknownExample = JsonUnknownExample(s, i, additionalProperties)
 
-  implicit val schema: Schema[JsonUnknownExample] = struct(
+  implicit val schema: Schema[JsonUnknownExample] = struct[JsonUnknownExample](
     string.optional[JsonUnknownExample]("s", _.s),
     int.optional[JsonUnknownExample]("i", _.i),
     AdditionalProperties.underlyingSchema.optional[JsonUnknownExample]("additionalProperties", _.additionalProperties).addHints(alloy.JsonUnknown()),

--- a/modules/bootstrapped/src/generated/smithy4s/example/KVStore.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/KVStore.scala
@@ -136,7 +136,7 @@ object KVStoreOperation {
       }
     }
 
-    implicit val schema: Schema[PutError] = union(
+    implicit val schema: Schema[PutError] = union[PutError](
       PutError.UnauthorizedErrorCase.alt,
     ){
       _.$ordinal
@@ -211,7 +211,7 @@ object KVStoreOperation {
       }
     }
 
-    implicit val schema: Schema[GetError] = union(
+    implicit val schema: Schema[GetError] = union[GetError](
       GetError.UnauthorizedErrorCase.alt,
       GetError.KeyNotFoundErrorCase.alt,
     ){
@@ -289,7 +289,7 @@ object KVStoreOperation {
       }
     }
 
-    implicit val schema: Schema[DeleteError] = union(
+    implicit val schema: Schema[DeleteError] = union[DeleteError](
       DeleteError.UnauthorizedErrorCase.alt,
       DeleteError.KeyNotFoundErrorCase.alt,
     ){

--- a/modules/bootstrapped/src/generated/smithy4s/example/Key.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/Key.scala
@@ -17,7 +17,7 @@ object Key extends ShapeTag.Companion[Key] {
   // constructor using the original order from the spec
   private def make(key: String): Key = Key(key)
 
-  implicit val schema: Schema[Key] = struct(
+  implicit val schema: Schema[Key] = struct[Key](
     string.required[Key]("key", _.key),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/KeyNotFoundError.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/KeyNotFoundError.scala
@@ -22,7 +22,7 @@ object KeyNotFoundError extends ShapeTag.Companion[KeyNotFoundError] {
   // constructor using the original order from the spec
   private def make(message: String): KeyNotFoundError = KeyNotFoundError(message)
 
-  implicit val schema: Schema[KeyNotFoundError] = struct(
+  implicit val schema: Schema[KeyNotFoundError] = struct[KeyNotFoundError](
     string.required[KeyNotFoundError]("message", _.message),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/KeyValue.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/KeyValue.scala
@@ -17,7 +17,7 @@ object KeyValue extends ShapeTag.Companion[KeyValue] {
   // constructor using the original order from the spec
   private def make(key: String, value: String): KeyValue = KeyValue(key, value)
 
-  implicit val schema: Schema[KeyValue] = struct(
+  implicit val schema: Schema[KeyValue] = struct[KeyValue](
     string.required[KeyValue]("key", _.key),
     string.required[KeyValue]("value", _.value),
   )(make).withId(id).addHints(hints)

--- a/modules/bootstrapped/src/generated/smithy4s/example/ListCitiesInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/ListCitiesInput.scala
@@ -18,7 +18,7 @@ object ListCitiesInput extends ShapeTag.Companion[ListCitiesInput] {
   // constructor using the original order from the spec
   private def make(nextToken: Option[String], pageSize: Option[Int]): ListCitiesInput = ListCitiesInput(nextToken, pageSize)
 
-  implicit val schema: Schema[ListCitiesInput] = struct(
+  implicit val schema: Schema[ListCitiesInput] = struct[ListCitiesInput](
     string.optional[ListCitiesInput]("nextToken", _.nextToken),
     int.optional[ListCitiesInput]("pageSize", _.pageSize),
   )(make).withId(id).addHints(hints)

--- a/modules/bootstrapped/src/generated/smithy4s/example/ListCitiesOutput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/ListCitiesOutput.scala
@@ -17,7 +17,7 @@ object ListCitiesOutput extends ShapeTag.Companion[ListCitiesOutput] {
   // constructor using the original order from the spec
   private def make(nextToken: Option[String], items: List[CitySummary]): ListCitiesOutput = ListCitiesOutput(items, nextToken)
 
-  implicit val schema: Schema[ListCitiesOutput] = struct(
+  implicit val schema: Schema[ListCitiesOutput] = struct[ListCitiesOutput](
     string.optional[ListCitiesOutput]("nextToken", _.nextToken),
     CitySummaries.underlyingSchema.required[ListCitiesOutput]("items", _.items),
   )(make).withId(id).addHints(hints)

--- a/modules/bootstrapped/src/generated/smithy4s/example/ListPublishersOutput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/ListPublishersOutput.scala
@@ -18,7 +18,7 @@ object ListPublishersOutput extends ShapeTag.Companion[ListPublishersOutput] {
   // constructor using the original order from the spec
   private def make(publishers: List[PublisherId]): ListPublishersOutput = ListPublishersOutput(publishers)
 
-  implicit val schema: Schema[ListPublishersOutput] = struct(
+  implicit val schema: Schema[ListPublishersOutput] = struct[ListPublishersOutput](
     PublishersList.underlyingSchema.required[ListPublishersOutput]("publishers", _.publishers),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/MenuItem.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/MenuItem.scala
@@ -17,7 +17,7 @@ object MenuItem extends ShapeTag.Companion[MenuItem] {
   // constructor using the original order from the spec
   private def make(food: Food, price: Float, tags: Option[List[String]], extraData: Option[Map[String, String]]): MenuItem = MenuItem(food, price, tags, extraData)
 
-  implicit val schema: Schema[MenuItem] = struct(
+  implicit val schema: Schema[MenuItem] = struct[MenuItem](
     Food.schema.required[MenuItem]("food", _.food),
     float.required[MenuItem]("price", _.price),
     Tags.underlyingSchema.optional[MenuItem]("tags", _.tags),

--- a/modules/bootstrapped/src/generated/smithy4s/example/MixinErrorExample.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/MixinErrorExample.scala
@@ -23,7 +23,7 @@ object MixinErrorExample extends ShapeTag.Companion[MixinErrorExample] {
   // constructor using the original order from the spec
   private def make(a: Option[String], b: Option[Int], c: Option[Long], d: Option[Boolean]): MixinErrorExample = MixinErrorExample(a, b, c, d)
 
-  implicit val schema: Schema[MixinErrorExample] = struct(
+  implicit val schema: Schema[MixinErrorExample] = struct[MixinErrorExample](
     string.optional[MixinErrorExample]("a", _.a),
     int.optional[MixinErrorExample]("b", _.b),
     long.optional[MixinErrorExample]("c", _.c),

--- a/modules/bootstrapped/src/generated/smithy4s/example/MixinExample.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/MixinExample.scala
@@ -20,7 +20,7 @@ object MixinExample extends ShapeTag.Companion[MixinExample] {
   // constructor using the original order from the spec
   private def make(a: Option[String], b: Option[Int], c: Option[Long], d: Option[Boolean]): MixinExample = MixinExample(a, b, c, d)
 
-  implicit val schema: Schema[MixinExample] = struct(
+  implicit val schema: Schema[MixinExample] = struct[MixinExample](
     string.optional[MixinExample]("a", _.a),
     int.optional[MixinExample]("b", _.b),
     long.optional[MixinExample]("c", _.c),

--- a/modules/bootstrapped/src/generated/smithy4s/example/MixinOptionalMemberDefaultAdded.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/MixinOptionalMemberDefaultAdded.scala
@@ -17,7 +17,7 @@ object MixinOptionalMemberDefaultAdded extends ShapeTag.Companion[MixinOptionalM
   // constructor using the original order from the spec
   private def make(a: String): MixinOptionalMemberDefaultAdded = MixinOptionalMemberDefaultAdded(a)
 
-  implicit val schema: Schema[MixinOptionalMemberDefaultAdded] = struct(
+  implicit val schema: Schema[MixinOptionalMemberDefaultAdded] = struct[MixinOptionalMemberDefaultAdded](
     string.field[MixinOptionalMemberDefaultAdded]("a", _.a).addHints(smithy.api.Default(smithy4s.Document.fromString("test"))),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/MixinOptionalMemberOverride.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/MixinOptionalMemberOverride.scala
@@ -17,7 +17,7 @@ object MixinOptionalMemberOverride extends ShapeTag.Companion[MixinOptionalMembe
   // constructor using the original order from the spec
   private def make(a: String): MixinOptionalMemberOverride = MixinOptionalMemberOverride(a)
 
-  implicit val schema: Schema[MixinOptionalMemberOverride] = struct(
+  implicit val schema: Schema[MixinOptionalMemberOverride] = struct[MixinOptionalMemberOverride](
     string.required[MixinOptionalMemberOverride]("a", _.a),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/MixinRequiredMemberDefaultAdded.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/MixinRequiredMemberDefaultAdded.scala
@@ -17,7 +17,7 @@ object MixinRequiredMemberDefaultAdded extends ShapeTag.Companion[MixinRequiredM
   // constructor using the original order from the spec
   private def make(description: String): MixinRequiredMemberDefaultAdded = MixinRequiredMemberDefaultAdded(description)
 
-  implicit val schema: Schema[MixinRequiredMemberDefaultAdded] = struct(
+  implicit val schema: Schema[MixinRequiredMemberDefaultAdded] = struct[MixinRequiredMemberDefaultAdded](
     string.required[MixinRequiredMemberDefaultAdded]("description", _.description).addHints(smithy.api.Default(smithy4s.Document.fromString("different description"))),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/MovieTheater.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/MovieTheater.scala
@@ -20,7 +20,7 @@ object MovieTheater extends ShapeTag.Companion[MovieTheater] {
   // constructor using the original order from the spec
   private def make(name: Option[String]): MovieTheater = MovieTheater(name)
 
-  implicit val schema: Schema[MovieTheater] = struct(
+  implicit val schema: Schema[MovieTheater] = struct[MovieTheater](
     string.optional[MovieTheater]("name", _.name),
   )(make).withId(id).addHints(hints)
 

--- a/modules/bootstrapped/src/generated/smithy4s/example/NameCollision.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/NameCollision.scala
@@ -128,7 +128,7 @@ object NameCollisionOperation {
       }
     }
 
-    implicit val schema: Schema[MyOpError] = union(
+    implicit val schema: Schema[MyOpError] = union[MyOpError](
       MyOpError.MyOpErrorCase.alt,
     ){
       _.$ordinal

--- a/modules/bootstrapped/src/generated/smithy4s/example/NoMoreSpace.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/NoMoreSpace.scala
@@ -28,7 +28,7 @@ object NoMoreSpace extends ShapeTag.Companion[NoMoreSpace] {
   // constructor using the original order from the spec
   private def make(message: String, foo: Option[Foo]): NoMoreSpace = NoMoreSpace(message, foo)
 
-  implicit val schema: Schema[NoMoreSpace] = struct(
+  implicit val schema: Schema[NoMoreSpace] = struct[NoMoreSpace](
     string.required[NoMoreSpace]("message", _.message),
     Foo.schema.optional[NoMoreSpace]("foo", _.foo),
   )(make).withId(id).addHints(hints)

--- a/modules/bootstrapped/src/generated/smithy4s/example/NoSuchResource.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/NoSuchResource.scala
@@ -20,7 +20,7 @@ object NoSuchResource extends ShapeTag.Companion[NoSuchResource] {
   // constructor using the original order from the spec
   private def make(resourceType: String): NoSuchResource = NoSuchResource(resourceType)
 
-  implicit val schema: Schema[NoSuchResource] = struct(
+  implicit val schema: Schema[NoSuchResource] = struct[NoSuchResource](
     string.required[NoSuchResource]("resourceType", _.resourceType),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/NotFoundError.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/NotFoundError.scala
@@ -21,7 +21,7 @@ object NotFoundError extends ShapeTag.Companion[NotFoundError] {
   // constructor using the original order from the spec
   private def make(name: String): NotFoundError = NotFoundError(name)
 
-  implicit val schema: Schema[NotFoundError] = struct(
+  implicit val schema: Schema[NotFoundError] = struct[NotFoundError](
     string.required[NotFoundError]("name", _.name),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/Numeric.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/Numeric.scala
@@ -23,7 +23,7 @@ object Numeric extends ShapeTag.Companion[Numeric] {
   // constructor using the original order from the spec
   private def make(i: Int, f: Float, d: Double, s: Short, l: Long, bi: BigInt, bd: BigDecimal): Numeric = Numeric(i, f, d, s, l, bi, bd)
 
-  implicit val schema: Schema[Numeric] = struct(
+  implicit val schema: Schema[Numeric] = struct[Numeric](
     int.field[Numeric]("i", _.i).addHints(smithy.api.Default(smithy4s.Document.fromLong(1))),
     float.field[Numeric]("f", _.f).addHints(smithy.api.Default(smithy4s.Document.fromDouble(1.0d))),
     double.field[Numeric]("d", _.d).addHints(smithy.api.Default(smithy4s.Document.fromDouble(1.0d))),

--- a/modules/bootstrapped/src/generated/smithy4s/example/ObjectService.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/ObjectService.scala
@@ -154,7 +154,7 @@ object ObjectServiceOperation {
       }
     }
 
-    implicit val schema: Schema[GetObjectError] = union(
+    implicit val schema: Schema[GetObjectError] = union[GetObjectError](
       GetObjectError.ClientErrorCase.alt,
       GetObjectError.ServerErrorCase.alt,
     ){
@@ -244,7 +244,7 @@ object ObjectServiceOperation {
       }
     }
 
-    implicit val schema: Schema[PutObjectError] = union(
+    implicit val schema: Schema[PutObjectError] = union[PutObjectError](
       PutObjectError.ClientErrorCase.alt,
       PutObjectError.ServerErrorCase.alt,
       PutObjectError.NoMoreSpaceCase.alt,

--- a/modules/bootstrapped/src/generated/smithy4s/example/One.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/One.scala
@@ -17,7 +17,7 @@ object One extends ShapeTag.Companion[One] {
   // constructor using the original order from the spec
   private def make(value: Option[String]): One = One(value)
 
-  implicit val schema: Schema[One] = struct(
+  implicit val schema: Schema[One] = struct[One](
     string.optional[One]("value", _.value),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/OnlyUnknownDiscriminatedOpenUnion.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/OnlyUnknownDiscriminatedOpenUnion.scala
@@ -52,7 +52,7 @@ object OnlyUnknownDiscriminatedOpenUnion extends ShapeTag.Companion[OnlyUnknownD
     }
   }
 
-  implicit val schema: Schema[OnlyUnknownDiscriminatedOpenUnion] = union(
+  implicit val schema: Schema[OnlyUnknownDiscriminatedOpenUnion] = union[OnlyUnknownDiscriminatedOpenUnion](
     OnlyUnknownDiscriminatedOpenUnion.UnknownCase.alt,
   ){
     _.$ordinal

--- a/modules/bootstrapped/src/generated/smithy4s/example/OnlyUnknownOpenUnion.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/OnlyUnknownOpenUnion.scala
@@ -50,7 +50,7 @@ object OnlyUnknownOpenUnion extends ShapeTag.Companion[OnlyUnknownOpenUnion] {
     }
   }
 
-  implicit val schema: Schema[OnlyUnknownOpenUnion] = union(
+  implicit val schema: Schema[OnlyUnknownOpenUnion] = union[OnlyUnknownOpenUnion](
     OnlyUnknownOpenUnion.UnknownCase.alt,
   ){
     _.$ordinal

--- a/modules/bootstrapped/src/generated/smithy4s/example/OpticsStructure.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/OpticsStructure.scala
@@ -21,7 +21,7 @@ object OpticsStructure extends ShapeTag.Companion[OpticsStructure] {
   // constructor using the original order from the spec
   private def make(two: Option[OpticsEnum]): OpticsStructure = OpticsStructure(two)
 
-  implicit val schema: Schema[OpticsStructure] = struct(
+  implicit val schema: Schema[OpticsStructure] = struct[OpticsStructure](
     OpticsEnum.schema.optional[OpticsStructure]("two", _.two),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/OpticsUnion.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/OpticsUnion.scala
@@ -51,7 +51,7 @@ object OpticsUnion extends ShapeTag.Companion[OpticsUnion] {
     }
   }
 
-  implicit val schema: Schema[OpticsUnion] = union(
+  implicit val schema: Schema[OpticsUnion] = union[OpticsUnion](
     OpticsUnion.OneCase.alt,
   ){
     _.$ordinal

--- a/modules/bootstrapped/src/generated/smithy4s/example/OptionalOutputOutput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/OptionalOutputOutput.scala
@@ -19,7 +19,7 @@ object OptionalOutputOutput extends ShapeTag.Companion[OptionalOutputOutput] {
   // constructor using the original order from the spec
   private def make(body: Option[String]): OptionalOutputOutput = OptionalOutputOutput(body)
 
-  implicit val schema: Schema[OptionalOutputOutput] = struct(
+  implicit val schema: Schema[OptionalOutputOutput] = struct[OptionalOutputOutput](
     string.optional[OptionalOutputOutput]("body", _.body).addHints(smithy.api.HttpPayload()),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/OrderType.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/OrderType.scala
@@ -57,7 +57,7 @@ object OrderType extends ShapeTag.Companion[OrderType] {
     // constructor using the original order from the spec
     private def make(id: OrderNumber, locationId: Option[String]): InStoreOrder = InStoreOrder(id, locationId)
 
-    val schema: Schema[InStoreOrder] = struct(
+    val schema: Schema[InStoreOrder] = struct[InStoreOrder](
       OrderNumber.schema.required[InStoreOrder]("id", _.id),
       string.optional[InStoreOrder]("locationId", _.locationId),
     )(make).withId(id).addHints(hints)
@@ -93,7 +93,7 @@ object OrderType extends ShapeTag.Companion[OrderType] {
     }
   }
 
-  implicit val schema: Schema[OrderType] = union(
+  implicit val schema: Schema[OrderType] = union[OrderType](
     OrderType.OnlineCase.alt,
     OrderType.InStoreOrder.alt,
     OrderType.PreviewCase.alt,

--- a/modules/bootstrapped/src/generated/smithy4s/example/PackedInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/PackedInput.scala
@@ -17,7 +17,7 @@ object PackedInput extends ShapeTag.Companion[PackedInput] {
   // constructor using the original order from the spec
   private def make(key: String): PackedInput = PackedInput(key)
 
-  implicit val schema: Schema[PackedInput] = struct(
+  implicit val schema: Schema[PackedInput] = struct[PackedInput](
     string.required[PackedInput]("key", _.key),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/Patchable.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/Patchable.scala
@@ -18,7 +18,7 @@ object Patchable extends ShapeTag.Companion[Patchable] {
   // constructor using the original order from the spec
   private def make(allowExplicitNull: Option[Nullable[Int]]): Patchable = Patchable(allowExplicitNull)
 
-  implicit val schema: Schema[Patchable] = struct(
+  implicit val schema: Schema[Patchable] = struct[Patchable](
     int.nullable.optional[Patchable]("allowExplicitNull", _.allowExplicitNull),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/PatchableEdgeCases.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/PatchableEdgeCases.scala
@@ -19,7 +19,7 @@ object PatchableEdgeCases extends ShapeTag.Companion[PatchableEdgeCases] {
   // constructor using the original order from the spec
   private def make(required: Nullable[Int], requiredDefaultValue: Nullable[Int], requiredDefaultNull: Nullable[Int], defaultValue: Nullable[Int], defaultNull: Nullable[Int]): PatchableEdgeCases = PatchableEdgeCases(required, requiredDefaultValue, requiredDefaultNull, defaultValue, defaultNull)
 
-  implicit val schema: Schema[PatchableEdgeCases] = struct(
+  implicit val schema: Schema[PatchableEdgeCases] = struct[PatchableEdgeCases](
     int.nullable.required[PatchableEdgeCases]("required", _.required),
     int.nullable.required[PatchableEdgeCases]("requiredDefaultValue", _.requiredDefaultValue).addHints(smithy.api.Default(smithy4s.Document.fromLong(3))),
     int.nullable.required[PatchableEdgeCases]("requiredDefaultNull", _.requiredDefaultNull).addHints(smithy.api.Default(smithy4s.Document.nullDoc)),

--- a/modules/bootstrapped/src/generated/smithy4s/example/PathParams.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/PathParams.scala
@@ -21,7 +21,7 @@ object PathParams extends ShapeTag.Companion[PathParams] {
   // constructor using the original order from the spec
   private def make(str: String, int: Int, ts1: Timestamp, ts2: Timestamp, ts3: Timestamp, ts4: Timestamp, b: Boolean, ie: Numbers): PathParams = PathParams(str, int, ts1, ts2, ts3, ts4, b, ie)
 
-  implicit val schema: Schema[PathParams] = struct(
+  implicit val schema: Schema[PathParams] = struct[PathParams](
     string.required[PathParams]("str", _.str).addHints(smithy.api.HttpLabel()),
     int.required[PathParams]("int", _.int).addHints(smithy.api.HttpLabel()),
     timestamp.required[PathParams]("ts1", _.ts1).addHints(smithy.api.HttpLabel()),

--- a/modules/bootstrapped/src/generated/smithy4s/example/PayloadData.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/PayloadData.scala
@@ -16,7 +16,7 @@ object PayloadData extends ShapeTag.Companion[PayloadData] {
   // constructor using the original order from the spec
   private def make(testBiggerUnion: Option[TestBiggerUnion]): PayloadData = PayloadData(testBiggerUnion)
 
-  implicit val schema: Schema[PayloadData] = struct(
+  implicit val schema: Schema[PayloadData] = struct[PayloadData](
     TestBiggerUnion.schema.optional[PayloadData]("testBiggerUnion", _.testBiggerUnion),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/PersonContactInfo.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/PersonContactInfo.scala
@@ -66,7 +66,7 @@ object PersonContactInfo extends ShapeTag.Companion[PersonContactInfo] {
     }
   }
 
-  implicit val schema: Schema[PersonContactInfo] = union(
+  implicit val schema: Schema[PersonContactInfo] = union[PersonContactInfo](
     PersonContactInfo.EmailCase.alt,
     PersonContactInfo.PhoneCase.alt,
   ){

--- a/modules/bootstrapped/src/generated/smithy4s/example/PersonUnion.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/PersonUnion.scala
@@ -40,7 +40,7 @@ object PersonUnion extends ShapeTag.Companion[PersonUnion] {
     // constructor using the original order from the spec
     private def make(name: String): OtherPerson = OtherPerson(name)
 
-    val schema: Schema[OtherPerson] = struct(
+    val schema: Schema[OtherPerson] = struct[OtherPerson](
       string.required[OtherPerson]("name", _.name),
     )(make).withId(id).addHints(hints)
 
@@ -59,7 +59,7 @@ object PersonUnion extends ShapeTag.Companion[PersonUnion] {
     }
   }
 
-  implicit val schema: Schema[PersonUnion] = union(
+  implicit val schema: Schema[PersonUnion] = union[PersonUnion](
     PersonUnion.OtherPerson.alt,
   ){
     _.$ordinal

--- a/modules/bootstrapped/src/generated/smithy4s/example/Pizza.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/Pizza.scala
@@ -17,7 +17,7 @@ object Pizza extends ShapeTag.Companion[Pizza] {
   // constructor using the original order from the spec
   private def make(name: String, base: PizzaBase, toppings: List[Ingredient]): Pizza = Pizza(name, base, toppings)
 
-  implicit val schema: Schema[Pizza] = struct(
+  implicit val schema: Schema[Pizza] = struct[Pizza](
     string.required[Pizza]("name", _.name),
     PizzaBase.schema.required[Pizza]("base", _.base),
     Ingredients.underlyingSchema.required[Pizza]("toppings", _.toppings),

--- a/modules/bootstrapped/src/generated/smithy4s/example/PizzaAdminService.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/PizzaAdminService.scala
@@ -250,7 +250,7 @@ object PizzaAdminServiceOperation {
       }
     }
 
-    implicit val schema: Schema[CustomCodeError] = union(
+    implicit val schema: Schema[CustomCodeError] = union[CustomCodeError](
       CustomCodeError.UnknownServerErrorCase.alt,
     ){
       _.$ordinal
@@ -352,7 +352,7 @@ object PizzaAdminServiceOperation {
       }
     }
 
-    implicit val schema: Schema[GetIntEnumError] = union(
+    implicit val schema: Schema[GetIntEnumError] = union[GetIntEnumError](
       GetIntEnumError.UnknownServerErrorCase.alt,
     ){
       _.$ordinal
@@ -478,7 +478,7 @@ object PizzaAdminServiceOperation {
       }
     }
 
-    implicit val schema: Schema[GetEnumError] = union(
+    implicit val schema: Schema[GetEnumError] = union[GetEnumError](
       GetEnumError.UnknownServerErrorCase.alt,
     ){
       _.$ordinal
@@ -603,7 +603,7 @@ object PizzaAdminServiceOperation {
       }
     }
 
-    implicit val schema: Schema[AddMenuItemError] = union(
+    implicit val schema: Schema[AddMenuItemError] = union[AddMenuItemError](
       AddMenuItemError.GenericClientErrorCase.alt,
       AddMenuItemError.GenericServerErrorCase.alt,
       AddMenuItemError.PriceErrorCase.alt,
@@ -686,7 +686,7 @@ object PizzaAdminServiceOperation {
       }
     }
 
-    implicit val schema: Schema[HealthError] = union(
+    implicit val schema: Schema[HealthError] = union[HealthError](
       HealthError.UnknownServerErrorCase.alt,
     ){
       _.$ordinal
@@ -796,7 +796,7 @@ object PizzaAdminServiceOperation {
       }
     }
 
-    implicit val schema: Schema[GetMenuError] = union(
+    implicit val schema: Schema[GetMenuError] = union[GetMenuError](
       GetMenuError.FallbackErrorCase.alt,
       GetMenuError.FallbackError2Case.alt,
       GetMenuError.GenericClientErrorCase.alt,

--- a/modules/bootstrapped/src/generated/smithy4s/example/Podcast.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/Podcast.scala
@@ -57,7 +57,7 @@ object Podcast extends ShapeTag.Companion[Podcast] {
     // constructor using the original order from the spec
     private def make(title: Option[String], url: Option[String], durationMillis: Option[Long]): Video = Video(title, url, durationMillis)
 
-    val schema: Schema[Video] = struct(
+    val schema: Schema[Video] = struct[Video](
       string.optional[Video]("title", _.title),
       string.optional[Video]("url", _.url),
       long.optional[Video]("durationMillis", _.durationMillis),
@@ -83,7 +83,7 @@ object Podcast extends ShapeTag.Companion[Podcast] {
     // constructor using the original order from the spec
     private def make(title: Option[String], url: Option[String], durationMillis: Option[Long]): Audio = Audio(title, url, durationMillis)
 
-    val schema: Schema[Audio] = struct(
+    val schema: Schema[Audio] = struct[Audio](
       string.optional[Audio]("title", _.title),
       string.optional[Audio]("url", _.url),
       long.optional[Audio]("durationMillis", _.durationMillis),
@@ -106,7 +106,7 @@ object Podcast extends ShapeTag.Companion[Podcast] {
     }
   }
 
-  implicit val schema: Schema[Podcast] = union(
+  implicit val schema: Schema[Podcast] = union[Podcast](
     Podcast.Video.alt,
     Podcast.Audio.alt,
   ){

--- a/modules/bootstrapped/src/generated/smithy4s/example/PriceError.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/PriceError.scala
@@ -23,7 +23,7 @@ object PriceError extends ShapeTag.Companion[PriceError] {
   // constructor using the original order from the spec
   private def make(message: String, code: Int): PriceError = PriceError(message, code)
 
-  implicit val schema: Schema[PriceError] = struct(
+  implicit val schema: Schema[PriceError] = struct[PriceError](
     string.required[PriceError]("message", _.message),
     int.required[PriceError]("code", _.code).addHints(smithy.api.HttpHeader("X-CODE")),
   )(make).withId(id).addHints(hints)

--- a/modules/bootstrapped/src/generated/smithy4s/example/PutObjectInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/PutObjectInput.scala
@@ -20,7 +20,7 @@ object PutObjectInput extends ShapeTag.Companion[PutObjectInput] {
   // constructor using the original order from the spec
   private def make(key: ObjectKey, bucketName: BucketName, foo: Option[LowHigh], someValue: Option[SomeValue], data: String): PutObjectInput = PutObjectInput(key, bucketName, data, foo, someValue)
 
-  implicit val schema: Schema[PutObjectInput] = struct(
+  implicit val schema: Schema[PutObjectInput] = struct[PutObjectInput](
     ObjectKey.schema.required[PutObjectInput]("key", _.key).addHints(smithy.api.HttpLabel()),
     BucketName.schema.required[PutObjectInput]("bucketName", _.bucketName).addHints(smithy.api.HttpLabel()),
     LowHigh.schema.optional[PutObjectInput]("foo", _.foo).addHints(smithy.api.HttpHeader("X-Foo")),

--- a/modules/bootstrapped/src/generated/smithy4s/example/PutStreamedObjectInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/PutStreamedObjectInput.scala
@@ -17,7 +17,7 @@ object PutStreamedObjectInput extends ShapeTag.Companion[PutStreamedObjectInput]
   // constructor using the original order from the spec
   private def make(key: String): PutStreamedObjectInput = PutStreamedObjectInput(key)
 
-  implicit val schema: Schema[PutStreamedObjectInput] = struct(
+  implicit val schema: Schema[PutStreamedObjectInput] = struct[PutStreamedObjectInput](
     string.required[PutStreamedObjectInput]("key", _.key),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/Queries.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/Queries.scala
@@ -22,7 +22,7 @@ object Queries extends ShapeTag.Companion[Queries] {
   // constructor using the original order from the spec
   private def make(str: Option[String], int: Option[Int], ts1: Option[Timestamp], ts2: Option[Timestamp], ts3: Option[Timestamp], ts4: Option[Timestamp], b: Option[Boolean], sl: Option[List[String]], ie: Option[Numbers], on: Option[OpenNums], ons: Option[OpenNumsStr], dbl: Option[Double], slm: Option[Map[String, String]]): Queries = Queries(str, int, ts1, ts2, ts3, ts4, b, sl, ie, on, ons, dbl, slm)
 
-  implicit val schema: Schema[Queries] = struct(
+  implicit val schema: Schema[Queries] = struct[Queries](
     string.optional[Queries]("str", _.str).addHints(smithy.api.HttpQuery("str")),
     int.optional[Queries]("int", _.int).addHints(smithy.api.HttpQuery("int")),
     timestamp.optional[Queries]("ts1", _.ts1).addHints(smithy.api.HttpQuery("ts1")),

--- a/modules/bootstrapped/src/generated/smithy4s/example/QueriesWithDefaults.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/QueriesWithDefaults.scala
@@ -17,7 +17,7 @@ object QueriesWithDefaults extends ShapeTag.Companion[QueriesWithDefaults] {
   // constructor using the original order from the spec
   private def make(dflt: String): QueriesWithDefaults = QueriesWithDefaults(dflt)
 
-  implicit val schema: Schema[QueriesWithDefaults] = struct(
+  implicit val schema: Schema[QueriesWithDefaults] = struct[QueriesWithDefaults](
     string.field[QueriesWithDefaults]("dflt", _.dflt).addHints(smithy.api.Default(smithy4s.Document.fromString("test")), smithy.api.HttpQuery("dflt")),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/RandomOtherClientError.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/RandomOtherClientError.scala
@@ -22,7 +22,7 @@ object RandomOtherClientError extends ShapeTag.Companion[RandomOtherClientError]
   // constructor using the original order from the spec
   private def make(message: Option[String]): RandomOtherClientError = RandomOtherClientError(message)
 
-  implicit val schema: Schema[RandomOtherClientError] = struct(
+  implicit val schema: Schema[RandomOtherClientError] = struct[RandomOtherClientError](
     string.optional[RandomOtherClientError]("message", _.message),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/RandomOtherClientErrorWithCode.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/RandomOtherClientErrorWithCode.scala
@@ -23,7 +23,7 @@ object RandomOtherClientErrorWithCode extends ShapeTag.Companion[RandomOtherClie
   // constructor using the original order from the spec
   private def make(message: Option[String]): RandomOtherClientErrorWithCode = RandomOtherClientErrorWithCode(message)
 
-  implicit val schema: Schema[RandomOtherClientErrorWithCode] = struct(
+  implicit val schema: Schema[RandomOtherClientErrorWithCode] = struct[RandomOtherClientErrorWithCode](
     string.optional[RandomOtherClientErrorWithCode]("message", _.message),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/RandomOtherServerError.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/RandomOtherServerError.scala
@@ -22,7 +22,7 @@ object RandomOtherServerError extends ShapeTag.Companion[RandomOtherServerError]
   // constructor using the original order from the spec
   private def make(message: Option[String]): RandomOtherServerError = RandomOtherServerError(message)
 
-  implicit val schema: Schema[RandomOtherServerError] = struct(
+  implicit val schema: Schema[RandomOtherServerError] = struct[RandomOtherServerError](
     string.optional[RandomOtherServerError]("message", _.message),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/RandomOtherServerErrorWithCode.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/RandomOtherServerErrorWithCode.scala
@@ -23,7 +23,7 @@ object RandomOtherServerErrorWithCode extends ShapeTag.Companion[RandomOtherServ
   // constructor using the original order from the spec
   private def make(message: Option[String]): RandomOtherServerErrorWithCode = RandomOtherServerErrorWithCode(message)
 
-  implicit val schema: Schema[RandomOtherServerErrorWithCode] = struct(
+  implicit val schema: Schema[RandomOtherServerErrorWithCode] = struct[RandomOtherServerErrorWithCode](
     string.optional[RandomOtherServerErrorWithCode]("message", _.message),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/RangeCheck.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/RangeCheck.scala
@@ -19,7 +19,7 @@ object RangeCheck extends ShapeTag.Companion[RangeCheck] {
   // constructor using the original order from the spec
   private def make(qty: Int): RangeCheck = RangeCheck(qty)
 
-  implicit val schema: Schema[RangeCheck] = struct(
+  implicit val schema: Schema[RangeCheck] = struct[RangeCheck](
     int.validated(smithy.api.Range(min = Some(scala.math.BigDecimal(1.0)), max = None)).required[RangeCheck]("qty", _.qty),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/RecursiveDiscriminatedOpenUnion.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/RecursiveDiscriminatedOpenUnion.scala
@@ -74,7 +74,7 @@ object RecursiveDiscriminatedOpenUnion extends ShapeTag.Companion[RecursiveDiscr
     }
   }
 
-  implicit val schema: Schema[RecursiveDiscriminatedOpenUnion] = recursive(union(
+  implicit val schema: Schema[RecursiveDiscriminatedOpenUnion] = recursive(union[RecursiveDiscriminatedOpenUnion](
     RecursiveDiscriminatedOpenUnion.RecCase.alt,
     RecursiveDiscriminatedOpenUnion.EndCase.alt,
     RecursiveDiscriminatedOpenUnion.UnknownCase.alt,

--- a/modules/bootstrapped/src/generated/smithy4s/example/RecursiveInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/RecursiveInput.scala
@@ -17,7 +17,7 @@ object RecursiveInput extends ShapeTag.Companion[RecursiveInput] {
   // constructor using the original order from the spec
   private def make(hello: Option[smithy4s.example.RecursiveInput]): RecursiveInput = RecursiveInput(hello)
 
-  implicit val schema: Schema[RecursiveInput] = recursive(struct(
+  implicit val schema: Schema[RecursiveInput] = recursive(struct[RecursiveInput](
     smithy4s.example.RecursiveInput.schema.optional[RecursiveInput]("hello", _.hello),
   )(make).withId(id).addHints(hints))
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/RecursiveListWrapper.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/RecursiveListWrapper.scala
@@ -17,7 +17,7 @@ object RecursiveListWrapper extends ShapeTag.Companion[RecursiveListWrapper] {
   // constructor using the original order from the spec
   private def make(items: List[smithy4s.example.RecursiveListWrapper]): RecursiveListWrapper = RecursiveListWrapper(items)
 
-  implicit val schema: Schema[RecursiveListWrapper] = recursive(struct(
+  implicit val schema: Schema[RecursiveListWrapper] = recursive(struct[RecursiveListWrapper](
     RecursiveList.underlyingSchema.required[RecursiveListWrapper]("items", _.items),
   )(make).withId(id).addHints(hints))
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/RecursiveOpenUnion.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/RecursiveOpenUnion.scala
@@ -72,7 +72,7 @@ object RecursiveOpenUnion extends ShapeTag.Companion[RecursiveOpenUnion] {
     }
   }
 
-  implicit val schema: Schema[RecursiveOpenUnion] = recursive(union(
+  implicit val schema: Schema[RecursiveOpenUnion] = recursive(union[RecursiveOpenUnion](
     RecursiveOpenUnion.RecCase.alt,
     RecursiveOpenUnion.EndCase.alt,
     RecursiveOpenUnion.UnknownCase.alt,

--- a/modules/bootstrapped/src/generated/smithy4s/example/RecursiveTraitStructure.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/RecursiveTraitStructure.scala
@@ -20,7 +20,7 @@ object RecursiveTraitStructure extends ShapeTag.Companion[RecursiveTraitStructur
   // constructor using the original order from the spec
   private def make(name: Option[String]): RecursiveTraitStructure = RecursiveTraitStructure(name)
 
-  implicit val schema: Schema[RecursiveTraitStructure] = recursive(struct(
+  implicit val schema: Schema[RecursiveTraitStructure] = recursive(struct[RecursiveTraitStructure](
     string.optional[RecursiveTraitStructure]("name", _.name).addHints(smithy4s.example.RecursiveTraitStructure(name = None)),
   )(make).withId(id).addHints(hints))
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/ReservationInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/ReservationInput.scala
@@ -19,7 +19,7 @@ object ReservationInput extends ShapeTag.Companion[ReservationInput] {
   // constructor using the original order from the spec
   private def make(name: String, town: Option[String]): ReservationInput = ReservationInput(name, town)
 
-  implicit val schema: Schema[ReservationInput] = struct(
+  implicit val schema: Schema[ReservationInput] = struct[ReservationInput](
     string.required[ReservationInput]("name", _.name).addHints(smithy.api.HttpLabel()),
     string.optional[ReservationInput]("town", _.town).addHints(smithy.api.HttpQuery("town")),
   )(make).withId(id).addHints(hints)

--- a/modules/bootstrapped/src/generated/smithy4s/example/ReservationOutput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/ReservationOutput.scala
@@ -19,7 +19,7 @@ object ReservationOutput extends ShapeTag.Companion[ReservationOutput] {
   // constructor using the original order from the spec
   private def make(message: String): ReservationOutput = ReservationOutput(message)
 
-  implicit val schema: Schema[ReservationOutput] = struct(
+  implicit val schema: Schema[ReservationOutput] = struct[ReservationOutput](
     string.required[ReservationOutput]("message", _.message),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/RoundTripData.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/RoundTripData.scala
@@ -17,7 +17,7 @@ object RoundTripData extends ShapeTag.Companion[RoundTripData] {
   // constructor using the original order from the spec
   private def make(label: String, header: Option[String], query: Option[String], body: Option[String]): RoundTripData = RoundTripData(label, header, query, body)
 
-  implicit val schema: Schema[RoundTripData] = struct(
+  implicit val schema: Schema[RoundTripData] = struct[RoundTripData](
     string.required[RoundTripData]("label", _.label).addHints(smithy.api.HttpLabel(), smithy.api.Suppress(List("HttpBindingTraitIgnored.Input"))),
     string.optional[RoundTripData]("header", _.header).addHints(smithy.api.HttpHeader("HEADER")),
     string.optional[RoundTripData]("query", _.query).addHints(smithy.api.HttpQuery("query"), smithy.api.Suppress(List("HttpBindingTraitIgnored.Input"))),

--- a/modules/bootstrapped/src/generated/smithy4s/example/Salad.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/Salad.scala
@@ -17,7 +17,7 @@ object Salad extends ShapeTag.Companion[Salad] {
   // constructor using the original order from the spec
   private def make(name: String, ingredients: List[Ingredient]): Salad = Salad(name, ingredients)
 
-  implicit val schema: Schema[Salad] = struct(
+  implicit val schema: Schema[Salad] = struct[Salad](
     string.required[Salad]("name", _.name),
     Ingredients.underlyingSchema.required[Salad]("ingredients", _.ingredients),
   )(make).withId(id).addHints(hints)

--- a/modules/bootstrapped/src/generated/smithy4s/example/SampleOpenDiscriminatedUnion.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/SampleOpenDiscriminatedUnion.scala
@@ -73,7 +73,7 @@ object SampleOpenDiscriminatedUnion extends ShapeTag.Companion[SampleOpenDiscrim
     }
   }
 
-  implicit val schema: Schema[SampleOpenDiscriminatedUnion] = union(
+  implicit val schema: Schema[SampleOpenDiscriminatedUnion] = union[SampleOpenDiscriminatedUnion](
     SampleOpenDiscriminatedUnion.SCase.alt,
     SampleOpenDiscriminatedUnion.UCase.alt,
     SampleOpenDiscriminatedUnion.UnknownCase.alt,

--- a/modules/bootstrapped/src/generated/smithy4s/example/SampleOpenUnion.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/SampleOpenUnion.scala
@@ -72,7 +72,7 @@ object SampleOpenUnion extends ShapeTag.Companion[SampleOpenUnion] {
     }
   }
 
-  implicit val schema: Schema[SampleOpenUnion] = union(
+  implicit val schema: Schema[SampleOpenUnion] = union[SampleOpenUnion](
     SampleOpenUnion.StrCase.alt,
     SampleOpenUnion.UCase.alt,
     SampleOpenUnion.UnknownCase.alt,

--- a/modules/bootstrapped/src/generated/smithy4s/example/ServerError.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/ServerError.scala
@@ -22,7 +22,7 @@ object ServerError extends ShapeTag.Companion[ServerError] {
   // constructor using the original order from the spec
   private def make(message: Option[String]): ServerError = ServerError(message)
 
-  implicit val schema: Schema[ServerError] = struct(
+  implicit val schema: Schema[ServerError] = struct[ServerError](
     string.optional[ServerError]("message", _.message),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/ServerErrorCustomMessage.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/ServerErrorCustomMessage.scala
@@ -22,7 +22,7 @@ object ServerErrorCustomMessage extends ShapeTag.Companion[ServerErrorCustomMess
   // constructor using the original order from the spec
   private def make(messageField: Option[String]): ServerErrorCustomMessage = ServerErrorCustomMessage(messageField)
 
-  implicit val schema: Schema[ServerErrorCustomMessage] = struct(
+  implicit val schema: Schema[ServerErrorCustomMessage] = struct[ServerErrorCustomMessage](
     string.optional[ServerErrorCustomMessage]("messageField", _.messageField),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/ShouldHaveDynamicBinding.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/ShouldHaveDynamicBinding.scala
@@ -21,7 +21,7 @@ object ShouldHaveDynamicBinding extends ShapeTag.Companion[ShouldHaveDynamicBind
   // constructor using the original order from the spec
   private def make(a: Option[String], b: Option[String]): ShouldHaveDynamicBinding = ShouldHaveDynamicBinding(a, b)
 
-  implicit val schema: Schema[ShouldHaveDynamicBinding] = struct(
+  implicit val schema: Schema[ShouldHaveDynamicBinding] = struct[ShouldHaveDynamicBinding](
     string.optional[ShouldHaveDynamicBinding]("a", _.a).addHints(smithy.api.Since("2"), Hints.dynamic(ShapeId("smithy4s.example", "testDynamicBinding"), smithy4s.Document.obj("str" -> smithy4s.Document.fromString("test2"), "int" -> smithy4s.Document.fromLong(1234)))),
     string.validated(smithy.api.Length(min = Some(1L), max = None)).optional[ShouldHaveDynamicBinding]("b", _.b).addHints(Hints.dynamic(ShapeId("smithy4s.example", "testDynamicBinding"), smithy4s.Document.obj())),
   )(make).withId(id).addHints(hints)

--- a/modules/bootstrapped/src/generated/smithy4s/example/SomeCollections.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/SomeCollections.scala
@@ -19,7 +19,7 @@ object SomeCollections extends ShapeTag.Companion[SomeCollections] {
   // constructor using the original order from the spec
   private def make(someList: List[String], someSet: Set[String], someMap: Map[String, String]): SomeCollections = SomeCollections(someList, someSet, someMap)
 
-  implicit val schema: Schema[SomeCollections] = recursive(struct(
+  implicit val schema: Schema[SomeCollections] = recursive(struct[SomeCollections](
     StringList.underlyingSchema.required[SomeCollections]("someList", _.someList),
     StringSet.underlyingSchema.required[SomeCollections]("someSet", _.someSet),
     StringMap.underlyingSchema.required[SomeCollections]("someMap", _.someMap),

--- a/modules/bootstrapped/src/generated/smithy4s/example/StructForDiscrimination.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/StructForDiscrimination.scala
@@ -17,7 +17,7 @@ object StructForDiscrimination extends ShapeTag.Companion[StructForDiscriminatio
   // constructor using the original order from the spec
   private def make(str: String): StructForDiscrimination = StructForDiscrimination(str)
 
-  implicit val schema: Schema[StructForDiscrimination] = struct(
+  implicit val schema: Schema[StructForDiscrimination] = struct[StructForDiscrimination](
     string.required[StructForDiscrimination]("str", _.str),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/StructUsingMixinRequiredMember.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/StructUsingMixinRequiredMember.scala
@@ -17,7 +17,7 @@ object StructUsingMixinRequiredMember extends ShapeTag.Companion[StructUsingMixi
   // constructor using the original order from the spec
   private def make(description: String, extraField: String): StructUsingMixinRequiredMember = StructUsingMixinRequiredMember(description, extraField)
 
-  implicit val schema: Schema[StructUsingMixinRequiredMember] = struct(
+  implicit val schema: Schema[StructUsingMixinRequiredMember] = struct[StructUsingMixinRequiredMember](
     string.required[StructUsingMixinRequiredMember]("description", _.description),
     string.required[StructUsingMixinRequiredMember]("extraField", _.extraField),
   )(make).withId(id).addHints(hints)

--- a/modules/bootstrapped/src/generated/smithy4s/example/StructWithOpenUnion.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/StructWithOpenUnion.scala
@@ -17,7 +17,7 @@ object StructWithOpenUnion extends ShapeTag.Companion[StructWithOpenUnion] {
   // constructor using the original order from the spec
   private def make(union: SampleOpenUnion, str: String): StructWithOpenUnion = StructWithOpenUnion(union, str)
 
-  implicit val schema: Schema[StructWithOpenUnion] = struct(
+  implicit val schema: Schema[StructWithOpenUnion] = struct[StructWithOpenUnion](
     SampleOpenUnion.schema.required[StructWithOpenUnion]("union", _.union),
     string.required[StructWithOpenUnion]("str", _.str),
   )(make).withId(id).addHints(hints)

--- a/modules/bootstrapped/src/generated/smithy4s/example/StructureConstrainingEnum.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/StructureConstrainingEnum.scala
@@ -19,7 +19,7 @@ object StructureConstrainingEnum extends ShapeTag.Companion[StructureConstrainin
   // constructor using the original order from the spec
   private def make(letter: Option[Letters], card: Option[FaceCard]): StructureConstrainingEnum = StructureConstrainingEnum(letter, card)
 
-  implicit val schema: Schema[StructureConstrainingEnum] = struct(
+  implicit val schema: Schema[StructureConstrainingEnum] = struct[StructureConstrainingEnum](
     Letters.schema.validated(smithy.api.Length(min = Some(2L), max = None)).validated(smithy.api.Pattern(s"$$aaa$$")).optional[StructureConstrainingEnum]("letter", _.letter),
     FaceCard.schema.validated(smithy.api.Range(min = None, max = Some(scala.math.BigDecimal(1.0)))).optional[StructureConstrainingEnum]("card", _.card),
   )(make).withId(id).addHints(hints)

--- a/modules/bootstrapped/src/generated/smithy4s/example/StructureWithRefinedMember.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/StructureWithRefinedMember.scala
@@ -18,7 +18,7 @@ object StructureWithRefinedMember extends ShapeTag.Companion[StructureWithRefine
   // constructor using the original order from the spec
   private def make(otherAge: Option[smithy4s.refined.Age]): StructureWithRefinedMember = StructureWithRefinedMember(otherAge)
 
-  implicit val schema: Schema[StructureWithRefinedMember] = struct(
+  implicit val schema: Schema[StructureWithRefinedMember] = struct[StructureWithRefinedMember](
     int.refined[smithy4s.refined.Age](smithy4s.example.AgeFormat()).optional[StructureWithRefinedMember]("otherAge", _.otherAge),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/StructureWithRefinedTypes.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/StructureWithRefinedTypes.scala
@@ -22,7 +22,7 @@ object StructureWithRefinedTypes extends ShapeTag.Companion[StructureWithRefined
   // constructor using the original order from the spec
   private def make(age: Option[smithy4s.example.Age], personAge: PersonAge, requiredAge: smithy4s.example.Age, fancyList: Option[smithy4s.example.FancyList], unwrappedFancyList: Option[smithy4s.refined.FancyList], name: Option[smithy4s.example.Name], dogName: Option[smithy4s.refined.Name], inlineFieldConstraint: smithy4s.refined.Age, uuidField: UUID): StructureWithRefinedTypes = StructureWithRefinedTypes(requiredAge, personAge, inlineFieldConstraint, uuidField, age, fancyList, unwrappedFancyList, name, dogName)
 
-  implicit val schema: Schema[StructureWithRefinedTypes] = struct(
+  implicit val schema: Schema[StructureWithRefinedTypes] = struct[StructureWithRefinedTypes](
     smithy4s.example.Age.schema.optional[StructureWithRefinedTypes]("age", _.age),
     PersonAge.schema.field[StructureWithRefinedTypes]("personAge", _.personAge).addHints(smithy.api.Default(smithy4s.Document.fromLong(1))),
     smithy4s.example.Age.schema.required[StructureWithRefinedTypes]("requiredAge", _.requiredAge),

--- a/modules/bootstrapped/src/generated/smithy4s/example/StructureWithScalaImports.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/StructureWithScalaImports.scala
@@ -18,7 +18,7 @@ object StructureWithScalaImports extends ShapeTag.Companion[StructureWithScalaIm
   // constructor using the original order from the spec
   private def make(teenage: Option[Age]): StructureWithScalaImports = StructureWithScalaImports(teenage)
 
-  implicit val schema: Schema[StructureWithScalaImports] = struct(
+  implicit val schema: Schema[StructureWithScalaImports] = struct[StructureWithScalaImports](
     Age.schema.validated(smithy.api.Range(min = Some(scala.math.BigDecimal(13.0)), max = Some(scala.math.BigDecimal(19.0)))).optional[StructureWithScalaImports]("teenage", _.teenage),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/TestAdt.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/TestAdt.scala
@@ -48,7 +48,7 @@ object TestAdt extends ShapeTag.Companion[TestAdt] {
     // constructor using the original order from the spec
     private def make(lng: Option[Long], sht: Option[Short], blb: Option[Blob], str: Option[String]): AdtOne = AdtOne(lng, sht, blb, str)
 
-    val schema: Schema[AdtOne] = struct(
+    val schema: Schema[AdtOne] = struct[AdtOne](
       long.optional[AdtOne]("lng", _.lng),
       short.optional[AdtOne]("sht", _.sht),
       bytes.optional[AdtOne]("blb", _.blb),
@@ -69,7 +69,7 @@ object TestAdt extends ShapeTag.Companion[TestAdt] {
     // constructor using the original order from the spec
     private def make(lng: Option[Long], sht: Option[Short], int: Option[Int]): AdtTwo = AdtTwo(lng, sht, int)
 
-    val schema: Schema[AdtTwo] = struct(
+    val schema: Schema[AdtTwo] = struct[AdtTwo](
       long.optional[AdtTwo]("lng", _.lng),
       short.optional[AdtTwo]("sht", _.sht),
       int.optional[AdtTwo]("int", _.int),
@@ -92,7 +92,7 @@ object TestAdt extends ShapeTag.Companion[TestAdt] {
     }
   }
 
-  implicit val schema: Schema[TestAdt] = union(
+  implicit val schema: Schema[TestAdt] = union[TestAdt](
     TestAdt.AdtOne.alt,
     TestAdt.AdtTwo.alt,
   ){

--- a/modules/bootstrapped/src/generated/smithy4s/example/TestBiggerUnion.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/TestBiggerUnion.scala
@@ -59,7 +59,7 @@ object TestBiggerUnion extends ShapeTag.Companion[TestBiggerUnion] {
     }
   }
 
-  implicit val schema: Schema[TestBiggerUnion] = union(
+  implicit val schema: Schema[TestBiggerUnion] = union[TestBiggerUnion](
     TestBiggerUnion.OneCase.alt,
     TestBiggerUnion.TwoCase.alt,
   ){

--- a/modules/bootstrapped/src/generated/smithy4s/example/TestBody.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/TestBody.scala
@@ -22,7 +22,7 @@ object TestBody extends ShapeTag.Companion[TestBody] {
   // constructor using the original order from the spec
   private def make(data: Option[String]): TestBody = TestBody(data)
 
-  implicit val schema: Schema[TestBody] = struct(
+  implicit val schema: Schema[TestBody] = struct[TestBody](
     string.validated(smithy.api.Length(min = Some(10L), max = None)).optional[TestBody]("data", _.data),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/TestDiscriminatedInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/TestDiscriminatedInput.scala
@@ -17,7 +17,7 @@ object TestDiscriminatedInput extends ShapeTag.Companion[TestDiscriminatedInput]
   // constructor using the original order from the spec
   private def make(key: String): TestDiscriminatedInput = TestDiscriminatedInput(key)
 
-  implicit val schema: Schema[TestDiscriminatedInput] = struct(
+  implicit val schema: Schema[TestDiscriminatedInput] = struct[TestDiscriminatedInput](
     string.required[TestDiscriminatedInput]("key", _.key).addHints(smithy.api.HttpLabel()),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/TestDiscriminatedOutput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/TestDiscriminatedOutput.scala
@@ -16,7 +16,7 @@ object TestDiscriminatedOutput extends ShapeTag.Companion[TestDiscriminatedOutpu
   // constructor using the original order from the spec
   private def make(data: Option[PayloadData]): TestDiscriminatedOutput = TestDiscriminatedOutput(data)
 
-  implicit val schema: Schema[TestDiscriminatedOutput] = struct(
+  implicit val schema: Schema[TestDiscriminatedOutput] = struct[TestDiscriminatedOutput](
     PayloadData.schema.optional[TestDiscriminatedOutput]("data", _.data).addHints(smithy.api.HttpPayload()),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/TestDynamicBinding.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/TestDynamicBinding.scala
@@ -21,7 +21,7 @@ object TestDynamicBinding extends ShapeTag.Companion[TestDynamicBinding] {
   // constructor using the original order from the spec
   private def make(str: Option[String], int: Option[Int]): TestDynamicBinding = TestDynamicBinding(str, int)
 
-  implicit val schema: Schema[TestDynamicBinding] = recursive(struct(
+  implicit val schema: Schema[TestDynamicBinding] = recursive(struct[TestDynamicBinding](
     string.optional[TestDynamicBinding]("str", _.str),
     int.optional[TestDynamicBinding]("int", _.int),
   )(make).withId(id).addHints(hints))

--- a/modules/bootstrapped/src/generated/smithy4s/example/TestEmptyMixin.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/TestEmptyMixin.scala
@@ -17,7 +17,7 @@ object TestEmptyMixin extends ShapeTag.Companion[TestEmptyMixin] {
   // constructor using the original order from the spec
   private def make(a: Option[Long]): TestEmptyMixin = TestEmptyMixin(a)
 
-  implicit val schema: Schema[TestEmptyMixin] = struct(
+  implicit val schema: Schema[TestEmptyMixin] = struct[TestEmptyMixin](
     long.optional[TestEmptyMixin]("a", _.a),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/TestIdRef.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/TestIdRef.scala
@@ -17,7 +17,7 @@ object TestIdRef extends ShapeTag.Companion[TestIdRef] {
   // constructor using the original order from the spec
   private def make(test: Option[ShapeId], test2: Option[TestIdRefTwo]): TestIdRef = TestIdRef(test, test2)
 
-  implicit val schema: Schema[TestIdRef] = struct(
+  implicit val schema: Schema[TestIdRef] = struct[TestIdRef](
     string.refined[ShapeId](smithy.api.IdRef(selector = "*", failWhenMissing = None, errorMessage = None)).optional[TestIdRef]("test", _.test),
     TestIdRefTwo.schema.optional[TestIdRef]("test2", _.test2),
   )(make).withId(id).addHints(hints)

--- a/modules/bootstrapped/src/generated/smithy4s/example/TestIdRefUnion.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/TestIdRefUnion.scala
@@ -58,7 +58,7 @@ object TestIdRefUnion extends ShapeTag.Companion[TestIdRefUnion] {
     }
   }
 
-  implicit val schema: Schema[TestIdRefUnion] = union(
+  implicit val schema: Schema[TestIdRefUnion] = union[TestIdRefUnion](
     TestIdRefUnion.TestCase.alt,
     TestIdRefUnion.TestTwoCase.alt,
   ){

--- a/modules/bootstrapped/src/generated/smithy4s/example/TestInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/TestInput.scala
@@ -24,7 +24,7 @@ object TestInput extends ShapeTag.Companion[TestInput] {
   // constructor using the original order from the spec
   private def make(pathParam: String, queryParam: Option[String], body: TestBody): TestInput = TestInput(pathParam, body, queryParam)
 
-  implicit val schema: Schema[TestInput] = struct(
+  implicit val schema: Schema[TestInput] = struct[TestInput](
     string.validated(smithy.api.Length(min = Some(10L), max = None)).required[TestInput]("pathParam", _.pathParam).addHints(smithy.api.HttpLabel()),
     string.validated(smithy.api.Length(min = Some(10L), max = None)).optional[TestInput]("queryParam", _.queryParam).addHints(smithy.api.HttpQuery("queryParam")),
     TestBody.schema.required[TestInput]("body", _.body).addHints(smithy.api.HttpPayload()),

--- a/modules/bootstrapped/src/generated/smithy4s/example/TestMixinAdt.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/TestMixinAdt.scala
@@ -41,7 +41,7 @@ object TestMixinAdt extends ShapeTag.Companion[TestMixinAdt] {
     // constructor using the original order from the spec
     private def make(a: Option[String], b: Option[Int]): TestAdtMemberWithMixin = TestAdtMemberWithMixin(a, b)
 
-    val schema: Schema[TestAdtMemberWithMixin] = struct(
+    val schema: Schema[TestAdtMemberWithMixin] = struct[TestAdtMemberWithMixin](
       string.optional[TestAdtMemberWithMixin]("a", _.a),
       int.optional[TestAdtMemberWithMixin]("b", _.b),
     )(make).withId(id).addHints(hints)
@@ -61,7 +61,7 @@ object TestMixinAdt extends ShapeTag.Companion[TestMixinAdt] {
     }
   }
 
-  implicit val schema: Schema[TestMixinAdt] = union(
+  implicit val schema: Schema[TestMixinAdt] = union[TestMixinAdt](
     TestMixinAdt.TestAdtMemberWithMixin.alt,
   ){
     _.$ordinal

--- a/modules/bootstrapped/src/generated/smithy4s/example/TestStructurePatternTarget.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/TestStructurePatternTarget.scala
@@ -18,7 +18,7 @@ object TestStructurePatternTarget extends ShapeTag.Companion[TestStructurePatter
   // constructor using the original order from the spec
   private def make(one: String, two: Int): TestStructurePatternTarget = TestStructurePatternTarget(one, two)
 
-  implicit val schema: Schema[TestStructurePatternTarget] = struct(
+  implicit val schema: Schema[TestStructurePatternTarget] = struct[TestStructurePatternTarget](
     string.required[TestStructurePatternTarget]("one", _.one),
     int.required[TestStructurePatternTarget]("two", _.two),
   )(make).withId(id).addHints(hints)

--- a/modules/bootstrapped/src/generated/smithy4s/example/TestTrait.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/TestTrait.scala
@@ -23,7 +23,7 @@ object TestTrait extends ShapeTag.Companion[TestTrait] {
   // constructor using the original order from the spec
   private def make(orderType: Option[OrderType]): TestTrait = TestTrait(orderType)
 
-  implicit val schema: Schema[TestTrait] = recursive(struct(
+  implicit val schema: Schema[TestTrait] = recursive(struct[TestTrait](
     OrderType.schema.optional[TestTrait]("orderType", _.orderType),
   )(make).withId(id).addHints(hints))
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/Three.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/Three.scala
@@ -17,7 +17,7 @@ object Three extends ShapeTag.Companion[Three] {
   // constructor using the original order from the spec
   private def make(three: String): Three = Three(three)
 
-  implicit val schema: Schema[Three] = struct(
+  implicit val schema: Schema[Three] = struct[Three](
     string.required[Three]("three", _.three),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/TimestampOperationInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/TimestampOperationInput.scala
@@ -20,7 +20,7 @@ object TimestampOperationInput extends ShapeTag.Companion[TimestampOperationInpu
   // constructor using the original order from the spec
   private def make(httpDate: Timestamp, epochSeconds: Timestamp, dateTime: Timestamp): TimestampOperationInput = TimestampOperationInput(httpDate, epochSeconds, dateTime)
 
-  implicit val schema: Schema[TimestampOperationInput] = struct(
+  implicit val schema: Schema[TimestampOperationInput] = struct[TimestampOperationInput](
     timestamp.required[TimestampOperationInput]("httpDate", _.httpDate).addHints(smithy.api.Default(smithy4s.Document.fromString("Thu, 23 May 2024 10:20:30 GMT")), smithy.api.TimestampFormat.HTTP_DATE.widen),
     timestamp.required[TimestampOperationInput]("epochSeconds", _.epochSeconds).addHints(smithy.api.Default(smithy4s.Document.fromLong(1716459630)), smithy.api.TimestampFormat.EPOCH_SECONDS.widen),
     timestamp.required[TimestampOperationInput]("dateTime", _.dateTime).addHints(smithy.api.Default(smithy4s.Document.fromString("2024-05-23T10:20:30.000Z")), smithy.api.TimestampFormat.DATE_TIME.widen),

--- a/modules/bootstrapped/src/generated/smithy4s/example/Two.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/Two.scala
@@ -17,7 +17,7 @@ object Two extends ShapeTag.Companion[Two] {
   // constructor using the original order from the spec
   private def make(value: Option[Int]): Two = Two(value)
 
-  implicit val schema: Schema[Two] = struct(
+  implicit val schema: Schema[Two] = struct[Two](
     int.optional[Two]("value", _.value),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/UnauthorizedError.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/UnauthorizedError.scala
@@ -20,7 +20,7 @@ object UnauthorizedError extends ShapeTag.Companion[UnauthorizedError] {
   // constructor using the original order from the spec
   private def make(reason: String): UnauthorizedError = UnauthorizedError(reason)
 
-  implicit val schema: Schema[UnauthorizedError] = struct(
+  implicit val schema: Schema[UnauthorizedError] = struct[UnauthorizedError](
     string.required[UnauthorizedError]("reason", _.reason),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/UnionTraitWithUnitCase.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/UnionTraitWithUnitCase.scala
@@ -60,7 +60,7 @@ object UnionTraitWithUnitCase extends ShapeTag.Companion[UnionTraitWithUnitCase]
     }
   }
 
-  implicit val schema: Schema[UnionTraitWithUnitCase] = recursive(union(
+  implicit val schema: Schema[UnionTraitWithUnitCase] = recursive(union[UnionTraitWithUnitCase](
     UnionTraitWithUnitCase.UCase.alt,
     UnionTraitWithUnitCase.SCase.alt,
   ){

--- a/modules/bootstrapped/src/generated/smithy4s/example/UnionWithRefinedTypes.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/UnionWithRefinedTypes.scala
@@ -57,7 +57,7 @@ object UnionWithRefinedTypes extends ShapeTag.Companion[UnionWithRefinedTypes] {
     }
   }
 
-  implicit val schema: Schema[UnionWithRefinedTypes] = union(
+  implicit val schema: Schema[UnionWithRefinedTypes] = union[UnionWithRefinedTypes](
     UnionWithRefinedTypes.AgeCase.alt,
     UnionWithRefinedTypes.DogNameCase.alt,
   ){

--- a/modules/bootstrapped/src/generated/smithy4s/example/UnknownServerError.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/UnknownServerError.scala
@@ -21,7 +21,7 @@ object UnknownServerError extends ShapeTag.Companion[UnknownServerError] {
   // constructor using the original order from the spec
   private def make(errorCode: UnknownServerErrorCode, description: Option[String], stateHash: Option[String]): UnknownServerError = UnknownServerError(errorCode, description, stateHash)
 
-  implicit val schema: Schema[UnknownServerError] = struct(
+  implicit val schema: Schema[UnknownServerError] = struct[UnknownServerError](
     UnknownServerErrorCode.schema.required[UnknownServerError]("errorCode", _.errorCode),
     string.optional[UnknownServerError]("description", _.description),
     string.optional[UnknownServerError]("stateHash", _.stateHash),

--- a/modules/bootstrapped/src/generated/smithy4s/example/UntaggedUnion.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/UntaggedUnion.scala
@@ -59,7 +59,7 @@ object UntaggedUnion extends ShapeTag.Companion[UntaggedUnion] {
     }
   }
 
-  implicit val schema: Schema[UntaggedUnion] = union(
+  implicit val schema: Schema[UntaggedUnion] = union[UntaggedUnion](
     UntaggedUnion.ThreeCase.alt,
     UntaggedUnion.FourCase.alt,
   ){

--- a/modules/bootstrapped/src/generated/smithy4s/example/ValidatedFoo.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/ValidatedFoo.scala
@@ -16,7 +16,7 @@ object ValidatedFoo extends ShapeTag.Companion[ValidatedFoo] {
   // constructor using the original order from the spec
   private def make(name: ValidatedString): ValidatedFoo = ValidatedFoo(name)
 
-  implicit val schema: Schema[ValidatedFoo] = struct(
+  implicit val schema: Schema[ValidatedFoo] = struct[ValidatedFoo](
     ValidatedString.schema.field[ValidatedFoo]("name", _.name).addHints(smithy.api.Default(smithy4s.Document.fromString("abc"))),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/ValidationChecks.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/ValidationChecks.scala
@@ -18,7 +18,7 @@ object ValidationChecks extends ShapeTag.Companion[ValidationChecks] {
   // constructor using the original order from the spec
   private def make(str: Option[String], lst: Option[List[String]], int: Option[Int]): ValidationChecks = ValidationChecks(str, lst, int)
 
-  implicit val schema: Schema[ValidationChecks] = struct(
+  implicit val schema: Schema[ValidationChecks] = struct[ValidationChecks](
     string.validated(smithy.api.Length(min = Some(1L), max = Some(10L))).optional[ValidationChecks]("str", _.str).addHints(smithy.api.HttpQuery("str")),
     StringList.underlyingSchema.validated(smithy.api.Length(min = Some(1L), max = Some(10L))).optional[ValidationChecks]("lst", _.lst).addHints(smithy.api.HttpQuery("lst")),
     int.validated(smithy.api.Range(min = Some(scala.math.BigDecimal(1.0)), max = Some(scala.math.BigDecimal(10.0)))).optional[ValidationChecks]("int", _.int).addHints(smithy.api.HttpQuery("int")),

--- a/modules/bootstrapped/src/generated/smithy4s/example/Value.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/Value.scala
@@ -17,7 +17,7 @@ object Value extends ShapeTag.Companion[Value] {
   // constructor using the original order from the spec
   private def make(value: String): Value = Value(value)
 
-  implicit val schema: Schema[Value] = struct(
+  implicit val schema: Schema[Value] = struct[Value](
     string.required[Value]("value", _.value),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/VersionOutput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/VersionOutput.scala
@@ -17,7 +17,7 @@ object VersionOutput extends ShapeTag.Companion[VersionOutput] {
   // constructor using the original order from the spec
   private def make(version: String): VersionOutput = VersionOutput(version)
 
-  implicit val schema: Schema[VersionOutput] = struct(
+  implicit val schema: Schema[VersionOutput] = struct[VersionOutput](
     string.required[VersionOutput]("version", _.version).addHints(smithy.api.HttpPayload()),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/Weather.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/Weather.scala
@@ -154,7 +154,7 @@ object WeatherOperation {
       }
     }
 
-    implicit val schema: Schema[GetCityError] = union(
+    implicit val schema: Schema[GetCityError] = union[GetCityError](
       GetCityError.NoSuchResourceCase.alt,
     ){
       _.$ordinal

--- a/modules/bootstrapped/src/generated/smithy4s/example/accept/BlobOutputNoMediaTypeInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/accept/BlobOutputNoMediaTypeInput.scala
@@ -19,7 +19,7 @@ object BlobOutputNoMediaTypeInput extends ShapeTag.Companion[BlobOutputNoMediaTy
   // constructor using the original order from the spec
   private def make(data: Option[String]): BlobOutputNoMediaTypeInput = BlobOutputNoMediaTypeInput(data)
 
-  implicit val schema: Schema[BlobOutputNoMediaTypeInput] = struct(
+  implicit val schema: Schema[BlobOutputNoMediaTypeInput] = struct[BlobOutputNoMediaTypeInput](
     string.optional[BlobOutputNoMediaTypeInput]("data", _.data).addHints(smithy.api.HttpPayload()),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/accept/BlobOutputNoMediaTypeOutput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/accept/BlobOutputNoMediaTypeOutput.scala
@@ -20,7 +20,7 @@ object BlobOutputNoMediaTypeOutput extends ShapeTag.Companion[BlobOutputNoMediaT
   // constructor using the original order from the spec
   private def make(image: Option[Blob]): BlobOutputNoMediaTypeOutput = BlobOutputNoMediaTypeOutput(image)
 
-  implicit val schema: Schema[BlobOutputNoMediaTypeOutput] = struct(
+  implicit val schema: Schema[BlobOutputNoMediaTypeOutput] = struct[BlobOutputNoMediaTypeOutput](
     bytes.optional[BlobOutputNoMediaTypeOutput]("image", _.image).addHints(smithy.api.HttpPayload()),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/accept/BlobOutputWithMediaTypeInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/accept/BlobOutputWithMediaTypeInput.scala
@@ -19,7 +19,7 @@ object BlobOutputWithMediaTypeInput extends ShapeTag.Companion[BlobOutputWithMed
   // constructor using the original order from the spec
   private def make(data: Option[String]): BlobOutputWithMediaTypeInput = BlobOutputWithMediaTypeInput(data)
 
-  implicit val schema: Schema[BlobOutputWithMediaTypeInput] = struct(
+  implicit val schema: Schema[BlobOutputWithMediaTypeInput] = struct[BlobOutputWithMediaTypeInput](
     string.optional[BlobOutputWithMediaTypeInput]("data", _.data).addHints(smithy.api.HttpPayload()),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/accept/BlobOutputWithMediaTypeOutput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/accept/BlobOutputWithMediaTypeOutput.scala
@@ -21,7 +21,7 @@ object BlobOutputWithMediaTypeOutput extends ShapeTag.Companion[BlobOutputWithMe
   // constructor using the original order from the spec
   private def make(image: Option[PngImage]): BlobOutputWithMediaTypeOutput = BlobOutputWithMediaTypeOutput(image)
 
-  implicit val schema: Schema[BlobOutputWithMediaTypeOutput] = struct(
+  implicit val schema: Schema[BlobOutputWithMediaTypeOutput] = struct[BlobOutputWithMediaTypeOutput](
     PngImage.schema.optional[BlobOutputWithMediaTypeOutput]("image", _.image).addHints(smithy.api.HttpPayload()),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/accept/DefaultAcceptHeaderInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/accept/DefaultAcceptHeaderInput.scala
@@ -19,7 +19,7 @@ object DefaultAcceptHeaderInput extends ShapeTag.Companion[DefaultAcceptHeaderIn
   // constructor using the original order from the spec
   private def make(data: Option[String]): DefaultAcceptHeaderInput = DefaultAcceptHeaderInput(data)
 
-  implicit val schema: Schema[DefaultAcceptHeaderInput] = struct(
+  implicit val schema: Schema[DefaultAcceptHeaderInput] = struct[DefaultAcceptHeaderInput](
     string.optional[DefaultAcceptHeaderInput]("data", _.data),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/accept/DefaultAcceptHeaderOutput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/accept/DefaultAcceptHeaderOutput.scala
@@ -19,7 +19,7 @@ object DefaultAcceptHeaderOutput extends ShapeTag.Companion[DefaultAcceptHeaderO
   // constructor using the original order from the spec
   private def make(result: Option[String]): DefaultAcceptHeaderOutput = DefaultAcceptHeaderOutput(result)
 
-  implicit val schema: Schema[DefaultAcceptHeaderOutput] = struct(
+  implicit val schema: Schema[DefaultAcceptHeaderOutput] = struct[DefaultAcceptHeaderOutput](
     string.optional[DefaultAcceptHeaderOutput]("result", _.result).addHints(smithy.api.HttpPayload()),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/accept/JsonInputXmlOutputInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/accept/JsonInputXmlOutputInput.scala
@@ -21,7 +21,7 @@ object JsonInputXmlOutputInput extends ShapeTag.Companion[JsonInputXmlOutputInpu
   // constructor using the original order from the spec
   private def make(data: Option[JsonPayload]): JsonInputXmlOutputInput = JsonInputXmlOutputInput(data)
 
-  implicit val schema: Schema[JsonInputXmlOutputInput] = struct(
+  implicit val schema: Schema[JsonInputXmlOutputInput] = struct[JsonInputXmlOutputInput](
     JsonPayload.schema.optional[JsonInputXmlOutputInput]("data", _.data).addHints(smithy.api.HttpPayload()),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/accept/JsonInputXmlOutputOutput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/accept/JsonInputXmlOutputOutput.scala
@@ -21,7 +21,7 @@ object JsonInputXmlOutputOutput extends ShapeTag.Companion[JsonInputXmlOutputOut
   // constructor using the original order from the spec
   private def make(result: Option[XmlPayload]): JsonInputXmlOutputOutput = JsonInputXmlOutputOutput(result)
 
-  implicit val schema: Schema[JsonInputXmlOutputOutput] = struct(
+  implicit val schema: Schema[JsonInputXmlOutputOutput] = struct[JsonInputXmlOutputOutput](
     XmlPayload.schema.optional[JsonInputXmlOutputOutput]("result", _.result).addHints(smithy.api.HttpPayload()),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/accept/XmlOutputInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/accept/XmlOutputInput.scala
@@ -19,7 +19,7 @@ object XmlOutputInput extends ShapeTag.Companion[XmlOutputInput] {
   // constructor using the original order from the spec
   private def make(data: Option[String]): XmlOutputInput = XmlOutputInput(data)
 
-  implicit val schema: Schema[XmlOutputInput] = struct(
+  implicit val schema: Schema[XmlOutputInput] = struct[XmlOutputInput](
     string.optional[XmlOutputInput]("data", _.data).addHints(smithy.api.HttpPayload()),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/accept/XmlOutputOutput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/accept/XmlOutputOutput.scala
@@ -21,7 +21,7 @@ object XmlOutputOutput extends ShapeTag.Companion[XmlOutputOutput] {
   // constructor using the original order from the spec
   private def make(result: Option[XmlPayload]): XmlOutputOutput = XmlOutputOutput(result)
 
-  implicit val schema: Schema[XmlOutputOutput] = struct(
+  implicit val schema: Schema[XmlOutputOutput] = struct[XmlOutputOutput](
     XmlPayload.schema.optional[XmlOutputOutput]("result", _.result).addHints(smithy.api.HttpPayload()),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/bincompat/BincompatFriendlyTraitStruct.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/bincompat/BincompatFriendlyTraitStruct.scala
@@ -41,7 +41,7 @@ object BincompatFriendlyTraitStruct extends ShapeTag.Companion[BincompatFriendly
   // Members available up to version 3.0 (inclusive)
   def apply(base1: String, base2: String, base3: Option[String], added2_1: String, added3_1: String): BincompatFriendlyTraitStruct = new BincompatFriendlyTraitStruct(base1 = base1, base2 = base2, base3 = base3, added2_1 = added2_1, added3_1 = added3_1)
 
-  implicit val schema: Schema[BincompatFriendlyTraitStruct] = recursive(struct(
+  implicit val schema: Schema[BincompatFriendlyTraitStruct] = recursive(struct[BincompatFriendlyTraitStruct](
     string.required[BincompatFriendlyTraitStruct]("base1", _.base1),
     string.required[BincompatFriendlyTraitStruct]("base2", _.base2),
     string.optional[BincompatFriendlyTraitStruct]("base3", _.base3),

--- a/modules/bootstrapped/src/generated/smithy4s/example/bincompat/BincompatOneFieldStruct.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/bincompat/BincompatOneFieldStruct.scala
@@ -30,7 +30,7 @@ object BincompatOneFieldStruct extends ShapeTag.Companion[BincompatOneFieldStruc
   // Members available since the beginning
   def apply(s: Option[String] = None): BincompatOneFieldStruct = new BincompatOneFieldStruct(s = s)
 
-  implicit val schema: Schema[BincompatOneFieldStruct] = struct(
+  implicit val schema: Schema[BincompatOneFieldStruct] = struct[BincompatOneFieldStruct](
     string.optional[BincompatOneFieldStruct]("s", _.s),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/bincompat/BincompatStruct.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/bincompat/BincompatStruct.scala
@@ -46,7 +46,7 @@ object BincompatStruct extends ShapeTag.Companion[BincompatStruct] {
   // Members available up to version 4.0 (inclusive)
   def apply(base1: String, base2: String, base3: Option[String], base4: String, added2_1: String, added2_2: Option[String], added3_1: String, added3_2: Option[String], added4_1: String, added4_2: Option[Nullable[String]]): BincompatStruct = new BincompatStruct(base1 = base1, base2 = base2, base3 = base3, base4 = base4, added2_1 = added2_1, added2_2 = added2_2, added3_1 = added3_1, added3_2 = added3_2, added4_1 = added4_1, added4_2 = added4_2)
 
-  implicit val schema: Schema[BincompatStruct] = struct(
+  implicit val schema: Schema[BincompatStruct] = struct[BincompatStruct](
     string.required[BincompatStruct]("base1", _.base1),
     string.required[BincompatStruct]("base2", _.base2),
     string.optional[BincompatStruct]("base3", _.base3),

--- a/modules/bootstrapped/src/generated/smithy4s/example/bincompat/BincompatStructSmall.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/bincompat/BincompatStructSmall.scala
@@ -33,7 +33,7 @@ object BincompatStructSmall extends ShapeTag.Companion[BincompatStructSmall] {
   // Members available up to version 2.0 (inclusive)
   def apply(base1: String, added2_1: Option[String]): BincompatStructSmall = new BincompatStructSmall(base1 = base1, added2_1 = added2_1)
 
-  implicit val schema: Schema[BincompatStructSmall] = struct(
+  implicit val schema: Schema[BincompatStructSmall] = struct[BincompatStructSmall](
     string.required[BincompatStructSmall]("base1", _.base1),
     string.optional[BincompatStructSmall]("added2_1", _.added2_1),
   )(make).withId(id).addHints(hints)

--- a/modules/bootstrapped/src/generated/smithy4s/example/bincompat/BincompatTinyUnion.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/bincompat/BincompatTinyUnion.scala
@@ -47,7 +47,7 @@ object BincompatTinyUnion extends ShapeTag.Companion[BincompatTinyUnion] {
     }
   }
 
-  implicit val schema: Schema[BincompatTinyUnion] = union(
+  implicit val schema: Schema[BincompatTinyUnion] = union[BincompatTinyUnion](
     BincompatTinyUnion.S1Case.alt,
   ){
     _.$ordinal

--- a/modules/bootstrapped/src/generated/smithy4s/example/bincompat/BincompatUnion.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/bincompat/BincompatUnion.scala
@@ -59,7 +59,7 @@ object BincompatUnion extends ShapeTag.Companion[BincompatUnion] {
     }
   }
 
-  implicit val schema: Schema[BincompatUnion] = union(
+  implicit val schema: Schema[BincompatUnion] = union[BincompatUnion](
     BincompatUnion.S1Case.alt,
     BincompatUnion.S2Case.alt,
   ){

--- a/modules/bootstrapped/src/generated/smithy4s/example/collision/AlgParameterOperationInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/collision/AlgParameterOperationInput.scala
@@ -18,7 +18,7 @@ object AlgParameterOperationInput extends ShapeTag.Companion[AlgParameterOperati
   // constructor using the original order from the spec
   private def make(alg: String): AlgParameterOperationInput = AlgParameterOperationInput(alg)
 
-  implicit val schema: Schema[AlgParameterOperationInput] = struct(
+  implicit val schema: Schema[AlgParameterOperationInput] = struct[AlgParameterOperationInput](
     String.schema.required[AlgParameterOperationInput]("alg", _.alg),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/collision/Class.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/collision/Class.scala
@@ -57,7 +57,7 @@ object Class extends ShapeTag.Companion[Class] {
     }
   }
 
-  implicit val schema: Schema[Class] = recursive(union(
+  implicit val schema: Schema[Class] = recursive(union[Class](
     Class.AdtStruct.alt,
   ){
     _.$ordinal

--- a/modules/bootstrapped/src/generated/smithy4s/example/collision/ListInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/collision/ListInput.scala
@@ -18,7 +18,7 @@ object ListInput extends ShapeTag.Companion[ListInput] {
   // constructor using the original order from the spec
   private def make(list: List[String]): ListInput = ListInput(list)
 
-  implicit val schema: Schema[ListInput] = struct(
+  implicit val schema: Schema[ListInput] = struct[ListInput](
     MyList.underlyingSchema.required[ListInput]("list", _.list),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/collision/MapInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/collision/MapInput.scala
@@ -18,7 +18,7 @@ object MapInput extends ShapeTag.Companion[MapInput] {
   // constructor using the original order from the spec
   private def make(value: Map[String, String]): MapInput = MapInput(value)
 
-  implicit val schema: Schema[MapInput] = struct(
+  implicit val schema: Schema[MapInput] = struct[MapInput](
     MyMap.underlyingSchema.required[MapInput]("value", _.value),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/collision/OptionInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/collision/OptionInput.scala
@@ -18,7 +18,7 @@ object OptionInput extends ShapeTag.Companion[OptionInput] {
   // constructor using the original order from the spec
   private def make(value: Option[String]): OptionInput = OptionInput(value)
 
-  implicit val schema: Schema[OptionInput] = struct(
+  implicit val schema: Schema[OptionInput] = struct[OptionInput](
     String.schema.optional[OptionInput]("value", _.value),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/collision/PackageUnion.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/collision/PackageUnion.scala
@@ -47,7 +47,7 @@ object PackageUnion extends ShapeTag.Companion[PackageUnion] {
     }
   }
 
-  implicit val schema: Schema[PackageUnion] = union(
+  implicit val schema: Schema[PackageUnion] = union[PackageUnion](
     PackageUnion.ClassCase.alt,
   ){
     _.$ordinal

--- a/modules/bootstrapped/src/generated/smithy4s/example/collision/Packagee.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/collision/Packagee.scala
@@ -17,7 +17,7 @@ object Packagee extends ShapeTag.Companion[Packagee] {
   // constructor using the original order from the spec
   private def make(_class: Option[Int]): Packagee = Packagee(_class)
 
-  implicit val schema: Schema[Packagee] = struct(
+  implicit val schema: Schema[Packagee] = struct[Packagee](
     int.optional[Packagee]("class", _._class),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/collision/ReservedKeywordStructTrait.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/collision/ReservedKeywordStructTrait.scala
@@ -19,7 +19,7 @@ object ReservedKeywordStructTrait extends ShapeTag.Companion[ReservedKeywordStru
   // constructor using the original order from the spec
   private def make(_implicit: String, _package: Option[Packagee]): ReservedKeywordStructTrait = ReservedKeywordStructTrait(_implicit, _package)
 
-  implicit val schema: Schema[ReservedKeywordStructTrait] = recursive(struct(
+  implicit val schema: Schema[ReservedKeywordStructTrait] = recursive(struct[ReservedKeywordStructTrait](
     String.schema.required[ReservedKeywordStructTrait]("implicit", _._implicit),
     Packagee.schema.optional[ReservedKeywordStructTrait]("package", _._package),
   )(make).withId(id).addHints(hints))

--- a/modules/bootstrapped/src/generated/smithy4s/example/collision/ReservedKeywordTraitExampleStruct.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/collision/ReservedKeywordTraitExampleStruct.scala
@@ -19,7 +19,7 @@ object ReservedKeywordTraitExampleStruct extends ShapeTag.Companion[ReservedKeyw
   // constructor using the original order from the spec
   private def make(member: Option[String]): ReservedKeywordTraitExampleStruct = ReservedKeywordTraitExampleStruct(member)
 
-  implicit val schema: Schema[ReservedKeywordTraitExampleStruct] = struct(
+  implicit val schema: Schema[ReservedKeywordTraitExampleStruct] = struct[ReservedKeywordTraitExampleStruct](
     String.schema.optional[ReservedKeywordTraitExampleStruct]("member", _.member).addHints(smithy4s.example.collision.ReservedKeywordStructTrait(_implicit = smithy4s.example.collision.String("demo"), _package = Some(smithy4s.example.collision.Packagee(_class = Some(42)))), smithy4s.example.collision.ReservedKeywordUnionTrait.PackageCase(smithy4s.example.collision.PackageUnion.ClassCase(42).widen).widen),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/collision/ReservedKeywordTraitExampleUnion.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/collision/ReservedKeywordTraitExampleUnion.scala
@@ -50,7 +50,7 @@ object ReservedKeywordTraitExampleUnion extends ShapeTag.Companion[ReservedKeywo
     }
   }
 
-  implicit val schema: Schema[ReservedKeywordTraitExampleUnion] = union(
+  implicit val schema: Schema[ReservedKeywordTraitExampleUnion] = union[ReservedKeywordTraitExampleUnion](
     ReservedKeywordTraitExampleUnion.MemberCase.alt,
   ){
     _.$ordinal

--- a/modules/bootstrapped/src/generated/smithy4s/example/collision/ReservedKeywordUnionTrait.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/collision/ReservedKeywordUnionTrait.scala
@@ -49,7 +49,7 @@ object ReservedKeywordUnionTrait extends ShapeTag.Companion[ReservedKeywordUnion
     }
   }
 
-  implicit val schema: Schema[ReservedKeywordUnionTrait] = recursive(union(
+  implicit val schema: Schema[ReservedKeywordUnionTrait] = recursive(union[ReservedKeywordUnionTrait](
     ReservedKeywordUnionTrait.PackageCase.alt,
   ){
     _.$ordinal

--- a/modules/bootstrapped/src/generated/smithy4s/example/collision/Scala3ReservedKeywords.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/collision/Scala3ReservedKeywords.scala
@@ -16,7 +16,7 @@ object Scala3ReservedKeywords extends ShapeTag.Companion[Scala3ReservedKeywords]
   // constructor using the original order from the spec
   private def make(_export: Option[String], _enum: Option[String]): Scala3ReservedKeywords = Scala3ReservedKeywords(_export, _enum)
 
-  implicit val schema: Schema[Scala3ReservedKeywords] = struct(
+  implicit val schema: Schema[Scala3ReservedKeywords] = struct[Scala3ReservedKeywords](
     String.schema.optional[Scala3ReservedKeywords]("export", _._export),
     String.schema.optional[Scala3ReservedKeywords]("enum", _._enum),
   )(make).withId(id).addHints(hints)

--- a/modules/bootstrapped/src/generated/smithy4s/example/collision/SetInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/collision/SetInput.scala
@@ -18,7 +18,7 @@ object SetInput extends ShapeTag.Companion[SetInput] {
   // constructor using the original order from the spec
   private def make(set: Set[String]): SetInput = SetInput(set)
 
-  implicit val schema: Schema[SetInput] = struct(
+  implicit val schema: Schema[SetInput] = struct[SetInput](
     MySet.underlyingSchema.required[SetInput]("set", _.set),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/collision/TestReservedNamespaceImport.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/collision/TestReservedNamespaceImport.scala
@@ -17,7 +17,7 @@ object TestReservedNamespaceImport extends ShapeTag.Companion[TestReservedNamesp
   // constructor using the original order from the spec
   private def make(_package: Option[MyPackageString]): TestReservedNamespaceImport = TestReservedNamespaceImport(_package)
 
-  implicit val schema: Schema[TestReservedNamespaceImport] = struct(
+  implicit val schema: Schema[TestReservedNamespaceImport] = struct[TestReservedNamespaceImport](
     MyPackageString.schema.optional[TestReservedNamespaceImport]("package", _._package),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/collision/UnionWithCollision.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/collision/UnionWithCollision.scala
@@ -38,7 +38,7 @@ object UnionWithCollision extends ShapeTag.Companion[UnionWithCollision] {
     // constructor using the original order from the spec
     private def make(name: Option[String]): Struct = Struct(name)
 
-    val schema: Schema[Struct] = smithy4s.schema.Schema.struct(
+    val schema: Schema[Struct] = smithy4s.schema.Schema.struct[Struct](
       String.schema.optional[Struct]("name", _.name),
     )(make).withId(id).addHints(hints)
 
@@ -57,7 +57,7 @@ object UnionWithCollision extends ShapeTag.Companion[UnionWithCollision] {
     }
   }
 
-  implicit val schema: Schema[UnionWithCollision] = union(
+  implicit val schema: Schema[UnionWithCollision] = union[UnionWithCollision](
     UnionWithCollision.Struct.alt,
   ){
     _.$ordinal

--- a/modules/bootstrapped/src/generated/smithy4s/example/error/NotFoundError.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/error/NotFoundError.scala
@@ -21,7 +21,7 @@ object NotFoundError extends ShapeTag.Companion[NotFoundError] {
   // constructor using the original order from the spec
   private def make(error: Option[String]): NotFoundError = NotFoundError(error)
 
-  implicit val schema: Schema[NotFoundError] = struct(
+  implicit val schema: Schema[NotFoundError] = struct[NotFoundError](
     string.optional[NotFoundError]("error", _.error),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/greet/GreetInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/greet/GreetInput.scala
@@ -19,7 +19,7 @@ object GreetInput extends ShapeTag.Companion[GreetInput] {
   // constructor using the original order from the spec
   private def make(name: String): GreetInput = GreetInput(name)
 
-  implicit val schema: Schema[GreetInput] = struct(
+  implicit val schema: Schema[GreetInput] = struct[GreetInput](
     string.required[GreetInput]("name", _.name),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/greet/GreetOutput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/greet/GreetOutput.scala
@@ -19,7 +19,7 @@ object GreetOutput extends ShapeTag.Companion[GreetOutput] {
   // constructor using the original order from the spec
   private def make(message: String): GreetOutput = GreetOutput(message)
 
-  implicit val schema: Schema[GreetOutput] = struct(
+  implicit val schema: Schema[GreetOutput] = struct[GreetOutput](
     string.required[GreetOutput]("message", _.message),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/guides/auth/HealthCheckOutput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/guides/auth/HealthCheckOutput.scala
@@ -19,7 +19,7 @@ object HealthCheckOutput extends ShapeTag.Companion[HealthCheckOutput] {
   // constructor using the original order from the spec
   private def make(message: String): HealthCheckOutput = HealthCheckOutput(message)
 
-  implicit val schema: Schema[HealthCheckOutput] = struct(
+  implicit val schema: Schema[HealthCheckOutput] = struct[HealthCheckOutput](
     string.required[HealthCheckOutput]("message", _.message),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/guides/auth/HelloWorldAuthService.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/guides/auth/HelloWorldAuthService.scala
@@ -137,7 +137,7 @@ object HelloWorldAuthServiceOperation {
       }
     }
 
-    implicit val schema: Schema[SayWorldError] = union(
+    implicit val schema: Schema[SayWorldError] = union[SayWorldError](
       SayWorldError.NotAuthorizedErrorCase.alt,
     ){
       _.$ordinal
@@ -203,7 +203,7 @@ object HelloWorldAuthServiceOperation {
       }
     }
 
-    implicit val schema: Schema[HealthCheckError] = union(
+    implicit val schema: Schema[HealthCheckError] = union[HealthCheckError](
       HealthCheckError.NotAuthorizedErrorCase.alt,
     ){
       _.$ordinal

--- a/modules/bootstrapped/src/generated/smithy4s/example/guides/auth/NotAuthorizedError.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/guides/auth/NotAuthorizedError.scala
@@ -23,7 +23,7 @@ object NotAuthorizedError extends ShapeTag.Companion[NotAuthorizedError] {
   // constructor using the original order from the spec
   private def make(message: String): NotAuthorizedError = NotAuthorizedError(message)
 
-  implicit val schema: Schema[NotAuthorizedError] = struct(
+  implicit val schema: Schema[NotAuthorizedError] = struct[NotAuthorizedError](
     string.required[NotAuthorizedError]("message", _.message),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/guides/auth/World.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/guides/auth/World.scala
@@ -17,7 +17,7 @@ object World extends ShapeTag.Companion[World] {
   // constructor using the original order from the spec
   private def make(message: String): World = World(message)
 
-  implicit val schema: Schema[World] = struct(
+  implicit val schema: Schema[World] = struct[World](
     string.field[World]("message", _.message).addHints(smithy.api.Default(smithy4s.Document.fromString("World !"))),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/guides/hello/World.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/guides/hello/World.scala
@@ -17,7 +17,7 @@ object World extends ShapeTag.Companion[World] {
   // constructor using the original order from the spec
   private def make(message: String): World = World(message)
 
-  implicit val schema: Schema[World] = struct(
+  implicit val schema: Schema[World] = struct[World](
     string.field[World]("message", _.message).addHints(smithy.api.Default(smithy4s.Document.fromString("World !"))),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/hello/GenericServerError.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/hello/GenericServerError.scala
@@ -23,7 +23,7 @@ object GenericServerError extends ShapeTag.Companion[GenericServerError] {
   // constructor using the original order from the spec
   private def make(message: Option[String]): GenericServerError = GenericServerError(message)
 
-  implicit val schema: Schema[GenericServerError] = struct(
+  implicit val schema: Schema[GenericServerError] = struct[GenericServerError](
     string.optional[GenericServerError]("message", _.message),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/hello/Greeting.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/hello/Greeting.scala
@@ -17,7 +17,7 @@ object Greeting extends ShapeTag.Companion[Greeting] {
   // constructor using the original order from the spec
   private def make(message: String): Greeting = Greeting(message)
 
-  implicit val schema: Schema[Greeting] = struct(
+  implicit val schema: Schema[Greeting] = struct[Greeting](
     string.required[Greeting]("message", _.message),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/hello/HelloWorldService.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/hello/HelloWorldService.scala
@@ -139,7 +139,7 @@ object HelloWorldServiceOperation {
       }
     }
 
-    implicit val schema: Schema[HelloError] = union(
+    implicit val schema: Schema[HelloError] = union[HelloError](
       HelloError.GenericServerErrorCase.alt,
       HelloError.SpecificServerErrorCase.alt,
     ){

--- a/modules/bootstrapped/src/generated/smithy4s/example/hello/Person.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/hello/Person.scala
@@ -17,7 +17,7 @@ object Person extends ShapeTag.Companion[Person] {
   // constructor using the original order from the spec
   private def make(name: String, town: Option[String]): Person = Person(name, town)
 
-  implicit val schema: Schema[Person] = struct(
+  implicit val schema: Schema[Person] = struct[Person](
     string.required[Person]("name", _.name).addHints(smithy.api.HttpLabel()),
     string.optional[Person]("town", _.town).addHints(smithy.api.HttpQuery("town")),
   )(make).withId(id).addHints(hints)

--- a/modules/bootstrapped/src/generated/smithy4s/example/hello/SpecificServerError.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/hello/SpecificServerError.scala
@@ -23,7 +23,7 @@ object SpecificServerError extends ShapeTag.Companion[SpecificServerError] {
   // constructor using the original order from the spec
   private def make(message: Option[String]): SpecificServerError = SpecificServerError(message)
 
-  implicit val schema: Schema[SpecificServerError] = struct(
+  implicit val schema: Schema[SpecificServerError] = struct[SpecificServerError](
     string.optional[SpecificServerError]("message", _.message),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/imp/ImportService.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/imp/ImportService.scala
@@ -131,7 +131,7 @@ object ImportServiceOperation {
       }
     }
 
-    implicit val schema: Schema[ImportOperationError] = union(
+    implicit val schema: Schema[ImportOperationError] = union[ImportOperationError](
       ImportOperationError.NotFoundErrorCase.alt,
     ){
       _.$ordinal

--- a/modules/bootstrapped/src/generated/smithy4s/example/import_test/OpOutput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/import_test/OpOutput.scala
@@ -17,7 +17,7 @@ object OpOutput extends ShapeTag.Companion[OpOutput] {
   // constructor using the original order from the spec
   private def make(output: String): OpOutput = OpOutput(output)
 
-  implicit val schema: Schema[OpOutput] = struct(
+  implicit val schema: Schema[OpOutput] = struct[OpOutput](
     string.required[OpOutput]("output", _.output).addHints(smithy.api.HttpPayload()),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/product/ExampleOperationInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/product/ExampleOperationInput.scala
@@ -19,7 +19,7 @@ object ExampleOperationInput extends ShapeTag.Companion[ExampleOperationInput] {
   // constructor using the original order from the spec
   private def make(a: String): ExampleOperationInput = ExampleOperationInput(a)
 
-  implicit val schema: Schema[ExampleOperationInput] = struct(
+  implicit val schema: Schema[ExampleOperationInput] = struct[ExampleOperationInput](
     string.required[ExampleOperationInput]("a", _.a),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/product/ExampleOperationOutput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/product/ExampleOperationOutput.scala
@@ -19,7 +19,7 @@ object ExampleOperationOutput extends ShapeTag.Companion[ExampleOperationOutput]
   // constructor using the original order from the spec
   private def make(b: String): ExampleOperationOutput = ExampleOperationOutput(b)
 
-  implicit val schema: Schema[ExampleOperationOutput] = struct(
+  implicit val schema: Schema[ExampleOperationOutput] = struct[ExampleOperationOutput](
     string.required[ExampleOperationOutput]("b", _.b),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/protobuf/BigDecimalWrapper.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/protobuf/BigDecimalWrapper.scala
@@ -19,7 +19,7 @@ object BigDecimalWrapper extends ShapeTag.Companion[BigDecimalWrapper] {
   // constructor using the original order from the spec
   private def make(bigDecimal: BigDecimal): BigDecimalWrapper = BigDecimalWrapper(bigDecimal)
 
-  implicit val schema: Schema[BigDecimalWrapper] = struct(
+  implicit val schema: Schema[BigDecimalWrapper] = struct[BigDecimalWrapper](
     bigdecimal.required[BigDecimalWrapper]("bigDecimal", _.bigDecimal),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/protobuf/Enums.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/protobuf/Enums.scala
@@ -18,7 +18,7 @@ object Enums extends ShapeTag.Companion[Enums] {
   // constructor using the original order from the spec
   private def make(closedString: ClosedString, openString: OpenString, closedInt: ClosedInt, openInt: OpenInt): Enums = Enums(closedString, openString, closedInt, openInt)
 
-  implicit val schema: Schema[Enums] = struct(
+  implicit val schema: Schema[Enums] = struct[Enums](
     ClosedString.schema.required[Enums]("closedString", _.closedString),
     OpenString.schema.required[Enums]("openString", _.openString),
     ClosedInt.schema.required[Enums]("closedInt", _.closedInt),

--- a/modules/bootstrapped/src/generated/smithy4s/example/protobuf/InlinedUnionWrapper.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/protobuf/InlinedUnionWrapper.scala
@@ -18,7 +18,7 @@ object InlinedUnionWrapper extends ShapeTag.Companion[InlinedUnionWrapper] {
   // constructor using the original order from the spec
   private def make(myInlinedUnion: Option[MyInlinedUnion]): InlinedUnionWrapper = InlinedUnionWrapper(myInlinedUnion)
 
-  implicit val schema: Schema[InlinedUnionWrapper] = struct(
+  implicit val schema: Schema[InlinedUnionWrapper] = struct[InlinedUnionWrapper](
     MyInlinedUnion.schema.optional[InlinedUnionWrapper]("myInlinedUnion", _.myInlinedUnion),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/protobuf/IntListWrapper.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/protobuf/IntListWrapper.scala
@@ -18,7 +18,7 @@ object IntListWrapper extends ShapeTag.Companion[IntListWrapper] {
   // constructor using the original order from the spec
   private def make(ints: List[Int]): IntListWrapper = IntListWrapper(ints)
 
-  implicit val schema: Schema[IntListWrapper] = struct(
+  implicit val schema: Schema[IntListWrapper] = struct[IntListWrapper](
     IntList.underlyingSchema.required[IntListWrapper]("ints", _.ints),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/protobuf/Integers.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/protobuf/Integers.scala
@@ -19,7 +19,7 @@ object Integers extends ShapeTag.Companion[Integers] {
   // constructor using the original order from the spec
   private def make(int: Int, sint: Int, uint: Int, fixedUint: Int, fixedSint: Int): Integers = Integers(int, sint, uint, fixedUint, fixedSint)
 
-  implicit val schema: Schema[Integers] = struct(
+  implicit val schema: Schema[Integers] = struct[Integers](
     int.required[Integers]("int", _.int),
     int.required[Integers]("sint", _.sint).addHints(alloy.proto.ProtoNumType.SIGNED.widen),
     int.required[Integers]("uint", _.uint).addHints(alloy.proto.ProtoNumType.UNSIGNED.widen),

--- a/modules/bootstrapped/src/generated/smithy4s/example/protobuf/Longs.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/protobuf/Longs.scala
@@ -19,7 +19,7 @@ object Longs extends ShapeTag.Companion[Longs] {
   // constructor using the original order from the spec
   private def make(long: Long, slong: Long, ulong: Long, fixedLong: Long, fixedSlong: Long): Longs = Longs(long, slong, ulong, fixedLong, fixedSlong)
 
-  implicit val schema: Schema[Longs] = struct(
+  implicit val schema: Schema[Longs] = struct[Longs](
     long.required[Longs]("long", _.long),
     long.required[Longs]("slong", _.slong).addHints(alloy.proto.ProtoNumType.SIGNED.widen),
     long.required[Longs]("ulong", _.ulong).addHints(alloy.proto.ProtoNumType.UNSIGNED.widen),

--- a/modules/bootstrapped/src/generated/smithy4s/example/protobuf/MessageWrapper.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/protobuf/MessageWrapper.scala
@@ -18,7 +18,7 @@ object MessageWrapper extends ShapeTag.Companion[MessageWrapper] {
   // constructor using the original order from the spec
   private def make(message: Integers): MessageWrapper = MessageWrapper(message)
 
-  implicit val schema: Schema[MessageWrapper] = struct(
+  implicit val schema: Schema[MessageWrapper] = struct[MessageWrapper](
     Integers.schema.required[MessageWrapper]("message", _.message),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/protobuf/MyInlinedUnion.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/protobuf/MyInlinedUnion.scala
@@ -60,7 +60,7 @@ object MyInlinedUnion extends ShapeTag.Companion[MyInlinedUnion] {
     }
   }
 
-  implicit val schema: Schema[MyInlinedUnion] = union(
+  implicit val schema: Schema[MyInlinedUnion] = union[MyInlinedUnion](
     MyInlinedUnion.IntCase.alt,
     MyInlinedUnion.BoolCase.alt,
   ){

--- a/modules/bootstrapped/src/generated/smithy4s/example/protobuf/MyIntListWrapper.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/protobuf/MyIntListWrapper.scala
@@ -18,7 +18,7 @@ object MyIntListWrapper extends ShapeTag.Companion[MyIntListWrapper] {
   // constructor using the original order from the spec
   private def make(ints: List[MyInt]): MyIntListWrapper = MyIntListWrapper(ints)
 
-  implicit val schema: Schema[MyIntListWrapper] = struct(
+  implicit val schema: Schema[MyIntListWrapper] = struct[MyIntListWrapper](
     MyIntList.underlyingSchema.required[MyIntListWrapper]("ints", _.ints),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/protobuf/MyUnion.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/protobuf/MyUnion.scala
@@ -84,7 +84,7 @@ object MyUnion extends ShapeTag.Companion[MyUnion] {
     }
   }
 
-  implicit val schema: Schema[MyUnion] = union(
+  implicit val schema: Schema[MyUnion] = union[MyUnion](
     MyUnion.IntCase.alt,
     MyUnion.BoolCase.alt,
     MyUnion.ListCase.alt,

--- a/modules/bootstrapped/src/generated/smithy4s/example/protobuf/OptionalMessageWrapper.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/protobuf/OptionalMessageWrapper.scala
@@ -18,7 +18,7 @@ object OptionalMessageWrapper extends ShapeTag.Companion[OptionalMessageWrapper]
   // constructor using the original order from the spec
   private def make(message: Option[Integers]): OptionalMessageWrapper = OptionalMessageWrapper(message)
 
-  implicit val schema: Schema[OptionalMessageWrapper] = struct(
+  implicit val schema: Schema[OptionalMessageWrapper] = struct[OptionalMessageWrapper](
     Integers.schema.optional[OptionalMessageWrapper]("message", _.message),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/protobuf/OptionalStringWrapper.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/protobuf/OptionalStringWrapper.scala
@@ -19,7 +19,7 @@ object OptionalStringWrapper extends ShapeTag.Companion[OptionalStringWrapper] {
   // constructor using the original order from the spec
   private def make(string: Option[String]): OptionalStringWrapper = OptionalStringWrapper(string)
 
-  implicit val schema: Schema[OptionalStringWrapper] = struct(
+  implicit val schema: Schema[OptionalStringWrapper] = struct[OptionalStringWrapper](
     string.optional[OptionalStringWrapper]("string", _.string),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/protobuf/OtherScalars.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/protobuf/OtherScalars.scala
@@ -23,7 +23,7 @@ object OtherScalars extends ShapeTag.Companion[OtherScalars] {
   // constructor using the original order from the spec
   private def make(boolean: Boolean, byte: Byte, float: Float, double: Double, short: Short): OtherScalars = OtherScalars(boolean, byte, float, double, short)
 
-  implicit val schema: Schema[OtherScalars] = struct(
+  implicit val schema: Schema[OtherScalars] = struct[OtherScalars](
     boolean.required[OtherScalars]("boolean", _.boolean),
     byte.required[OtherScalars]("byte", _.byte),
     float.required[OtherScalars]("float", _.float),

--- a/modules/bootstrapped/src/generated/smithy4s/example/protobuf/Recursive.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/protobuf/Recursive.scala
@@ -19,7 +19,7 @@ object Recursive extends ShapeTag.Companion[Recursive] {
   // constructor using the original order from the spec
   private def make(recursive: Option[smithy4s.example.protobuf.Recursive]): Recursive = Recursive(recursive)
 
-  implicit val schema: Schema[Recursive] = recursive(struct(
+  implicit val schema: Schema[Recursive] = recursive(struct[Recursive](
     smithy4s.example.protobuf.Recursive.schema.optional[Recursive]("recursive", _.recursive),
   )(make).withId(id).addHints(hints))
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/protobuf/RefinedIntWrapped.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/protobuf/RefinedIntWrapped.scala
@@ -19,7 +19,7 @@ object RefinedIntWrapped extends ShapeTag.Companion[RefinedIntWrapped] {
   // constructor using the original order from the spec
   private def make(int: Int): RefinedIntWrapped = RefinedIntWrapped(int)
 
-  implicit val schema: Schema[RefinedIntWrapped] = struct(
+  implicit val schema: Schema[RefinedIntWrapped] = struct[RefinedIntWrapped](
     int.validated(smithy.api.Range(min = Some(scala.math.BigDecimal(1.0)), max = Some(scala.math.BigDecimal(10.0)))).required[RefinedIntWrapped]("int", _.int),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/protobuf/StringListWrapper.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/protobuf/StringListWrapper.scala
@@ -18,7 +18,7 @@ object StringListWrapper extends ShapeTag.Companion[StringListWrapper] {
   // constructor using the original order from the spec
   private def make(strings: List[String], wrappedStrings: List[String]): StringListWrapper = StringListWrapper(strings, wrappedStrings)
 
-  implicit val schema: Schema[StringListWrapper] = struct(
+  implicit val schema: Schema[StringListWrapper] = struct[StringListWrapper](
     StringList.underlyingSchema.required[StringListWrapper]("strings", _.strings),
     WrappedStringList.underlyingSchema.required[StringListWrapper]("wrappedStrings", _.wrappedStrings),
   )(make).withId(id).addHints(hints)

--- a/modules/bootstrapped/src/generated/smithy4s/example/protobuf/StringMapWrapper.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/protobuf/StringMapWrapper.scala
@@ -18,7 +18,7 @@ object StringMapWrapper extends ShapeTag.Companion[StringMapWrapper] {
   // constructor using the original order from the spec
   private def make(values: Map[String, Int]): StringMapWrapper = StringMapWrapper(values)
 
-  implicit val schema: Schema[StringMapWrapper] = struct(
+  implicit val schema: Schema[StringMapWrapper] = struct[StringMapWrapper](
     StringMap.underlyingSchema.required[StringMapWrapper]("values", _.values),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/protobuf/StringWrapper.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/protobuf/StringWrapper.scala
@@ -19,7 +19,7 @@ object StringWrapper extends ShapeTag.Companion[StringWrapper] {
   // constructor using the original order from the spec
   private def make(string: String): StringWrapper = StringWrapper(string)
 
-  implicit val schema: Schema[StringWrapper] = struct(
+  implicit val schema: Schema[StringWrapper] = struct[StringWrapper](
     string.required[StringWrapper]("string", _.string),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/protobuf/StructureWithCustomIndexes.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/protobuf/StructureWithCustomIndexes.scala
@@ -19,7 +19,7 @@ object StructureWithCustomIndexes extends ShapeTag.Companion[StructureWithCustom
   // constructor using the original order from the spec
   private def make(a: Option[Int], b: Int, c: Int, d: Option[UnionWithCustomIndexes]): StructureWithCustomIndexes = StructureWithCustomIndexes(c, b, a, d)
 
-  implicit val schema: Schema[StructureWithCustomIndexes] = struct(
+  implicit val schema: Schema[StructureWithCustomIndexes] = struct[StructureWithCustomIndexes](
     int.optional[StructureWithCustomIndexes]("a", _.a).addHints(alloy.proto.ProtoIndex(4)),
     int.field[StructureWithCustomIndexes]("b", _.b).addHints(alloy.proto.ProtoIndex(3), smithy.api.Default(smithy4s.Document.fromLong(0))),
     int.required[StructureWithCustomIndexes]("c", _.c).addHints(alloy.proto.ProtoIndex(2)),

--- a/modules/bootstrapped/src/generated/smithy4s/example/protobuf/UUIDWrapper.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/protobuf/UUIDWrapper.scala
@@ -20,7 +20,7 @@ object UUIDWrapper extends ShapeTag.Companion[UUIDWrapper] {
   // constructor using the original order from the spec
   private def make(uuid: Option[UUID], compactUUID: Option[CompactUUID]): UUIDWrapper = UUIDWrapper(uuid, compactUUID)
 
-  implicit val schema: Schema[UUIDWrapper] = struct(
+  implicit val schema: Schema[UUIDWrapper] = struct[UUIDWrapper](
     uuid.optional[UUIDWrapper]("uuid", _.uuid),
     CompactUUID.schema.optional[UUIDWrapper]("compactUUID", _.compactUUID),
   )(make).withId(id).addHints(hints)

--- a/modules/bootstrapped/src/generated/smithy4s/example/protobuf/UnionWithCustomIndexes.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/protobuf/UnionWithCustomIndexes.scala
@@ -75,7 +75,7 @@ object UnionWithCustomIndexes extends ShapeTag.Companion[UnionWithCustomIndexes]
     }
   }
 
-  implicit val schema: Schema[UnionWithCustomIndexes] = union(
+  implicit val schema: Schema[UnionWithCustomIndexes] = union[UnionWithCustomIndexes](
     UnionWithCustomIndexes.ACase.alt,
     UnionWithCustomIndexes.BCase.alt,
     UnionWithCustomIndexes.CCase.alt,

--- a/modules/bootstrapped/src/generated/smithy4s/example/protobuf/UnionWrapper.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/protobuf/UnionWrapper.scala
@@ -18,7 +18,7 @@ object UnionWrapper extends ShapeTag.Companion[UnionWrapper] {
   // constructor using the original order from the spec
   private def make(myUnion: Option[MyUnion]): UnionWrapper = UnionWrapper(myUnion)
 
-  implicit val schema: Schema[UnionWrapper] = struct(
+  implicit val schema: Schema[UnionWrapper] = struct[UnionWrapper](
     MyUnion.schema.optional[UnionWrapper]("myUnion", _.myUnion),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/protobuf/WrappedScalars.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/protobuf/WrappedScalars.scala
@@ -20,7 +20,7 @@ object WrappedScalars extends ShapeTag.Companion[WrappedScalars] {
   // constructor using the original order from the spec
   private def make(int: Option[Int], bool: Option[Boolean]): WrappedScalars = WrappedScalars(int, bool)
 
-  implicit val schema: Schema[WrappedScalars] = struct(
+  implicit val schema: Schema[WrappedScalars] = struct[WrappedScalars](
     int.optional[WrappedScalars]("int", _.int).addHints(alloy.proto.ProtoWrapped()),
     boolean.optional[WrappedScalars]("bool", _.bool).addHints(alloy.proto.ProtoWrapped()),
   )(make).withId(id).addHints(hints)

--- a/modules/bootstrapped/src/generated/smithy4s/example/reservedNameOverride/Set.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/reservedNameOverride/Set.scala
@@ -18,7 +18,7 @@ object Set extends ShapeTag.Companion[Set] {
   // constructor using the original order from the spec
   private def make(someField: String, otherField: Int): Set = Set(someField, otherField)
 
-  implicit val schema: Schema[Set] = struct(
+  implicit val schema: Schema[Set] = struct[Set](
     string.required[Set]("someField", _.someField),
     int.required[Set]("otherField", _.otherField),
   )(make).withId(id).addHints(hints)

--- a/modules/bootstrapped/src/generated/smithy4s/example/reservedNameOverride/SetOpInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/reservedNameOverride/SetOpInput.scala
@@ -18,7 +18,7 @@ object SetOpInput extends ShapeTag.Companion[SetOpInput] {
   // constructor using the original order from the spec
   private def make(set: Set): SetOpInput = SetOpInput(set)
 
-  implicit val schema: Schema[SetOpInput] = struct(
+  implicit val schema: Schema[SetOpInput] = struct[SetOpInput](
     Set.schema.required[SetOpInput]("set", _.set),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/test/ComplexError.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/test/ComplexError.scala
@@ -25,7 +25,7 @@ object ComplexError extends ShapeTag.Companion[ComplexError] {
   // constructor using the original order from the spec
   private def make(value: Int, message: String, details: Option[ErrorDetails]): ComplexError = ComplexError(value, message, details)
 
-  implicit val schema: Schema[ComplexError] = struct(
+  implicit val schema: Schema[ComplexError] = struct[ComplexError](
     int.required[ComplexError]("value", _.value),
     string.required[ComplexError]("message", _.message),
     ErrorDetails.schema.optional[ComplexError]("details", _.details),

--- a/modules/bootstrapped/src/generated/smithy4s/example/test/ErrorDetails.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/test/ErrorDetails.scala
@@ -19,7 +19,7 @@ object ErrorDetails extends ShapeTag.Companion[ErrorDetails] {
   // constructor using the original order from the spec
   private def make(date: Timestamp, location: String): ErrorDetails = ErrorDetails(date, location)
 
-  implicit val schema: Schema[ErrorDetails] = struct(
+  implicit val schema: Schema[ErrorDetails] = struct[ErrorDetails](
     timestamp.required[ErrorDetails]("date", _.date).addHints(smithy.api.TimestampFormat.EPOCH_SECONDS.widen),
     string.required[ErrorDetails]("location", _.location),
   )(make).withId(id).addHints(hints)

--- a/modules/bootstrapped/src/generated/smithy4s/example/test/HelloInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/test/HelloInput.scala
@@ -19,7 +19,7 @@ object HelloInput extends ShapeTag.Companion[HelloInput] {
   // constructor using the original order from the spec
   private def make(name: String): HelloInput = HelloInput(name)
 
-  implicit val schema: Schema[HelloInput] = struct(
+  implicit val schema: Schema[HelloInput] = struct[HelloInput](
     string.required[HelloInput]("name", _.name).addHints(smithy.api.HttpLabel()),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/test/HelloOutput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/test/HelloOutput.scala
@@ -19,7 +19,7 @@ object HelloOutput extends ShapeTag.Companion[HelloOutput] {
   // constructor using the original order from the spec
   private def make(message: String): HelloOutput = HelloOutput(message)
 
-  implicit val schema: Schema[HelloOutput] = struct(
+  implicit val schema: Schema[HelloOutput] = struct[HelloOutput](
     string.required[HelloOutput]("message", _.message),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/test/HelloService.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/test/HelloService.scala
@@ -174,7 +174,7 @@ object HelloServiceOperation {
       }
     }
 
-    implicit val schema: Schema[SayHelloError] = union(
+    implicit val schema: Schema[SayHelloError] = union[SayHelloError](
       SayHelloError.ComplexErrorCase.alt,
       SayHelloError.SimpleErrorCase.alt,
     ){

--- a/modules/bootstrapped/src/generated/smithy4s/example/test/SayHelloInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/test/SayHelloInput.scala
@@ -19,7 +19,7 @@ object SayHelloInput extends ShapeTag.Companion[SayHelloInput] {
   // constructor using the original order from the spec
   private def make(greeting: Option[String], query: Option[String], name: Option[String]): SayHelloInput = SayHelloInput(greeting, query, name)
 
-  implicit val schema: Schema[SayHelloInput] = struct(
+  implicit val schema: Schema[SayHelloInput] = struct[SayHelloInput](
     string.optional[SayHelloInput]("greeting", _.greeting).addHints(smithy.api.HttpHeader("X-Greeting")),
     string.optional[SayHelloInput]("query", _.query).addHints(smithy.api.HttpQuery("Hi")),
     string.optional[SayHelloInput]("name", _.name),

--- a/modules/bootstrapped/src/generated/smithy4s/example/test/SayHelloOutput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/test/SayHelloOutput.scala
@@ -17,7 +17,7 @@ object SayHelloOutput extends ShapeTag.Companion[SayHelloOutput] {
   // constructor using the original order from the spec
   private def make(payload: SayHelloPayload, header1: String): SayHelloOutput = SayHelloOutput(payload, header1)
 
-  implicit val schema: Schema[SayHelloOutput] = struct(
+  implicit val schema: Schema[SayHelloOutput] = struct[SayHelloOutput](
     SayHelloPayload.schema.required[SayHelloOutput]("payload", _.payload).addHints(smithy.api.HttpPayload()),
     string.required[SayHelloOutput]("header1", _.header1).addHints(smithy.api.HttpHeader("X-H1")),
   )(make).withId(id).addHints(hints)

--- a/modules/bootstrapped/src/generated/smithy4s/example/test/SayHelloPayload.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/test/SayHelloPayload.scala
@@ -17,7 +17,7 @@ object SayHelloPayload extends ShapeTag.Companion[SayHelloPayload] {
   // constructor using the original order from the spec
   private def make(result: String): SayHelloPayload = SayHelloPayload(result)
 
-  implicit val schema: Schema[SayHelloPayload] = struct(
+  implicit val schema: Schema[SayHelloPayload] = struct[SayHelloPayload](
     string.required[SayHelloPayload]("result", _.result),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/test/SimpleError.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/test/SimpleError.scala
@@ -21,7 +21,7 @@ object SimpleError extends ShapeTag.Companion[SimpleError] {
   // constructor using the original order from the spec
   private def make(expected: Int): SimpleError = SimpleError(expected)
 
-  implicit val schema: Schema[SimpleError] = struct(
+  implicit val schema: Schema[SimpleError] = struct[SimpleError](
     int.required[SimpleError]("expected", _.expected),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/test/TestPathInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/test/TestPathInput.scala
@@ -19,7 +19,7 @@ object TestPathInput extends ShapeTag.Companion[TestPathInput] {
   // constructor using the original order from the spec
   private def make(path: String): TestPathInput = TestPathInput(path)
 
-  implicit val schema: Schema[TestPathInput] = struct(
+  implicit val schema: Schema[TestPathInput] = struct[TestPathInput](
     string.required[TestPathInput]("path", _.path).addHints(smithy.api.HttpLabel()),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/weather/Dog.scala
+++ b/modules/bootstrapped/src/generated/weather/Dog.scala
@@ -17,7 +17,7 @@ object Dog extends ShapeTag.Companion[Dog] {
   // constructor using the original order from the spec
   private def make(name: String): Dog = Dog(name)
 
-  implicit val schema: Schema[Dog] = struct(
+  implicit val schema: Schema[Dog] = struct[Dog](
     string.required[Dog]("name", _.name),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/weather/GetWeatherInput.scala
+++ b/modules/bootstrapped/src/generated/weather/GetWeatherInput.scala
@@ -19,7 +19,7 @@ object GetWeatherInput extends ShapeTag.Companion[GetWeatherInput] {
   // constructor using the original order from the spec
   private def make(city: String): GetWeatherInput = GetWeatherInput(city)
 
-  implicit val schema: Schema[GetWeatherInput] = struct(
+  implicit val schema: Schema[GetWeatherInput] = struct[GetWeatherInput](
     string.required[GetWeatherInput]("city", _.city).addHints(smithy.api.HttpLabel()),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/weather/GetWeatherOutput.scala
+++ b/modules/bootstrapped/src/generated/weather/GetWeatherOutput.scala
@@ -19,7 +19,7 @@ object GetWeatherOutput extends ShapeTag.Companion[GetWeatherOutput] {
   // constructor using the original order from the spec
   private def make(weather: String): GetWeatherOutput = GetWeatherOutput(weather)
 
-  implicit val schema: Schema[GetWeatherOutput] = struct(
+  implicit val schema: Schema[GetWeatherOutput] = struct[GetWeatherOutput](
     string.required[GetWeatherOutput]("weather", _.weather),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/codegen/src/smithy4s/codegen/internals/Renderer.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/Renderer.scala
@@ -777,14 +777,14 @@ private[internals] class Renderer(compilationUnit: CompilationUnit) { self =>
           if (fields.size <= 22) {
             val definition =
               if (recursive) line"$recursive_($struct_" else line"$struct_"
-            line"${schemaImplicit}val schema: $Schema_[${product.nameRef}] = $definition"
+            line"${schemaImplicit}val schema: $Schema_[${product.nameRef}] = $definition[${product.nameRef}]"
               .args(renderedFields)
               .appendToLast("(make).withId(id).addHints(hints)")
               .appendToLast(if (recursive) ")" else "")
           } else {
             val definition =
-              if (recursive) line"$recursive_($struct_.genericArity"
-              else line"$struct_.genericArity"
+              if (recursive) line"$recursive_($struct_[${product.nameRef}].genericArity"
+              else line"$struct_[${product.nameRef}].genericArity"
             line"${schemaImplicit}val schema: $Schema_[${product.nameRef}] = $definition"
               .args(renderedFields)
               .block(
@@ -1051,7 +1051,7 @@ private[internals] class Renderer(compilationUnit: CompilationUnit) { self =>
             )} = $tpe.schema.oneOf[${name}](${renderStringLiteral(altName)})"""
           },
           block(
-            line"$union_(${members.map { case (n, _) => altVal(n) }.intercalate(line", ")})"
+            line"$union_[${name}](${members.map { case (n, _) => altVal(n) }.intercalate(line", ")})"
           )(
             members.zipWithIndex.map { case ((altName, _), index) =>
               line"case _: $altName => $index"
@@ -1343,9 +1343,9 @@ private[internals] class Renderer(compilationUnit: CompilationUnit) { self =>
         locally {
           val union =
             if (recursive)
-              line"implicit val schema: $Schema_[$name] = $recursive_($union_"
+              line"implicit val schema: $Schema_[$name] = $recursive_($union_[$name]"
             else
-              line"implicit val schema: $Schema_[$name] = $union_"
+              line"implicit val schema: $Schema_[$name] = $union_[$name]"
           union
             .args {
               caseNamesAndIsUnit.map { case (caseName, _) =>

--- a/modules/codegen/test/src/smithy4s/codegen/internals/DefaultRenderModeSpec.scala
+++ b/modules/codegen/test/src/smithy4s/codegen/internals/DefaultRenderModeSpec.scala
@@ -67,7 +67,7 @@ final class DefaultRenderModeSpec extends munit.FunSuite {
          |  // constructor using the original order from the spec
          |  private def make(one: Option[String], two: String, three: String, four: String, five: Option[Nullable[String]], six: Nullable[String], seven: Nullable[String], eight: Nullable[String]): Test = Test(one, two, three, four, five, six, seven, eight)
          |
-         |  implicit val schema: Schema[Test] = struct(
+         |  implicit val schema: Schema[Test] = struct[Test](
          |    string.optional[Test]("one", _.one),
          |    string.field[Test]("two", _.two).addHints(smithy.api.Default(smithy4s.Document.fromString("test"))),
          |    string.required[Test]("three", _.three),
@@ -131,7 +131,7 @@ final class DefaultRenderModeSpec extends munit.FunSuite {
          |  // constructor using the original order from the spec
          |  private def make(one: Option[String], two: String, three: String, four: String, five: Option[Nullable[String]], six: Nullable[String], seven: Nullable[String], eight: Nullable[String]): Test = Test(two, three, four, six, seven, eight, one, five)
          |
-         |  implicit val schema: Schema[Test] = struct(
+         |  implicit val schema: Schema[Test] = struct[Test](
          |    string.optional[Test]("one", _.one),
          |    string.field[Test]("two", _.two).addHints(smithy.api.Default(smithy4s.Document.fromString("test"))),
          |    string.required[Test]("three", _.three),
@@ -197,7 +197,7 @@ final class DefaultRenderModeSpec extends munit.FunSuite {
          |  // constructor using the original order from the spec
          |  private def make(one: Option[String], two: String, three: String, four: String, five: Option[Nullable[String]], six: Nullable[String], seven: Nullable[String], eight: Nullable[String]): Test = Test(three, eight, two, four, six, seven, one, five)
          |
-         |  implicit val schema: Schema[Test] = struct(
+         |  implicit val schema: Schema[Test] = struct[Test](
          |    string.optional[Test]("one", _.one),
          |    string.field[Test]("two", _.two).addHints(smithy.api.Default(smithy4s.Document.fromString("test"))),
          |    string.required[Test]("three", _.three),

--- a/modules/codegen/test/src/smithy4s/codegen/internals/RendererConfigSpec.scala
+++ b/modules/codegen/test/src/smithy4s/codegen/internals/RendererConfigSpec.scala
@@ -141,7 +141,7 @@ final class RendererConfigSpec extends munit.FunSuite {
          |  val schema: Schema[OperationError] = {
          |    val badRequestAlt = BadRequest.schema.oneOf[OperationError]("BadRequest")
          |    val internalServerErrorAlt = InternalServerError.schema.oneOf[OperationError]("InternalServerError")
-         |    union(badRequestAlt, internalServerErrorAlt) {
+         |    union[OperationError](badRequestAlt, internalServerErrorAlt) {
          |      case _: BadRequest => 0
          |      case _: InternalServerError => 1
          |    }
@@ -273,7 +273,7 @@ final class RendererConfigSpec extends munit.FunSuite {
          |      def internalServerError(value: InternalServerError): A = default
          |    }
          |  }
-         |  implicit val schema: Schema[OperationError] = union(
+         |  implicit val schema: Schema[OperationError] = union[OperationError](
          |    OperationError.BadRequestCase.alt,
          |    OperationError.InternalServerErrorCase.alt,
          |  ){

--- a/modules/codegen/test/src/smithy4s/codegen/transformers/AwsStandardTypesTransformerSpec.scala
+++ b/modules/codegen/test/src/smithy4s/codegen/transformers/AwsStandardTypesTransformerSpec.scala
@@ -91,7 +91,7 @@ final class AwsStandardTypesTransformerSpec extends munit.FunSuite {
         |  // constructor using the original order from the spec
         |  private def make(i: Int, d: Option[Date], l: Option[Long]): TestStructure = TestStructure(i, d, l)
         |
-        |  implicit val schema: Schema[TestStructure] = struct(
+        |  implicit val schema: Schema[TestStructure] = struct[TestStructure](
         |    int.required[TestStructure]("i", _.i),
         |    Date.schema.optional[TestStructure]("d", _.d),
         |    Long.schema.optional[TestStructure]("l", _.l),
@@ -154,7 +154,7 @@ final class AwsStandardTypesTransformerSpec extends munit.FunSuite {
         |  // constructor using the original order from the spec
         |  private def make(s: Option[String]): TestStructure = TestStructure(s)
         |
-        |  implicit val schema: Schema[TestStructure] = struct(
+        |  implicit val schema: Schema[TestStructure] = struct[TestStructure](
         |    string.validated(smithy.api.Length(min = Some(5L), max = Some(10L))).optional[TestStructure]("s", _.s),
         |  )(make).withId(id).addHints(hints)
         |}""".stripMargin
@@ -217,7 +217,7 @@ final class AwsStandardTypesTransformerSpec extends munit.FunSuite {
         |  // constructor using the original order from the spec
         |  private def make(i: Int): TestStructure = TestStructure(i)
         |
-        |  implicit val schema: Schema[TestStructure] = struct(
+        |  implicit val schema: Schema[TestStructure] = struct[TestStructure](
         |    int.field[TestStructure]("i", _.i).addHints(smithy.api.Default(smithy4s.Document.fromLong(5))),
         |  )(make).withId(id).addHints(hints)
         |}""".stripMargin


### PR DESCRIPTION
/fixes #1890

This PR adds type params for the partially applied schemas `struct` and `union` in generated code to improve compilation performance in Scala 3 (potentially for Scala 2 but I haven't checked). See #1890 for more info

## PR Checklist (not all items are relevant to all PRs)

- [x] Added unit-tests (for runtime code)
- [x] Added bootstrapped code + smoke tests (when the rendering logic is modified)
- [ ] Added build-plugins integration tests (when reflection loading is required at codegen-time)
- [ ] Added alloy compliance tests (when simpleRestJson protocol behaviour is expanded/updated)
- [ ] Updated dynamic module to match generated-code behaviour
- [ ] Added documentation
- [ ] Updated changelog
