### PR TITLE
Unary gRPC support (core + http4s integration)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,6 @@ ThisBuild / scalafixDependencies += "com.github.liancheng" %% "organize-imports"
 ThisBuild / dynverSeparator := "-"
 ThisBuild / versionScheme := Some("early-semver")
 ThisBuild / mimaBaseVersion := "0.18.0"
-ThisBuild / version := "0.18.47-SNAPSHOT"
 
 // for Alloy snapshots
 // as well as any other dependency snapshots.

--- a/build.sbt
+++ b/build.sbt
@@ -20,6 +20,7 @@ ThisBuild / scalafixDependencies += "com.github.liancheng" %% "organize-imports"
 ThisBuild / dynverSeparator := "-"
 ThisBuild / versionScheme := Some("early-semver")
 ThisBuild / mimaBaseVersion := "0.18.0"
+ThisBuild / version := "0.18.47-SNAPSHOT"
 
 // for Alloy snapshots
 // as well as any other dependency snapshots.
@@ -64,6 +65,8 @@ lazy val allModules = Seq(
   bootstrapped,
   tests,
   http4s,
+  grpc,
+  `grpc-http4s`,
   cats,
   `http4s-kernel`,
   `http4s-swagger`,
@@ -886,6 +889,52 @@ lazy val http4s = projectMatrix
   .http4sPlatform(allJvmScalaVersions, jvmDimSettings)
 
 /**
+ * Module that contains gRPC runtime support (backend-agnostic).
+ */
+lazy val grpc = projectMatrix
+  .in(file("modules/grpc"))
+  .dependsOn(
+    core,
+    protobuf,
+    cats
+  )
+  .settings(
+    isMimaEnabled := false,
+    libraryDependencies ++= Seq(
+      Dependencies.Cats.core.value,
+      Dependencies.CatsEffect3.value,
+      Dependencies.Fs2.core.value
+    ) ++ munitDeps.value ++ weaverDeps.value
+  )
+  .jvmPlatform(allJvmScalaVersions, jvmDimSettings)
+  .jsPlatform(allJsScalaVersions, jsDimSettings)
+  .nativePlatform(allNativeScalaVersions, nativeDimSettings)
+
+/**
+ * Module that contains http4s integration for gRPC.
+ */
+lazy val `grpc-http4s` = projectMatrix
+  .in(file("modules/grpc-http4s"))
+  .dependsOn(
+    grpc,
+    `http4s-kernel`,
+    bootstrapped % "test->compile"
+  )
+  .settings(
+    isMimaEnabled := false,
+    libraryDependencies ++= {
+      Seq(
+        Dependencies.Http4s.core.value,
+        Dependencies.Http4s.dsl.value,
+        Dependencies.Http4s.client.value,
+        Dependencies.Http4s.emberClient.value % Test,
+        Dependencies.Http4s.emberServer.value % Test
+      ) ++ weaverDeps.value
+    }
+  )
+  .http4sJvmPlatform(allJvmScalaVersions, jvmDimSettings)
+
+/**
  * Module that contains a function to derive a documentation endpoint
  */
 lazy val `http4s-swagger` = projectMatrix
@@ -1052,7 +1101,8 @@ lazy val bootstrapped = projectMatrix
       "weather",
       "smithy4s.example.product",
       "smithy4s.example.reservedNameOverride",
-      "smithy4s.example.bincompat"
+      "smithy4s.example.bincompat",
+      "smithy4s.example.grpc"
     ),
     smithySpecs := IO.listFiles(
       (ThisBuild / baseDirectory).value / "sampleSpecs"

--- a/modules/bootstrapped/resources/smithy4s/example/grpc/grpc.proto
+++ b/modules/bootstrapped/resources/smithy4s/example/grpc/grpc.proto
@@ -1,0 +1,19 @@
+syntax = "proto3";
+
+package smithy4s.example.grpc;
+
+message GreetInput {
+  string name = 1;
+}
+
+message GreetOutput {
+  string greeting = 1;
+}
+
+message NotFoundError {
+  string message = 1;
+}
+
+message PermissionDeniedError {
+  string message = 1;
+}

--- a/modules/bootstrapped/src/generated/smithy4s/example/grpc/GreetInput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/grpc/GreetInput.scala
@@ -1,0 +1,23 @@
+package smithy4s.example.grpc
+
+import smithy4s.Hints
+import smithy4s.Schema
+import smithy4s.ShapeId
+import smithy4s.ShapeTag
+import smithy4s.schema.Schema.string
+import smithy4s.schema.Schema.struct
+
+final case class GreetInput(name: String)
+
+object GreetInput extends ShapeTag.Companion[GreetInput] {
+  val id: ShapeId = ShapeId("smithy4s.example.grpc", "GreetInput")
+
+  val hints: Hints = Hints.empty
+
+  // constructor using the original order from the spec
+  private def make(name: String): GreetInput = GreetInput(name)
+
+  implicit val schema: Schema[GreetInput] = struct(
+    string.required[GreetInput]("name", _.name),
+  )(make).withId(id).addHints(hints)
+}

--- a/modules/bootstrapped/src/generated/smithy4s/example/grpc/GreetOutput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/grpc/GreetOutput.scala
@@ -1,0 +1,23 @@
+package smithy4s.example.grpc
+
+import smithy4s.Hints
+import smithy4s.Schema
+import smithy4s.ShapeId
+import smithy4s.ShapeTag
+import smithy4s.schema.Schema.string
+import smithy4s.schema.Schema.struct
+
+final case class GreetOutput(greeting: String)
+
+object GreetOutput extends ShapeTag.Companion[GreetOutput] {
+  val id: ShapeId = ShapeId("smithy4s.example.grpc", "GreetOutput")
+
+  val hints: Hints = Hints.empty
+
+  // constructor using the original order from the spec
+  private def make(greeting: String): GreetOutput = GreetOutput(greeting)
+
+  implicit val schema: Schema[GreetOutput] = struct(
+    string.required[GreetOutput]("greeting", _.greeting),
+  )(make).withId(id).addHints(hints)
+}

--- a/modules/bootstrapped/src/generated/smithy4s/example/grpc/GrpcGreetingService.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/grpc/GrpcGreetingService.scala
@@ -1,0 +1,156 @@
+package smithy4s.example.grpc
+
+import smithy4s.Endpoint
+import smithy4s.Hints
+import smithy4s.Schema
+import smithy4s.Service
+import smithy4s.ShapeId
+import smithy4s.Transformation
+import smithy4s.kinds.PolyFunction5
+import smithy4s.kinds.toPolyFunction5.const5
+import smithy4s.schema.ErrorSchema
+import smithy4s.schema.OperationSchema
+import smithy4s.schema.Schema.bijection
+import smithy4s.schema.Schema.union
+
+trait GrpcGreetingServiceGen[F[_, _, _, _, _]] {
+  self =>
+
+  def greet(name: String): F[GreetInput, GrpcGreetingServiceOperation.GreetError, GreetOutput, Nothing, Nothing]
+
+  final def transform: Transformation.PartiallyApplied[GrpcGreetingServiceGen[F]] = Transformation.of[GrpcGreetingServiceGen[F]](this)
+}
+
+object GrpcGreetingServiceGen extends Service.Mixin[GrpcGreetingServiceGen, GrpcGreetingServiceOperation] {
+
+  val id: ShapeId = ShapeId("smithy4s.example.grpc", "GrpcGreetingService")
+  val version: String = ""
+
+  val hints: Hints = Hints(
+    alloy.proto.Grpc(),
+  ).lazily
+
+  def apply[F[_]](implicit F: Impl[F]): F.type = F
+
+  object ErrorAware {
+    def apply[F[_, _]](implicit F: ErrorAware[F]): F.type = F
+    type Default[F[+_, +_]] = Constant[smithy4s.kinds.stubs.Kind2[F]#toKind5]
+  }
+
+  val endpoints: Vector[smithy4s.Endpoint[GrpcGreetingServiceOperation, _, _, _, _, _]] = Vector(
+    GrpcGreetingServiceOperation.Greet,
+  )
+
+  def input[I, E, O, SI, SO](op: GrpcGreetingServiceOperation[I, E, O, SI, SO]): I = op.input
+  def ordinal[I, E, O, SI, SO](op: GrpcGreetingServiceOperation[I, E, O, SI, SO]): Int = op.ordinal
+  override def endpoint[I, E, O, SI, SO](op: GrpcGreetingServiceOperation[I, E, O, SI, SO]) = op.endpoint
+  class Constant[P[-_, +_, +_, +_, +_]](value: P[Any, Nothing, Nothing, Nothing, Nothing]) extends GrpcGreetingServiceOperation.Transformed[GrpcGreetingServiceOperation, P](reified, const5(value))
+  type Default[F[+_]] = Constant[smithy4s.kinds.stubs.Kind1[F]#toKind5]
+  def reified: GrpcGreetingServiceGen[GrpcGreetingServiceOperation] = GrpcGreetingServiceOperation.reified
+  def mapK5[P[_, _, _, _, _], P1[_, _, _, _, _]](alg: GrpcGreetingServiceGen[P], f: PolyFunction5[P, P1]): GrpcGreetingServiceGen[P1] = new GrpcGreetingServiceOperation.Transformed(alg, f)
+  def fromPolyFunction[P[_, _, _, _, _]](f: PolyFunction5[GrpcGreetingServiceOperation, P]): GrpcGreetingServiceGen[P] = new GrpcGreetingServiceOperation.Transformed(reified, f)
+  def toPolyFunction[P[_, _, _, _, _]](impl: GrpcGreetingServiceGen[P]): PolyFunction5[GrpcGreetingServiceOperation, P] = GrpcGreetingServiceOperation.toPolyFunction(impl)
+
+  type GreetError = GrpcGreetingServiceOperation.GreetError
+  val GreetError = GrpcGreetingServiceOperation.GreetError
+}
+
+sealed trait GrpcGreetingServiceOperation[Input, Err, Output, StreamedInput, StreamedOutput] {
+  def run[F[_, _, _, _, _]](impl: GrpcGreetingServiceGen[F]): F[Input, Err, Output, StreamedInput, StreamedOutput]
+  def ordinal: Int
+  def input: Input
+  def endpoint: Endpoint[GrpcGreetingServiceOperation, Input, Err, Output, StreamedInput, StreamedOutput]
+}
+
+object GrpcGreetingServiceOperation {
+
+  object reified extends GrpcGreetingServiceGen[GrpcGreetingServiceOperation] {
+    def greet(name: String): Greet = Greet(GreetInput(name))
+  }
+  class Transformed[P[_, _, _, _, _], P1[_ ,_ ,_ ,_ ,_]](alg: GrpcGreetingServiceGen[P], f: PolyFunction5[P, P1]) extends GrpcGreetingServiceGen[P1] {
+    def greet(name: String): P1[GreetInput, GrpcGreetingServiceOperation.GreetError, GreetOutput, Nothing, Nothing] = f[GreetInput, GrpcGreetingServiceOperation.GreetError, GreetOutput, Nothing, Nothing](this.alg.greet(name))
+  }
+
+  def toPolyFunction[P[_, _, _, _, _]](impl: GrpcGreetingServiceGen[P]): PolyFunction5[GrpcGreetingServiceOperation, P] = new PolyFunction5[GrpcGreetingServiceOperation, P] {
+    def apply[I, E, O, SI, SO](op: GrpcGreetingServiceOperation[I, E, O, SI, SO]): P[I, E, O, SI, SO] = op.run(impl) 
+  }
+  final case class Greet(input: GreetInput) extends GrpcGreetingServiceOperation[GreetInput, GrpcGreetingServiceOperation.GreetError, GreetOutput, Nothing, Nothing] {
+    def run[F[_, _, _, _, _]](impl: GrpcGreetingServiceGen[F]): F[GreetInput, GrpcGreetingServiceOperation.GreetError, GreetOutput, Nothing, Nothing] = impl.greet(input.name)
+    def ordinal: Int = 0
+    def endpoint: smithy4s.Endpoint[GrpcGreetingServiceOperation,GreetInput, GrpcGreetingServiceOperation.GreetError, GreetOutput, Nothing, Nothing] = Greet
+  }
+  object Greet extends smithy4s.Endpoint[GrpcGreetingServiceOperation,GreetInput, GrpcGreetingServiceOperation.GreetError, GreetOutput, Nothing, Nothing] {
+    val schema: OperationSchema[GreetInput, GrpcGreetingServiceOperation.GreetError, GreetOutput, Nothing, Nothing] = Schema.operation(ShapeId("smithy4s.example.grpc", "Greet"))
+      .withInput(GreetInput.schema)
+      .withError(GreetError.errorSchema)
+      .withOutput(GreetOutput.schema)
+    def wrap(input: GreetInput): Greet = Greet(input)
+  }
+  sealed trait GreetError extends scala.Product with scala.Serializable { self =>
+    @inline final def widen: GreetError = this
+    def $ordinal: Int
+
+    object project {
+      def notFoundError: Option[NotFoundError] = GreetError.NotFoundErrorCase.alt.project.lift(self).map(_.notFoundError)
+      def permissionDeniedError: Option[PermissionDeniedError] = GreetError.PermissionDeniedErrorCase.alt.project.lift(self).map(_.permissionDeniedError)
+    }
+
+    def accept[A](visitor: GreetError.Visitor[A]): A = this match {
+      case value: GreetError.NotFoundErrorCase => visitor.notFoundError(value.notFoundError)
+      case value: GreetError.PermissionDeniedErrorCase => visitor.permissionDeniedError(value.permissionDeniedError)
+    }
+  }
+  object GreetError extends ErrorSchema.Companion[GreetError] {
+
+    def notFoundError(notFoundError: NotFoundError): GreetError = NotFoundErrorCase(notFoundError)
+    def permissionDeniedError(permissionDeniedError: PermissionDeniedError): GreetError = PermissionDeniedErrorCase(permissionDeniedError)
+
+    val id: ShapeId = ShapeId("smithy4s.example.grpc", "GreetError")
+
+    val hints: Hints = Hints.empty
+
+    final case class NotFoundErrorCase(notFoundError: NotFoundError) extends GreetError { final def $ordinal: Int = 0 }
+    final case class PermissionDeniedErrorCase(permissionDeniedError: PermissionDeniedError) extends GreetError { final def $ordinal: Int = 1 }
+
+    object NotFoundErrorCase {
+      val hints: Hints = Hints.empty
+      val schema: Schema[GreetError.NotFoundErrorCase] = bijection(NotFoundError.schema.addHints(hints), GreetError.NotFoundErrorCase(_), _.notFoundError)
+      val alt = schema.oneOf[GreetError]("NotFoundError")
+    }
+    object PermissionDeniedErrorCase {
+      val hints: Hints = Hints.empty
+      val schema: Schema[GreetError.PermissionDeniedErrorCase] = bijection(PermissionDeniedError.schema.addHints(hints), GreetError.PermissionDeniedErrorCase(_), _.permissionDeniedError)
+      val alt = schema.oneOf[GreetError]("PermissionDeniedError")
+    }
+
+    trait Visitor[A] {
+      def notFoundError(value: NotFoundError): A
+      def permissionDeniedError(value: PermissionDeniedError): A
+    }
+
+    object Visitor {
+      trait Default[A] extends Visitor[A] {
+        def default: A
+        def notFoundError(value: NotFoundError): A = default
+        def permissionDeniedError(value: PermissionDeniedError): A = default
+      }
+    }
+
+    implicit val schema: Schema[GreetError] = union(
+      GreetError.NotFoundErrorCase.alt,
+      GreetError.PermissionDeniedErrorCase.alt,
+    ){
+      _.$ordinal
+    }
+    def liftError(throwable: Throwable): Option[GreetError] = throwable match {
+      case e: NotFoundError => Some(GreetError.NotFoundErrorCase(e))
+      case e: PermissionDeniedError => Some(GreetError.PermissionDeniedErrorCase(e))
+      case _ => None
+    }
+    def unliftError(e: GreetError): Throwable = e match {
+      case GreetError.NotFoundErrorCase(e) => e
+      case GreetError.PermissionDeniedErrorCase(e) => e
+    }
+  }
+}
+

--- a/modules/bootstrapped/src/generated/smithy4s/example/grpc/NotFoundError.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/grpc/NotFoundError.scala
@@ -1,0 +1,29 @@
+package smithy4s.example.grpc
+
+import smithy4s.Hints
+import smithy4s.Schema
+import smithy4s.ShapeId
+import smithy4s.ShapeTag
+import smithy4s.Smithy4sThrowable
+import smithy4s.schema.Schema.string
+import smithy4s.schema.Schema.struct
+
+final case class NotFoundError(message: String) extends Smithy4sThrowable {
+  override def getMessage(): String = message
+}
+
+object NotFoundError extends ShapeTag.Companion[NotFoundError] {
+  val id: ShapeId = ShapeId("smithy4s.example.grpc", "NotFoundError")
+
+  val hints: Hints = Hints(
+    alloy.proto.GrpcError(code = 5, message = Some("Resource not found")),
+    smithy.api.Error.CLIENT.widen,
+  ).lazily
+
+  // constructor using the original order from the spec
+  private def make(message: String): NotFoundError = NotFoundError(message)
+
+  implicit val schema: Schema[NotFoundError] = struct(
+    string.required[NotFoundError]("message", _.message),
+  )(make).withId(id).addHints(hints)
+}

--- a/modules/bootstrapped/src/generated/smithy4s/example/grpc/PermissionDeniedError.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/grpc/PermissionDeniedError.scala
@@ -1,0 +1,29 @@
+package smithy4s.example.grpc
+
+import smithy4s.Hints
+import smithy4s.Schema
+import smithy4s.ShapeId
+import smithy4s.ShapeTag
+import smithy4s.Smithy4sThrowable
+import smithy4s.schema.Schema.string
+import smithy4s.schema.Schema.struct
+
+final case class PermissionDeniedError(message: String) extends Smithy4sThrowable {
+  override def getMessage(): String = message
+}
+
+object PermissionDeniedError extends ShapeTag.Companion[PermissionDeniedError] {
+  val id: ShapeId = ShapeId("smithy4s.example.grpc", "PermissionDeniedError")
+
+  val hints: Hints = Hints(
+    alloy.proto.GrpcError(code = 7, message = Some("Permission denied")),
+    smithy.api.Error.CLIENT.widen,
+  ).lazily
+
+  // constructor using the original order from the spec
+  private def make(message: String): PermissionDeniedError = PermissionDeniedError(message)
+
+  implicit val schema: Schema[PermissionDeniedError] = struct(
+    string.required[PermissionDeniedError]("message", _.message),
+  )(make).withId(id).addHints(hints)
+}

--- a/modules/bootstrapped/src/generated/smithy4s/example/grpc/package.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/grpc/package.scala
@@ -1,0 +1,8 @@
+package smithy4s.example
+
+package object grpc {
+  type GrpcGreetingService[F[_]] = smithy4s.kinds.FunctorAlgebra[GrpcGreetingServiceGen, F]
+  val GrpcGreetingService = GrpcGreetingServiceGen
+
+
+}

--- a/modules/core/src/smithy4s/client/UnaryClientCompiler.scala
+++ b/modules/core/src/smithy4s/client/UnaryClientCompiler.scala
@@ -29,6 +29,23 @@ object UnaryClientCompiler {
       middleware: Endpoint.Middleware[Client],
       isSuccessful: Response => Boolean
   )(implicit F: MonadThrowLike[F]): service.FunctorEndpointCompiler[F] =
+    make(
+      service,
+      client,
+      toSmithy4sClient,
+      makeClientCodecs,
+      middleware,
+      (response: Response) => F.pure(isSuccessful(response))
+    )
+
+  def make[Alg[_[_, _, _, _, _]], F[_], Client, Request, Response](
+      service: smithy4s.Service[Alg],
+      client: Client,
+      toSmithy4sClient: Client => UnaryLowLevelClient[F, Request, Response],
+      makeClientCodecs: UnaryClientCodecs.Make[F, Request, Response],
+      middleware: Endpoint.Middleware[Client],
+      isSuccessfulF: Response => F[Boolean]
+  )(implicit F: MonadThrowLike[F]): service.FunctorEndpointCompiler[F] =
     new service.FunctorEndpointCompiler[F] {
       def apply[I, E, O, SI, SO](
           endpoint: service.Endpoint[I, E, O, SI, SO]
@@ -39,10 +56,10 @@ object UnaryClientCompiler {
 
         val adaptedClient = toSmithy4sClient(transformedClient)
 
-        UnaryClientEndpoint(
+        UnaryClientEndpoint.make(
           adaptedClient,
           makeClientCodecs(endpoint.schema),
-          isSuccessful
+          isSuccessfulF
         )
       }
     }

--- a/modules/core/src/smithy4s/client/UnaryClientEndpoint.scala
+++ b/modules/core/src/smithy4s/client/UnaryClientEndpoint.scala
@@ -26,15 +26,25 @@ object UnaryClientEndpoint {
       clientCodecs: UnaryClientCodecs[F, Request, Response, I, E, O],
       isSuccessful: Response => Boolean
   )(implicit F: MonadThrowLike[F]): (I => F[O]) = {
+    make(lowLevelClient, clientCodecs, (response: Response) => F.pure(isSuccessful(response)))
+  }
+
+  def make[F[_], Request, Response, I, E, O, SI, SO](
+      lowLevelClient: UnaryLowLevelClient[F, Request, Response],
+      clientCodecs: UnaryClientCodecs[F, Request, Response, I, E, O],
+      isSuccessfulF: Response => F[Boolean]
+  )(implicit F: MonadThrowLike[F]): (I => F[O]) = {
 
     import clientCodecs._
     def inputToRequest(input: I): F[Request] =
       inputEncoder(input)
 
     def outputFromResponse(response: Response): F[O] =
-      if (isSuccessful(response)) outputDecoder(response)
-      else
-        F.flatMap(errorDecoder(response))(F.raiseError[O](_))
+      F.flatMap(isSuccessfulF(response)) {
+        case true => outputDecoder(response)
+        case false =>
+          F.flatMap(errorDecoder(response))(F.raiseError[O](_))
+      }
 
     (input: I) =>
       F.flatMap(inputToRequest(input)) { request =>

--- a/modules/grpc-http4s/src/smithy4s/grpc/http4s/GrpcProtocolBuilder.scala
+++ b/modules/grpc-http4s/src/smithy4s/grpc/http4s/GrpcProtocolBuilder.scala
@@ -1,0 +1,350 @@
+/*
+ *  Copyright 2021-2026 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package smithy4s.grpc.http4s
+
+import alloy.proto.{Grpc, GrpcStatusCode}
+import cats.effect.{Concurrent, Resource}
+import cats.syntax.all._
+import org.http4s._
+import org.http4s.client.Client
+import org.http4s.headers.`Content-Type`
+import org.http4s.implicits._
+import smithy4s.{Blob, Endpoint, Service, UnsupportedProtocolError, checkProtocol}
+import smithy4s.client.UnaryClientCompiler
+import smithy4s.grpc._
+import smithy4s.grpc.http4s.internals.{GrpcHttp4sCodecs, GrpcHttp4sLowLevelClient}
+import smithy4s.grpc.internals.{GrpcConstants, GrpcUnaryClientCodecs, GrpcUnaryServerCodecs}
+import smithy4s.interopcats._
+import smithy4s.kinds.FunctorAlgebra
+import smithy4s.protobuf.ProtobufCodec
+import smithy4s.schema.CachedSchemaCompiler
+import smithy4s.server.UnaryServerEndpoint
+
+class GrpcProtocolBuilder private (
+    payloadCompiler: CachedSchemaCompiler[ProtobufCodec]
+)(
+    requireHttp2: Boolean = true,
+    maxMessageSize: Int = 4 * 1024 * 1024
+) {
+
+  def withRequireHttp2(value: Boolean): GrpcProtocolBuilder =
+    new GrpcProtocolBuilder(payloadCompiler)(value, maxMessageSize)
+
+  def withMaxMessageSize(value: Int): GrpcProtocolBuilder =
+    new GrpcProtocolBuilder(payloadCompiler)(requireHttp2, value)
+
+  def withPayloadCompiler(
+      value: CachedSchemaCompiler[ProtobufCodec]
+  ): GrpcProtocolBuilder =
+    new GrpcProtocolBuilder(value)(requireHttp2, maxMessageSize)
+
+  def apply[Alg[_[_, _, _, _, _]]](
+      service: Service[Alg]
+  ): ServiceBuilder[Alg] = new ServiceBuilder(service)
+
+  def routes[Alg[_[_, _, _, _, _]], F[_]](
+      impl: FunctorAlgebra[Alg, F]
+  )(implicit service: Service[Alg], F: Concurrent[F]): RouterBuilder[Alg, F] =
+    apply(service).routes(impl)
+
+  class ServiceBuilder[Alg[_[_, _, _, _, _]]] private[http4s] (
+      val service: Service[Alg]
+  ) {
+
+    def client[F[_]: Concurrent](client: Client[F]): ClientBuilder[Alg, F] =
+      new ClientBuilder[Alg, F](
+        client = client,
+        service = service,
+        uri = uri"http://localhost:50051",
+        middleware = Endpoint.Middleware.noop,
+        strictTrailers = false,
+        strictStatusDetails = false,
+        requireHttp2 = GrpcProtocolBuilder.this.requireHttp2,
+        maxMessageSize = GrpcProtocolBuilder.this.maxMessageSize,
+        payloadCompiler = GrpcProtocolBuilder.this.payloadCompiler
+      )
+
+    def routes[F[_]: Concurrent](
+        impl: FunctorAlgebra[Alg, F]
+    ): RouterBuilder[Alg, F] =
+      new RouterBuilder[Alg, F](
+        service = service,
+        impl = impl,
+        middleware = Endpoint.Middleware.noop,
+        requireHttp2 = GrpcProtocolBuilder.this.requireHttp2,
+        maxMessageSize = GrpcProtocolBuilder.this.maxMessageSize,
+        payloadCompiler = GrpcProtocolBuilder.this.payloadCompiler
+      )
+  }
+
+  class ClientBuilder[Alg[_[_, _, _, _, _]], F[_]] private[http4s] (
+      client: Client[F],
+      val service: Service[Alg],
+      uri: Uri,
+      middleware: GrpcClientMiddleware[F],
+      strictTrailers: Boolean,
+      strictStatusDetails: Boolean,
+      requireHttp2: Boolean,
+      maxMessageSize: Int,
+      payloadCompiler: CachedSchemaCompiler[ProtobufCodec]
+  )(implicit F: Concurrent[F]) {
+
+    def uri(uri: Uri): ClientBuilder[Alg, F] = copy(uri = uri)
+
+    def middleware(mid: GrpcClientMiddleware[F]): ClientBuilder[Alg, F] =
+      copy(middleware = mid)
+
+    def strictTrailers(value: Boolean): ClientBuilder[Alg, F] =
+      copy(strictTrailers = value)
+
+    def strictStatusDetails(value: Boolean): ClientBuilder[Alg, F] =
+      copy(strictStatusDetails = value)
+
+    def make: Either[UnsupportedProtocolError, service.Impl[F]] =
+      checkProtocol(service, Grpc).map { _ =>
+          val compiler = UnaryClientCompiler.make(
+            service,
+            client,
+            (c: Client[F]) => GrpcHttp4sLowLevelClient(c, uri, requireHttp2),
+            GrpcUnaryClientCodecs.builder(service)
+              .withCompiler(payloadCompiler)
+              .withMaxMessageSize(maxMessageSize)
+              .withStrictTrailers(strictTrailers)
+              .withStrictStatusDetails(strictStatusDetails)
+              .build(),
+            middleware,
+            (response: GrpcResponse[Blob]) => F.pure(response.isSuccessful)
+          )
+
+        service.impl {
+          new service.FunctorEndpointCompiler[F] {
+            def apply[I, E, O, SI, SO](
+                endpoint: service.Endpoint[I, E, O, SI, SO]
+            ): I => F[O] =
+              if (
+                endpoint.schema.streamedInput.nonEmpty || endpoint.schema.streamedOutput.nonEmpty
+              ) {
+                _ =>
+                  implicitly[Concurrent[F]].raiseError(
+                    GrpcFailure.Unimplemented(
+                      s"gRPC streaming not supported for ${service.id} ${endpoint.id}"
+                    )
+                  )
+              } else {
+                compiler(endpoint)
+              }
+          }
+        }
+      }
+
+    def resource: Resource[F, service.Impl[F]] =
+      make.leftWiden[Throwable].liftTo[Resource[F, *]]
+
+    private def copy(
+        client: Client[F] = client,
+        service: Service[Alg] = service,
+        uri: Uri = uri,
+        middleware: GrpcClientMiddleware[F] = middleware,
+        strictTrailers: Boolean = strictTrailers,
+        strictStatusDetails: Boolean = strictStatusDetails,
+        requireHttp2: Boolean = requireHttp2,
+        maxMessageSize: Int = maxMessageSize,
+        payloadCompiler: CachedSchemaCompiler[ProtobufCodec] = payloadCompiler
+    ): ClientBuilder[Alg, F] =
+      new ClientBuilder[Alg, F](
+        client,
+        service,
+        uri,
+        middleware,
+        strictTrailers,
+        strictStatusDetails,
+        requireHttp2,
+        maxMessageSize,
+        payloadCompiler
+      )
+  }
+
+  class RouterBuilder[Alg[_[_, _, _, _, _]], F[_]] private[http4s] (
+      service: Service[Alg],
+      impl: FunctorAlgebra[Alg, F],
+      middleware: GrpcServerMiddleware[F],
+      requireHttp2: Boolean,
+      maxMessageSize: Int,
+      payloadCompiler: CachedSchemaCompiler[ProtobufCodec]
+  )(implicit F: Concurrent[F]) {
+
+    def middleware(mid: GrpcServerMiddleware[F]): RouterBuilder[Alg, F] =
+      copy(middleware = mid)
+
+    def maxMessageSize(value: Int): RouterBuilder[Alg, F] =
+      copy(maxMessageSize = value)
+
+    def make: Either[UnsupportedProtocolError, HttpRoutes[F]] =
+      checkProtocol(service, Grpc).map { _ =>
+        val endpoints = service.endpoints
+        val interpreter =
+          service.toPolyFunction[smithy4s.kinds.Kind1[F]#toKind5](impl)
+        val routes = endpoints.map { endpoint =>
+          val path = GrpcProtocolBuilder.grpcPath(service)(endpoint)
+          val handler =
+            if (
+              endpoint.schema.streamedInput.nonEmpty || endpoint.schema.streamedOutput.nonEmpty
+            ) {
+              (_: Request[F]) =>
+                F.raiseError[Response[F]](
+                  GrpcFailure.Unimplemented(
+                    s"gRPC streaming not supported for ${service.id} ${endpoint.id}"
+                  )
+                )
+            } else {
+              endpointHandler(interpreter, endpoint)
+            }
+          path -> handler
+        }.toMap
+
+        HttpRoutes.of[F] { case request =>
+          val isGrpcRequest =
+            request.method == org.http4s.Method.POST &&
+              request.headers
+                .get[`Content-Type`]
+                .exists(h => GrpcHttp4sCodecs.grpcContentTypes.contains(h.mediaType))
+          val segments = request.uri.path.segments.map(_.decoded()).toList
+          val parsedPath = smithy4s.grpc.GrpcMethodPath.parseSegments(
+            segments,
+            request.uri.path.endsWithSlash
+          ).toOption
+          parsedPath.flatMap(routes.get) match {
+            case Some(handler) => handler(request)
+            case None if isGrpcRequest =>
+              val message = parsedPath match {
+                case Some(valid) => s"Method not found: ${valid.render}"
+                case None        => "Invalid gRPC method path"
+              }
+              val trailers = GrpcMetadata.empty
+                .addText(GrpcConstants.grpcStatusHeader, GrpcStatusCode.UNIMPLEMENTED.intValue.toString)
+                .addText(GrpcConstants.grpcMessageHeader, GrpcMessageEncoding.encode(message))
+              GrpcHttp4sCodecs.grpcResponseToHttp4s[F](
+                GrpcResponse(Blob.empty, GrpcMetadata.empty, trailers, GrpcCompression.Identity)
+              )
+            case None => Response.notFound[F].pure[F]
+          }
+        }
+      }
+
+    def resource: Resource[F, HttpRoutes[F]] =
+      make.leftWiden[Throwable].liftTo[Resource[F, *]]
+
+    private def endpointHandler[I, E, O, SI, SO](
+        interpreter: smithy4s.kinds.FunctorInterpreter[service.Operation, F],
+        endpoint: service.Endpoint[I, E, O, SI, SO]
+    ): Request[F] => F[Response[F]] = {
+          val base = UnaryServerEndpoint(
+            interpreter,
+            endpoint,
+            GrpcUnaryServerCodecs.builder[F]
+              .withCompiler(payloadCompiler)
+              .withMaxMessageSize(maxMessageSize)
+              .build()
+              .apply(endpoint.schema),
+            middleware.prepare(service)(endpoint)
+          )
+
+      val path = GrpcProtocolBuilder.grpcPath(service)(endpoint)
+
+      (request: Request[F]) =>
+        if (request.method != org.http4s.Method.POST) {
+          Response[F](status = Status.MethodNotAllowed)
+            .putHeaders(
+              Header.Raw(org.typelevel.ci.CIString("Allow"), "POST")
+            )
+            .pure[F]
+        } else if (
+          requireHttp2 && request.httpVersion != HttpVersion.`HTTP/2`
+        ) {
+          Response[F](status = Status.UpgradeRequired).pure[F]
+        } else if (
+          !request.headers
+            .get[`Content-Type`]
+            .exists(h =>
+              GrpcHttp4sCodecs.grpcContentTypes.contains(h.mediaType)
+            )
+        ) {
+          Response[F](status = Status.UnsupportedMediaType).pure[F]
+        } else {
+          GrpcHttp4sCodecs.toGrpcRequest(request, path, maxMessageSize)
+            .flatMap(base)
+            .flatMap(GrpcHttp4sCodecs.grpcResponseToHttp4s[F])
+        }
+    }
+
+    private def copy(
+        service: Service[Alg] = service,
+        impl: FunctorAlgebra[Alg, F] = impl,
+        middleware: GrpcServerMiddleware[F] = middleware,
+        requireHttp2: Boolean = requireHttp2,
+        maxMessageSize: Int = maxMessageSize,
+        payloadCompiler: CachedSchemaCompiler[ProtobufCodec] = payloadCompiler
+    ): RouterBuilder[Alg, F] =
+      new RouterBuilder[Alg, F](
+        service,
+        impl,
+        middleware,
+        requireHttp2,
+        maxMessageSize,
+        payloadCompiler
+      )
+  }
+}
+
+object GrpcProtocolBuilder {
+  def grpcPath[Alg[_[_, _, _, _, _]]](
+      service: Service[Alg]
+  )(
+      endpoint: Endpoint[service.Operation, _, _, _, _, _]
+  ): smithy4s.grpc.GrpcMethodPath =
+    smithy4s.grpc.GrpcMethodPath(
+      s"${service.id.namespace}.${service.id.name}",
+      endpoint.id.name
+    )
+
+  private[GrpcProtocolBuilder] val default: GrpcProtocolBuilder =
+    new GrpcProtocolBuilder(ProtobufCodec)()
+
+  def apply[Alg[_[_, _, _, _, _]]](
+      service: Service[Alg]
+  ): default.ServiceBuilder[Alg] = default(service)
+
+  def routes[Alg[_[_, _, _, _, _]], F[_]](
+      impl: FunctorAlgebra[Alg, F]
+  )(implicit
+      service: Service[Alg],
+      F: Concurrent[F]
+  ): default.RouterBuilder[Alg, F] =
+    default.routes(impl)
+
+  def withRequireHttp2(value: Boolean): GrpcProtocolBuilder =
+    default.withRequireHttp2(value)
+
+  def withMaxMessageSize(value: Int): GrpcProtocolBuilder =
+    default.withMaxMessageSize(value)
+
+  def withPayloadCompiler(
+      value: CachedSchemaCompiler[ProtobufCodec]
+  ): GrpcProtocolBuilder =
+    default.withPayloadCompiler(value)
+
+}

--- a/modules/grpc-http4s/src/smithy4s/grpc/http4s/internals/GrpcHttp4sCodecs.scala
+++ b/modules/grpc-http4s/src/smithy4s/grpc/http4s/internals/GrpcHttp4sCodecs.scala
@@ -1,0 +1,93 @@
+/*
+ *  Copyright 2021-2026 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package smithy4s
+package grpc
+package http4s
+package internals
+
+import cats.effect.Concurrent
+import cats.implicits._
+import fs2.Stream
+import org.http4s.{Header, MediaType, Request, Response, Status}
+import org.http4s.headers.`Content-Type`
+import org.typelevel.ci.CIString
+import smithy4s.Blob
+import smithy4s.grpc._
+import smithy4s.grpc.internals.{ GrpcConstants }
+import smithy4s.interopcats._
+
+private[http4s] object GrpcHttp4sCodecs {
+
+  private[http4s] val grpcMediaType: MediaType =
+    MediaType.unsafeParse("application/grpc")
+  private[http4s] val grpcProtoMediaType: MediaType =
+    MediaType.unsafeParse("application/grpc+proto")
+  private[http4s] val grpcContentTypes: Set[MediaType] =
+    Set(grpcMediaType, grpcProtoMediaType)
+
+  def toGrpcRequest[F[_]](
+      request: Request[F],
+      path: GrpcMethodPath,
+      maxMessageSize: Int
+  )(implicit F: Concurrent[F]): F[GrpcRequest[Blob]] = {
+    val timeout = request.headers.get(CIString(GrpcConstants.grpcTimeoutHeader))
+      .map(_.head.value)
+      .flatMap(h => GrpcTimeout.parse(h).toOption)
+
+    val encoding = request.headers.get(CIString(GrpcConstants.grpcEncodingHeader))
+      .map(_.head.value)
+      .getOrElse("identity")
+
+    val acceptEncoding = request.headers
+      .get(CIString(GrpcConstants.grpcAcceptEncodingHeader))
+      .map(_.head.value)
+      .toList
+      .flatMap(_.split(',').toList.map(_.trim).filter(_.nonEmpty))
+
+    val accepted = acceptEncoding.map(GrpcCompression.parseLenient)
+
+    // We read at most 5 + maxMessageSize + 1 bytes: the gRPC framing header (5 bytes),
+    // the largest valid payload, and one extra byte to detect truncation vs overflow
+    // without buffering unbounded data into memory.
+    val grpcHeaderSizeBytes = 5L
+    val overflowProbeBytes  = 1L
+    val maxBytesToRead      = grpcHeaderSizeBytes + maxMessageSize.toLong + overflowProbeBytes
+    for {
+      metadata <- GrpcHttp4sMetadata.fromApplicationHeaders[F](request.headers)
+      bytes    <- request.body.take(maxBytesToRead).compile.toVector
+    } yield GrpcRequest(
+      message              = Blob(bytes.toArray),
+      headers              = metadata,
+      timeout              = timeout,
+      compression          = GrpcCompression.parseLenient(encoding),
+      acceptedCompressions = accepted,
+      path                 = path
+    )
+  }
+
+  def grpcResponseToHttp4s[F[_]](response: GrpcResponse[Blob])(implicit F: Concurrent[F]): F[Response[F]] = {
+    val headers  = GrpcHttp4sMetadata.toHeaders(response.headers)
+    val body     = Stream.chunk(fs2.Chunk.array(response.message.toArray)).covary[F]
+    val trailers = GrpcHttp4sMetadata.toHeaders(response.trailers)
+    val base = Response[F](status = Status.Ok, headers = headers)
+      .withContentType(`Content-Type`(grpcProtoMediaType))
+      .withBodyStream(body)
+      .withTrailerHeaders(F.pure(trailers))
+      .putHeaders(Header.Raw(CIString(GrpcConstants.grpcAcceptEncodingHeader), GrpcCompression.Identity.name))
+    F.pure(base)
+  }
+}

--- a/modules/grpc-http4s/src/smithy4s/grpc/http4s/internals/GrpcHttp4sLowLevelClient.scala
+++ b/modules/grpc-http4s/src/smithy4s/grpc/http4s/internals/GrpcHttp4sLowLevelClient.scala
@@ -1,0 +1,134 @@
+/*
+ *  Copyright 2021-2026 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package smithy4s.grpc.http4s.internals
+
+import cats.effect.Concurrent
+import cats.syntax.all._
+import fs2.{Chunk, Stream}
+import org.http4s.{Header, HttpVersion, Method, Request, Response, Uri}
+import org.http4s.client.Client
+import org.http4s.headers.`Content-Type`
+import smithy4s.Blob
+import smithy4s.client.UnaryLowLevelClient
+import smithy4s.grpc._
+import smithy4s.grpc.internals.GrpcConstants
+import smithy4s.interopcats._
+
+private[http4s] final case class GrpcHttp4sLowLevelClient[F[_]](
+    client: Client[F],
+    baseUri: Uri,
+    requireHttp2: Boolean
+)(implicit F: Concurrent[F])
+    extends UnaryLowLevelClient[F, GrpcRequest[Blob], GrpcResponse[Blob]] {
+
+  def run[Output](request: GrpcRequest[Blob])(
+      cb: GrpcResponse[Blob] => F[Output]
+  ): F[Output] = {
+    val httpRequest = toHttpRequest(request)
+    client.run(httpRequest).use { response =>
+      fromHttpResponse(response).flatMap(cb)
+    }
+  }
+
+  private def toHttpRequest(request: GrpcRequest[Blob]): Request[F] = {
+    val uri = baseUri.withPath(Uri.Path.unsafeFromString(request.path.render))
+    val metadataHeaders = GrpcHttp4sMetadata.toHeaders(request.headers)
+    val timeoutHeader = request.timeout
+      .map(t => Header.Raw(org.typelevel.ci.CIString(GrpcConstants.grpcTimeoutHeader), t.toHeader))
+    val acceptEncodingHeader = request.acceptedCompressions match {
+      case Nil => None
+      case values =>
+        Some(
+          Header.Raw(
+            org.typelevel.ci.CIString(GrpcConstants.grpcAcceptEncodingHeader),
+            values.map(_.name).mkString(",")
+          )
+        )
+    }
+    val headers = acceptEncodingHeader match {
+      case Some(h) => metadataHeaders.put(h)
+      case None    => metadataHeaders
+    }
+    val headersWithTimeout = timeoutHeader match {
+      case Some(h) => headers.put(h)
+      case None    => headers
+    }
+
+    val framedBody = Stream
+      .chunk(Chunk.array(request.message.toArray))
+
+    Request[F](
+      method = Method.POST,
+      uri = uri,
+      httpVersion = if (requireHttp2) HttpVersion.`HTTP/2` else HttpVersion.`HTTP/1.1`,
+      headers = headersWithTimeout
+    )
+      .withContentType(`Content-Type`(GrpcHttp4sCodecs.grpcProtoMediaType))
+      .putHeaders(Header.Raw(org.typelevel.ci.CIString(GrpcConstants.grpcEncodingHeader), request.compression.name))
+      .putHeaders(Header.Raw(org.typelevel.ci.CIString("TE"), "trailers"))
+      .withBodyStream(framedBody)
+  }
+
+  private def fromHttpResponse(response: Response[F]): F[GrpcResponse[Blob]] =
+    if (requireHttp2 && response.httpVersion != HttpVersion.`HTTP/2`) {
+      F.raiseError(GrpcFailure.Http2Required)
+    } else {
+      for {
+        headers <- GrpcHttp4sMetadata.fromApplicationHeaders[F](response.headers)
+        rawHeaders <- GrpcHttp4sMetadata.fromTrailers[F](response.headers)
+        encodingHeader = response.headers
+          .get(org.typelevel.ci.CIString(GrpcConstants.grpcEncodingHeader))
+          .map(_.head.value)
+          .getOrElse("identity")
+        parsedEncoding = GrpcCompression.parseLenient(encodingHeader)
+        bytes <- response.body.compile.toVector
+        trailers <- response.trailerHeaders
+        trailerMetadata <- GrpcHttp4sMetadata.fromTrailers[F](trailers)
+        effectiveTrailers = {
+          // gRPC allows Trailers-Only responses (single HEADERS with END_STREAM), which ember
+          // surfaces as Response.headers while completing trailerHeaders as empty.
+          // See https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md and
+          // https://github.com/http4s/http4s/blob/v0.23.33/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Stream.scala#L226-L244
+          // https://github.com/http4s/http4s/blob/v0.23.33/core/shared/src/main/scala/org/http4s/Message.scala#L200-L210
+          if (trailerMetadata.nonEmpty) trailerMetadata
+          else if (rawHeaders.getText(GrpcConstants.grpcStatusHeader).nonEmpty) {
+            val grpcPrefix = smithy4s.http.CaseInsensitive("grpc-")
+            val excluded = Set(
+              smithy4s.http.CaseInsensitive(GrpcConstants.grpcEncodingHeader),
+              smithy4s.http.CaseInsensitive(GrpcConstants.grpcAcceptEncodingHeader),
+              smithy4s.http.CaseInsensitive(GrpcConstants.grpcTimeoutHeader)
+            )
+            rawHeaders.keys
+              .filter(key => key.startsWith(grpcPrefix) && !excluded.contains(key))
+              .foldLeft(GrpcMetadata.empty) { (acc, key) =>
+                rawHeaders.get(key.toString).foldLeft(acc) { (acc2, value) =>
+                  value match {
+                    case GrpcMetadata.Value.Text(text) => acc2.addText(key.toString, text)
+                    case GrpcMetadata.Value.Binary(bin) => acc2.addBinary(key.toString, bin)
+                  }
+                }
+              }
+          } else trailerMetadata
+        }
+      } yield GrpcResponse(
+        message = Blob(bytes.toArray),
+        headers = headers,
+        trailers = effectiveTrailers,
+        compression = parsedEncoding
+      )
+    }
+}

--- a/modules/grpc-http4s/src/smithy4s/grpc/http4s/internals/GrpcHttp4sMetadata.scala
+++ b/modules/grpc-http4s/src/smithy4s/grpc/http4s/internals/GrpcHttp4sMetadata.scala
@@ -1,0 +1,77 @@
+/*
+ *  Copyright 2021-2026 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package smithy4s.grpc.http4s.internals
+
+import org.http4s.{Header, Headers}
+import org.typelevel.ci.CIString
+import smithy4s.capability.MonadThrowLike
+import smithy4s.grpc.GrpcMetadata
+import smithy4s.grpc.internals.GrpcMetadataCodec
+
+private[http4s] object GrpcHttp4sMetadata {
+  def fromApplicationHeaders[F[_]](
+      headers: Headers
+  )(implicit F: MonadThrowLike[F]): F[GrpcMetadata] =
+    decodeHeaders(headers) { name =>
+      val lower = name.toLowerCase
+      !lower.startsWith(":") &&
+      !lower.startsWith("grpc-") &&
+      lower != "content-type" &&
+      lower != "te"
+    }
+
+  def fromTrailers[F[_]](
+      headers: Headers
+  )(implicit F: MonadThrowLike[F]): F[GrpcMetadata] =
+    decodeHeaders(headers)(name => !name.startsWith(":"))
+
+  private def decodeHeaders[F[_]](
+      headers: Headers
+  )(include: String => Boolean)(implicit F: MonadThrowLike[F]): F[GrpcMetadata] =
+    headers.headers.foldLeft(F.pure(GrpcMetadata.empty)) { (accF, header) =>
+      val name = header.name.toString
+      if (!include(name)) accF
+      else {
+        F.flatMap(accF) { acc =>
+          if (name.toLowerCase.endsWith("-bin")) {
+            F.flatMap(F.liftEither(GrpcMetadataCodec.decodeBinaryHeaderValue(header.value))) {
+              blobs =>
+                F.pure(blobs.foldLeft(acc) { (innerAcc, blob) =>
+                  innerAcc.addBinary(name, blob)
+                })
+            }
+          } else {
+            F.pure(acc.addText(name, header.value))
+          }
+        }
+      }
+    }
+
+  def toHeaders(metadata: GrpcMetadata): Headers = {
+    metadata.values.foldLeft(Headers.empty) { case (acc, (key, values)) =>
+      val name = key.toString
+      values.foldLeft(acc) { (headers, value) =>
+        val rawValue = value match {
+          case GrpcMetadata.Value.Text(text) => text
+          case GrpcMetadata.Value.Binary(blob) =>
+            GrpcMetadataCodec.encodeBinaryHeaderValue(blob)
+        }
+        headers ++ Headers(Header.Raw(CIString(name), rawValue))
+      }
+    }
+  }
+}

--- a/modules/grpc-http4s/src/smithy4s/grpc/http4s/package.scala
+++ b/modules/grpc-http4s/src/smithy4s/grpc/http4s/package.scala
@@ -1,0 +1,28 @@
+/*
+ *  Copyright 2021-2026 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package smithy4s.grpc
+
+import org.http4s.client.Client
+import smithy4s.{Blob, Endpoint}
+
+package object http4s {
+  type GrpcServerMiddleware[F[_]] =
+    Endpoint.Middleware[GrpcRequest[Blob] => F[GrpcResponse[Blob]]]
+
+  type GrpcClientMiddleware[F[_]] =
+    Endpoint.Middleware[Client[F]]
+}

--- a/modules/grpc-http4s/test/src/smithy4s/grpc/http4s/GrpcHttp4sMetadataSpec.scala
+++ b/modules/grpc-http4s/test/src/smithy4s/grpc/http4s/GrpcHttp4sMetadataSpec.scala
@@ -1,0 +1,119 @@
+/*
+ *  Copyright 2021-2026 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package smithy4s.grpc.http4s
+
+import cats.effect.IO
+import org.http4s.{Header, Headers}
+import org.typelevel.ci.CIString
+import smithy4s.Blob
+import smithy4s.grpc._
+import smithy4s.grpc.http4s.internals.GrpcHttp4sMetadata
+import smithy4s.grpc.internals.GrpcConstants
+import smithy4s.interopcats._
+import weaver.SimpleIOSuite
+
+import java.util.Base64
+
+object GrpcHttp4sMetadataSpec extends SimpleIOSuite {
+
+  test("binary metadata round-trips") {
+    val original = GrpcMetadata.empty.addBinary("test-bin", Blob(Array[Byte](1, 2, 3)))
+    val headers  = GrpcHttp4sMetadata.toHeaders(original)
+    GrpcHttp4sMetadata.fromApplicationHeaders[IO](headers).map { roundTripped =>
+      expect.same(roundTripped, original)
+    }
+  }
+
+  test("binary metadata accepts padded base64") {
+    val blob    = Blob(Array[Byte](1, 2, 3, 4))
+    val padded  = Base64.getEncoder.encodeToString(blob.toArray)
+    val headers = Headers(Header.Raw(CIString("test-bin"), padded))
+    GrpcHttp4sMetadata.fromApplicationHeaders[IO](headers).map { metadata =>
+      expect.same(metadata.getBinary("test-bin"), Vector(blob))
+    }
+  }
+
+  test("binary metadata accepts unpadded base64") {
+    val blob     = Blob(Array[Byte](1, 2, 3, 4))
+    val unpadded = Base64.getEncoder.withoutPadding().encodeToString(blob.toArray)
+    val headers  = Headers(Header.Raw(CIString("test-bin"), unpadded))
+    GrpcHttp4sMetadata.fromApplicationHeaders[IO](headers).map { metadata =>
+      expect.same(metadata.getBinary("test-bin"), Vector(blob))
+    }
+  }
+
+  test("binary metadata splits comma-joined values keeping empties") {
+    val first   = Blob(Array[Byte](1, 2, 3))
+    val second  = Blob(Array[Byte](4, 5))
+    val enc1    = Base64.getEncoder.withoutPadding().encodeToString(first.toArray)
+    val enc2    = Base64.getEncoder.encodeToString(second.toArray)
+    val headers = Headers(Header.Raw(CIString("test-bin"), s"$enc1,, $enc2"))
+    GrpcHttp4sMetadata.fromApplicationHeaders[IO](headers).map { metadata =>
+      expect.same(metadata.getBinary("test-bin"), Vector(first, Blob.empty, second))
+    }
+  }
+
+  test("fromApplicationHeaders strips protocol headers") {
+    val binary        = Blob(Array[Byte](1, 2, 3))
+    val binaryEncoded = Base64.getEncoder.withoutPadding().encodeToString(binary.toArray)
+    val headers = Headers(
+      Header.Raw(CIString("x-foo"), "bar"),
+      Header.Raw(CIString("x-bin-bin"), binaryEncoded),
+      Header.Raw(CIString(GrpcConstants.grpcStatusHeader), "0"),
+      Header.Raw(CIString(GrpcConstants.grpcMessageHeader), "ok"),
+      Header.Raw(CIString(GrpcConstants.grpcEncodingHeader), "gzip"),
+      Header.Raw(CIString(GrpcConstants.grpcAcceptEncodingHeader), "gzip"),
+      Header.Raw(CIString(GrpcConstants.grpcTimeoutHeader), "1S"),
+      Header.Raw(CIString(GrpcConstants.grpcStatusDetailsHeader), "AAAA"),
+      Header.Raw(CIString("content-type"), "application/grpc+proto"),
+      Header.Raw(CIString("te"), "trailers"),
+      Header.Raw(CIString(":status"), "200")
+    )
+    GrpcHttp4sMetadata.fromApplicationHeaders[IO](headers).map { metadata =>
+      expect.same(metadata.getText("x-foo"), Vector("bar")) &&
+      expect.same(metadata.getBinary("x-bin-bin"), Vector(binary)) &&
+      expect(metadata.getText(GrpcConstants.grpcStatusHeader).isEmpty) &&
+      expect(metadata.getText(GrpcConstants.grpcMessageHeader).isEmpty) &&
+      expect(metadata.getText(GrpcConstants.grpcEncodingHeader).isEmpty) &&
+      expect(metadata.getText(GrpcConstants.grpcAcceptEncodingHeader).isEmpty) &&
+      expect(metadata.getText(GrpcConstants.grpcTimeoutHeader).isEmpty) &&
+      expect(metadata.getBinary(GrpcConstants.grpcStatusDetailsHeader).isEmpty) &&
+      expect(metadata.getText("content-type").isEmpty) &&
+      expect(metadata.getText("te").isEmpty) &&
+      expect(metadata.getText(":status").isEmpty)
+    }
+  }
+
+  test("fromTrailers preserves grpc fields and drops pseudo-headers") {
+    val details        = Blob(Array[Byte](4, 5, 6))
+    val detailsEncoded = Base64.getEncoder.withoutPadding().encodeToString(details.toArray)
+    val headers = Headers(
+      Header.Raw(CIString(GrpcConstants.grpcStatusHeader), "7"),
+      Header.Raw(CIString(GrpcConstants.grpcMessageHeader), "denied"),
+      Header.Raw(CIString(GrpcConstants.grpcStatusDetailsHeader), detailsEncoded),
+      Header.Raw(CIString("x-trailer"), "ok"),
+      Header.Raw(CIString(":status"), "200")
+    )
+    GrpcHttp4sMetadata.fromTrailers[IO](headers).map { metadata =>
+      expect.same(metadata.getText(GrpcConstants.grpcStatusHeader), Vector("7")) &&
+      expect.same(metadata.getText(GrpcConstants.grpcMessageHeader), Vector("denied")) &&
+      expect.same(metadata.getBinary(GrpcConstants.grpcStatusDetailsHeader), Vector(details)) &&
+      expect.same(metadata.getText("x-trailer"), Vector("ok")) &&
+      expect(metadata.getText(":status").isEmpty)
+    }
+  }
+}

--- a/modules/grpc-http4s/test/src/smithy4s/grpc/http4s/GrpcProtocolBuilderSpec.scala
+++ b/modules/grpc-http4s/test/src/smithy4s/grpc/http4s/GrpcProtocolBuilderSpec.scala
@@ -1,0 +1,340 @@
+/*
+ *  Copyright 2021-2026 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package smithy4s.grpc.http4s
+
+import alloy.proto.{Grpc, GrpcStatusCode}
+import cats.effect.{IO, Ref, Resource}
+import fs2.{Chunk, Stream}
+import org.http4s.{Header, Headers, HttpApp, HttpVersion, Method, Request, Response, Status, Uri}
+import org.http4s.client.Client
+import org.http4s.headers.`Content-Type`
+import org.typelevel.ci.CIString
+import smithy4s.{Blob, Endpoint, Hints, Schema, ShapeId}
+import smithy4s.grpc._
+import smithy4s.grpc.http4s.internals.{GrpcHttp4sCodecs, GrpcHttp4sLowLevelClient}
+import smithy4s.grpc.internals.GrpcConstants
+import smithy4s.kinds.{FunctorAlgebra, PolyFunction5}
+import weaver.SimpleIOSuite
+
+object GrpcProtocolBuilderSpec extends SimpleIOSuite {
+
+  private val pingSchema =
+    Schema.operation(ShapeId("test", "Ping"))
+
+  private val pingEndpoint: Endpoint[DummyOp, Unit, Nothing, Unit, Nothing, Nothing] =
+    new Endpoint[DummyOp, Unit, Nothing, Unit, Nothing, Nothing] {
+      val schema = pingSchema
+      def wrap(input: Unit): DummyOp[Unit, Nothing, Unit, Nothing, Nothing] = DummyOp.Ping
+    }
+
+  private object DummyService extends smithy4s.Service.Reflective[DummyOp] {
+    val id: ShapeId                                                = ShapeId("test", "DummyService")
+    val version: String                                            = ""
+    val hints: Hints                                               = Hints(Grpc())
+    val endpoints: IndexedSeq[Endpoint[_, _, _, _, _]]             = Vector(pingEndpoint)
+    def input[I, E, O, SI, SO](op: DummyOp[I, E, O, SI, SO]): I   = op.input
+    def ordinal[I, E, O, SI, SO](op: DummyOp[I, E, O, SI, SO]): Int = op.ordinal
+  }
+
+  private sealed trait DummyOp[I, E, O, SI, SO] {
+    def input: I
+    def ordinal: Int
+    def endpoint: Endpoint[DummyOp, I, E, O, SI, SO]
+  }
+
+  private object DummyOp {
+    case object Ping extends DummyOp[Unit, Nothing, Unit, Nothing, Nothing] {
+      val input: Unit  = ()
+      val ordinal: Int = 0
+      val endpoint = pingEndpoint
+    }
+  }
+
+  private val dummyImpl: FunctorAlgebra[PolyFunction5.From[DummyOp]#Algebra, IO] =
+    new PolyFunction5[DummyOp, smithy4s.kinds.Kind1[IO]#toKind5] {
+      def apply[I, E, O, SI, SO](op: DummyOp[I, E, O, SI, SO]): IO[O] =
+        IO.pure(().asInstanceOf[O])
+    }
+
+  private val grpcBody: Stream[IO, Byte] =
+    Stream.chunk(Chunk.array(GrpcFrame.encode(GrpcFrame(compressed = false, Blob.empty))))
+
+  test("requireHttp2 returns 426 for HTTP/1.1 request") {
+    GrpcProtocolBuilder.withRequireHttp2(true)(DummyService).routes(dummyImpl).make.fold(
+      err => IO.pure(failure(err.getMessage)),
+      routes => {
+        val request = Request[IO](
+          method = Method.POST,
+          uri = Uri.unsafeFromString("/test.DummyService/Ping"),
+          httpVersion = HttpVersion.`HTTP/1.1`
+        ).withContentType(`Content-Type`(GrpcHttp4sCodecs.grpcProtoMediaType))
+        routes.orNotFound(request).map { response =>
+          expect.eql(response.status, Status.UpgradeRequired)
+        }
+      }
+    )
+  }
+
+  test("GET returns 405 with Allow header") {
+    GrpcProtocolBuilder.withRequireHttp2(false)(DummyService).routes(dummyImpl).make.fold(
+      err => IO.pure(failure(err.getMessage)),
+      routes => {
+        val request = Request[IO](
+          method = Method.GET,
+          uri = Uri.unsafeFromString("/test.DummyService/Ping")
+        ).withContentType(`Content-Type`(GrpcHttp4sCodecs.grpcProtoMediaType))
+        routes.orNotFound(request).map { response =>
+          expect.eql(response.status, Status.MethodNotAllowed) &&
+          expect(response.headers.headers.exists(h => h.name.toString == "Allow" && h.value == "POST"))
+        }
+      }
+    )
+  }
+
+  test("unsupported content-type returns 415") {
+    GrpcProtocolBuilder.withRequireHttp2(false)(DummyService).routes(dummyImpl).make.fold(
+      err => IO.pure(failure(err.getMessage)),
+      routes => {
+        val request = Request[IO](
+          method = Method.POST,
+          uri = Uri.unsafeFromString("/test.DummyService/Ping")
+        ).withContentType(`Content-Type`(org.http4s.MediaType.text.plain))
+        routes.orNotFound(request).map { response =>
+          expect.eql(response.status, Status.UnsupportedMediaType)
+        }
+      }
+    )
+  }
+
+  test("unknown gRPC method returns UNIMPLEMENTED in trailers") {
+    GrpcProtocolBuilder.withRequireHttp2(false)(DummyService).routes(dummyImpl).make.fold(
+      err => IO.pure(failure(err.getMessage)),
+      routes => {
+        val request = Request[IO](
+          method = Method.POST,
+          uri = Uri.unsafeFromString("/test.DummyService/Unknown")
+        ).withContentType(`Content-Type`(GrpcHttp4sCodecs.grpcProtoMediaType))
+          .withBodyStream(grpcBody)
+        routes.orNotFound(request).flatMap { response =>
+          response.trailerHeaders.map { trailers =>
+            val status  = trailers.get(CIString(GrpcConstants.grpcStatusHeader)).map(_.head.value)
+            val message = trailers.get(CIString(GrpcConstants.grpcMessageHeader)).map(_.head.value)
+            expect.eql(response.status, Status.Ok) &&
+            expect.same(status, Some(GrpcStatusCode.UNIMPLEMENTED.intValue.toString)) &&
+            expect.same(message, Some(GrpcMessageEncoding.encode("Method not found: /test.DummyService/Unknown")))
+          }
+        }
+      }
+    )
+  }
+
+  test("trailing slash on gRPC path is accepted") {
+    GrpcProtocolBuilder.withRequireHttp2(false)(DummyService).routes(dummyImpl).make.fold(
+      err => IO.pure(failure(err.getMessage)),
+      routes => {
+        val request = Request[IO](
+          method = Method.POST,
+          uri = Uri.unsafeFromString("/test.DummyService/Ping/")
+        ).withContentType(`Content-Type`(GrpcHttp4sCodecs.grpcProtoMediaType))
+          .withBodyStream(grpcBody)
+        routes.orNotFound(request).flatMap { response =>
+          response.trailerHeaders.map { trailers =>
+            val status = trailers.get(CIString(GrpcConstants.grpcStatusHeader)).map(_.head.value)
+            expect.eql(response.status, Status.Ok) &&
+            expect.same(status, Some(GrpcStatusCode.OK.intValue.toString))
+          }
+        }
+      }
+    )
+  }
+
+  test("server maps unknown throwable to INTERNAL") {
+    val failingImpl: FunctorAlgebra[PolyFunction5.From[DummyOp]#Algebra, IO] =
+      new PolyFunction5[DummyOp, smithy4s.kinds.Kind1[IO]#toKind5] {
+        def apply[I, E, O, SI, SO](op: DummyOp[I, E, O, SI, SO]): IO[O] =
+          IO.raiseError(new RuntimeException("boom"))
+      }
+    GrpcProtocolBuilder.withRequireHttp2(false)(DummyService).routes(failingImpl).make.fold(
+      err => IO.pure(failure(err.getMessage)),
+      routes => {
+        val request = Request[IO](
+          method = Method.POST,
+          uri = Uri.unsafeFromString("/test.DummyService/Ping")
+        ).withContentType(`Content-Type`(GrpcHttp4sCodecs.grpcProtoMediaType))
+          .withBodyStream(grpcBody)
+        routes.orNotFound(request).flatMap { response =>
+          response.trailerHeaders.map { trailers =>
+            val status  = trailers.get(CIString(GrpcConstants.grpcStatusHeader)).map(_.head.value)
+            val message = trailers.get(CIString(GrpcConstants.grpcMessageHeader)).map(_.head.value)
+            expect.eql(response.status, Status.Ok) &&
+            expect.same(status, Some(GrpcStatusCode.INTERNAL.intValue.toString)) &&
+            expect.same(message, Some(GrpcMessageEncoding.encode("Unhandled gRPC error")))
+          }
+        }
+      }
+    )
+  }
+
+  test("server middleware receives service and endpoint ids") {
+    for {
+      ref <- Ref.of[IO, Option[(ShapeId, ShapeId)]](None)
+      middleware = new Endpoint.Middleware.Standard[GrpcRequest[Blob] => IO[GrpcResponse[Blob]]] {
+        def prepare(
+            serviceId: ShapeId,
+            endpointId: ShapeId,
+            serviceHints: Hints,
+            endpointHints: Hints
+        ): (GrpcRequest[Blob] => IO[GrpcResponse[Blob]]) => (GrpcRequest[Blob] => IO[GrpcResponse[Blob]]) =
+          handler => request => ref.set(Some(serviceId -> endpointId)) *> handler(request)
+      }
+      routes <- GrpcProtocolBuilder
+        .withRequireHttp2(false)(DummyService)
+        .routes(dummyImpl)
+        .middleware(middleware)
+        .make
+        .fold(err => IO.raiseError(new RuntimeException(err.getMessage)), IO.pure)
+      request = Request[IO](
+        method = Method.POST,
+        uri = Uri.unsafeFromString("/test.DummyService/Ping")
+      ).withContentType(`Content-Type`(GrpcHttp4sCodecs.grpcProtoMediaType))
+        .withBodyStream(grpcBody)
+      _        <- routes.orNotFound(request)
+      captured <- ref.get
+    } yield expect.same(captured, Some(DummyService.id -> pingEndpoint.id))
+  }
+
+  test("low-level client sends TE: trailers header") {
+    for {
+      ref <- Ref.of[IO, Option[Request[IO]]](None)
+      client = Client[IO] { request =>
+        Resource.eval(
+          ref.set(Some(request)).as(Response[IO](status = Status.Ok).withTrailerHeaders(IO.pure(Headers.empty)))
+        )
+      }
+      lowLevel = GrpcHttp4sLowLevelClient(client, Uri.unsafeFromString("http://localhost"), requireHttp2 = false)
+      request = GrpcRequest(
+        message = Blob.empty, headers = GrpcMetadata.empty, timeout = None,
+        compression = GrpcCompression.Identity, acceptedCompressions = Nil,
+        path = GrpcMethodPath("test.DummyService", "Ping")
+      )
+      _        <- lowLevel.run(request)(IO.pure)
+      captured <- ref.get
+    } yield {
+      val hasTe = captured.exists(_.headers.headers.exists(h => h.name.toString == "TE" && h.value == "trailers"))
+      expect(hasTe)
+    }
+  }
+
+  test("low-level client propagates grpc-timeout header") {
+    for {
+      ref <- Ref.of[IO, Option[Request[IO]]](None)
+      client = Client[IO] { request =>
+        Resource.eval(
+          ref.set(Some(request)).as(Response[IO](status = Status.Ok).withTrailerHeaders(IO.pure(Headers.empty)))
+        )
+      }
+      lowLevel = GrpcHttp4sLowLevelClient(client, Uri.unsafeFromString("http://localhost"), requireHttp2 = false)
+      timeout  = GrpcTimeout(10, GrpcTimeout.Seconds)
+      request = GrpcRequest(
+        message = Blob.empty, headers = GrpcMetadata.empty, timeout = Some(timeout),
+        compression = GrpcCompression.Identity, acceptedCompressions = Nil,
+        path = GrpcMethodPath("test.DummyService", "Ping")
+      )
+      _        <- lowLevel.run(request)(IO.pure)
+      captured <- ref.get
+    } yield {
+      val hasTimeout = captured.exists(
+        _.headers.headers.exists(h => h.name.toString == GrpcConstants.grpcTimeoutHeader && h.value == timeout.toHeader)
+      )
+      expect(hasTimeout)
+    }
+  }
+
+  test("low-level client handles trailers-only responses") {
+    val httpApp = HttpApp[IO] { _ =>
+      val headers = Headers(
+        `Content-Type`(GrpcHttp4sCodecs.grpcProtoMediaType),
+        Header.Raw(CIString(GrpcConstants.grpcStatusHeader), "7"),
+        Header.Raw(CIString(GrpcConstants.grpcMessageHeader), GrpcMessageEncoding.encode("denied")),
+        Header.Raw(CIString("grpc-foo"), "bar"),
+        Header.Raw(CIString(GrpcConstants.grpcEncodingHeader), "gzip")
+      )
+      IO.pure(Response[IO](status = Status.Ok, headers = headers))
+    }
+    val client   = Client.fromHttpApp(httpApp)
+    val lowLevel = GrpcHttp4sLowLevelClient(client, Uri.unsafeFromString("http://localhost"), requireHttp2 = false)
+    val request = GrpcRequest(
+      message = Blob.empty, headers = GrpcMetadata.empty, timeout = None,
+      compression = GrpcCompression.Identity, acceptedCompressions = Nil,
+      path = GrpcMethodPath("test.DummyService", "Ping")
+    )
+    lowLevel.run(request)(IO.pure).map { response =>
+      val status   = response.trailers.getText(GrpcConstants.grpcStatusHeader).headOption
+      val custom   = response.trailers.getText("grpc-foo").headOption
+      val encoding = response.trailers.getText(GrpcConstants.grpcEncodingHeader).headOption
+      expect.same(status, Some("7")) &&
+      expect.same(custom, Some("bar")) &&
+      expect(encoding.isEmpty) &&
+      expect(response.headers.getText(GrpcConstants.grpcStatusHeader).isEmpty)
+    }
+  }
+
+  test("low-level client does not enforce strict trailers") {
+    val httpApp = HttpApp[IO] { _ =>
+      IO.pure(Response[IO](status = Status.Ok).withTrailerHeaders(IO.pure(Headers.empty)))
+    }
+    val client   = Client.fromHttpApp(httpApp)
+    val lowLevel = GrpcHttp4sLowLevelClient(client, Uri.unsafeFromString("http://localhost"), requireHttp2 = false)
+    val request = GrpcRequest(
+      message = Blob.empty, headers = GrpcMetadata.empty, timeout = None,
+      compression = GrpcCompression.Identity, acceptedCompressions = Nil,
+      path = GrpcMethodPath("test.DummyService", "Ping")
+    )
+    lowLevel.run(request)(IO.pure).map { response =>
+      expect(response.trailers == GrpcMetadata.empty)
+    }
+  }
+
+  test("low-level client enforces HTTP/2 when required") {
+    val httpApp  = HttpApp[IO](_ => IO.pure(Response[IO](status = Status.Ok)))
+    val client   = Client.fromHttpApp(httpApp)
+    val lowLevel = GrpcHttp4sLowLevelClient(client, Uri.unsafeFromString("http://localhost"), requireHttp2 = true)
+    val request = GrpcRequest(
+      message = Blob.empty, headers = GrpcMetadata.empty, timeout = None,
+      compression = GrpcCompression.Identity, acceptedCompressions = Nil,
+      path = GrpcMethodPath("test.DummyService", "Ping")
+    )
+    lowLevel.run(request)(IO.pure).attempt.map { result =>
+      expect(result == Left(GrpcFailure.Http2Required))
+    }
+  }
+
+  test("toGrpcRequest limits body to max frame size") {
+    val maxMessageSize     = 8
+    val grpcHeaderSize     = 5L
+    val overflowProbeBytes = 1L
+    val limit              = grpcHeaderSize + maxMessageSize.toLong + overflowProbeBytes
+    val body = Stream.chunk(Chunk.array(Array.fill(limit.toInt)(1.toByte))) ++
+      Stream.raiseError[IO](new RuntimeException("pulled past limit"))
+    val request = Request[IO](method = Method.POST)
+      .withBodyStream(body)
+      .withContentType(`Content-Type`(GrpcHttp4sCodecs.grpcProtoMediaType))
+    GrpcHttp4sCodecs.toGrpcRequest(request, GrpcMethodPath("test.DummyService", "Ping"), maxMessageSize).map { grpcRequest =>
+      expect.same(grpcRequest.message.size.toLong, limit)
+    }
+  }
+}

--- a/modules/grpc-http4s/test/src/smithy4s/grpc/http4s/GrpcStatusHintSpec.scala
+++ b/modules/grpc-http4s/test/src/smithy4s/grpc/http4s/GrpcStatusHintSpec.scala
@@ -1,0 +1,162 @@
+/*
+ *  Copyright 2021-2026 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package smithy4s.grpc.http4s
+
+import cats.effect.IO
+import cats.effect.kernel.Ref
+import cats.effect.kernel.Resource
+import org.http4s.{Response, Status, Uri}
+import org.http4s.client.Client
+import smithy4s.example.grpc._
+import smithy4s.grpc.GrpcFailure
+import smithy4s.grpc.GrpcMessageEncoding
+import smithy4s.grpc.internals.GrpcConstants
+import smithy4s.kinds.PolyFunction5
+import weaver.{Expectations, SimpleIOSuite}
+
+object GrpcStatusHintSpec extends SimpleIOSuite {
+
+  private val Impl: GrpcGreetingServiceGen.Impl[IO] =
+    GrpcGreetingServiceGen.fromPolyFunction(
+      new PolyFunction5[GrpcGreetingServiceOperation, smithy4s.kinds.Kind1[IO]#toKind5] {
+        def apply[I, E, O, SI, SO](op: GrpcGreetingServiceOperation[I, E, O, SI, SO]): IO[O] =
+          op match {
+            case GrpcGreetingServiceOperation.Greet(GreetInput(name)) =>
+              (name match {
+                case "missing" => IO.raiseError(NotFoundError("not found"))
+                case "denied"  => IO.raiseError(PermissionDeniedError("permission denied"))
+                case _         => IO.pure(GreetOutput(s"Hello, $name!"))
+              }).asInstanceOf[IO[O]]
+          }
+      }
+    )
+
+  private val builder = GrpcProtocolBuilder.withRequireHttp2(false)
+
+  // Resource providing both the typed client and an intercepted last response,
+  // so raw HTTP assertions can be made on the response produced by the server.
+  private def withClientAndResponse(
+      f: (GrpcGreetingServiceGen.Impl[IO], Ref[IO, Option[Response[IO]]]) => IO[Expectations]
+  ): IO[Expectations] =
+    builder(GrpcGreetingServiceGen).routes(Impl).resource.use { httpRoutes =>
+      Ref[IO].of(Option.empty[Response[IO]]).flatMap { lastResponse =>
+        val intercepting: Client[IO] = Client { req =>
+          Resource.eval(
+            httpRoutes.orNotFound.run(req).flatMap { resp =>
+              lastResponse.set(Some(resp)).as(resp)
+            }
+          )
+        }
+        builder(GrpcGreetingServiceGen)
+          .client(intercepting)
+          .uri(Uri.unsafeFromString("http://localhost"))
+          .make
+          .fold(
+            err => IO.raiseError(new RuntimeException(err.getMessage)),
+            client => f(client, lastResponse)
+          )
+      }
+    }
+
+  test("typed: NotFoundError round-trips via grpc-status 5") {
+    withClientAndResponse { (client, _) =>
+      client.greet("missing").attempt.map {
+        case Left(e: NotFoundError) => expect.eql(e.message, "not found")
+        case Left(e: GrpcFailure)   => failure(s"unexpected GrpcFailure with status ${e.status}")
+        case Left(e)                => failure(s"unexpected error: $e")
+        case Right(_)               => failure("expected error, got success")
+      }
+    }
+  }
+
+  test("typed: PermissionDeniedError round-trips via grpc-status 7") {
+    withClientAndResponse { (client, _) =>
+      client.greet("denied").attempt.map {
+        case Left(e: PermissionDeniedError) => expect.eql(e.message, "permission denied")
+        case Left(e: GrpcFailure)           => failure(s"unexpected GrpcFailure with status ${e.status}")
+        case Left(e)                        => failure(s"unexpected error: $e")
+        case Right(_)                       => failure("expected error, got success")
+      }
+    }
+  }
+
+  test("typed: successful response decodes correctly") {
+    withClientAndResponse { (client, _) =>
+      client.greet("World").map { output =>
+        expect.eql(output.greeting, "Hello, World!")
+      }
+    }
+  }
+
+  test("raw: NotFoundError response has HTTP 200 and grpc-status trailer 5") {
+    withClientAndResponse { (client, lastResponse) =>
+      client.greet("missing").attempt >> lastResponse.get.flatMap {
+        case None => IO.pure(failure("no response captured"))
+        case Some(response) =>
+          response.trailerHeaders.map { trailers =>
+            val grpcStatus = trailers
+              .get(org.typelevel.ci.CIString(GrpcConstants.grpcStatusHeader))
+              .map(_.head.value)
+            val grpcMessage = trailers
+              .get(org.typelevel.ci.CIString(GrpcConstants.grpcMessageHeader))
+              .map(_.head.value)
+              .flatMap(GrpcMessageEncoding.decode(_).toOption)
+            expect.eql(response.status, Status.Ok) &&
+            expect.eql(grpcStatus, Some("5")) &&
+            expect.eql(grpcMessage, Some("Resource not found"))
+          }
+      }
+    }
+  }
+
+  test("raw: PermissionDeniedError response has HTTP 200 and grpc-status trailer 7") {
+    withClientAndResponse { (client, lastResponse) =>
+      client.greet("denied").attempt >> lastResponse.get.flatMap {
+        case None => IO.pure(failure("no response captured"))
+        case Some(response) =>
+          response.trailerHeaders.map { trailers =>
+            val grpcStatus = trailers
+              .get(org.typelevel.ci.CIString(GrpcConstants.grpcStatusHeader))
+              .map(_.head.value)
+            val grpcMessage = trailers
+              .get(org.typelevel.ci.CIString(GrpcConstants.grpcMessageHeader))
+              .map(_.head.value)
+              .flatMap(GrpcMessageEncoding.decode(_).toOption)
+            expect.eql(response.status, Status.Ok) &&
+            expect.eql(grpcStatus, Some("7")) &&
+            expect.eql(grpcMessage, Some("Permission denied"))
+          }
+      }
+    }
+  }
+
+  test("raw: successful response has HTTP 200 and grpc-status trailer 0") {
+    withClientAndResponse { (client, lastResponse) =>
+      client.greet("World") >> lastResponse.get.flatMap {
+        case None => IO.pure(failure("no response captured"))
+        case Some(response) =>
+          response.trailerHeaders.map { trailers =>
+            val grpcStatus = trailers
+              .get(org.typelevel.ci.CIString(GrpcConstants.grpcStatusHeader))
+              .map(_.head.value)
+            expect.eql(response.status, Status.Ok) &&
+            expect.eql(grpcStatus, Some("0"))
+          }
+      }
+    }
+  }
+}

--- a/modules/grpc/src/smithy4s/grpc/ErrorPayload.scala
+++ b/modules/grpc/src/smithy4s/grpc/ErrorPayload.scala
@@ -1,0 +1,58 @@
+/*
+ *  Copyright 2021-2026 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package smithy4s.grpc
+
+import alloy.proto.ProtoIndex
+import smithy4s.Blob
+import smithy4s.Schema
+import smithy4s.schema.Schema.{blob, int, list, string, struct}
+
+// Wire-compatible with google.protobuf.Any.
+final case class StatusDetails(
+    typeUrl: String,
+    value: Blob
+)
+
+object StatusDetails {
+  implicit val schema: Schema[StatusDetails] = {
+    val typeUrl = string.required[StatusDetails]("typeUrl", _.typeUrl)
+      .addHints(ProtoIndex(1))
+    val value = blob.required[StatusDetails]("value", _.value)
+      .addHints(ProtoIndex(2))
+    struct(typeUrl, value)(StatusDetails.apply)
+  }
+}
+
+// Wire-compatible with google.rpc.Status.
+final case class ErrorPayload(
+    code: Option[Int],
+    message: Option[String],
+    details: Option[List[StatusDetails]]
+)
+
+object ErrorPayload {
+  implicit val schema: Schema[ErrorPayload] = {
+    val code = int.optional[ErrorPayload]("code", _.code)
+      .addHints(ProtoIndex(1))
+    val message = string.optional[ErrorPayload]("message", _.message)
+      .addHints(ProtoIndex(2))
+    val details = list(StatusDetails.schema)
+      .optional[ErrorPayload]("details", _.details)
+      .addHints(ProtoIndex(3))
+    struct(code, message, details)(ErrorPayload.apply)
+  }
+}

--- a/modules/grpc/src/smithy4s/grpc/GrpcCompression.scala
+++ b/modules/grpc/src/smithy4s/grpc/GrpcCompression.scala
@@ -1,0 +1,59 @@
+/*
+ *  Copyright 2021-2026 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package smithy4s.grpc
+
+sealed trait GrpcCompression extends Product with Serializable {
+  def name: String
+  def isEnabled: Boolean
+}
+
+object GrpcCompression {
+  case object Identity extends GrpcCompression {
+    val name: String = "identity"
+    val isEnabled: Boolean = false
+  }
+
+  case object Gzip extends GrpcCompression {
+    val name: String = "gzip"
+    val isEnabled: Boolean = true
+  }
+
+  case object Deflate extends GrpcCompression {
+    val name: String = "deflate"
+    val isEnabled: Boolean = true
+  }
+
+  final case class Custom(name: String) extends GrpcCompression {
+    val isEnabled: Boolean = true
+  }
+
+  final case class UnknownCompression(value: String)
+
+  val supported: List[GrpcCompression] = List(Identity, Gzip, Deflate)
+
+  def fromString(value: String): Either[UnknownCompression, GrpcCompression] =
+    // gRPC compression names are case-insensitive; we normalize unknowns to lowercase.
+    value.toLowerCase match {
+      case "identity" => Right(Identity)
+      case "gzip"     => Right(Gzip)
+      case "deflate"  => Right(Deflate)
+      case other       => Left(UnknownCompression(other))
+    }
+
+  def parseLenient(value: String): GrpcCompression =
+    fromString(value).getOrElse(Custom(value))
+}

--- a/modules/grpc/src/smithy4s/grpc/GrpcFailure.scala
+++ b/modules/grpc/src/smithy4s/grpc/GrpcFailure.scala
@@ -1,0 +1,51 @@
+/*
+ *  Copyright 2021-2026 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package smithy4s.grpc
+
+import alloy.proto.GrpcStatusCode
+import scala.util.control.NoStackTrace
+
+sealed abstract class GrpcFailure(val status: GrpcStatusCode, val message: String)
+  extends Throwable(message)
+    with NoStackTrace
+
+object GrpcFailure {
+
+  final case class InvalidFrame(errorMessage: String)
+      extends GrpcFailure(GrpcStatusCode.INVALID_ARGUMENT, errorMessage)
+
+  final case class UnsupportedCompression(encoding: String)
+      extends GrpcFailure(GrpcStatusCode.UNIMPLEMENTED, s"Unsupported gRPC compression: ${encoding}")
+
+  case object MissingCompressionEncoding
+      extends GrpcFailure(GrpcStatusCode.INVALID_ARGUMENT, "Missing gRPC compression encoding")
+
+  case object Http2Required extends GrpcFailure(
+    GrpcStatusCode.UNIMPLEMENTED,
+    "gRPC requires HTTP/2"
+  )
+
+  final case class Unimplemented(override val message: String) extends GrpcFailure(GrpcStatusCode.UNIMPLEMENTED, message)
+}
+
+final case class InvalidStatus(value: String) extends Throwable(s"Received invalid gRPC status ${value}") with NoStackTrace
+
+case object MissingTrailers extends Throwable("Response is missing gRPC trailers") with NoStackTrace
+
+final case class StatusCodeMismatch(grpcStatus: Int, detailsStatus: Int) 
+  extends Throwable(s"Status code mismatch grpc-status=${grpcStatus}; grpc-status-details-bin = ${detailsStatus}")
+  with NoStackTrace

--- a/modules/grpc/src/smithy4s/grpc/GrpcFrame.scala
+++ b/modules/grpc/src/smithy4s/grpc/GrpcFrame.scala
@@ -1,0 +1,87 @@
+/*
+ *  Copyright 2021-2026 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package smithy4s.grpc
+
+import smithy4s.Blob
+import smithy4s.capability._
+import smithy4s.grpc.GrpcFailure.InvalidFrame
+
+final case class GrpcFrame(compressed: Boolean, message: Blob)
+
+object GrpcFrame {
+  object Error {
+    val MissingFrame = "Missing frame"
+    val TruncatedHeader = "Truncated gRPC frame header"
+    val TruncatedMessage = "Truncated gRPC frame message"
+    val InvalidCompressionFlag = "Invalid gRPC compression flag"
+    val MessageTooLarge = "gRPC message exceeds max size"
+    val MultipleFrames = "Multiple gRPC frames in unary request"
+  }
+
+  def decodeUnary[F[_]](bytes: Blob, maxMessageSize: Int)(implicit F: MonadThrowLike[F]): F[GrpcFrame] = {
+    val dataLength = bytes.size.toLong
+    if (dataLength == 0) F.raiseError(InvalidFrame(Error.MissingFrame))
+    else if (dataLength < 5) F.raiseError(InvalidFrame(Error.TruncatedHeader))
+    else {
+      val flag = bytes(0)
+      val lengthLong = readLength(bytes)
+      if (flag != 0 && flag != 1) F.raiseError(InvalidFrame(Error.InvalidCompressionFlag))
+      // Check size before casting to Int or slicing to avoid overflow and large allocations.
+      else if (lengthLong > maxMessageSize.toLong) F.raiseError(InvalidFrame(Error.MessageTooLarge))
+      else if (lengthLong > Int.MaxValue.toLong) F.raiseError(InvalidFrame(Error.MessageTooLarge))
+      else {
+        // Use Long arithmetic to avoid overflow when lengthLong is near Int.MaxValue.
+        val expectedSize = 5L + lengthLong
+        if (dataLength < expectedSize) F.raiseError(InvalidFrame(Error.TruncatedMessage))
+        else if (dataLength > expectedSize) F.raiseError(InvalidFrame(Error.MultipleFrames))
+        else {
+          val length = lengthLong.toInt
+          val message = Array.ofDim[Byte](length)
+          bytes.copyToArray(message, 0, 5, length)
+          F.pure(GrpcFrame(flag == 1, Blob(message)))
+        }
+      }
+    }
+  }
+
+  def encode(frame: GrpcFrame): Array[Byte] = {
+    val messageSize = frame.message.size
+    val header = encodeHeader(frame.compressed, messageSize) // Array[Byte] length 5
+    val out = new Array[Byte](header.length + messageSize)
+    System.arraycopy(header, 0, out, 0, header.length)
+    frame.message.copyToArray(out, header.length, 0, messageSize)
+    out
+  }
+
+  private def encodeHeader(compressed: Boolean, length: Int): Array[Byte] = {
+    val header = new Array[Byte](5)
+    header(0) = if (compressed) 1.toByte else 0.toByte
+    header(1) = ((length >>> 24) & 0xff).toByte
+    header(2) = ((length >>> 16) & 0xff).toByte
+    header(3) = ((length >>> 8) & 0xff).toByte
+    header(4) = (length & 0xff).toByte
+    header
+  }
+
+  // gRPC encodes the message length as an unsigned 32-bit big-endian integer.
+  // We return a Long to avoid signed Int overflow and to compare safely before casting.
+  private def readLength(bytes: Blob): Long =
+    ((bytes(1) & 0xffL) << 24) |
+      ((bytes(2) & 0xffL) << 16) |
+      ((bytes(3) & 0xffL) << 8) |
+      (bytes(4) & 0xffL)
+}

--- a/modules/grpc/src/smithy4s/grpc/GrpcMessageEncoding.scala
+++ b/modules/grpc/src/smithy4s/grpc/GrpcMessageEncoding.scala
@@ -1,0 +1,103 @@
+/*
+ *  Copyright 2021-2026 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package smithy4s.grpc
+
+import java.nio.charset.StandardCharsets
+import scala.collection.mutable.ArrayBuilder
+
+object GrpcMessageEncoding {
+
+  sealed trait DecodeError extends Product with Serializable {
+    def message: String
+  }
+
+  object DecodeError {
+    final case class InvalidPercentEncoding(value: String, index: Int)
+        extends DecodeError {
+      val message: String = s"Invalid percent-encoding at index $index in '$value'"
+    }
+
+    final case class InvalidAscii(value: String, index: Int) extends DecodeError {
+      val message: String = s"Invalid ASCII character at index $index in '$value'"
+    }
+  }
+
+  def encode(value: String): String = {
+    val bytes = value.getBytes(StandardCharsets.UTF_8)
+    val builder = new StringBuilder(bytes.length)
+    var i = 0
+    while (i < bytes.length) {
+      val b = bytes(i) & 0xff
+      if (isUnreserved(b)) builder.append(b.toChar)
+      else {
+        builder.append('%')
+        builder.append(toHexUpper(b >>> 4))
+        builder.append(toHexUpper(b & 0x0f))
+      }
+      i += 1
+    }
+    builder.toString
+  }
+
+  def decode(value: String): Either[DecodeError, String] = {
+    val builder = ArrayBuilder.make[Byte]
+
+    @annotation.tailrec
+    def loop(i: Int): Either[DecodeError, String] = {
+      if (i >= value.length) {
+        Right(new String(builder.result(), StandardCharsets.UTF_8))
+      } else {
+        val ch = value.charAt(i)
+        if (ch == '%') {
+          if (i + 2 >= value.length) {
+            Left(DecodeError.InvalidPercentEncoding(value, i))
+          } else {
+            val hi = fromHex(value.charAt(i + 1))
+            val lo = fromHex(value.charAt(i + 2))
+            if (hi < 0 || lo < 0) {
+              Left(DecodeError.InvalidPercentEncoding(value, i))
+            } else {
+              builder += ((hi << 4) + lo).toByte
+              loop(i + 3)
+            }
+          }
+        } else if (ch <= 0x7f) {
+          builder += ch.toByte
+          loop(i + 1)
+        } else {
+          Left(DecodeError.InvalidAscii(value, i))
+        }
+      }
+    }
+
+    loop(0)
+  }
+
+  // gRPC Percent-Byte-Unencoded = %x20-%x24 / %x26-%x7E (space and VCHAR, except '%').
+  private def isUnreserved(b: Int): Boolean =
+    (b >= 0x20 && b <= 0x24) || (b >= 0x26 && b <= 0x7e)
+
+  private def toHexUpper(n: Int): Char =
+    if (n < 10) (n + '0').toChar else (n - 10 + 'A').toChar
+
+  private def fromHex(c: Char): Int = {
+    if (c >= '0' && c <= '9') c - '0'
+    else if (c >= 'A' && c <= 'F') c - 'A' + 10
+    else if (c >= 'a' && c <= 'f') c - 'a' + 10
+    else -1
+  }
+}

--- a/modules/grpc/src/smithy4s/grpc/GrpcMetadata.scala
+++ b/modules/grpc/src/smithy4s/grpc/GrpcMetadata.scala
@@ -1,0 +1,73 @@
+/*
+ *  Copyright 2021-2026 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package smithy4s.grpc
+
+import smithy4s.Blob
+import smithy4s.http.CaseInsensitive
+
+final case class GrpcMetadata private (
+    values: Map[CaseInsensitive, Vector[GrpcMetadata.Value]]
+) {
+
+  def isEmpty: Boolean = values.isEmpty
+
+  def nonEmpty: Boolean = values.nonEmpty
+
+  def keys: Set[CaseInsensitive] = values.keySet
+
+  def get(key: String): Vector[GrpcMetadata.Value] =
+    values.getOrElse(CaseInsensitive(key), Vector.empty)
+
+  def getText(key: String): Vector[String] =
+    get(key).collect { case GrpcMetadata.Value.Text(value) => value }
+
+  def getBinary(key: String): Vector[Blob] =
+    get(key).collect { case GrpcMetadata.Value.Binary(value) => value }
+
+  def add(key: String, value: GrpcMetadata.Value): GrpcMetadata = {
+    val k = CaseInsensitive(key)
+    val updated = values.getOrElse(k, Vector.empty) :+ value
+    GrpcMetadata(values.updated(k, updated))
+  }
+
+  def addText(key: String, value: String): GrpcMetadata =
+    add(key, GrpcMetadata.Value.Text(value))
+
+  def addBinary(key: String, value: Blob): GrpcMetadata =
+    add(key, GrpcMetadata.Value.Binary(value))
+
+  def ++(other: GrpcMetadata): GrpcMetadata =
+    other.values.foldLeft(this) { case (acc, (k, vals)) =>
+      val updated = acc.values.getOrElse(k, Vector.empty) ++ vals
+      GrpcMetadata(acc.values.updated(k, updated))
+    }
+
+}
+
+object GrpcMetadata {
+  val empty: GrpcMetadata = GrpcMetadata(Map.empty[CaseInsensitive, Vector[GrpcMetadata.Value]])
+
+  def apply(values: (String, Value)*): GrpcMetadata =
+    values.foldLeft(empty) { case (acc, (k, v)) => acc.add(k, v) }
+
+  sealed trait Value extends Product with Serializable
+
+  object Value {
+    final case class Text(value: String) extends Value
+    final case class Binary(value: Blob) extends Value
+  }
+}

--- a/modules/grpc/src/smithy4s/grpc/GrpcMethodPath.scala
+++ b/modules/grpc/src/smithy4s/grpc/GrpcMethodPath.scala
@@ -1,0 +1,43 @@
+/*
+ *  Copyright 2021-2026 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package smithy4s.grpc
+
+final case class GrpcMethodPath(service: String, method: String) {
+  def render: String = s"/$service/$method"
+}
+
+object GrpcMethodPath {
+  sealed trait ParseError extends Product with Serializable
+  case object InvalidFormat extends ParseError
+
+  def parse(rawPath: String): Either[ParseError, GrpcMethodPath] = {
+    val normalized =
+      if (rawPath.length > 1 && rawPath.endsWith("/")) rawPath.dropRight(1) else rawPath
+    val segments = normalized.split('/').filter(_.nonEmpty).toList
+    segments match {
+      case service :: method :: Nil => Right(GrpcMethodPath(service, method))
+      case _                        => Left(InvalidFormat)
+    }
+  }
+
+  def parseSegments(segments: List[String], hasTrailingSlash: Boolean): Either[ParseError, GrpcMethodPath] =
+    segments match {
+      case service :: method :: Nil => Right(GrpcMethodPath(service, method))
+      case Nil if hasTrailingSlash  => Left(InvalidFormat)
+      case _                        => Left(InvalidFormat)
+    }
+}

--- a/modules/grpc/src/smithy4s/grpc/GrpcRequest.scala
+++ b/modules/grpc/src/smithy4s/grpc/GrpcRequest.scala
@@ -1,0 +1,28 @@
+/*
+ *  Copyright 2021-2026 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package smithy4s.grpc
+
+final case class GrpcRequest[A](
+    message: A,
+    headers: GrpcMetadata,
+    timeout: Option[GrpcTimeout],
+    compression: GrpcCompression,
+    acceptedCompressions: List[GrpcCompression],
+    path: GrpcMethodPath
+){
+  def mapMessage[B](f: A => B): GrpcRequest[B] = copy(message = f(message))
+}

--- a/modules/grpc/src/smithy4s/grpc/GrpcResponse.scala
+++ b/modules/grpc/src/smithy4s/grpc/GrpcResponse.scala
@@ -1,0 +1,29 @@
+/*
+ *  Copyright 2021-2026 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package smithy4s.grpc
+
+final case class GrpcResponse[A](
+    message: A,
+    headers: GrpcMetadata,
+    trailers: GrpcMetadata,
+    compression: GrpcCompression
+) {
+  def mapMessage[B](f: A => B): GrpcResponse[B] = copy(message = f(message))
+
+  def isSuccessful: Boolean =
+    trailers.getText("grpc-status").headOption.exists(_ == "0")
+}

--- a/modules/grpc/src/smithy4s/grpc/GrpcTimeout.scala
+++ b/modules/grpc/src/smithy4s/grpc/GrpcTimeout.scala
@@ -1,0 +1,104 @@
+/*
+ *  Copyright 2021-2026 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package smithy4s.grpc
+
+import scala.concurrent.duration._
+
+final case class GrpcTimeout(amount: Long, unit: GrpcTimeout.Unit) {
+  def toHeader: String = s"$amount${unit.suffix}"
+  def toFiniteDuration: FiniteDuration = unit.toFiniteDuration(amount)
+}
+
+object GrpcTimeout {
+
+  sealed trait Unit {
+    def suffix: Char
+    def toFiniteDuration(amount: Long): FiniteDuration
+  }
+
+  case object Nanoseconds extends Unit {
+    val suffix: Char = 'n'
+    def toFiniteDuration(amount: Long): FiniteDuration = amount.nanos
+  }
+
+  case object Microseconds extends Unit {
+    val suffix: Char = 'u'
+    def toFiniteDuration(amount: Long): FiniteDuration = amount.micros
+  }
+
+  case object Milliseconds extends Unit {
+    val suffix: Char = 'm'
+    def toFiniteDuration(amount: Long): FiniteDuration = amount.millis
+  }
+
+  case object Seconds extends Unit {
+    val suffix: Char = 'S'
+    def toFiniteDuration(amount: Long): FiniteDuration = amount.seconds
+  }
+
+  case object Minutes extends Unit {
+    val suffix: Char = 'M'
+    def toFiniteDuration(amount: Long): FiniteDuration = amount.minutes
+  }
+
+  case object Hours extends Unit {
+    val suffix: Char = 'H'
+    def toFiniteDuration(amount: Long): FiniteDuration = amount.hours
+  }
+
+  sealed trait ParseError extends Product with Serializable {
+    def message: String
+  }
+
+  object ParseError {
+    final case class InvalidFormat(value: String) extends ParseError {
+      val message: String = s"Invalid grpc-timeout: $value"
+    }
+
+    final case class InvalidUnit(value: String) extends ParseError {
+      val message: String = s"Invalid grpc-timeout unit: $value"
+    }
+  }
+
+  def parse(value: String): Either[ParseError, GrpcTimeout] = {
+    if (value.length < 2) Left(ParseError.InvalidFormat(value))
+    else {
+      val (digits, suffixStr) = value.splitAt(value.length - 1)
+      if (digits.isEmpty || !digits.forall(_.isDigit) || digits.length > 8)
+        Left(ParseError.InvalidFormat(value))
+      else {
+        val unit = suffixStr.charAt(0) match {
+          case 'n' => Some(Nanoseconds)
+          case 'u' => Some(Microseconds)
+          case 'm' => Some(Milliseconds)
+          case 'S' => Some(Seconds)
+          case 'M' => Some(Minutes)
+          case 'H' => Some(Hours)
+          case _   => None
+        }
+        unit.toRight(ParseError.InvalidUnit(value)).flatMap { u =>
+          scala.util.Try(digits.toLong).toEither
+            .left.map(_ => ParseError.InvalidFormat(value))
+            .flatMap { amount =>
+              if (amount <= 0) Left(ParseError.InvalidFormat(value))
+              else Right(GrpcTimeout(amount, u))
+            }
+        }
+      }
+    }
+  }
+}

--- a/modules/grpc/src/smithy4s/grpc/GrpcTypeUrl.scala
+++ b/modules/grpc/src/smithy4s/grpc/GrpcTypeUrl.scala
@@ -1,0 +1,26 @@
+/*
+ *  Copyright 2021-2026 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package smithy4s.grpc
+
+import smithy4s.ShapeId
+
+object GrpcTypeUrl {
+  private val Prefix = "type.googleapis.com/"
+
+  def fromShapeId(shapeId: ShapeId): String =
+    Prefix + shapeId.toString.replace('#', '.')
+}

--- a/modules/grpc/src/smithy4s/grpc/internals/GrpcCodecHelpers.scala
+++ b/modules/grpc/src/smithy4s/grpc/internals/GrpcCodecHelpers.scala
@@ -1,0 +1,62 @@
+/*
+ *  Copyright 2021-2026 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package smithy4s.grpc.internals
+
+import alloy.proto.GrpcStatusCode
+import cats.effect.Concurrent
+import smithy4s.Blob
+import smithy4s.grpc._
+
+private[grpc] object GrpcCodecHelpers {
+
+  val successTrailers: GrpcMetadata =
+    GrpcMetadata.empty
+      .addText(GrpcConstants.grpcStatusHeader, GrpcStatusCode.OK.intValue.toString)
+
+  val internalErrorTrailers: GrpcMetadata =
+    GrpcMetadata.empty
+      .addText(GrpcConstants.grpcStatusHeader, GrpcStatusCode.INTERNAL.intValue.toString)
+
+  def encodeUnaryFrame(payload: Blob): Blob =
+    Blob(GrpcFrame.encode(GrpcFrame(compressed = false, payload)).toArray)
+
+  def buildTrailers(
+      status: Int,
+      message: Option[String],
+      payload: Option[ErrorPayload],
+      encodePayload: ErrorPayload => Blob
+  ): GrpcMetadata = {
+    val base = GrpcMetadata.empty
+      .addText(GrpcConstants.grpcStatusHeader, status.toString)
+    val withMessage = message.filter(_.nonEmpty) match {
+      case Some(value) => base.addText(GrpcConstants.grpcMessageHeader, GrpcMessageEncoding.encode(value))
+      case None        => base
+    }
+    payload match {
+      case Some(details) => withMessage.addBinary(GrpcConstants.grpcStatusDetailsHeader, encodePayload(details))
+      case None          => withMessage
+    }
+  }
+
+  def ensureTrailers[F[_]](
+      response: GrpcResponse[Blob],
+      strictTrailers: Boolean
+  )(implicit F: Concurrent[F]): F[Unit] =
+    F.raiseWhen(strictTrailers && response.trailers.getText(GrpcConstants.grpcStatusHeader).isEmpty)(
+      MissingTrailers
+    )
+}

--- a/modules/grpc/src/smithy4s/grpc/internals/GrpcConstants.scala
+++ b/modules/grpc/src/smithy4s/grpc/internals/GrpcConstants.scala
@@ -1,0 +1,26 @@
+/*
+ *  Copyright 2021-2026 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package smithy4s.grpc.internals
+
+private[smithy4s] object GrpcConstants {
+  val grpcStatusHeader: String         = "grpc-status"
+  val grpcMessageHeader: String        = "grpc-message"
+  val grpcEncodingHeader: String       = "grpc-encoding"
+  val grpcAcceptEncodingHeader: String = "grpc-accept-encoding"
+  val grpcTimeoutHeader: String        = "grpc-timeout"
+  val grpcStatusDetailsHeader: String  = "grpc-status-details-bin"
+}

--- a/modules/grpc/src/smithy4s/grpc/internals/GrpcMetadataCodec.scala
+++ b/modules/grpc/src/smithy4s/grpc/internals/GrpcMetadataCodec.scala
@@ -1,0 +1,41 @@
+/*
+ *  Copyright 2021-2026 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package smithy4s.grpc.internals
+
+import smithy4s.Blob
+
+import java.util.Base64
+import scala.util.Try
+
+private[grpc] object GrpcMetadataCodec {
+  def decodeBinaryHeaderValue(value: String): Either[Throwable, Vector[Blob]] = {
+    // gRPC binary headers may be comma-joined; empty entries are valid and decode to empty bytes.
+    // gRPC requires accepting both padded and unpadded standard base64 encodings.
+    // Base64 decoder accepts padded and unpadded input per JDK 8+ contract.
+    val decoder = Base64.getDecoder
+    val tokens = value.split(",", -1).toVector.map(_.trim)
+    tokens.foldLeft(Right(Vector.empty): Either[Throwable, Vector[Blob]]) {
+      case (Right(acc), token) =>
+        Try(decoder.decode(token)).toEither.map(bytes => acc :+ Blob(bytes))
+      case (left @ Left(_), _) => left
+    }
+  }
+
+  def encodeBinaryHeaderValue(blob: Blob): String =
+    Base64.getEncoder.withoutPadding().encodeToString(blob.toArray)
+
+}

--- a/modules/grpc/src/smithy4s/grpc/internals/GrpcUnaryClientCodecs.scala
+++ b/modules/grpc/src/smithy4s/grpc/internals/GrpcUnaryClientCodecs.scala
@@ -1,0 +1,209 @@
+/*
+ *  Copyright 2021-2026 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package smithy4s.grpc.internals
+
+import cats.effect.Concurrent
+import cats.implicits._
+import smithy4s.{Blob, Service}
+import smithy4s.capability.MonadThrowLike
+import smithy4s.client.UnaryClientCodecs
+import smithy4s.grpc._
+import smithy4s.interopcats._
+import smithy4s.protobuf.{ProtobufCodec, ProtobufReadError}
+import smithy4s.schema.{Alt, CachedSchemaCompiler, ErrorSchema, OperationSchema}
+
+private[grpc] object GrpcUnaryClientCodecs {
+
+  def builder[Alg[_[_, _, _, _, _]], F[_]: Concurrent](
+      service: Service[Alg]
+  ): Builder[Alg, F] =
+    BuilderImpl[Alg, F](
+      service            = service,
+      compiler           = ProtobufCodec,
+      maxMessageSize     = 4 * 1024 * 1024,
+      strictTrailers     = false,
+      strictStatusDetails = false
+    )
+
+  trait Builder[Alg[_[_, _, _, _, _]], F[_]] {
+    def withCompiler(c: CachedSchemaCompiler[ProtobufCodec]): Builder[Alg, F]
+    def withMaxMessageSize(n: Int): Builder[Alg, F]
+    def withStrictTrailers(v: Boolean): Builder[Alg, F]
+    def withStrictStatusDetails(v: Boolean): Builder[Alg, F]
+    def build(): UnaryClientCodecs.Make[F, GrpcRequest[Blob], GrpcResponse[Blob]]
+  }
+
+  private case class BuilderImpl[Alg[_[_, _, _, _, _]], F[_]](
+      service: Service[Alg],
+      compiler: CachedSchemaCompiler[ProtobufCodec],
+      maxMessageSize: Int,
+      strictTrailers: Boolean,
+      strictStatusDetails: Boolean
+  )(implicit F: Concurrent[F])
+      extends Builder[Alg, F] {
+
+    def withCompiler(c: CachedSchemaCompiler[ProtobufCodec]): Builder[Alg, F] = copy(compiler = c)
+    def withMaxMessageSize(n: Int): Builder[Alg, F]                           = copy(maxMessageSize = n)
+    def withStrictTrailers(v: Boolean): Builder[Alg, F]                       = copy(strictTrailers = v)
+    def withStrictStatusDetails(v: Boolean): Builder[Alg, F]                  = copy(strictStatusDetails = v)
+
+    def build(): UnaryClientCodecs.Make[F, GrpcRequest[Blob], GrpcResponse[Blob]] =
+      new UnaryClientCodecs.Make[F, GrpcRequest[Blob], GrpcResponse[Blob]] {
+        def apply[I, E, O, SI, SO](
+            schema: OperationSchema[I, E, O, SI, SO]
+        ): UnaryClientCodecs[F, GrpcRequest[Blob], GrpcResponse[Blob], I, E, O] = {
+
+          val cache       = compiler.createCache()
+          val inputCodec  = compiler.fromSchema(schema.input, cache)
+          val outputCodec = compiler.fromSchema(schema.output, cache)
+
+          def inputEncoder(input: I): F[GrpcRequest[Blob]] = {
+            val payload = inputCodec.writeBlob(input)
+            if (payload.size > maxMessageSize)
+              F.raiseError(GrpcFailure.InvalidFrame(GrpcFrame.Error.MessageTooLarge))
+            else {
+              val frame = GrpcCodecHelpers.encodeUnaryFrame(payload)
+              F.pure(
+                GrpcRequest(
+                  message             = frame,
+                  headers             = GrpcMetadata.empty,
+                  timeout             = None,
+                  compression         = GrpcCompression.Identity,
+                  acceptedCompressions = List(GrpcCompression.Identity),
+                  path = GrpcMethodPath(
+                    s"${service.id.namespace}.${service.id.name}",
+                    schema.id.name
+                  )
+                )
+              )
+            }
+          }
+
+          def outputDecoder(response: GrpcResponse[Blob]): F[O] =
+            for {
+              _       <- GrpcCodecHelpers.ensureTrailers(response, strictTrailers)
+              frame   <- GrpcFrame.decodeUnary[F](response.message, maxMessageSize)
+              _ <- F.raiseUnless(response.compression == GrpcCompression.Identity)(
+                GrpcFailure.UnsupportedCompression(response.compression.name)
+              )
+              _ <- F.raiseWhen(frame.compressed)(
+                GrpcFailure.UnsupportedCompression(response.compression.name)
+              )
+              decoded <- MonadThrowLike[F].liftEither(outputCodec.readBlob(frame.message))
+            } yield decoded
+
+          val errorPayloadCodec = compiler.fromSchema(ErrorPayload.schema, cache)
+
+          def parseStatus(response: GrpcResponse[Blob]): F[Int] =
+            response.trailers.getText(GrpcConstants.grpcStatusHeader).headOption match {
+              case None      => F.raiseError(MissingTrailers)
+              case Some(raw) =>
+                scala.util.Try(raw.toInt).toOption match {
+                  case Some(value) => F.pure(value)
+                  case None        => F.raiseError(InvalidStatus(raw))
+                }
+            }
+
+          def decodeMessage(response: GrpcResponse[Blob]): Option[String] =
+            response.trailers
+              .getText(GrpcConstants.grpcMessageHeader)
+              .headOption
+              .map(raw => GrpcMessageEncoding.decode(raw).toOption.getOrElse(raw))
+              .filter(_.nonEmpty)
+
+          def fallbackError(status: Int, message: Option[String]): Throwable = {
+            val base = s"gRPC error status=$status"
+            message.filter(_.nonEmpty) match {
+              case Some(value) => new RuntimeException(s"$base message=$value")
+              case None        => new RuntimeException(base)
+            }
+          }
+
+          def decodeAlt[A](
+              errorSchema: ErrorSchema[E],
+              alt: Alt[E, A]
+          ): (String, Blob => Either[ProtobufReadError, Throwable]) = {
+            val codec   = compiler.fromSchema(alt.schema, cache)
+            val typeUrl = GrpcTypeUrl.fromShapeId(alt.schema.shapeId)
+            val decode: Blob => Either[ProtobufReadError, Throwable] = blob =>
+              codec.readBlob(blob).map(value => errorSchema.unliftError(alt.inject(value)))
+            typeUrl -> decode
+          }
+
+          val errorDecoders: Map[String, Blob => Either[ProtobufReadError, Throwable]] =
+            schema.error
+              .map(es => es.alternatives.map(decodeAlt(es, _)).toMap)
+              .getOrElse(Map.empty)
+
+          def decodeSimple(response: GrpcResponse[Blob]): F[Throwable] =
+            parseStatus(response).map(status => fallbackError(status, decodeMessage(response)))
+
+          def decodeFromPayload(response: GrpcResponse[Blob], errorPayload: ErrorPayload): F[Throwable] = {
+            val trailerMessage = decodeMessage(response)
+            for {
+              status <- parseStatus(response)
+              _ <- errorPayload.code match {
+                case Some(detailsStatus) if detailsStatus != status && strictStatusDetails =>
+                  F.raiseError(StatusCodeMismatch(status, detailsStatus))
+                case _ => F.unit
+              }
+              result <- {
+                val message  = trailerMessage.orElse(errorPayload.message)
+                val fallback = fallbackError(status, message)
+                errorPayload.details.flatMap(_.headOption) match {
+                  case Some(detail) =>
+                    errorDecoders.get(detail.typeUrl) match {
+                      case Some(decode) =>
+                        decode(detail.value) match {
+                          case Right(decoded) => F.pure(decoded)
+                          case Left(_)        => F.pure(fallback)
+                        }
+                      case None =>
+                        if (detail.typeUrl == GrpcTypeUrl.fromShapeId(ProtobufReadError.id)) {
+                          val protoCodec = compiler.fromSchema(ProtobufReadError.schema, cache)
+                          protoCodec.readBlob(detail.value) match {
+                            case Right(decoded) => F.pure(decoded)
+                            case Left(_)        => F.pure(fallback)
+                          }
+                        } else F.pure(fallback)
+                    }
+                  case None => F.pure(fallback)
+                }
+              }
+            } yield result
+          }
+
+          def errorDecoder(response: GrpcResponse[Blob]): F[Throwable] =
+            for {
+              _         <- GrpcCodecHelpers.ensureTrailers(response, strictTrailers)
+              throwable <-
+                response.trailers
+                  .getBinary(GrpcConstants.grpcStatusDetailsHeader)
+                  .headOption
+                  .fold(decodeSimple(response)) { blob =>
+                    errorPayloadCodec.readBlob(blob) match {
+                      case Right(payload) => decodeFromPayload(response, payload)
+                      case Left(_)        => decodeSimple(response)
+                    }
+                  }
+            } yield throwable
+
+          new UnaryClientCodecs(inputEncoder, errorDecoder, outputDecoder)
+        }
+      }
+  }
+}

--- a/modules/grpc/src/smithy4s/grpc/internals/GrpcUnaryServerCodecs.scala
+++ b/modules/grpc/src/smithy4s/grpc/internals/GrpcUnaryServerCodecs.scala
@@ -1,0 +1,222 @@
+/*
+ *  Copyright 2021-2026 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package smithy4s.grpc.internals
+
+import alloy.proto.{GrpcError, GrpcErrorMessage, GrpcStatusCode}
+import cats.effect.Concurrent
+import cats.implicits._
+import smithy.api.Error
+import smithy4s.Blob
+import smithy4s.capability.MonadThrowLike
+import smithy4s.grpc._
+import smithy4s.interopcats._
+import smithy4s.protobuf.{ProtobufCodec, ProtobufReadError}
+import smithy4s.schema.{Alt, CachedSchemaCompiler, ErrorSchema, OperationSchema, Schema, Primitive}
+import smithy4s.schema.Schema.StructSchema
+import smithy4s.server.UnaryServerCodecs
+
+private[grpc] object GrpcUnaryServerCodecs {
+
+  def builder[F[_]: Concurrent]: Builder[F] =
+    BuilderImpl[F](
+      compiler = ProtobufCodec,
+      maxMessageSize = 4 * 1024 * 1024
+    )
+
+  trait Builder[F[_]] {
+    def withCompiler(c: CachedSchemaCompiler[ProtobufCodec]): Builder[F]
+    def withMaxMessageSize(n: Int): Builder[F]
+    def build(): UnaryServerCodecs.Make[F, GrpcRequest[Blob], GrpcResponse[Blob]]
+  }
+
+  /** Encodes an error as a [[GrpcResponse]] with the given status code, encoding
+    * the error value itself inside [[ErrorPayload]] `grpc-status-details-bin`.
+    * Used to surface internal errors (e.g. [[ProtobufReadError]]) back to the
+    * client with a machine-readable payload.
+    */
+  def schemaBasedErrorEncoder[F[_], Err <: Throwable](
+      compiler: CachedSchemaCompiler[ProtobufCodec]
+  )(
+      cache: compiler.Cache,
+      code: GrpcStatusCode,
+      error: Err
+  )(implicit F: Concurrent[F], schema: Schema[Err]): F[GrpcResponse[Blob]] = {
+    val errorCodec        = compiler.fromSchema(schema, cache)
+    val errorPayloadCodec = compiler.fromSchema(ErrorPayload.schema, cache)
+    val errorPayload = ErrorPayload(
+      code = Some(code.intValue),
+      message = Some(error.getMessage()),
+      details = Some(List(StatusDetails(
+        typeUrl = GrpcTypeUrl.fromShapeId(ProtobufReadError.id),
+        value   = errorCodec.writeBlob(error)
+      )))
+    )
+    val trailers =
+      GrpcMetadata.empty
+        .addText(GrpcConstants.grpcStatusHeader, code.intValue.toString())
+        .addBinary(GrpcConstants.grpcStatusDetailsHeader, errorPayloadCodec.writeBlob(errorPayload))
+    F.pure(GrpcResponse(Blob.empty, GrpcMetadata.empty, trailers, GrpcCompression.Identity))
+  }
+
+  private case class BuilderImpl[F[_]](
+      compiler: CachedSchemaCompiler[ProtobufCodec],
+      maxMessageSize: Int
+  )(implicit F: Concurrent[F])
+      extends Builder[F] {
+
+    def withCompiler(c: CachedSchemaCompiler[ProtobufCodec]): Builder[F] = copy(compiler = c)
+    def withMaxMessageSize(n: Int): Builder[F]                           = copy(maxMessageSize = n)
+
+    def build(): UnaryServerCodecs.Make[F, GrpcRequest[Blob], GrpcResponse[Blob]] =
+      new UnaryServerCodecs.Make[F, GrpcRequest[Blob], GrpcResponse[Blob]] {
+        def apply[I, E, O, SI, SO](
+            schema: OperationSchema[I, E, O, SI, SO]
+        ): UnaryServerCodecs[F, GrpcRequest[Blob], GrpcResponse[Blob], I, E, O] = {
+
+          val cache       = compiler.createCache()
+          val inputCodec  = compiler.fromSchema(schema.input, cache)
+          val outputCodec = compiler.fromSchema(schema.output, cache)
+
+          def inputDecoder(request: GrpcRequest[Blob]): F[I] =
+            for {
+              frame <- GrpcFrame.decodeUnary[F](request.message, maxMessageSize)
+              _ <- F.raiseUnless(request.compression == GrpcCompression.Identity)(
+                GrpcFailure.UnsupportedCompression(request.compression.name)
+              )
+              _ <- F.raiseWhen(frame.compressed)(
+                GrpcFailure.UnsupportedCompression(request.compression.name)
+              )
+              decoded <- MonadThrowLike[F].liftEither(inputCodec.readBlob(frame.message))
+            } yield decoded
+
+          def errorEncoder(error: E): F[GrpcResponse[Blob]] =
+            schema.error match {
+              case Some(errorSchema) =>
+                F.pure(buildErrorDispatch(errorSchema, compiler)(cache)(error))
+              case None =>
+                F.pure(GrpcResponse(Blob.empty, GrpcMetadata.empty, GrpcCodecHelpers.internalErrorTrailers, GrpcCompression.Identity))
+            }
+
+          def throwableEncoder(throwable: Throwable): F[GrpcResponse[Blob]] =
+            throwable match {
+              case e: ProtobufReadError =>
+                schemaBasedErrorEncoder(compiler)(cache, GrpcStatusCode.INVALID_ARGUMENT, e)
+              case e: GrpcFailure =>
+                val trailers =
+                  GrpcMetadata.empty
+                    .addText(GrpcConstants.grpcStatusHeader, e.status.intValue.toString())
+                    .addText(GrpcConstants.grpcMessageHeader, e.message)
+                F.pure(GrpcResponse(Blob.empty, GrpcMetadata.empty, trailers, GrpcCompression.Identity))
+              case _ =>
+                val trailers =
+                  GrpcMetadata.empty
+                    .addText(GrpcConstants.grpcStatusHeader, GrpcStatusCode.INTERNAL.intValue.toString())
+                    .addText(GrpcConstants.grpcMessageHeader, GrpcMessageEncoding.encode("Unhandled gRPC error"))
+                F.pure(GrpcResponse(Blob.empty, GrpcMetadata.empty, trailers, GrpcCompression.Identity))
+            }
+
+          def outputEncoder(output: O): F[GrpcResponse[Blob]] = {
+            val payload = outputCodec.writeBlob(output)
+            if (payload.size > maxMessageSize)
+              F.raiseError(GrpcFailure.InvalidFrame(GrpcFrame.Error.MessageTooLarge))
+            else {
+              val frame = GrpcCodecHelpers.encodeUnaryFrame(payload)
+              F.pure(GrpcResponse(frame, GrpcMetadata.empty, GrpcCodecHelpers.successTrailers, GrpcCompression.Identity))
+            }
+          }
+
+          new UnaryServerCodecs(inputDecoder, errorEncoder, throwableEncoder, outputEncoder)
+        }
+      }
+  }
+
+  private def buildErrorDispatch[E](
+      errorSchema: ErrorSchema[E],
+      compiler: CachedSchemaCompiler[ProtobufCodec]
+  )(cache: compiler.Cache): E => GrpcResponse[Blob] = {
+    val dispatcher        = Alt.Dispatcher(errorSchema.alternatives, errorSchema.ordinal)
+    val errorPayloadCodec = compiler.fromSchema(ErrorPayload.schema, cache)
+    val precompiler = new Alt.Precompiler[* => GrpcResponse[Blob]] {
+      def apply[A](label: String, altSchema: Schema[A]): A => GrpcResponse[Blob] = {
+        val codec          = compiler.fromSchema(altSchema, cache)
+        val typeUrl        = GrpcTypeUrl.fromShapeId(altSchema.shapeId)
+        val status         = grpcStatusFromSchema(altSchema)
+        val dynamicMessage = grpcErrorMessageAccessor(altSchema)
+        val staticMessage  = altSchema.hints.get(GrpcError).flatMap(_.message)
+        (a: A) => {
+          val bytes   = codec.writeBlob(a)
+          val details = StatusDetails(typeUrl = typeUrl, value = bytes)
+          val message = dynamicMessage(a).filter(_.nonEmpty).orElse(staticMessage.filter(_.nonEmpty))
+          val payload = ErrorPayload(
+            code    = Some(status),
+            message = message,
+            details = Some(List(details))
+          )
+          GrpcResponse(
+            Blob.empty,
+            GrpcMetadata.empty,
+            GrpcCodecHelpers.buildTrailers(status, message, Some(payload), errorPayloadCodec.writeBlob),
+            GrpcCompression.Identity
+          )
+        }
+      }
+    }
+    dispatcher.compile(precompiler)
+  }
+
+  private def grpcErrorMessageAccessor[A](schema: Schema[A]): A => Option[String] = {
+    def extractor[B](schema: Schema[B]): Option[B => Option[String]] = schema match {
+      case Schema.PrimitiveSchema(_, _, Primitive.PString) =>
+        Some((b: B) => Option(b.asInstanceOf[String]))
+      case Schema.OptionSchema(underlying) =>
+        extractor(underlying).map { get =>
+          (b: B) => b.asInstanceOf[Option[Any]].flatMap(v => get(v.asInstanceOf[Any]))
+        }
+      case Schema.BijectionSchema(underlying, bijection) =>
+        extractor(underlying).map { get => (b: B) => get(bijection.from(b)) }
+      case Schema.RefinementSchema(underlying, refinement) =>
+        extractor(underlying).map { get => (b: B) => get(refinement.from(b)) }
+      case Schema.LazySchema(suspend) =>
+        extractor(suspend.value)
+      case _ => None
+    }
+
+    schema match {
+      case StructSchema(_, _, fields, _) =>
+        fields
+          .collectFirst {
+            case field if field.memberHints.has(GrpcErrorMessage) =>
+              extractor(field.schema).map(get => (a: A) => get(field.get(a)))
+          }
+          .flatten
+          .getOrElse((_: A) => None)
+      case _ => (_: A) => None
+    }
+  }
+
+  private def grpcStatusFromSchema(schema: Schema[_]): Int =
+    schema.hints
+      .get(GrpcError)
+      .map(_.code)
+      .orElse(
+        schema.hints.get(Error).map {
+          case Error.CLIENT => GrpcStatusCode.INVALID_ARGUMENT.intValue
+          case Error.SERVER => GrpcStatusCode.INTERNAL.intValue
+        }
+      )
+      .getOrElse(GrpcStatusCode.UNKNOWN.intValue)
+}

--- a/modules/grpc/test/src/smithy4s/grpc/GrpcFramingSpec.scala
+++ b/modules/grpc/test/src/smithy4s/grpc/GrpcFramingSpec.scala
@@ -1,0 +1,112 @@
+/*
+ *  Copyright 2021-2026 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package smithy4s.grpc
+
+import cats.effect.IO
+import smithy4s.Blob
+import smithy4s.interopcats._
+import weaver.SimpleIOSuite
+
+object GrpcFrameSpec extends SimpleIOSuite {
+
+  test("encode and decode a single frame") {
+    val frame = GrpcFrame(compressed = false, Blob(Array[Byte](1, 2, 3)))
+    val bytes = GrpcFrame.encode(frame)
+    GrpcFrame.decodeUnary[IO](Blob(bytes), 1024).map { decoded =>
+      expect.eql(bytes.take(5).toVector, Vector[Byte](0, 0, 0, 0, 3)) &&
+      expect.eql(decoded.compressed, false) &&
+      expect(decoded.message.sameBytesAs(frame.message))
+    }
+  }
+
+  test("invalid compression flag fails decoding") {
+    val bytes = Vector[Byte](2, 0, 0, 0, 0)
+    GrpcFrame.decodeUnary[IO](Blob(bytes.toArray), 1024).attempt.map { result =>
+      expect.same(result, Left(GrpcFailure.InvalidFrame(GrpcFrame.Error.InvalidCompressionFlag)))
+    }
+  }
+
+  test("decodeUnary succeeds at max size") {
+    val max = 3
+    val frame = GrpcFrame(compressed = false, Blob(Array[Byte](1, 2, 3)))
+    val bytes = GrpcFrame.encode(frame)
+    GrpcFrame.decodeUnary[IO](Blob(bytes), max).map { decoded =>
+      expect.same(decoded, frame)
+    }
+  }
+
+  test("decodeUnary fails over max size") {
+    val max = 3
+    val frame = GrpcFrame(compressed = false, Blob(Array[Byte](1, 2, 3, 4)))
+    val bytes = GrpcFrame.encode(frame)
+    GrpcFrame.decodeUnary[IO](Blob(bytes), max).attempt.map { result =>
+      expect.same(result, Left(GrpcFailure.InvalidFrame(GrpcFrame.Error.MessageTooLarge)))
+    }
+  }
+
+  test("decodeUnary fails on empty input") {
+    val decoded = GrpcFrame.decodeUnary[IO](Blob.empty, 16)
+    decoded.attempt.map { result =>
+      expect.same(result, Left(GrpcFailure.InvalidFrame(GrpcFrame.Error.MissingFrame)))
+    }
+  }
+
+  test("decodeUnary fails on multiple frames") {
+    val frame1 = GrpcFrame(compressed = false, Blob(Array[Byte](1)))
+    val frame2 = GrpcFrame(compressed = false, Blob(Array[Byte](2)))
+    val bytes1 = GrpcFrame.encode(frame1)
+    val bytes2 = GrpcFrame.encode(frame2)
+    GrpcFrame.decodeUnary[IO](Blob(bytes1 ++ bytes2), 16).attempt.map { result =>
+      expect.same(result, Left(GrpcFailure.InvalidFrame(GrpcFrame.Error.MultipleFrames)))
+    }
+  }
+
+  test("decodeUnary treats 2GiB length as too large") {
+    val header = Array[Byte](0, 0x80.toByte, 0, 0, 0)
+    GrpcFrame.decodeUnary[IO](Blob(header), Int.MaxValue).attempt.map { result =>
+      expect.same(result, Left(GrpcFailure.InvalidFrame(GrpcFrame.Error.MessageTooLarge)))
+    }
+  }
+
+  test("decodeUnary treats max uint32 length as too large") {
+    val header = Array[Byte](0, 0xff.toByte, 0xff.toByte, 0xff.toByte, 0xff.toByte)
+    GrpcFrame.decodeUnary[IO](Blob(header), Int.MaxValue).attempt.map { result =>
+      expect.same(result, Left(GrpcFailure.InvalidFrame(GrpcFrame.Error.MessageTooLarge)))
+    }
+  }
+
+  test("decodeUnary still reports truncated message for large valid lengths") {
+    val header = Array[Byte](0, 0x7f.toByte, 0xff.toByte, 0xff.toByte, 0xff.toByte)
+    GrpcFrame.decodeUnary[IO](Blob(header), Int.MaxValue).attempt.map { result =>
+      expect.same(result, Left(GrpcFailure.InvalidFrame(GrpcFrame.Error.TruncatedMessage)))
+    }
+  }
+
+  test("decodeSingle fails on truncated header") {
+    val decoded = GrpcFrame.decodeUnary[IO](Blob(Array[Byte](0, 0, 0)), 16)
+    decoded.attempt.map { result =>
+      expect.same(result, Left(GrpcFailure.InvalidFrame(GrpcFrame.Error.TruncatedHeader)))
+    }
+  }
+
+  test("decodeSingle fails on truncated message") {
+    val decoded = GrpcFrame.decodeUnary[IO](Blob(Array[Byte](0, 0, 0, 0, 2, 1)), 16)
+    decoded.attempt.map { result =>
+      expect.same(result, Left(GrpcFailure.InvalidFrame(GrpcFrame.Error.TruncatedMessage)))
+    }
+  }
+}

--- a/modules/grpc/test/src/smithy4s/grpc/GrpcMessageEncodingSpec.scala
+++ b/modules/grpc/test/src/smithy4s/grpc/GrpcMessageEncodingSpec.scala
@@ -1,0 +1,66 @@
+/*
+ *  Copyright 2021-2026 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package smithy4s.grpc
+
+import weaver.SimpleIOSuite
+
+object GrpcMessageEncodingSpec extends SimpleIOSuite {
+
+  pureTest("percent-encode grpc-message") {
+    val input = "hello world"
+    val encoded = GrpcMessageEncoding.encode(input)
+    val decoded = GrpcMessageEncoding.decode(encoded)
+    expect.eql(encoded, "hello world") &&
+    expect.same(decoded, Right(input))
+  }
+
+  pureTest("invalid percent-encoding fails") {
+    val decoded = GrpcMessageEncoding.decode("bad%2G")
+    expect.same(
+      decoded,
+      Left(GrpcMessageEncoding.DecodeError.InvalidPercentEncoding("bad%2G", 3))
+    )
+  }
+
+  pureTest("roundtrips empty grpc-message") {
+    val input = ""
+    val encoded = GrpcMessageEncoding.encode(input)
+    val decoded = GrpcMessageEncoding.decode(encoded)
+    expect.eql(encoded, "") && expect.same(decoded, Right(input))
+  }
+
+  pureTest("encode leaves grpc-allowed bytes unencoded") {
+    val input = "hello world! a&b=c x(y)z[]{}\""
+    val encoded = GrpcMessageEncoding.encode(input)
+    val decoded = GrpcMessageEncoding.decode(encoded)
+    expect.eql(encoded, input) && expect.same(decoded, Right(input))
+  }
+
+  pureTest("encode percent-encodes %") {
+    val input = "100% legit"
+    val encoded = GrpcMessageEncoding.encode(input)
+    val decoded = GrpcMessageEncoding.decode(encoded)
+    expect.eql(encoded, "100%25 legit") && expect.same(decoded, Right(input))
+  }
+
+  pureTest("percent-encodes unicode characters") {
+    val input = "snowman ☃"
+    val encoded = GrpcMessageEncoding.encode(input)
+    val decoded = GrpcMessageEncoding.decode(encoded)
+    expect(decoded == Right(input))
+  }
+}

--- a/modules/grpc/test/src/smithy4s/grpc/GrpcMetadataCodecSpec.scala
+++ b/modules/grpc/test/src/smithy4s/grpc/GrpcMetadataCodecSpec.scala
@@ -1,0 +1,46 @@
+package smithy4s.grpc
+
+import smithy4s.Blob
+import smithy4s.grpc.internals.GrpcMetadataCodec
+import weaver.SimpleIOSuite
+
+import java.util.Base64
+
+object GrpcMetadataCodecSpec extends SimpleIOSuite {
+
+  pureTest("decodeBinaryHeaderValue accepts padded base64") {
+    val blob = Blob(Array[Byte](1, 2, 3, 4))
+    val padded = Base64.getEncoder.encodeToString(blob.toArray)
+    expect.same(GrpcMetadataCodec.decodeBinaryHeaderValue(padded), Right(Vector(blob)))
+  }
+
+  pureTest("decodeBinaryHeaderValue accepts unpadded base64") {
+    val blob = Blob(Array[Byte](5, 6, 7, 8))
+    val unpadded = Base64.getEncoder.withoutPadding().encodeToString(blob.toArray)
+    expect.same(GrpcMetadataCodec.decodeBinaryHeaderValue(unpadded), Right(Vector(blob)))
+  }
+
+  pureTest("decodeBinaryHeaderValue splits comma-joined values, keeping empties") {
+    val first = Blob(Array[Byte](1, 2, 3))
+    val second = Blob(Array[Byte](4, 5))
+    val firstEncoded = Base64.getEncoder.withoutPadding().encodeToString(first.toArray)
+    val secondEncoded = Base64.getEncoder.encodeToString(second.toArray)
+    val headerValue = s"$firstEncoded,, $secondEncoded"
+    expect.same(
+      GrpcMetadataCodec.decodeBinaryHeaderValue(headerValue),
+      Right(Vector(first, Blob.empty, second))
+    )
+  }
+
+  pureTest("decodeBinaryHeaderValue trims whitespace around tokens") {
+    val first = Blob(Array[Byte](9, 10))
+    val second = Blob(Array[Byte](11, 12, 13))
+    val firstEncoded = Base64.getEncoder.withoutPadding().encodeToString(first.toArray)
+    val secondEncoded = Base64.getEncoder.encodeToString(second.toArray)
+    val headerValue = s"  $firstEncoded ,  $secondEncoded  "
+    expect.same(
+      GrpcMetadataCodec.decodeBinaryHeaderValue(headerValue),
+      Right(Vector(first, second))
+    )
+  }
+}

--- a/modules/grpc/test/src/smithy4s/grpc/GrpcMethodPathSpec.scala
+++ b/modules/grpc/test/src/smithy4s/grpc/GrpcMethodPathSpec.scala
@@ -1,0 +1,43 @@
+/*
+ *  Copyright 2021-2026 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package smithy4s.grpc
+
+import weaver.SimpleIOSuite
+
+object GrpcMethodPathSpec extends SimpleIOSuite {
+
+  pureTest("parse grpc method path") {
+    expect.same(
+      GrpcMethodPath.parse("/test.Service/Call"),
+      Right(GrpcMethodPath("test.Service", "Call"))
+    )
+  }
+
+  pureTest("parse grpc method path with trailing slash") {
+    expect.same(
+      GrpcMethodPath.parse("/test.Service/Call/"),
+      Right(GrpcMethodPath("test.Service", "Call"))
+    )
+  }
+
+  pureTest("parseSegments rejects invalid shapes") {
+    expect.same(
+      GrpcMethodPath.parseSegments(List("test.Service"), hasTrailingSlash = false),
+      Left(GrpcMethodPath.InvalidFormat)
+    )
+  }
+}

--- a/modules/grpc/test/src/smithy4s/grpc/GrpcStatusDetailsSpec.scala
+++ b/modules/grpc/test/src/smithy4s/grpc/GrpcStatusDetailsSpec.scala
@@ -1,0 +1,84 @@
+/*
+ *  Copyright 2021-2026 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package smithy4s.grpc
+
+import smithy4s.Blob
+import smithy4s.protobuf.ProtobufCodec
+import weaver.SimpleIOSuite
+
+object GrpcStatusDetailsSpec extends SimpleIOSuite {
+
+  private val errorPayloadCodec =
+    ProtobufCodec.fromSchema(ErrorPayload.schema, ProtobufCodec.createCache())
+
+  pureTest("encode and decode ErrorPayload") {
+    val status = ErrorPayload(
+      code = Some(3),
+      message = Some("invalid"),
+      details = Some(
+        List(
+          StatusDetails(
+            typeUrl = "example.Type",
+            value = Blob(Array[Byte](1, 2, 3))
+          )
+        )
+      )
+    )
+    val encoded = errorPayloadCodec.writeBlob(status)
+    val decoded = errorPayloadCodec.readBlob(encoded)
+    expect.same(decoded, Right(status))
+  }
+
+  pureTest("encode and decode ErrorPayload with empty details") {
+    val status = ErrorPayload(
+      code = Some(0),
+      message = None,
+      details = Some(Nil)
+    )
+    val encoded = errorPayloadCodec.writeBlob(status)
+    val decoded = errorPayloadCodec.readBlob(encoded)
+    val details = decoded.map(_.details.getOrElse(Nil))
+    expect.same(details, Right(Nil))
+  }
+
+  pureTest("encode and decode ErrorPayload without details") {
+    val status = ErrorPayload(
+      code = None,
+      message = Some("ok"),
+      details = None
+    )
+    val encoded = errorPayloadCodec.writeBlob(status)
+    val decoded = errorPayloadCodec.readBlob(encoded)
+    expect.same(decoded, Right(status))
+  }
+
+  pureTest("encode and decode ErrorPayload with multiple details") {
+    val status = ErrorPayload(
+      code = Some(7),
+      message = Some("denied"),
+      details = Some(
+        List(
+          StatusDetails("example.One", Blob(Array[Byte](1))),
+          StatusDetails("example.Two", Blob(Array[Byte](2, 3)))
+        )
+      )
+    )
+    val encoded = errorPayloadCodec.writeBlob(status)
+    val decoded = errorPayloadCodec.readBlob(encoded)
+    expect.same(decoded, Right(status))
+  }
+}

--- a/modules/grpc/test/src/smithy4s/grpc/GrpcTimeoutSpec.scala
+++ b/modules/grpc/test/src/smithy4s/grpc/GrpcTimeoutSpec.scala
@@ -1,0 +1,47 @@
+/*
+ *  Copyright 2021-2026 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package smithy4s.grpc
+
+import weaver.SimpleIOSuite
+
+object GrpcTimeoutSpec extends SimpleIOSuite {
+
+  pureTest("parse grpc-timeout units") {
+    expect.same(GrpcTimeout.parse("1n"), Right(GrpcTimeout(1, GrpcTimeout.Nanoseconds))) &&
+    expect.same(GrpcTimeout.parse("2u"), Right(GrpcTimeout(2, GrpcTimeout.Microseconds))) &&
+    expect.same(GrpcTimeout.parse("3m"), Right(GrpcTimeout(3, GrpcTimeout.Milliseconds))) &&
+    expect.same(GrpcTimeout.parse("4S"), Right(GrpcTimeout(4, GrpcTimeout.Seconds))) &&
+    expect.same(GrpcTimeout.parse("5M"), Right(GrpcTimeout(5, GrpcTimeout.Minutes))) &&
+    expect.same(GrpcTimeout.parse("6H"), Right(GrpcTimeout(6, GrpcTimeout.Hours)))
+  }
+
+  pureTest("parse invalid grpc-timeout formats") {
+    expect(GrpcTimeout.parse("").isLeft) &&
+    expect(GrpcTimeout.parse("x").isLeft) &&
+    expect(GrpcTimeout.parse("10").isLeft) &&
+    expect(GrpcTimeout.parse("10X").isLeft) &&
+    expect(GrpcTimeout.parse("0S").isLeft) &&
+    expect(GrpcTimeout.parse("000S").isLeft) &&
+    expect(GrpcTimeout.parse("123456789S").isLeft) &&
+    expect(GrpcTimeout.parse("12345678S").isRight)
+  }
+
+  pureTest("grpc-timeout roundtrip header") {
+    val timeout = GrpcTimeout(42, GrpcTimeout.Milliseconds)
+    expect.same(GrpcTimeout.parse(timeout.toHeader), Right(timeout))
+  }
+}

--- a/modules/grpc/test/src/smithy4s/grpc/GrpcUnaryClientCodecsSpec.scala
+++ b/modules/grpc/test/src/smithy4s/grpc/GrpcUnaryClientCodecsSpec.scala
@@ -1,0 +1,207 @@
+/*
+ *  Copyright 2021-2026 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package smithy4s.grpc
+
+import alloy.proto.{Grpc, GrpcStatusCode}
+import cats.effect.IO
+import smithy4s.{Blob, Hints, Schema, ShapeId}
+import smithy4s.grpc.internals.{GrpcConstants, GrpcUnaryClientCodecs}
+import smithy4s.protobuf.{ProtobufCodec, ProtobufReadError}
+import smithy4s.kinds.PolyFunction5
+import weaver.SimpleIOSuite
+
+object GrpcUnaryClientCodecsSpec extends SimpleIOSuite {
+
+  private val pingSchema =
+    Schema.operation(ShapeId("test", "Ping"))
+
+  private val pingEndpoint: smithy4s.Endpoint[DummyOp, Unit, Nothing, Unit, Nothing, Nothing] =
+    new smithy4s.Endpoint[DummyOp, Unit, Nothing, Unit, Nothing, Nothing] {
+      val schema = pingSchema
+      def wrap(input: Unit): DummyOp[Unit, Nothing, Unit, Nothing, Nothing] = DummyOp.Ping
+    }
+
+  private object DummyService extends smithy4s.Service.Reflective[DummyOp] {
+    val id: ShapeId                                               = ShapeId("test", "DummyService")
+    val version: String                                           = ""
+    val hints: Hints                                              = Hints(Grpc())
+    val endpoints: IndexedSeq[smithy4s.Endpoint[DummyOp, _, _, _, _, _]]  = Vector(pingEndpoint)
+    def input[I, E, O, SI, SO](op: DummyOp[I, E, O, SI, SO]): I  = op.input
+    def ordinal[I, E, O, SI, SO](op: DummyOp[I, E, O, SI, SO]): Int = op.ordinal
+  }
+
+  private sealed trait DummyOp[I, E, O, SI, SO] {
+    def input: I
+    def ordinal: Int
+    def endpoint: smithy4s.Endpoint[DummyOp, I, E, O, SI, SO]
+  }
+
+  private object DummyOp {
+    case object Ping extends DummyOp[Unit, Nothing, Unit, Nothing, Nothing] {
+      val input: Unit = ()
+      val ordinal: Int = 0
+      val endpoint = pingEndpoint
+    }
+  }
+
+  private val maxMessageSize = 1024
+
+  private val errorPayloadCodec =
+    ProtobufCodec.fromSchema(ErrorPayload.schema, ProtobufCodec.createCache())
+
+  private def clientCodecs(strictTrailers: Boolean, strictStatusDetails: Boolean) =
+    GrpcUnaryClientCodecs.builder[PolyFunction5.From[DummyOp]#Algebra, IO](DummyService)
+      .withMaxMessageSize(maxMessageSize)
+      .withStrictTrailers(strictTrailers)
+      .withStrictStatusDetails(strictStatusDetails)
+      .build()
+
+  test("strictTrailers enforced in outputDecoder") {
+    val unary = clientCodecs(strictTrailers = true, strictStatusDetails = false)
+      .apply[Unit, Nothing, Unit, Nothing, Nothing](pingSchema)
+    val response = GrpcResponse(Blob.empty, GrpcMetadata.empty, GrpcMetadata.empty, GrpcCompression.Identity)
+    unary.outputDecoder(response).attempt.map { result =>
+      expect(result == Left(MissingTrailers))
+    }
+  }
+
+  test("outputDecoder rejects unsupported compression") {
+    val unary = clientCodecs(strictTrailers = true, strictStatusDetails = false)
+      .apply[Unit, Nothing, Unit, Nothing, Nothing](pingSchema)
+    val trailers = GrpcMetadata.empty.addText(GrpcConstants.grpcStatusHeader, "0")
+    val framed   = GrpcFrame.encode(GrpcFrame(compressed = false, Blob.empty))
+    val response = GrpcResponse(Blob(framed), GrpcMetadata.empty, trailers, GrpcCompression.Gzip)
+    unary.outputDecoder(response).attempt.map { result =>
+      expect.same(result, Left(GrpcFailure.UnsupportedCompression("gzip")))
+    }
+  }
+
+  test("outputDecoder fails on invalid protobuf") {
+    val unary = clientCodecs(strictTrailers = true, strictStatusDetails = false)
+      .apply[Unit, Nothing, Unit, Nothing, Nothing](pingSchema)
+    val trailers = GrpcMetadata.empty.addText(GrpcConstants.grpcStatusHeader, "0")
+    val framed   = GrpcFrame.encode(GrpcFrame(compressed = false, Blob(Array[Byte](1, 2, 3))))
+    val response = GrpcResponse(Blob(framed), GrpcMetadata.empty, trailers, GrpcCompression.Identity)
+    unary.outputDecoder(response).attempt.map { result =>
+      result match {
+        case Left(_: ProtobufReadError) => expect(true)
+        case _                          => failure("expected ProtobufReadError")
+      }
+    }
+  }
+
+  test("errorDecoder fails on missing grpc-status") {
+    val unary    = clientCodecs(strictTrailers = false, strictStatusDetails = false)
+      .apply[Unit, Nothing, Unit, Nothing, Nothing](pingSchema)
+    val response = GrpcResponse(Blob.empty, GrpcMetadata.empty, GrpcMetadata.empty, GrpcCompression.Identity)
+    unary.errorDecoder(response).attempt.map { result =>
+      expect.same(result, Left(MissingTrailers))
+    }
+  }
+
+  test("errorDecoder fails on invalid grpc-status") {
+    val unary    = clientCodecs(strictTrailers = false, strictStatusDetails = false)
+      .apply[Unit, Nothing, Unit, Nothing, Nothing](pingSchema)
+    val trailers = GrpcMetadata.empty.addText(GrpcConstants.grpcStatusHeader, "abc")
+    val response = GrpcResponse(Blob.empty, GrpcMetadata.empty, trailers, GrpcCompression.Identity)
+    unary.errorDecoder(response).attempt.map { result =>
+      expect(result == Left(InvalidStatus("abc")))
+    }
+  }
+
+  test("errorDecoder falls back gracefully when details blob is undecodable") {
+    val unary    = clientCodecs(strictTrailers = false, strictStatusDetails = false)
+      .apply[Unit, Nothing, Unit, Nothing, Nothing](pingSchema)
+    val trailers = GrpcMetadata.empty
+      .addText(GrpcConstants.grpcStatusHeader, "7")
+      .addText(GrpcConstants.grpcMessageHeader, GrpcMessageEncoding.encode("denied"))
+      .addBinary(GrpcConstants.grpcStatusDetailsHeader, Blob(Array[Byte](1, 2, 3)))
+    val response = GrpcResponse(Blob.empty, GrpcMetadata.empty, trailers, GrpcCompression.Identity)
+    unary.errorDecoder(response).map { decoded =>
+      decoded match {
+        case e: RuntimeException =>
+          expect(e.getMessage.contains("status=7")) &&
+          expect(e.getMessage.contains("denied"))
+        case other =>
+          failure(s"expected RuntimeException, got ${other.getClass.getName}")
+      }
+    }
+  }
+
+  test("status details mismatch normalizes in permissive mode") {
+    val unary = clientCodecs(strictTrailers = false, strictStatusDetails = false)
+      .apply[Unit, Nothing, Unit, Nothing, Nothing](pingSchema)
+    val payload = ErrorPayload(code = Some(GrpcStatusCode.INVALID_ARGUMENT.intValue), message = Some("payload"), details = None)
+    val trailers = GrpcMetadata.empty
+      .addText(GrpcConstants.grpcStatusHeader, "7")
+      .addText(GrpcConstants.grpcMessageHeader, GrpcMessageEncoding.encode("denied"))
+      .addBinary(GrpcConstants.grpcStatusDetailsHeader, errorPayloadCodec.writeBlob(payload))
+    val response = GrpcResponse(Blob.empty, GrpcMetadata.empty, trailers, GrpcCompression.Identity)
+    unary.errorDecoder(response).map { decoded =>
+      decoded match {
+        case e: RuntimeException =>
+          expect(e.getMessage.contains("status=7")) &&
+          expect(e.getMessage.contains("denied"))
+        case other =>
+          failure(s"expected RuntimeException, got ${other.getClass.getName}")
+      }
+    }
+  }
+
+  test("status details mismatch fails in strict mode") {
+    val unary = clientCodecs(strictTrailers = false, strictStatusDetails = true)
+      .apply[Unit, Nothing, Unit, Nothing, Nothing](pingSchema)
+    val payload = ErrorPayload(code = Some(GrpcStatusCode.INVALID_ARGUMENT.intValue), message = Some("payload"), details = None)
+    val trailers = GrpcMetadata.empty
+      .addText(GrpcConstants.grpcStatusHeader, GrpcStatusCode.PERMISSION_DENIED.intValue.toString)
+      .addBinary(GrpcConstants.grpcStatusDetailsHeader, errorPayloadCodec.writeBlob(payload))
+    val response = GrpcResponse(Blob.empty, GrpcMetadata.empty, trailers, GrpcCompression.Identity)
+    unary.errorDecoder(response).attempt.map { result =>
+      expect.same(
+        result,
+        Left(StatusCodeMismatch(GrpcStatusCode.PERMISSION_DENIED.intValue, GrpcStatusCode.INVALID_ARGUMENT.intValue))
+      )
+    }
+  }
+
+  test("strictStatusDetails accepts matching status codes") {
+    val unary = clientCodecs(strictTrailers = false, strictStatusDetails = true)
+      .apply[Unit, Nothing, Unit, Nothing, Nothing](pingSchema)
+    val payload = ErrorPayload(code = Some(7), message = Some("payload"), details = None)
+    val trailers = GrpcMetadata.empty
+      .addText(GrpcConstants.grpcStatusHeader, "7")
+      .addBinary(GrpcConstants.grpcStatusDetailsHeader, errorPayloadCodec.writeBlob(payload))
+    val response = GrpcResponse(Blob.empty, GrpcMetadata.empty, trailers, GrpcCompression.Identity)
+    unary.errorDecoder(response).map { decoded =>
+      decoded match {
+        case e: RuntimeException =>
+          expect(e.getMessage.contains("status=7")) &&
+          expect(e.getMessage.contains("payload"))
+        case other =>
+          failure(s"expected RuntimeException, got ${other.getClass.getName}")
+      }
+    }
+  }
+
+  test("inputEncoder constructs GrpcRequest with correct method path") {
+    val unary = clientCodecs(strictTrailers = false, strictStatusDetails = false)
+      .apply[Unit, Nothing, Unit, Nothing, Nothing](pingSchema)
+    unary.inputEncoder(()).map { request =>
+      expect.same(request.path, GrpcMethodPath("test.DummyService", "Ping"))
+    }
+  }
+}

--- a/modules/grpc/test/src/smithy4s/grpc/GrpcUnaryServerCodecsSpec.scala
+++ b/modules/grpc/test/src/smithy4s/grpc/GrpcUnaryServerCodecsSpec.scala
@@ -1,0 +1,237 @@
+/*
+ *  Copyright 2021-2026 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package smithy4s.grpc
+
+import alloy.proto.{GrpcError, GrpcErrorMessage, GrpcStatusCode}
+import cats.effect.{Concurrent, IO}
+import smithy4s.{Blob, Hints, Newtype, Schema, ShapeId}
+import smithy4s.grpc.internals.{GrpcConstants, GrpcUnaryServerCodecs}
+import smithy4s.protobuf.{ProtobufCodec, ProtobufReadError}
+import weaver.SimpleIOSuite
+
+object GrpcUnaryServerCodecsSpec extends SimpleIOSuite {
+
+  private final case class DynamicError(message: Option[String], other: String)
+      extends RuntimeException(message.orNull)
+
+  private object NewtypeMessage extends Newtype[String] {
+    val id: ShapeId                      = ShapeId("test", "NewtypeMessage")
+    val hints: Hints                     = Hints.empty
+    val underlyingSchema: Schema[String] = Schema.string.withId(id).addHints(hints)
+    implicit val schema: Schema[NewtypeMessage.Type] =
+      smithy4s.schema.Schema.bijection(underlyingSchema, asBijection)
+  }
+
+  private type NewtypeMessage = NewtypeMessage.Type
+
+  private final case class NewtypeError(message: Option[NewtypeMessage], other: String)
+      extends RuntimeException(message.map(NewtypeMessage.value).orNull)
+
+  private val dynamicErrorSchema: Schema[DynamicError] = {
+    val message = Schema.string
+      .optional[DynamicError]("message", _.message)
+      .addHints(GrpcErrorMessage())
+    val other = Schema.string.required[DynamicError]("other", _.other)
+    Schema
+      .struct(message, other)(DynamicError.apply)
+      .withId(ShapeId("test", "DynamicError"))
+  }
+
+  private val newtypeErrorSchema: Schema[NewtypeError] = {
+    val message = NewtypeMessage.schema
+      .optional[NewtypeError]("message", _.message)
+      .addHints(GrpcErrorMessage())
+    val other = Schema.string.required[NewtypeError]("other", _.other)
+    Schema
+      .struct(message, other)(NewtypeError.apply)
+      .withId(ShapeId("test", "NewtypeError"))
+  }
+
+  private val newtypeError =
+    newtypeErrorSchema.asError(identity) {
+      case e: NewtypeError => Some(e)
+      case _               => None
+    }
+
+  private val dynamicErrorSchemaWithStatic: Schema[DynamicError] =
+    dynamicErrorSchema.addHints(GrpcError(code = 7, message = Some("static")))
+
+  private val dynamicErrorSchemaWithoutStatic: Schema[DynamicError] =
+    dynamicErrorSchema.addHints(GrpcError(code = 7, message = None))
+
+  private val dynamicError =
+    dynamicErrorSchemaWithStatic.asError(identity) {
+      case e: DynamicError => Some(e)
+      case _               => None
+    }
+
+  private val dynamicErrorNoStatic =
+    dynamicErrorSchemaWithoutStatic.asError(identity) {
+      case e: DynamicError => Some(e)
+      case _               => None
+    }
+
+  private def serverCodecs =
+    GrpcUnaryServerCodecs.builder[IO]
+      .withMaxMessageSize(1024)
+      .build()
+
+  private def grpcMessage(response: GrpcResponse[Blob]): Option[String] =
+    response.trailers
+      .getText(GrpcConstants.grpcMessageHeader)
+      .headOption
+      .flatMap(GrpcMessageEncoding.decode(_).toOption)
+
+  test("modeled error uses dynamic grpc-message over static") {
+    val operation = Schema.operation(ShapeId("test", "Dynamic")).withError(dynamicError)
+    val unary     = serverCodecs(operation)
+    val error     = DynamicError(message = Some("dynamic"), other = "x")
+    unary.errorEncoder(error).map { response =>
+      expect.same(grpcMessage(response), Some("dynamic"))
+    }
+  }
+
+  test("modeled error falls back to static grpc-message") {
+    val operation = Schema.operation(ShapeId("test", "Dynamic")).withError(dynamicError)
+    val unary     = serverCodecs(operation)
+    val error     = DynamicError(message = None, other = "x")
+    unary.errorEncoder(error).map { response =>
+      expect.same(grpcMessage(response), Some("static"))
+    }
+  }
+
+  test("modeled error omits grpc-message when none provided") {
+    val operation = Schema.operation(ShapeId("test", "DynamicNoStatic")).withError(dynamicErrorNoStatic)
+    val unary     = serverCodecs(operation)
+    val error     = DynamicError(message = None, other = "x")
+    unary.errorEncoder(error).map { response =>
+      expect.same(grpcMessage(response), None)
+    }
+  }
+
+  test("modeled error uses grpc-message for newtype string") {
+    val operation = Schema.operation(ShapeId("test", "Newtype")).withError(newtypeError)
+    val unary     = serverCodecs(operation)
+    val error     = NewtypeError(message = Some(NewtypeMessage("dynamic")), other = "x")
+    unary.errorEncoder(error).map { response =>
+      expect.same(grpcMessage(response), Some("dynamic"))
+    }
+  }
+
+  test("throwableEncoder omits details-bin for GrpcFailure") {
+    val unary = serverCodecs.apply[Unit, Nothing, Unit, Nothing, Nothing](
+      Schema.operation(ShapeId("test", "Ping"))
+    )
+    unary.throwableEncoder(GrpcFailure.Unimplemented("boom")).map { response =>
+      expect(response.trailers.getBinary(GrpcConstants.grpcStatusDetailsHeader).isEmpty)
+    }
+  }
+
+  test("throwableEncoder maps ProtobufReadError to INVALID_ARGUMENT") {
+    val unary = serverCodecs.apply[Unit, Nothing, Unit, Nothing, Nothing](
+      Schema.operation(ShapeId("test", "Ping"))
+    )
+    val error = ProtobufReadError.Other(new RuntimeException("bad proto"))
+    unary.throwableEncoder(error).map { response =>
+      val status = response.trailers.getText(GrpcConstants.grpcStatusHeader).headOption
+      expect.same(status, Some(GrpcStatusCode.INVALID_ARGUMENT.intValue.toString))
+    }
+  }
+
+  test("throwableEncoder maps unknown throwable to INTERNAL") {
+    val unary = serverCodecs.apply[Unit, Nothing, Unit, Nothing, Nothing](
+      Schema.operation(ShapeId("test", "Ping"))
+    )
+    unary.throwableEncoder(new RuntimeException("boom")).map { response =>
+      val status = response.trailers.getText(GrpcConstants.grpcStatusHeader).headOption
+      expect.same(status, Some(GrpcStatusCode.INTERNAL.intValue.toString))
+    }
+  }
+
+  test("schemaBasedErrorEncoder uses provided status code") {
+    val compiler          = ProtobufCodec
+    val cache             = compiler.createCache()
+    val statusCode        = GrpcStatusCode.INTERNAL
+    val errorPayloadCodec = ProtobufCodec.fromSchema(ErrorPayload.schema, ProtobufCodec.createCache())
+    val error: ProtobufReadError = ProtobufReadError.Other(new RuntimeException("boom"))
+    GrpcUnaryServerCodecs.schemaBasedErrorEncoder(compiler)(cache, statusCode, error)(
+      Concurrent[IO], ProtobufReadError.schema
+    ).map { response =>
+      val status  = response.trailers.getText(GrpcConstants.grpcStatusHeader).headOption
+      val payload = response.trailers
+        .getBinary(GrpcConstants.grpcStatusDetailsHeader)
+        .headOption
+        .flatMap(blob => errorPayloadCodec.readBlob(blob).toOption)
+      expect.same(status, Some(statusCode.intValue.toString)) &&
+      expect.same(payload.flatMap(_.code), Some(statusCode.intValue))
+    }
+  }
+
+  test("inputDecoder rejects compressed frames") {
+    val unary = serverCodecs.apply[Unit, Nothing, Unit, Nothing, Nothing](
+      Schema.operation(ShapeId("test", "Ping"))
+    )
+    val frame = GrpcFrame.encode(GrpcFrame(compressed = true, Blob.empty))
+    val request = GrpcRequest(
+      message              = Blob(frame),
+      headers              = GrpcMetadata.empty,
+      timeout              = None,
+      compression          = GrpcCompression.Identity,
+      acceptedCompressions = Nil,
+      path                 = GrpcMethodPath("test.DummyService", "Ping")
+    )
+    unary.inputDecoder(request).attempt.map { result =>
+      expect.same(result, Left(GrpcFailure.UnsupportedCompression(GrpcCompression.Identity.name)))
+    }
+  }
+
+  test("inputDecoder rejects unsupported compression") {
+    val unary = serverCodecs.apply[Unit, Nothing, Unit, Nothing, Nothing](
+      Schema.operation(ShapeId("test", "Ping"))
+    )
+    val frame = GrpcFrame.encode(GrpcFrame(compressed = false, Blob.empty))
+    val request = GrpcRequest(
+      message              = Blob(frame),
+      headers              = GrpcMetadata.empty,
+      timeout              = None,
+      compression          = GrpcCompression.Gzip,
+      acceptedCompressions = Nil,
+      path                 = GrpcMethodPath("test.DummyService", "Ping")
+    )
+    unary.inputDecoder(request).attempt.map { result =>
+      expect.same(result, Left(GrpcFailure.UnsupportedCompression("gzip")))
+    }
+  }
+
+  test("outputEncoder succeeds") {
+    val unary = serverCodecs.apply[Unit, Nothing, Unit, Nothing, Nothing](
+      Schema.operation(ShapeId("test", "Ping"))
+    )
+    unary.outputEncoder(()).map { response =>
+      val status = response.trailers.getText(GrpcConstants.grpcStatusHeader).headOption
+      expect.same(status, Some(GrpcStatusCode.OK.intValue.toString))
+    }
+  }
+
+  test("outputEncoder rejects oversized payload") {
+    val codecs = GrpcUnaryServerCodecs.builder[IO].withMaxMessageSize(-1).build()
+    val unary  = codecs.apply[Unit, Nothing, Unit, Nothing, Nothing](Schema.operation(ShapeId("test", "Ping")))
+    unary.outputEncoder(()).attempt.map { result =>
+      expect.same(result, Left(GrpcFailure.InvalidFrame(GrpcFrame.Error.MessageTooLarge)))
+    }
+  }
+}

--- a/modules/protobuf/src/main/scala/smithy4s/protobuf/ProtobufReadError.scala
+++ b/modules/protobuf/src/main/scala/smithy4s/protobuf/ProtobufReadError.scala
@@ -16,21 +16,45 @@
 
 package smithy4s.protobuf
 
-import smithy4s.ShapeId
-import smithy4s.Hint
+import alloy.proto.ProtoIndex
+import smithy4s.{ Hint, Hints, Schema, ShapeId }
+import smithy4s.schema.Schema.{document, int, string, struct, union}
 
 sealed trait ProtobufReadError extends Throwable
 
 // scalafmt: { maxColumn = 120}
 object ProtobufReadError {
+  val id: ShapeId = ShapeId("smithy4s.protobuf", "ProtobufReadError")
+
+  implicit val schema: Schema[ProtobufReadError] = {
+    val missingRequiredField = MissingRequiredField.schema
+      .oneOf[ProtobufReadError]("missingRequiredField")
+    val violatedConstraint = ViolatedConstraint.schema
+      .oneOf[ProtobufReadError]("violatedConstraint")
+    val other = Other.schema
+      .oneOf[ProtobufReadError]("other")
+
+    union(missingRequiredField, violatedConstraint, other) {
+      case _: MissingRequiredField => 0
+      case _: ViolatedConstraint   => 1
+      case _: Other                => 2
+    }.withId(id)
+  }
+
   final case class Other private (cause: Throwable) extends ProtobufReadError {
-    override def getMessage() = "Failed to decode protobuf message"
+    override def getMessage() = cause.getMessage()
     override def getCause(): Throwable = cause
+
   }
 
   object Other {
     def apply(cause: Throwable): Other = new Other(cause)
     def unapply(error: Other): Some[Other] = Some(error)
+    val schema: Schema[Other] = {
+      val message = string.required[Other]("message", _.getMessage)
+        .addHints(ProtoIndex(1))
+      struct(message)(message => Other(new RuntimeException(message)))
+    }
   }
 
   final case class MissingRequiredField private (
@@ -48,6 +72,15 @@ object ProtobufReadError {
     def apply(shapeId: ShapeId, fieldName: String, index: Int): MissingRequiredField =
       new MissingRequiredField(shapeId, fieldName, index)
     def unapply(error: MissingRequiredField): Some[MissingRequiredField] = Some(error)
+    val schema: Schema[MissingRequiredField] = {
+      val shapeId = ShapeId.schema.required[MissingRequiredField]("shapeId", _.shapeId)
+        .addHints(ProtoIndex(1))
+      val fieldName = string.required[MissingRequiredField]("fieldName", _.fieldName)
+        .addHints(ProtoIndex(2))
+      val index = int.required[MissingRequiredField]("index", _.index)
+        .addHints(ProtoIndex(3))
+      struct(shapeId, fieldName, index)(MissingRequiredField.apply)
+    }
   }
 
   final case class ViolatedConstraint private (
@@ -63,6 +96,23 @@ object ProtobufReadError {
   object ViolatedConstraint {
     def apply(hint: Hint, message: String): ViolatedConstraint = new ViolatedConstraint(hint, message)
     def unapply(error: ViolatedConstraint): Some[ViolatedConstraint] = Some(error)
+    private val hintSchema: Schema[Hint] = {
+      // Static bindings are rehydrated as DynamicBinding values after round-trip.
+      val keyId = ShapeId.schema.required[Hint]("keyId", _.keyId)
+        .addHints(ProtoIndex(1))
+      val value = document.required[Hint]("value", hint => hint match {
+        case static: Hints.Binding.StaticBinding[_] => static.toDynamicBinding.value
+        case dynamic: Hints.Binding.DynamicBinding  => dynamic.value
+      }).addHints(ProtoIndex(2))
+      struct(keyId, value)(Hints.Binding.DynamicBinding.apply)
+    }
+    val schema: Schema[ViolatedConstraint] = {
+      val hint = hintSchema.required[ViolatedConstraint]("hint", _.hint)
+        .addHints(ProtoIndex(1))
+      val message = string.required[ViolatedConstraint]("message", _.message)
+        .addHints(ProtoIndex(2))
+      struct(hint, message)(ViolatedConstraint.apply)
+    }
   }
 
 }

--- a/modules/protobuf/test/src/smithy4s/protobuf/ProtobufReadErrorSpec.scala
+++ b/modules/protobuf/test/src/smithy4s/protobuf/ProtobufReadErrorSpec.scala
@@ -1,0 +1,51 @@
+/*
+ *  Copyright 2021-2026 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package smithy4s.protobuf
+
+import smithy4s.ShapeId
+import weaver.SimpleIOSuite
+
+object ProtobufReadErrorSpec extends SimpleIOSuite {
+  private val codec =
+    ProtobufCodec.fromSchema(ProtobufReadError.schema, ProtobufCodec.createCache())
+
+  pureTest("ProtobufReadError schema roundtrips MissingRequiredField") {
+    val error = ProtobufReadError.MissingRequiredField(
+      ShapeId("example", "Input"),
+      "field",
+      1
+    )
+    val decoded = codec.readBlob(codec.writeBlob(error))
+    expect.same(decoded, Right(error))
+  }
+
+  pureTest("ProtobufReadError schema roundtrips ViolatedConstraint") {
+    val error = ProtobufReadError.ViolatedConstraint(
+      smithy.api.Length(min = Some(1), max = None),
+      "too short"
+    )
+    val decoded = codec.readBlob(codec.writeBlob(error))
+    expect.same(decoded, Right(error))
+  }
+
+  pureTest("ProtobufReadError schema roundtrips Other") {
+    val error = ProtobufReadError.Other(new RuntimeException("boom"))
+    val decoded = codec.readBlob(codec.writeBlob(error))
+
+    expect.same(decoded.map(_.getMessage), Right(error.getMessage))
+  }
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -32,7 +32,7 @@ object Dependencies {
 
   val Alloy = new {
     val org = "com.disneystreaming.alloy"
-    val alloyVersion = "0.3.36"
+    val alloyVersion = "dev-SNAPSHOT"
     val core = org % "alloy-core" % alloyVersion
     val openapi = org %% "alloy-openapi" % alloyVersion
     val protobuf = org % "alloy-protobuf" % alloyVersion

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -32,7 +32,7 @@ object Dependencies {
 
   val Alloy = new {
     val org = "com.disneystreaming.alloy"
-    val alloyVersion = "dev-SNAPSHOT"
+    val alloyVersion = "0.3.36"
     val core = org % "alloy-core" % alloyVersion
     val openapi = org %% "alloy-openapi" % alloyVersion
     val protobuf = org % "alloy-protobuf" % alloyVersion

--- a/sampleSpecs/grpc.smithy
+++ b/sampleSpecs/grpc.smithy
@@ -1,0 +1,41 @@
+$version: "2"
+
+namespace smithy4s.example.grpc
+
+use alloy.proto#grpc
+use alloy.proto#grpcError
+
+@grpc
+service GrpcGreetingService {
+    operations: [Greet]
+}
+
+operation Greet {
+    input: GreetInput
+    output: GreetOutput
+    errors: [NotFoundError, PermissionDeniedError]
+}
+
+structure GreetInput {
+    @required
+    name: String
+}
+
+structure GreetOutput {
+    @required
+    greeting: String
+}
+
+@error("client")
+@grpcError(code: 5, message: "Resource not found")
+structure NotFoundError {
+    @required
+    message: String
+}
+
+@error("client")
+@grpcError(code: 7, message: "Permission denied")
+structure PermissionDeniedError {
+    @required
+    message: String
+}


### PR DESCRIPTION
Purpose
- Introduce unary gRPC support for smithy4s services using Alloy’s gRPC protocol modeling.
- Provide a reusable, transport-agnostic gRPC protocol layer plus an http4s transport integration that follows gRPC semantics around framing, metadata, trailers, and structured errors.

What’s implemented (smithy4s + gRPC spec)
- A transport-agnostic unary gRPC “protocol core”:
  - Unary framing/deframing with message size limits
  - Canonical handling of gRPC metadata headers/trailers, including binary metadata base64 rules
  - Structured error propagation that can carry machine-readable details alongside grpc-status/grpc-message, and client-side decoding back into modeled errors when possible (with configurable strictness)
- A transport-specific http4s integration layer:
  - Server routing and request validation for unary gRPC over HTTP (method/content-type gating, optional HTTP/2 requirement, canonical method-path parsing incl. trailing slashes)
  - Client request construction and response decoding consistent with gRPC trailer semantics, including “trailers-only” responses as exposed by http4s/ember
  - Separation between gRPC protocol mechanics and http4s plumbing, so other transports can reuse the same core logic

Dependencies / open questions
- This PR depends on yet-unreleased Alloy updates in https://github.com/disneystreaming/alloy/pull/271 (gRPC-related modeling traits used to drive status codes and error message selection).
- Carrier structures for rich error details (the protobuf envelope used in grpc-status-details-bin) are currently implemented in smithy4s. The definition/location of these carriers is still up for debate and can move between the Alloy and smithy4s changes.


TODO (gRPC spec compliance + grpc-java/grpc-go parity)
  - Implement streaming (client/server/bidi), including backpressure and flow control correctness
  - Implement real compression (gzip at least): negotiation and per-message compression bit support
  - Implement deadline + cancellation enforcement end-to-end (grpc-timeout, cancellations, status mapping)
  - Harden HTTP/2 mapping requirements and protocol error mapping (pseudo-headers, non-200 handling, missing trailers, intermediaries)
  - Expand rich error details handling (grpc-status-details-bin) beyond “first detail”, tighten strictness/precedence rules
  - Implement retry and hedging policies (service config parity)
  - Implement name resolution + baseline load-balancing (pick_first, round_robin) with connectivity state model
  - Implement connection lifecycle features: GOAWAY/drain behavior and keepalive/ping policies
  - Add configurable limits: max inbound/outbound message size and metadata size, with correct RESOURCE_EXHAUSTED behavior
  - Add interceptor/context propagation parity suitable for Scala FP (deadline/cancel/metadata/locals)
  - Add standard ecosystem services: reflection, health checking, channelz-style diagnostics
  - Add observability parity: structured metrics (attempts/retries), tracing propagation and spans

## PR Checklist (not all items are relevant to all PRs)

- [ ] Added unit-tests (for runtime code)
- [ ] Added bootstrapped code + smoke tests (when the rendering logic is modified)
- [ ] Added build-plugins integration tests (when reflection loading is required at codegen-time)
- [ ] Added alloy compliance tests (when simpleRestJson protocol behaviour is expanded/updated)
- [ ] Updated dynamic module to match generated-code behaviour
- [ ] Added documentation
- [ ] Updated changelog
