### PR TITLE
set up bincompat-friendly core codegen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Thank you!
 
 # 0.19.0
 
+## Binary-Compatible-Friendly Codegen Enabled in Core Module in [#1900](https://github.com/disneystreaming/smithy4s/pull/1900)
+
+Now `alloy` and `smithy` namespaces and sub-namespaces are generated in core with binary-compatible-friendly mode enabled.
+
 ## Add Mill 1.x support
 
 The Mill codegen plugin now supports Mill 1.x (tested with 1.1.2), in addition to the existing Mill 0.11.x and 0.12.x support.

--- a/build.sbt
+++ b/build.sbt
@@ -235,7 +235,8 @@ lazy val core = projectMatrix
         .taskValue
     },
     scalacOptions ++= Seq(
-      "-Wconf:msg=value noInlineDocumentSupport in class ProtocolDefinition is deprecated:silent"
+      "-Wconf:msg=value noInlineDocumentSupport in class ProtocolDefinition is deprecated:silent",
+      "-Wconf:msg=value noInlineDocumentSupport is deprecated:silent"
     ),
     libraryDependencies ++= weaverDeps.value,
     libraryDependencies += Dependencies.collectionsCompat.value,

--- a/modules/bootstrapped/test/src-js/smithy4s/TimestampSpec.scala
+++ b/modules/bootstrapped/test/src-js/smithy4s/TimestampSpec.scala
@@ -72,7 +72,7 @@ class TimestampSpec() extends munit.FunSuite with munit.ScalaCheckSuite {
       val epochSecond = (i.valueOf() / 1000).toLong
       val nano = (i.valueOf() % 1000).toInt * 1000000
       val ts = Timestamp(epochSecond, nano)
-      val formatted = ts.format(TimestampFormat.DATE_TIME)
+      val formatted = ts.formatDateTime
       val parsed = Timestamp.parse(formatted, TimestampFormat.DATE_TIME)
       expect.same(formatted, i.toISOString().replace(".000", ""))
       expect.same(parsed, Some(ts))
@@ -87,8 +87,7 @@ class TimestampSpec() extends munit.FunSuite with munit.ScalaCheckSuite {
       val offsetSeconds = totalOffset % 60
       val epochSecond = (i.valueOf() / 1000).toLong
       val nano = (i.valueOf() % 1000).toInt * 1000000
-      val formatted = Timestamp(epochSecond, nano)
-        .format(TimestampFormat.DATE_TIME)
+      val formatted = Timestamp(epochSecond, nano).formatDateTime
         .dropRight(1) + {
         if (offsetSeconds == 0)
           f"${if (o >= 0) "+" else "-"}$offsetHours%02d:$offsetMinutes%02d"
@@ -112,7 +111,7 @@ class TimestampSpec() extends munit.FunSuite with munit.ScalaCheckSuite {
       val epochSecond = (i.valueOf() / 1000).toLong
       val nano = (i.valueOf() % 1000).toInt * 1000000
       val ts = Timestamp(epochSecond, nano)
-      val formatted = ts.format(TimestampFormat.HTTP_DATE)
+      val formatted = ts.formatHttpDate
       val parsed = Timestamp.parse(formatted, TimestampFormat.HTTP_DATE)
       expect.same(formatted, i.toUTCString())
       expect.same(parsed, Some(ts))
@@ -124,7 +123,7 @@ class TimestampSpec() extends munit.FunSuite with munit.ScalaCheckSuite {
       val epochSecond = (i.valueOf() / 1000).toLong
       val nano = (i.valueOf() % 1000).toInt * 1000000
       val ts = Timestamp(epochSecond, nano)
-      val formatted = ts.format(TimestampFormat.EPOCH_SECONDS)
+      val formatted = ts.formatEpochSeconds
       val parsed = Timestamp.parse(formatted, TimestampFormat.EPOCH_SECONDS)
       val expected =
         if (nano != 0) {

--- a/modules/bootstrapped/test/src-jvm/smithy4s/TimestampSpec.scala
+++ b/modules/bootstrapped/test/src-jvm/smithy4s/TimestampSpec.scala
@@ -81,7 +81,7 @@ class TimestampSpec() extends munit.FunSuite with munit.ScalaCheckSuite {
   property("Converts to/from DATE_TIME format") {
     forAll { (i: Instant) =>
       val ts = Timestamp(i.getEpochSecond, i.getNano)
-      val formatted = ts.format(TimestampFormat.DATE_TIME)
+      val formatted = ts.formatDateTime
       val parsed = Timestamp.parse(formatted, TimestampFormat.DATE_TIME)
       expect.same(formatted, i.toString)
       expect.same(parsed, Some(ts))
@@ -94,8 +94,7 @@ class TimestampSpec() extends munit.FunSuite with munit.ScalaCheckSuite {
       val offsetHours = totalOffset / 3600
       val offsetMinutes = (totalOffset % 3600) / 60
       val offsetSeconds = totalOffset % 60
-      val formatted = Timestamp(i.getEpochSecond, i.getNano)
-        .format(TimestampFormat.DATE_TIME)
+      val formatted = Timestamp(i.getEpochSecond, i.getNano).formatDateTime
         .dropRight(1) + {
         if (offsetSeconds == 0)
           f"${if (o >= 0) "+" else "-"}$offsetHours%02d:$offsetMinutes%02d"
@@ -117,7 +116,7 @@ class TimestampSpec() extends munit.FunSuite with munit.ScalaCheckSuite {
   property("Converts to/from HTTP_DATE format") {
     forAll { (i: Instant) =>
       val ts = Timestamp(i.getEpochSecond, i.getNano)
-      val formatted = ts.format(TimestampFormat.HTTP_DATE)
+      val formatted = ts.formatHttpDate
       val parsed = Timestamp.parse(formatted, TimestampFormat.HTTP_DATE)
       val expected = imfDateFormatter
         .format(i)
@@ -132,7 +131,7 @@ class TimestampSpec() extends munit.FunSuite with munit.ScalaCheckSuite {
   property("Converts to/from EPOCH_SECONDS format") {
     forAll { (i: Instant) =>
       val ts = Timestamp(i.getEpochSecond, i.getNano)
-      val formatted = ts.format(TimestampFormat.EPOCH_SECONDS)
+      val formatted = ts.formatEpochSeconds
       val parsed = Timestamp.parse(formatted, TimestampFormat.EPOCH_SECONDS)
       val expected =
         if (i.getNano != 0) {

--- a/modules/codegen/src/smithy4s/codegen/internals/SmithyToIR.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/SmithyToIR.scala
@@ -154,20 +154,11 @@ private[codegen] class SmithyToIR(
     NamespacePattern.fromString("alloy.*")
   )
 
+  // for now if you want to add more namespaces, you'll need to use a ModelTransformer
+  // we don't allow metadata configuration since that would bypass model validation
+  // such as not allowing bincompat trait in conjunction with ADT trait.
   private val smithy4sBinCompatHintNamespacePatterns: Set[NamespacePattern] =
-    smithy4sDefaultBinCompatHintNamespacePatterns ++
-      model
-        .getMetadata()
-        .asScala
-        .get("smithy4sBinCompatNamespacePatterns")
-        .toSet
-        .flatMap((n: Node) => n.asArrayNode().asScala)
-        .flatMap(_.getElements().asScala)
-        .flatMap(
-          _.asStringNode().asScala.map(n =>
-            NamespacePattern.fromString(n.getValue)
-          )
-        )
+    smithy4sDefaultBinCompatHintNamespacePatterns
 
   private def fieldModifier(member: MemberShape): Field.Modifier = {
     val hasRequired = member.hasTrait(classOf[RequiredTrait])

--- a/modules/codegen/src/smithy4s/codegen/internals/SmithyToIR.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/SmithyToIR.scala
@@ -146,6 +146,29 @@ private[codegen] class SmithyToIR(
           )
         )
 
+  private val smithy4sDefaultBinCompatHintNamespacePatterns
+      : Set[NamespacePattern] = Set(
+    NamespacePattern.fromString("smithy"),
+    NamespacePattern.fromString("smithy.*"),
+    NamespacePattern.fromString("alloy"),
+    NamespacePattern.fromString("alloy.*")
+  )
+
+  private val smithy4sBinCompatHintNamespacePatterns: Set[NamespacePattern] =
+    smithy4sDefaultBinCompatHintNamespacePatterns ++
+      model
+        .getMetadata()
+        .asScala
+        .get("smithy4sBinCompatNamespacePatterns")
+        .toSet
+        .flatMap((n: Node) => n.asArrayNode().asScala)
+        .flatMap(_.getElements().asScala)
+        .flatMap(
+          _.asStringNode().asScala.map(n =>
+            NamespacePattern.fromString(n.getValue)
+          )
+        )
+
   private def fieldModifier(member: MemberShape): Field.Modifier = {
     val hasRequired = member.hasTrait(classOf[RequiredTrait])
     val hasNullable = member.hasTrait(classOf[alloy.NullableTrait])
@@ -1165,7 +1188,19 @@ private[codegen] class SmithyToIR(
     val nonConstraintNonMetaTraits = nonMetaTraits.collect {
       case t if ConstraintTrait.unapply(t).isEmpty => t
     }
+
+    val stdlibBincompatFriendlyTrait = {
+      if (
+        smithy4sBinCompatHintNamespacePatterns.exists(
+          _.matches(shape.namespace)
+        )
+      ) {
+        Some(Hint.BincompatFriendly)
+      } else None
+    }
+
     allTraits.collect(traitToHint(shape)) ++
+      stdlibBincompatFriendlyTrait ++
       documentationHint(shape) ++
       nonConstraintNonMetaTraits
         .filter(tr =>

--- a/modules/compliance-tests/src/smithy4s/compliancetests/internals/ServerHttpComplianceTestCase.scala
+++ b/modules/compliance-tests/src/smithy4s/compliancetests/internals/ServerHttpComplianceTestCase.scala
@@ -253,7 +253,7 @@ private[compliancetests] class ServerHttpComplianceTestCase[
       )
       val code =
         endpoint.hints.get[smithy.api.Http].map(_.code).getOrElse(newHttp.code)
-      Hints(newHttp.copy(code = code))
+      Hints(newHttp.withCode(code = code))
     }
     val amendedOperation =
       Schema

--- a/modules/core/src/smithy4s/http/HttpBinding.scala
+++ b/modules/core/src/smithy4s/http/HttpBinding.scala
@@ -129,7 +129,7 @@ object HttpBinding extends ShapeTag.Companion[HttpBinding] {
       field: String,
       fieldHints: Hints
   ): Option[HttpBinding] = {
-    fieldHints.get(HttpLabel).map { case HttpLabel() =>
+    fieldHints.get(HttpLabel).map { _ =>
       PathBinding(field)
     } orElse fieldHints.get(HttpQuery).map { case HttpQuery(name) =>
       QueryBinding(name)

--- a/modules/core/src/smithy4s/http/internals/ErrorCodeSchemaVisitor.scala
+++ b/modules/core/src/smithy4s/http/internals/ErrorCodeSchemaVisitor.scala
@@ -69,6 +69,9 @@ private[http] class ErrorCodeSchemaVisitor(
       .orElse(hints.get(smithy.api.Error).map {
         case smithy.api.Error.CLIENT => 400
         case smithy.api.Error.SERVER => 500
+        // In the event that an enum value is added to smithy.api.Error
+        // we will fallback to server error code
+        case _ => 500
       })
   }
 

--- a/modules/core/src/smithy4s/http/internals/SchemaVisitorPathEncoder.scala
+++ b/modules/core/src/smithy4s/http/internals/SchemaVisitorPathEncoder.scala
@@ -71,9 +71,22 @@ class SchemaVisitorPathEncoder(urlEncodeHttpLabelValues: Boolean)
       case Primitive.PTimestamp =>
         val fmt =
           hints.get(TimestampFormat).getOrElse(TimestampFormat.DATE_TIME)
+        val format: smithy4s.time.Timestamp => String =
+          fmt match {
+            case TimestampFormat.DATE_TIME =>
+              _.formatDateTime
+            case TimestampFormat.EPOCH_SECONDS =>
+              _.formatEpochSeconds
+            case TimestampFormat.HTTP_DATE =>
+              _.formatHttpDate
+            case fmt =>
+              throw new IllegalArgumentException(
+                s"Found unsupported timestamp format: '$fmt'"
+              )
+          }
         Some(
           PathEncode.raw(
-            _.format(fmt),
+            format(_),
             urlEncode = this.urlEncodeHttpLabelValues
           )
         )

--- a/modules/core/src/smithy4s/internals/DocumentDecoderSchemaVisitor.scala
+++ b/modules/core/src/smithy4s/internals/DocumentDecoderSchemaVisitor.scala
@@ -206,6 +206,13 @@ class DocumentDecoderSchemaVisitor(
               value.setScale(0, BigDecimal.RoundingMode.FLOOR).toLong
             Timestamp(epochSeconds, ((value - epochSeconds) * 1000000000).toInt)
         }
+      case fmt =>
+        // At least this case will be encountered during compilation rather than actual decoding
+        // We just don't know if a new timestampFormat will be added, but if it is then
+        // a new version of smithy4s needs to be released with support for it.
+        throw new IllegalArgumentException(
+          s"Found unsupported timestamp format '$fmt'"
+        )
     }
   }
 

--- a/modules/core/src/smithy4s/internals/DocumentEncoderSchemaVisitor.scala
+++ b/modules/core/src/smithy4s/internals/DocumentEncoderSchemaVisitor.scala
@@ -101,8 +101,8 @@ class DocumentEncoderSchemaVisitor(
       hints
         .get(TimestampFormat)
         .getOrElse(TimestampFormat.EPOCH_SECONDS) match {
-        case DATE_TIME => ts => DString(ts.format(DATE_TIME))
-        case HTTP_DATE => ts => DString(ts.format(HTTP_DATE))
+        case DATE_TIME => ts => DString(ts.formatDateTime)
+        case HTTP_DATE => ts => DString(ts.formatHttpDate)
         case EPOCH_SECONDS =>
           ts =>
             DNumber(
@@ -117,6 +117,13 @@ class DocumentEncoderSchemaVisitor(
                   )
               })
             )
+        case fmt =>
+          // At least this case will be encountered during compilation rather than actual encoding
+          // We just don't know if a new timestampFormat will be added, but if it is then
+          // a new version of smithy4s needs to be released with support for it.
+          throw new IllegalArgumentException(
+            s"Found unsupported timestamp format: '$fmt'"
+          )
       }
     case PDocument  => from(identity)
     case PFloat     => from(float => DNumber(BigDecimal(float.toDouble)))

--- a/modules/core/src/smithy4s/internals/DocumentKeyEncoder.scala
+++ b/modules/core/src/smithy4s/internals/DocumentKeyEncoder.scala
@@ -79,11 +79,18 @@ object DocumentKeyEncoder {
               .get(TimestampFormat)
               .getOrElse(DATE_TIME) match {
               case DATE_TIME =>
-                instance { ts => ts.format(DATE_TIME) }
+                instance { ts => ts.formatDateTime }
               case HTTP_DATE =>
-                instance { ts => ts.format(HTTP_DATE) }
+                instance { ts => ts.formatHttpDate }
               case EPOCH_SECONDS =>
                 forBigDecimal { ts => BigDecimal(ts.epochSecond) }
+              case fmt =>
+                // At least this case will be encountered during compilation rather than actual encoding
+                // We just don't know if a new timestampFormat will be added, but if it is then
+                // a new version of smithy4s needs to be released with support for it.
+                throw new IllegalArgumentException(
+                  s"Found unsupported timestamp format: '$fmt'"
+                )
             }
           case PDocument       => None
           case PLocalDate      => asString

--- a/modules/core/src/smithy4s/schema/Primitive.scala
+++ b/modules/core/src/smithy4s/schema/Primitive.scala
@@ -193,7 +193,15 @@ object Primitive extends smithy4s.ScalaCompat {
 
   private def timestampWriter(hints: Hints): Timestamp => String = {
     val finalFormat = timestampFormat(hints)
-    _.format(finalFormat)
+    finalFormat match {
+      case TimestampFormat.DATE_TIME     => _.formatDateTime
+      case TimestampFormat.EPOCH_SECONDS => _.formatEpochSeconds
+      case TimestampFormat.HTTP_DATE     => _.formatHttpDate
+      case fmt =>
+        throw new IllegalArgumentException(
+          s"Found unexpected timestamp format: '$fmt'"
+        )
+    }
   }
 
   private def unsafeStringParser[A](f: String => A): String => Option[A] = s =>

--- a/modules/core/src/smithy4s/time/Timestamp.scala
+++ b/modules/core/src/smithy4s/time/Timestamp.scala
@@ -31,11 +31,22 @@ case class Timestamp private (epochSecond: Long, nano: Int)
     diff > 0 || diff == 0 && nano > other.nano
   }
 
-  def format(format: TimestampFormat): String = format match {
-    case TimestampFormat.DATE_TIME     => formatToString(0)
-    case TimestampFormat.EPOCH_SECONDS => formatEpochSeconds
-    case TimestampFormat.HTTP_DATE     => formatToString(1)
+  /**
+   * Formats the Timestamp as a String using the given TimestampFormat
+   * 
+   * Returns an Option value since an unsupported TimestampFormat could be provided.
+   * 
+   * Supported formats are `DATE_TIME`, `EPOCH_SECONDS`, and `HTTP_DATE`
+   */
+  def format(format: TimestampFormat): Option[String] = format match {
+    case TimestampFormat.DATE_TIME     => Some(formatToString(0))
+    case TimestampFormat.EPOCH_SECONDS => Some(formatEpochSeconds)
+    case TimestampFormat.HTTP_DATE     => Some(formatToString(1))
+    case _                             => None
   }
+
+  def formatDateTime: String = formatToString(0)
+  def formatHttpDate: String = formatToString(1)
 
   def conciseDateTime: String = formatToString(3)
 
@@ -51,7 +62,9 @@ case class Timestamp private (epochSecond: Long, nano: Int)
     */
   def truncateToSeconds: Timestamp = copy(nano = 0)
 
-  override def toString: String = format(TimestampFormat.DATE_TIME)
+  override def toString: String = format(
+    TimestampFormat.DATE_TIME
+  ).get // we know `DATE_TIME` is a supported format
 
   private[this] def formatToString(internalFormat: Int): String = {
     val s = new java.lang.StringBuilder(32)
@@ -112,7 +125,7 @@ case class Timestamp private (epochSecond: Long, nano: Int)
     }
   }
 
-  private[this] def formatEpochSeconds: String = {
+  def formatEpochSeconds: String = {
     val s = new java.lang.StringBuilder(32)
     s.append(epochSecond)
     TimeUtil.appendNano(nano, s)
@@ -194,11 +207,12 @@ object Timestamp extends TimestampCompanionPlatform {
   def fromEpochSecond(epochSecond: Long): Timestamp = Timestamp(epochSecond, 0)
 
   def parse(string: String, format: TimestampFormat): Option[Timestamp] = try {
-    new Some(format match {
-      case TimestampFormat.DATE_TIME     => parseDateTime(string)
-      case TimestampFormat.EPOCH_SECONDS => parseEpochSeconds(string)
-      case TimestampFormat.HTTP_DATE     => parseHTTPDate(string)
-    })
+    format match {
+      case TimestampFormat.DATE_TIME     => new Some(parseDateTime(string))
+      case TimestampFormat.EPOCH_SECONDS => new Some(parseEpochSeconds(string))
+      case TimestampFormat.HTTP_DATE     => new Some(parseHTTPDate(string))
+      case _                             => None
+    }
   } catch {
     case NonFatal(_) => None
   }
@@ -209,6 +223,7 @@ object Timestamp extends TimestampCompanionPlatform {
     case TimestampFormat.EPOCH_SECONDS => "epoch-second timestamp"
     case TimestampFormat.HTTP_DATE =>
       "http-date timestamp (EEE, dd MMM yyyy hh:mm:ss.sss z)"
+    case other => s"unknown format: '${other.name}'"
   }
 
   private[this] def parseDateTime(s: String): Timestamp = {

--- a/modules/docs/resources/markdown/04-codegen/01-customisation/16-binary-compatibility.md
+++ b/modules/docs/resources/markdown/04-codegen/01-customisation/16-binary-compatibility.md
@@ -88,6 +88,14 @@ structure Hello {
 
 This will change the structure of generated code so that it's possible to evolve in a bincompat safe way.
 
+An alternative way of configuring `bincompatFriendly` codegen is to configure the `smithy4sBinCompatNamespacePatterns` metadata key in your Smithy files.
+
+```smithy
+metadata smithy4sBinCompatNamespacePatterns = ["foo", "foo.*"]
+```
+
+The above metadata configuration will configure Smithy4s to generate `bincompatFriendly` for all shapes with ShapeIds starting with `foo#` or `foo.`.
+
 ## Support
 
 At the time of writing, the following shapes can be made bincompat-friendly:

--- a/modules/docs/resources/markdown/04-codegen/01-customisation/16-binary-compatibility.md
+++ b/modules/docs/resources/markdown/04-codegen/01-customisation/16-binary-compatibility.md
@@ -88,14 +88,6 @@ structure Hello {
 
 This will change the structure of generated code so that it's possible to evolve in a bincompat safe way.
 
-An alternative way of configuring `bincompatFriendly` codegen is to configure the `smithy4sBinCompatNamespacePatterns` metadata key in your Smithy files.
-
-```smithy
-metadata smithy4sBinCompatNamespacePatterns = ["foo", "foo.*"]
-```
-
-The above metadata configuration will configure Smithy4s to generate `bincompatFriendly` for all shapes with ShapeIds starting with `foo#` or `foo.`.
-
 ## Support
 
 At the time of writing, the following shapes can be made bincompat-friendly:

--- a/modules/json/src/smithy4s/json/internals/SchemaVisitorJCodec.scala
+++ b/modules/json/src/smithy4s/json/internals/SchemaVisitorJCodec.scala
@@ -352,7 +352,7 @@ private[smithy4s] class SchemaVisitorJCodec(
         }
 
       def encodeValue(x: Timestamp, out: JsonWriter): Unit =
-        out.writeNonEscapedAsciiVal(x.format(TimestampFormat.DATE_TIME))
+        out.writeNonEscapedAsciiVal(x.formatDateTime)
 
       def decodeKey(in: JsonReader): Timestamp =
         Timestamp.parse(in.readKeyAsString(), TimestampFormat.DATE_TIME) match {
@@ -361,7 +361,7 @@ private[smithy4s] class SchemaVisitorJCodec(
         }
 
       def encodeKey(x: Timestamp, out: JsonWriter): Unit =
-        out.writeNonEscapedAsciiKey(x.format(TimestampFormat.DATE_TIME))
+        out.writeNonEscapedAsciiKey(x.formatDateTime)
     }
 
     val timestampHttpDate: JCodec[Timestamp] = new JCodec[Timestamp] {
@@ -374,7 +374,7 @@ private[smithy4s] class SchemaVisitorJCodec(
         }
 
       def encodeValue(x: Timestamp, out: JsonWriter): Unit =
-        out.writeNonEscapedAsciiVal(x.format(TimestampFormat.HTTP_DATE))
+        out.writeNonEscapedAsciiVal(x.formatHttpDate)
 
       def decodeKey(in: JsonReader): Timestamp =
         Timestamp.parse(in.readKeyAsString(), TimestampFormat.HTTP_DATE) match {
@@ -383,7 +383,7 @@ private[smithy4s] class SchemaVisitorJCodec(
         }
 
       def encodeKey(x: Timestamp, out: JsonWriter): Unit =
-        out.writeNonEscapedAsciiKey(x.format(TimestampFormat.HTTP_DATE))
+        out.writeNonEscapedAsciiKey(x.formatHttpDate)
     }
 
     val timestampEpochSeconds: JCodec[Timestamp] = new JCodec[Timestamp] {
@@ -655,6 +655,13 @@ private[smithy4s] class SchemaVisitorJCodec(
       case TimestampFormat.EPOCH_SECONDS =>
         PrimitiveJCodecs.timestampEpochSeconds
       case TimestampFormat.HTTP_DATE => PrimitiveJCodecs.timestampHttpDate
+      case fmt                       =>
+        // At least this case will be encountered during compilation rather than actual encoding/decoding
+        // We just don't know if a new timestampFormat will be added, but if it is then
+        // a new version of smithy4s needs to be released with support for it.
+        throw new IllegalArgumentException(
+          s"Found unsupported timestamp format: '$fmt'"
+        )
     }
   }
 

--- a/modules/json/test/src/smithy4s/json/SchemaVisitorJCodecPropertyTests.scala
+++ b/modules/json/test/src/smithy4s/json/SchemaVisitorJCodecPropertyTests.scala
@@ -87,28 +87,28 @@ class SchemaVisitorJsonCodecPropertyTests()
       result match {
         case Right(_) =>
           hint.value match {
-            case Length(min, max) =>
+            case l: Length =>
               val size: Int = data match {
                 case m: Map[_, _] => m.size
                 case l: List[_]   => l.size
                 case s: String    => s.size
                 case b: Blob      => b.size
               }
-              expect(min.forall(_ <= size))
-              expect(max.forall(_ >= size))
-            case Range(min, max) =>
+              expect(l.min.forall(_ <= size))
+              expect(l.max.forall(_ >= size))
+            case r: Range =>
               val value = BigDecimal(data.toString)
-              expect(min.forall(_ <= value))
-              expect(max.forall(_ >= value))
+              expect(r.min.forall(_ <= value))
+              expect(r.max.forall(_ >= value))
           }
         case Left(PayloadError(_, _, message)) =>
           hint.value match {
-            case Length(min, max) =>
-              expect(min.isEmpty || message.contains(min.get.toString))
-              expect(max.isEmpty || message.contains(max.get.toString))
-            case Range(min, max) =>
-              expect(min.isEmpty || message.contains(min.get.toString))
-              expect(max.isEmpty || message.contains(max.get.toString))
+            case l: Length =>
+              expect(l.min.isEmpty || message.contains(l.min.get.toString))
+              expect(l.max.isEmpty || message.contains(l.max.get.toString))
+            case r: Range =>
+              expect(r.min.isEmpty || message.contains(r.min.get.toString))
+              expect(r.max.isEmpty || message.contains(r.max.get.toString))
           }
         case _ => fail("result should have matched one of the above cases")
       }

--- a/modules/protobuf/src/main/scala/smithy4s/protobuf/internals/ScalarCodec.scala
+++ b/modules/protobuf/src/main/scala/smithy4s/protobuf/internals/ScalarCodec.scala
@@ -57,6 +57,11 @@ private[protobuf] object ScalarCodec {
     case Some(FIXED_SIGNED) => SignedFixedIntCodec
     case Some(SIGNED)       => SignedIntCodec
     case Some(UNSIGNED)     => UnsignedIntCodec
+    case Some(fmt)          =>
+      // At least this case will be encountered during compilation rather than actual encoding/decoding
+      // We just don't know if a new timestampFormat will be added, but if it is then
+      // a new version of smithy4s needs to be released with support for it.
+      throw new IllegalArgumentException(s"Found unsupported timestamp format: '$fmt'")
   }
 
   object IntCodec extends ScalarCodec[Int] {
@@ -118,6 +123,11 @@ private[protobuf] object ScalarCodec {
     case Some(FIXED_SIGNED) => SignedFixedLongCodec
     case Some(SIGNED)       => SignedLongCodec
     case Some(UNSIGNED)     => UnsignedLongCodec
+    case Some(fmt)          =>
+      // At least this case will be encountered during compilation rather than actual encoding/decoding
+      // We just don't know if a new timestampFormat will be added, but if it is then
+      // a new version of smithy4s needs to be released with support for it.
+      throw new IllegalArgumentException(s"Found unsupported timestamp format: '$fmt'")
   }
 
   object LongCodec extends ScalarCodec[Long] {

--- a/project/Smithy4sBuildPlugin.scala
+++ b/project/Smithy4sBuildPlugin.scala
@@ -101,7 +101,8 @@ case class MillCustomRow(mv: String) extends CustomRow {
           .binaryWith(s"mill${millPlatformStr}_", ""),
         libraryDependencies ++= config.millDeps(mv),
         Compile / unmanagedSourceDirectories ++= {
-          val base = (Compile / sourceDirectory).value.getParentFile.getParentFile
+          val base =
+            (Compile / sourceDirectory).value.getParentFile.getParentFile
           val versionDir = base / s"src-mill-${suffix}"
           if (config.includesSharedSources)
             Seq(base / "src-mill-shared", versionDir)
@@ -388,7 +389,7 @@ object Smithy4sBuildPlugin extends AutoPlugin {
       .filterNot(_ == "-Xcheckinit")
       .map {
         case "-Xfatal-warnings" if !scalaVersion.startsWith("3.3.") => "-Werror"
-        case other => other
+        case other                                                  => other
       }
   }
 


### PR DESCRIPTION
Generate the smithy and alloy classes with bincompat friendly codegen enabled. Basically a port of #1776 with some changes to handle open enums like `TimestampFormat`. In these cases, I opted to throw exceptions off of the hot-path such that they'd be triggered at runtime, but during application start up. This is obviously not "pure" but personally I think that is a fine trade off given that it is very much an edge case. I don't think it makes sense to change / encode the possibility of this failure at a higher level which would add complexity with basically no benefit.

This also provides a metadata key for configuring namespaces that should be generated with bincompat friendly mode in addition to the existing trait-based approach.

Let me know what you think.

---

Closes #1777.