### PR TITLE
update case classes to regular classes in core/schema

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1152,31 +1152,31 @@ lazy val benchmark = projectMatrix
   .jvmPlatform(List(Scala213), jvmDimSettings)
   .settings(Smithy4sBuildPlugin.doNotPublishArtifact)
 
-lazy val `aws-sandbox` = projectMatrix
-  .in(file("modules/aws-sandbox"))
-  .dependsOn(`aws-http4s`)
-  .settings(
-    Compile / allowedNamespaces := Seq(
-      "com.amazonaws.cloudwatch",
-      "com.amazonaws.ec2"
-    ),
-    genSmithy(Compile),
-    // Ignore deprecation warnings here - it's all generated code, anyway.
-    scalacOptions ++= Seq(
-      "-Wconf:cat=deprecation:silent"
-    ),
-    smithy4sDependencies ++= Seq(
-      "com.disneystreaming.smithy" % "aws-cloudwatch-spec" % "2025.04.08",
-      "com.disneystreaming.smithy" % "aws-ec2-spec" % "2025.04.08"
-    ),
-    libraryDependencies ++= Seq(
-      Dependencies.Http4s.emberClient.value,
-      Dependencies.Slf4jSimple % Runtime
-    ),
-    run / fork := true
-  )
-  .jvmPlatform(List(Scala213), jvmDimSettings)
-  .settings(Smithy4sBuildPlugin.doNotPublishArtifact)
+//lazy val `aws-sandbox` = projectMatrix
+//  .in(file("modules/aws-sandbox"))
+//  .dependsOn(`aws-http4s`)
+//  .settings(
+//    Compile / allowedNamespaces := Seq(
+//      "com.amazonaws.cloudwatch",
+//      "com.amazonaws.ec2"
+//    ),
+//    genSmithy(Compile),
+//    // Ignore deprecation warnings here - it's all generated code, anyway.
+//    scalacOptions ++= Seq(
+//      "-Wconf:cat=deprecation:silent"
+//    ),
+//    smithy4sDependencies ++= Seq(
+//      "com.disneystreaming.smithy" % "aws-cloudwatch-spec" % "2025.04.08",
+//      "com.disneystreaming.smithy" % "aws-ec2-spec" % "2025.04.08"
+//    ),
+//    libraryDependencies ++= Seq(
+//      Dependencies.Http4s.emberClient.value,
+//      Dependencies.Slf4jSimple % Runtime
+//    ),
+//    run / fork := true
+//  )
+//  .jvmPlatform(List(Scala213), jvmDimSettings)
+//  .settings(Smithy4sBuildPlugin.doNotPublishArtifact)
 
 def genSmithy(config: Configuration) = Def.settings(
   Seq(

--- a/modules/core/src/smithy4s/internals/DocumentDecoderSchemaVisitor.scala
+++ b/modules/core/src/smithy4s/internals/DocumentDecoderSchemaVisitor.scala
@@ -565,10 +565,10 @@ class DocumentDecoderSchemaVisitor(
     val handleUnknownTag: (String, List[PayloadPath.Segment], Document) => U =
       alternatives
         .find(hasUnknown(_))
-        .map { case Alt(_, instance, inject, _) =>
-          val compiled = apply(instance)
+        .map { case s: Alt[a, b] =>
+          val compiled = apply(s.schema)
           (_: String, pp: List[PayloadPath.Segment], doc: Document) =>
-            inject(compiled(pp, doc))
+            s.inject(compiled(pp, doc))
         }
         .getOrElse { (key, pp, _) =>
           throw new PayloadError(
@@ -581,11 +581,11 @@ class DocumentDecoderSchemaVisitor(
     val decoders: DecoderMap[U] =
       alternatives
         .filterNot(hasUnknown(_))
-        .map { case alt @ Alt(_, instance, inject, _) =>
+        .map { case alt: Alt[_, _] =>
           val label = jsonLabel(alt)
-          val compiled = apply(instance)
+          val compiled = apply(alt.schema)
           val decoder = { (pp: List[PayloadPath.Segment], doc: Document) =>
-            inject(compiled(label :: pp, doc))
+            alt.inject(compiled(label :: pp, doc))
           }
           label -> decoder
         }

--- a/modules/core/src/smithy4s/schema/Alt.scala
+++ b/modules/core/src/smithy4s/schema/Alt.scala
@@ -24,35 +24,56 @@ import kinds._
 /**
   * Represents a member of coproduct type (sealed trait)
   */
-final case class Alt[U, A](
-    label: String,
-    schema: Schema[A],
-    inject: A => U,
-    project: PartialFunction[U, A]
+final class Alt[U, A](
+    val label: String,
+    val schema: Schema[A],
+    val inject: A => U,
+    val project: PartialFunction[U, A]
 ) {
 
   def hints: Hints = schema.hints
   def memberHints: Hints = schema.hints.memberHints
 
   def addHints(newHints: Hints): Alt[U, A] =
-    copy(schema = schema.addMemberHints(newHints))
+    new Alt(label, schema.addMemberHints(newHints), inject, project)
 
   def addHints(newHints: Hint*): Alt[U, A] =
     addHints(Hints(newHints: _*))
 
   def transformHintsLocally(f: Hints => Hints): Alt[U, A] =
-    copy(schema = schema.transformHintsLocally(f))
+    new Alt(label, schema.transformHintsLocally(f), inject, project)
 
   def transformHintsTransitively(f: Hints => Hints): Alt[U, A] =
-    copy(schema = schema.transformHintsTransitively(f))
+    new Alt(label, schema.transformHintsTransitively(f), inject, project)
 
   def validated[C](c: C)(implicit
       constraint: RefinementProvider.Simple[C, A]
   ): Alt[U, A] =
-    copy(schema = schema.validated(c)(constraint))
+    new Alt(label, schema.validated(c)(constraint), inject, project)
 
+  def withSchema(schema: Schema[A]): Alt[U, A] =
+    new Alt(label, schema, inject, project)
+
+  override def equals(obj: Any): Boolean = obj match {
+    case that: Alt[_, _] => this.label == that.label && this.schema == that.schema && this.inject == that.inject && this.project == that.project
+    case _ => false
+  }
+  override def hashCode(): Int = {
+    var result = label.##
+    result = 31 * result + schema.##
+    result = 31 * result + inject.##
+    result = 31 * result + project.##
+    result
+  }
+  override def toString: String = s"Alt($label, $schema, $inject, $project)"
 }
 object Alt {
+
+  def apply[U, A](label: String, schema: Schema[A], inject: A => U, project: PartialFunction[U, A]): Alt[U, A] =
+    new Alt(label, schema, inject, project)
+
+  def unapply[U, A](x: Alt[U, A]): Some[(String, Schema[A], A => U, PartialFunction[U, A])] =
+    Some((x.label, x.schema, x.inject, x.project))
 
   /**
     * Precompiles an Alt to produce an instance of `G`

--- a/modules/core/src/smithy4s/schema/EnumValue.scala
+++ b/modules/core/src/smithy4s/schema/EnumValue.scala
@@ -17,16 +17,36 @@
 package smithy4s
 package schema
 
-case class EnumValue[E](
-    stringValue: String,
-    intValue: Int,
-    value: E,
-    name: String,
-    hints: Hints
+final class EnumValue[E](
+    val stringValue: String,
+    val intValue: Int,
+    val value: E,
+    val name: String,
+    val hints: Hints
 ) {
   def map[A](f: E => A): EnumValue[A] =
-    copy(value = f(value))
+    new EnumValue(stringValue, intValue, f(value), name, hints)
 
   def transformHints(f: Hints => Hints): EnumValue[E] =
-    copy(hints = f(hints))
+    new EnumValue(stringValue, intValue, value, name, f(hints))
+
+  override def equals(obj: Any): Boolean = obj match {
+    case that: EnumValue[_] => this.stringValue == that.stringValue && this.intValue == that.intValue && this.value == that.value && this.name == that.name && this.hints == that.hints
+    case _ => false
+  }
+  override def hashCode(): Int = {
+    var result = stringValue.##
+    result = 31 * result + intValue.##
+    result = 31 * result + value.##
+    result = 31 * result + name.##
+    result = 31 * result + hints.##
+    result
+  }
+  override def toString: String = s"EnumValue($stringValue, $intValue, $value, $name, $hints)"
+}
+object EnumValue {
+  def apply[E](stringValue: String, intValue: Int, value: E, name: String, hints: Hints): EnumValue[E] =
+    new EnumValue(stringValue, intValue, value, name, hints)
+  def unapply[E](x: EnumValue[E]): Some[(String, Int, E, String, Hints)] =
+    Some((x.stringValue, x.intValue, x.value, x.name, x.hints))
 }

--- a/modules/core/src/smithy4s/schema/ErrorSchema.scala
+++ b/modules/core/src/smithy4s/schema/ErrorSchema.scala
@@ -37,7 +37,7 @@ case class ErrorSchema[E] private[smithy4s] (
   def transformHintsLocally(f: Hints => Hints): ErrorSchema[E] = {
     val newSchema = schema match {
       case u: Schema.UnionSchema[E] =>
-        u.copy(alternatives = u.alternatives.map(_.transformHintsLocally(f)))
+        u.withAlternatives(u.alternatives.map(_.transformHintsLocally(f)))
       case other => other.transformHintsLocally(f)
     }
     copy(schema = newSchema)
@@ -46,7 +46,7 @@ case class ErrorSchema[E] private[smithy4s] (
   def transformHintsTransitively(f: Hints => Hints): ErrorSchema[E] = {
     val newSchema = schema match {
       case u: Schema.UnionSchema[E] =>
-        u.copy(alternatives = u.alternatives.map(_.transformHintsLocally(f)))
+        u.withAlternatives(u.alternatives.map(_.transformHintsLocally(f)))
       case other => other.transformHintsLocally(f)
     }
     copy(schema = newSchema)

--- a/modules/core/src/smithy4s/schema/Field.scala
+++ b/modules/core/src/smithy4s/schema/Field.scala
@@ -20,10 +20,10 @@ package schema
 /**
   * Represents a member of product type (case class)
   */
-final case class Field[S, A](
-    label: String,
-    schema: Schema[A],
-    get: S => A
+final class Field[S, A](
+    val label: String,
+    val schema: Schema[A],
+    val get: S => A
 ) {
 
   /**
@@ -72,35 +72,56 @@ final case class Field[S, A](
   def isRequired: Boolean = hints.has(smithy.api.Required)
 
   def transformHintsLocally(f: Hints => Hints): Field[S, A] =
-    copy(schema = schema.transformHintsLocally(f))
+    new Field(label, schema.transformHintsLocally(f), get)
 
   def transformHintsTransitively(f: Hints => Hints) =
-    copy(schema = schema.transformHintsTransitively(f))
+    new Field(label, schema.transformHintsTransitively(f), get)
 
   def contramap[S0](f: S0 => S): Field[S0, A] =
-    Field(label, schema, get.compose(f))
+    new Field(label, schema, get.compose(f))
 
   def addHints(newHints: Hint*): Field[S, A] =
-    copy(schema = schema.addMemberHints(newHints: _*))
+    new Field(label, schema.addMemberHints(newHints: _*), get)
 
   def addHints(newHints: Hints): Field[S, A] =
-    copy(schema = schema.addMemberHints(newHints))
+    new Field(label, schema.addMemberHints(newHints), get)
+
+  def withSchema(schema: Schema[A]): Field[S, A] =
+    new Field(label, schema, get)
+
+  override def equals(obj: Any): Boolean = obj match {
+    case that: Field[_, _] => this.label == that.label && this.schema == that.schema && this.get == that.get
+    case _ => false
+  }
+  override def hashCode(): Int = {
+    var result = label.##
+    result = 31 * result + schema.##
+    result = 31 * result + get.##
+    result
+  }
+  override def toString: String = s"Field($label, $schema, $get)"
 }
 
 object Field {
+
+  def apply[S, A](label: String, schema: Schema[A], get: S => A): Field[S, A] =
+    new Field(label, schema, get)
+
+  def unapply[S, A](x: Field[S, A]): Some[(String, Schema[A], S => A)] =
+    Some((x.label, x.schema, x.get))
 
   def required[S, A](
       label: String,
       schema: Schema[A],
       get: S => A
   ): Field[S, A] =
-    Field(label, schema, get).addHints(smithy.api.Required())
+    new Field(label, schema, get).addHints(smithy.api.Required())
 
   def optional[S, A](
       label: String,
       schema: Schema[A],
       get: S => Option[A]
   ): Field[S, Option[A]] =
-    Field(label, schema.option, get)
+    new Field(label, schema.option, get)
 
 }

--- a/modules/core/src/smithy4s/schema/FieldFilter.scala
+++ b/modules/core/src/smithy4s/schema/FieldFilter.scala
@@ -175,11 +175,11 @@ object FieldFilter {
         else
           (v: f[inner]) => o.tag.isNone(v)
 
-      case BijectionSchema(underlying, bijection) =>
-        this(underlying).compose(bijection.from)
+      case s: BijectionSchema[_, _] =>
+        this(s.underlying).compose(s.bijection.from)
 
-      case RefinementSchema(underlying, refinement) =>
-        this(underlying).compose(refinement.from)
+      case s: RefinementSchema[_, _] =>
+        this(s.underlying).compose(s.refinement.from)
 
       // technically, realistically this case is probably not reachable
       // because a recursive schema be wrapped in an option first, and wouldn't be traversed by this visitor.

--- a/modules/core/src/smithy4s/schema/Schema.scala
+++ b/modules/core/src/smithy4s/schema/Schema.scala
@@ -46,8 +46,8 @@ sealed trait Schema[A]{
     case EnumerationSchema(_, hints, values, tag) => EnumerationSchema(newId, hints, values, tag)
     case StructSchema(_, hints, fields, make) => StructSchema(newId, hints, fields, make)
     case UnionSchema(_, hints, alternatives, dispatch) => UnionSchema(newId, hints, alternatives, dispatch)
-    case BijectionSchema(schema, bijection) => BijectionSchema(schema.withId(newId), bijection)
-    case RefinementSchema(schema, refinement) => RefinementSchema(schema.withId(newId), refinement)
+    case s: BijectionSchema[_, _] => BijectionSchema(s.underlying.withId(newId), s.bijection)
+    case s: RefinementSchema[_, _] => RefinementSchema(s.underlying.withId(newId), s.refinement)
     case LazySchema(suspend) => LazySchema(suspend.map(_.withId(newId)))
     case s: OptionSchema[c, a] => OptionSchema(s.tag, s.underlying.withId(newId)).asInstanceOf[Schema[A]]
   }
@@ -61,8 +61,8 @@ sealed trait Schema[A]{
     case EnumerationSchema(shapeId, hints, values, tag) => EnumerationSchema(shapeId, f(hints), values, tag)
     case StructSchema(shapeId, hints, fields, make) => StructSchema(shapeId, f(hints), fields, make)
     case UnionSchema(shapeId, hints, alternatives, dispatch) => UnionSchema(shapeId, f(hints), alternatives, dispatch)
-    case BijectionSchema(schema, bijection) => BijectionSchema(schema.transformHintsLocally(f), bijection)
-    case RefinementSchema(schema, refinement) => RefinementSchema(schema.transformHintsLocally(f), refinement)
+    case s: BijectionSchema[_, _] => BijectionSchema(s.underlying.transformHintsLocally(f), s.bijection)
+    case s: RefinementSchema[_, _] => RefinementSchema(s.underlying.transformHintsLocally(f), s.refinement)
     case LazySchema(suspend) => LazySchema(suspend.map(_.transformHintsLocally(f)))
     case s: OptionSchema[c, a] => OptionSchema(s.tag, s.underlying.transformHintsLocally(f)).asInstanceOf[Schema[A]]
   }
@@ -169,27 +169,225 @@ object Schema {
 
   def apply[A](implicit ev: Schema[A]): ev.type = ev
 
-  final case class PrimitiveSchema[P](shapeId: ShapeId, hints: Hints, tag: Primitive[P]) extends Schema[P]
-  final case class CollectionSchema[C[_], A](shapeId: ShapeId, hints: Hints, tag: CollectionTag[C], member: Schema[A]) extends Schema[C[A]]
-  final case class MapSchema[C[_, _], K, V](shapeId: ShapeId, hints: Hints, tag: MapTag[C], key: Schema[K], value: Schema[V]) extends Schema[C[K, V]]
-  final case class EnumerationSchema[E](shapeId: ShapeId, hints: Hints, tag: EnumTag[E], values: List[EnumValue[E]]) extends Schema[E]
-  final case class StructSchema[S](shapeId: ShapeId, hints: Hints, fields: Vector[Field[S, _]], make: IndexedSeq[Any] => S) extends Schema[S]
-  final case class UnionSchema[U](shapeId: ShapeId, hints: Hints, alternatives: Vector[Alt[U, _]], ordinal: U => Int) extends Schema[U]
-  final case class OptionSchema[C[_], A](tag: OptionalTag[C], underlying: Schema[A]) extends Schema[C[A]]{
+  final class PrimitiveSchema[P](val shapeId: ShapeId, val hints: Hints, val tag: Primitive[P]) extends Schema[P] {
+    override def equals(obj: Any): Boolean = obj match {
+      case that: PrimitiveSchema[_] => this.shapeId == that.shapeId && this.hints == that.hints && this.tag == that.tag
+      case _ => false
+    }
+    override def hashCode(): Int = {
+      var result = shapeId.##
+      result = 31 * result + hints.##
+      result = 31 * result + tag.##
+      result
+    }
+    override def toString: String = s"PrimitiveSchema($shapeId, $hints, $tag)"
+  }
+  object PrimitiveSchema {
+    def apply[P](shapeId: ShapeId, hints: Hints, tag: Primitive[P]): PrimitiveSchema[P] =
+      new PrimitiveSchema(shapeId, hints, tag)
+    def unapply[P](x: PrimitiveSchema[P]): Some[(ShapeId, Hints, Primitive[P])] =
+      Some((x.shapeId, x.hints, x.tag))
+  }
+
+  final class CollectionSchema[C[_], A](val shapeId: ShapeId, val hints: Hints, val tag: CollectionTag[C], val member: Schema[A]) extends Schema[C[A]] {
+    override def equals(obj: Any): Boolean = obj match {
+      case that: CollectionSchema[_, _] => this.shapeId == that.shapeId && this.hints == that.hints && this.tag == that.tag && this.member == that.member
+      case _ => false
+    }
+    override def hashCode(): Int = {
+      var result = shapeId.##
+      result = 31 * result + hints.##
+      result = 31 * result + tag.##
+      result = 31 * result + member.##
+      result
+    }
+    override def toString: String = s"CollectionSchema($shapeId, $hints, $tag, $member)"
+
+    def withMember(member: Schema[A]): CollectionSchema[C, A] =
+      new CollectionSchema(shapeId, hints, tag, member)
+  }
+  object CollectionSchema {
+    def apply[C[_], A](shapeId: ShapeId, hints: Hints, tag: CollectionTag[C], member: Schema[A]): CollectionSchema[C, A] =
+      new CollectionSchema(shapeId, hints, tag, member)
+    def unapply[C[_], A](x: CollectionSchema[C, A]): Some[(ShapeId, Hints, CollectionTag[C], Schema[A])] =
+      Some((x.shapeId, x.hints, x.tag, x.member))
+  }
+
+  final class MapSchema[C[_, _], K, V](val shapeId: ShapeId, val hints: Hints, val tag: MapTag[C], val key: Schema[K], val value: Schema[V]) extends Schema[C[K, V]] {
+    override def equals(obj: Any): Boolean = obj match {
+      case that: MapSchema[_, _, _] => this.shapeId == that.shapeId && this.hints == that.hints && this.tag == that.tag && this.key == that.key && this.value == that.value
+      case _ => false
+    }
+    override def hashCode(): Int = {
+      var result = shapeId.##
+      result = 31 * result + hints.##
+      result = 31 * result + tag.##
+      result = 31 * result + key.##
+      result = 31 * result + value.##
+      result
+    }
+    override def toString: String = s"MapSchema($shapeId, $hints, $tag, $key, $value)"
+
+    def withKeyAndValue(key: Schema[K], value: Schema[V]): MapSchema[C, K, V] =
+      new MapSchema(shapeId, hints, tag, key, value)
+  }
+  object MapSchema {
+    def apply[C[_, _], K, V](shapeId: ShapeId, hints: Hints, tag: MapTag[C], key: Schema[K], value: Schema[V]): MapSchema[C, K, V] =
+      new MapSchema(shapeId, hints, tag, key, value)
+    def unapply[C[_, _], K, V](x: MapSchema[C, K, V]): Some[(ShapeId, Hints, MapTag[C], Schema[K], Schema[V])] =
+      Some((x.shapeId, x.hints, x.tag, x.key, x.value))
+  }
+
+  final class EnumerationSchema[E](val shapeId: ShapeId, val hints: Hints, val tag: EnumTag[E], val values: List[EnumValue[E]]) extends Schema[E] {
+    override def equals(obj: Any): Boolean = obj match {
+      case that: EnumerationSchema[_] => this.shapeId == that.shapeId && this.hints == that.hints && this.tag == that.tag && this.values == that.values
+      case _ => false
+    }
+    override def hashCode(): Int = {
+      var result = shapeId.##
+      result = 31 * result + hints.##
+      result = 31 * result + tag.##
+      result = 31 * result + values.##
+      result
+    }
+    override def toString: String = s"EnumerationSchema($shapeId, $hints, $tag, $values)"
+  }
+  object EnumerationSchema {
+    def apply[E](shapeId: ShapeId, hints: Hints, tag: EnumTag[E], values: List[EnumValue[E]]): EnumerationSchema[E] =
+      new EnumerationSchema(shapeId, hints, tag, values)
+    def unapply[E](x: EnumerationSchema[E]): Some[(ShapeId, Hints, EnumTag[E], List[EnumValue[E]])] =
+      Some((x.shapeId, x.hints, x.tag, x.values))
+  }
+
+  final class StructSchema[S](val shapeId: ShapeId, val hints: Hints, val fields: Vector[Field[S, _]], val make: IndexedSeq[Any] => S) extends Schema[S] {
+    override def equals(obj: Any): Boolean = obj match {
+      case that: StructSchema[_] => this.shapeId == that.shapeId && this.hints == that.hints && this.fields == that.fields && this.make == that.make
+      case _ => false
+    }
+    override def hashCode(): Int = {
+      var result = shapeId.##
+      result = 31 * result + hints.##
+      result = 31 * result + fields.##
+      result = 31 * result + make.##
+      result
+    }
+    override def toString: String = s"StructSchema($shapeId, $hints, $fields, $make)"
+
+    def withFields(fields: Vector[Field[S, _]]): StructSchema[S] =
+      new StructSchema(shapeId, hints, fields, make)
+  }
+  object StructSchema {
+    def apply[S](shapeId: ShapeId, hints: Hints, fields: Vector[Field[S, _]], make: IndexedSeq[Any] => S): StructSchema[S] =
+      new StructSchema(shapeId, hints, fields, make)
+    def unapply[S](x: StructSchema[S]): Some[(ShapeId, Hints, Vector[Field[S, _]], IndexedSeq[Any] => S)] =
+      Some((x.shapeId, x.hints, x.fields, x.make))
+  }
+
+  final class UnionSchema[U](val shapeId: ShapeId, val hints: Hints, val alternatives: Vector[Alt[U, _]], val ordinal: U => Int) extends Schema[U] {
+    override def equals(obj: Any): Boolean = obj match {
+      case that: UnionSchema[_] => this.shapeId == that.shapeId && this.hints == that.hints && this.alternatives == that.alternatives && this.ordinal == that.ordinal
+      case _ => false
+    }
+    override def hashCode(): Int = {
+      var result = shapeId.##
+      result = 31 * result + hints.##
+      result = 31 * result + alternatives.##
+      result = 31 * result + ordinal.##
+      result
+    }
+    override def toString: String = s"UnionSchema($shapeId, $hints, $alternatives, $ordinal)"
+
+    def withAlternatives(alternatives: Vector[Alt[U, _]]): UnionSchema[U] =
+      new UnionSchema(shapeId, hints, alternatives, ordinal)
+  }
+  object UnionSchema {
+    def apply[U](shapeId: ShapeId, hints: Hints, alternatives: Vector[Alt[U, _]], ordinal: U => Int): UnionSchema[U] =
+      new UnionSchema(shapeId, hints, alternatives, ordinal)
+    def unapply[U](x: UnionSchema[U]): Some[(ShapeId, Hints, Vector[Alt[U, _]], U => Int)] =
+      Some((x.shapeId, x.hints, x.alternatives, x.ordinal))
+  }
+
+  final class OptionSchema[C[_], A](val tag: OptionalTag[C], val underlying: Schema[A]) extends Schema[C[A]] {
     def hints: Hints = underlying.hints
     def shapeId: ShapeId = underlying.shapeId
+    override def equals(obj: Any): Boolean = obj match {
+      case that: OptionSchema[_, _] => this.tag == that.tag && this.underlying == that.underlying
+      case _ => false
+    }
+    override def hashCode(): Int = {
+      var result = tag.##
+      result = 31 * result + underlying.##
+      result
+    }
+    override def toString: String = s"OptionSchema($tag, $underlying)"
+
+    def withUnderlying(underlying: Schema[A]): OptionSchema[C, A] =
+      new OptionSchema(tag, underlying)
   }
-  final case class BijectionSchema[A, B](underlying: Schema[A], bijection: Bijection[A, B]) extends Schema[B]{
+  object OptionSchema {
+    def apply[C[_], A](tag: OptionalTag[C], underlying: Schema[A]): OptionSchema[C, A] =
+      new OptionSchema(tag, underlying)
+    def unapply[C[_], A](x: OptionSchema[C, A]): Some[(OptionalTag[C], Schema[A])] =
+      Some((x.tag, x.underlying))
+  }
+
+  final class BijectionSchema[A, B](val underlying: Schema[A], val bijection: Bijection[A, B]) extends Schema[B] {
     def shapeId = underlying.shapeId
     def hints = underlying.hints
+    override def equals(obj: Any): Boolean = obj match {
+      case that: BijectionSchema[_, _] => this.underlying == that.underlying && this.bijection == that.bijection
+      case _ => false
+    }
+    override def hashCode(): Int = {
+      var result = underlying.##
+      result = 31 * result + bijection.##
+      result
+    }
+    override def toString: String = s"BijectionSchema($underlying, $bijection)"
   }
-  final case class RefinementSchema[A, B](underlying: Schema[A], refinement: Refinement[A, B]) extends Schema[B]{
+  object BijectionSchema {
+    def apply[A, B](underlying: Schema[A], bijection: Bijection[A, B]): BijectionSchema[A, B] =
+      new BijectionSchema(underlying, bijection)
+    def unapply[A, B](x: BijectionSchema[A, B]): Some[(Schema[A], Bijection[A, B])] =
+      Some((x.underlying, x.bijection))
+  }
+
+  final class RefinementSchema[A, B](val underlying: Schema[A], val refinement: Refinement[A, B]) extends Schema[B] {
     def shapeId = underlying.shapeId
     def hints = underlying.hints
+    override def equals(obj: Any): Boolean = obj match {
+      case that: RefinementSchema[_, _] => this.underlying == that.underlying && this.refinement == that.refinement
+      case _ => false
+    }
+    override def hashCode(): Int = {
+      var result = underlying.##
+      result = 31 * result + refinement.##
+      result
+    }
+    override def toString: String = s"RefinementSchema($underlying, $refinement)"
   }
-  final case class LazySchema[A](suspend: Lazy[Schema[A]]) extends Schema[A]{
+  object RefinementSchema {
+    def apply[A, B](underlying: Schema[A], refinement: Refinement[A, B]): RefinementSchema[A, B] =
+      new RefinementSchema(underlying, refinement)
+    def unapply[A, B](x: RefinementSchema[A, B]): Some[(Schema[A], Refinement[A, B])] =
+      Some((x.underlying, x.refinement))
+  }
+
+  final class LazySchema[A](val suspend: Lazy[Schema[A]]) extends Schema[A] {
     def shapeId: ShapeId = suspend.value.shapeId
     def hints: Hints = suspend.value.hints
+    override def equals(obj: Any): Boolean = obj match {
+      case that: LazySchema[_] => this.suspend == that.suspend
+      case _ => false
+    }
+    override def hashCode(): Int = suspend.##
+    override def toString: String = s"LazySchema($suspend)"
+  }
+  object LazySchema {
+    def apply[A](suspend: Lazy[Schema[A]]): LazySchema[A] =
+      new LazySchema(suspend)
+    def unapply[A](x: LazySchema[A]): Some[Lazy[Schema[A]]] =
+      Some(x.suspend)
   }
 
   def transformHintsLocallyK(f: Hints => Hints): Schema ~> Schema = new (Schema ~> Schema){
@@ -218,30 +416,30 @@ object Schema {
       case e @ EnumerationSchema(_, _, _, _) => underlying(e)
       case p @ PrimitiveSchema(_, _, _)      => underlying(p)
       case u @ UnionSchema(_, _, _, _) =>
-        underlying(u.copy(alternatives = u.alternatives.map(handleAlt(_))))
-      case BijectionSchema(s, bijection) =>
-        underlying(BijectionSchema(this(s), bijection))
+        underlying(u.withAlternatives(u.alternatives.map(handleAlt(_))))
+      case s: BijectionSchema[_, _] =>
+        underlying(BijectionSchema(this(s.underlying), s.bijection))
       case LazySchema(suspend) =>
         underlying(LazySchema(suspend.map(this.apply)))
-      case RefinementSchema(s, refinement) =>
-        underlying(RefinementSchema(this(s), refinement))
-      case c: CollectionSchema[c, a] =>
-        underlying(c.copy(member = this(c.member)))
+      case s: RefinementSchema[_, _] =>
+        underlying(RefinementSchema(this(s.underlying), s.refinement))
+      case s: CollectionSchema[c, a] =>
+        underlying(s.withMember(this(s.member))): Schema[c[a]]
       case m: MapSchema[c, k, v] =>
-        underlying(m.copy(key = this(m.key), value = this(m.value)))
+        underlying(m.withKeyAndValue(key = this(m.key), value = this(m.value))): Schema[c[k, v]]
       case s @ StructSchema(_, _, _, _) =>
-        underlying(s.copy(fields = s.fields.map(handleField(_))))
+        underlying(s.withFields(s.fields.map(handleField(_))))
       case o: OptionSchema[c, a] =>
-        underlying(o.copy(underlying = this(o.underlying)))
+        underlying(o.withUnderlying(this(o.underlying))): Schema[c[a]]
     }
 
     private def handleField[S, A](
         field: Field[S, A]
-    ): Field[S, A] = field.copy(schema = this(field.schema))
+    ): Field[S, A] = field.withSchema(this(field.schema))
 
     private def handleAlt[S, A](
         alt: Alt[S, A]
-    ): Alt[S, A] = alt.copy(schema = this(alt.schema))
+    ): Alt[S, A] = alt.withSchema(this(alt.schema))
   }
 
   // format: off

--- a/modules/core/src/smithy4s/schema/SchemaPartition.scala
+++ b/modules/core/src/smithy4s/schema/SchemaPartition.scala
@@ -122,15 +122,15 @@ object SchemaPartition {
               }
             }
 
-          case BijectionSchema(underlying, bijection) =>
-            apply(underlying) match {
+          case s: BijectionSchema[_, _] =>
+            apply(s.underlying) match {
               case SchemaPartition.SplittingMatch(matching, notMatching) =>
                 SchemaPartition.SplittingMatch(
-                  matching.biject(_.map(bijection.to))(_.map(bijection.from)),
-                  notMatching.biject(_.map(bijection.to))(_.map(bijection.from))
+                  matching.biject(_.map(s.bijection.to))(_.map(s.bijection.from)),
+                  notMatching.biject(_.map(s.bijection.to))(_.map(s.bijection.from))
                 )
               case SchemaPartition.TotalMatch(total) =>
-                SchemaPartition.TotalMatch(total.biject(bijection))
+                SchemaPartition.TotalMatch(total.biject(s.bijection))
               case SchemaPartition.NoMatch() => SchemaPartition.NoMatch()
             }
           case LazySchema(s) => apply(s.value)

--- a/modules/core/src/smithy4s/schema/SchemaVisitor.scala
+++ b/modules/core/src/smithy4s/schema/SchemaVisitor.scala
@@ -41,8 +41,8 @@ trait SchemaVisitor[F[_]] extends (Schema ~> F) { self =>
     case EnumerationSchema(shapeId, hints, tag, values) => enumeration(shapeId, hints, tag, values)
     case StructSchema(shapeId, hints, fields, make) => struct(shapeId, hints, fields, make)
     case u@UnionSchema(shapeId, hints, alts, _) => union(shapeId, hints, alts, Alt.Dispatcher.fromUnion(u))
-    case BijectionSchema(schema, bijection) => biject(schema, bijection)
-    case RefinementSchema(schema, refinement) => refine(schema, refinement)
+    case s: BijectionSchema[_, _] => biject(s.underlying, s.bijection)
+    case s: RefinementSchema[_, _] => refine(s.underlying, s.refinement)
     case LazySchema(make) => lazily(make)
     case o: OptionSchema[c, a] => option[c,a](o.tag, o.underlying)
   }


### PR DESCRIPTION
I'm not sure we want to go down this road, just posting for the sake of discussion.

If we remove case classes from core, the benefit is basically more flexibility with binary compatibility. Especially for scala 2.12 which does not have the XSource 3 flag.

Cons of this approach:
- Less-good exhaustivity checking on pattern matching
- Worse performance on pattern matching (Scala compiler typically does not use unapply methods for pattern matching on case classes)
- Uglier
- Type inference in pattern matching can be annoying, see PR for some examples

## PR Checklist (not all items are relevant to all PRs)

- [ ] Added unit-tests (for runtime code)
- [ ] Added bootstrapped code + smoke tests (when the rendering logic is modified)
- [ ] Added build-plugins integration tests (when reflection loading is required at codegen-time)
- [ ] Added alloy compliance tests (when simpleRestJson protocol behaviour is expanded/updated)
- [ ] Updated dynamic module to match generated-code behaviour
- [ ] Added documentation
- [ ] Updated changelog
