### PR TITLE
Port effectful client codecs to series/0.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,6 @@ Thank you!
 
 # 0.19.0
 
-## Add effectful `make` overloads to `UnaryClientCompiler` and `UnaryClientEndpoint` in [#1910](https://github.com/disneystreaming/smithy4s/pull/1910)
-
-Add `make` methods to `UnaryClientEndpoint` and `UnaryClientCompiler` that accept an effectful success predicate (`Response => F[Boolean]`) in addition to the existing pure overloads (`Response => Boolean`). This enables protocols where determining success requires inspecting effectful response properties (e.g. HTTP/2 trailers).
-
 ## Binary-Compatible-Friendly Codegen Enabled in Core Module in [#1900](https://github.com/disneystreaming/smithy4s/pull/1900)
 
 Now `alloy` and `smithy` namespaces and sub-namespaces are generated in core with binary-compatible-friendly mode enabled.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Thank you!
 
 # 0.19.0
 
+## Add effectful `make` overloads to `UnaryClientCompiler` and `UnaryClientEndpoint` in [#1910](https://github.com/disneystreaming/smithy4s/pull/1910)
+
+Add `make` methods to `UnaryClientEndpoint` and `UnaryClientCompiler` that accept an effectful success predicate (`Response => F[Boolean]`) in addition to the existing pure overloads (`Response => Boolean`). This enables protocols where determining success requires inspecting effectful response properties (e.g. HTTP/2 trailers).
+
 ## Binary-Compatible-Friendly Codegen Enabled in Core Module in [#1900](https://github.com/disneystreaming/smithy4s/pull/1900)
 
 Now `alloy` and `smithy` namespaces and sub-namespaces are generated in core with binary-compatible-friendly mode enabled.

--- a/modules/core/src/smithy4s/client/UnaryClientCompiler.scala
+++ b/modules/core/src/smithy4s/client/UnaryClientCompiler.scala
@@ -29,6 +29,23 @@ object UnaryClientCompiler {
       middleware: Endpoint.Middleware[Client],
       isSuccessful: Response => Boolean
   )(implicit F: MonadThrowLike[F]): service.FunctorEndpointCompiler[F] =
+    make(
+      service,
+      client,
+      toSmithy4sClient,
+      makeClientCodecs,
+      middleware,
+      (response: Response) => F.pure(isSuccessful(response))
+    )
+
+  def make[Alg[_[_, _, _, _, _]], F[_], Client, Request, Response](
+      service: smithy4s.Service[Alg],
+      client: Client,
+      toSmithy4sClient: Client => UnaryLowLevelClient[F, Request, Response],
+      makeClientCodecs: UnaryClientCodecs.Make[F, Request, Response],
+      middleware: Endpoint.Middleware[Client],
+      isSuccessfulF: Response => F[Boolean]
+  )(implicit F: MonadThrowLike[F]): service.FunctorEndpointCompiler[F] =
     new service.FunctorEndpointCompiler[F] {
       def apply[I, E, O, SI, SO](
           endpoint: service.Endpoint[I, E, O, SI, SO]
@@ -39,10 +56,10 @@ object UnaryClientCompiler {
 
         val adaptedClient = toSmithy4sClient(transformedClient)
 
-        UnaryClientEndpoint(
+        UnaryClientEndpoint.make(
           adaptedClient,
           makeClientCodecs(endpoint.schema),
-          isSuccessful
+          isSuccessfulF
         )
       }
     }

--- a/modules/core/src/smithy4s/client/UnaryClientEndpoint.scala
+++ b/modules/core/src/smithy4s/client/UnaryClientEndpoint.scala
@@ -26,15 +26,25 @@ object UnaryClientEndpoint {
       clientCodecs: UnaryClientCodecs[F, Request, Response, I, E, O],
       isSuccessful: Response => Boolean
   )(implicit F: MonadThrowLike[F]): (I => F[O]) = {
+    make(lowLevelClient, clientCodecs, (response: Response) => F.pure(isSuccessful(response)))
+  }
+
+  def make[F[_], Request, Response, I, E, O, SI, SO](
+      lowLevelClient: UnaryLowLevelClient[F, Request, Response],
+      clientCodecs: UnaryClientCodecs[F, Request, Response, I, E, O],
+      isSuccessfulF: Response => F[Boolean]
+  )(implicit F: MonadThrowLike[F]): (I => F[O]) = {
 
     import clientCodecs._
     def inputToRequest(input: I): F[Request] =
       inputEncoder(input)
 
     def outputFromResponse(response: Response): F[O] =
-      if (isSuccessful(response)) outputDecoder(response)
-      else
-        F.flatMap(errorDecoder(response))(F.raiseError[O](_))
+      F.flatMap(isSuccessfulF(response)) {
+        case true => outputDecoder(response)
+        case false =>
+          F.flatMap(errorDecoder(response))(F.raiseError[O](_))
+      }
 
     (input: I) =>
       F.flatMap(inputToRequest(input)) { request =>


### PR DESCRIPTION
Add 'make' methods to UnaryClientEndpoint and UnaryClientCompiler that accept an effectful success predicate (Response => F[Boolean]) instead of a pure one (Response => Boolean). This enables protocols where determining success requires inspecting effectful response properties (e.g. HTTP/2 trailers).

Port of #1908 to series/0.19