### PR TITLE
Fix smithy4s-protobuf Scala.js dependency resolution

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -832,7 +832,7 @@ lazy val protobuf = projectMatrix
         )
       else
         Seq(
-          "com.thesamet.scalapb" %% "scalapb-runtime" % scalapb.compiler.Version.scalapbVersion
+          "com.thesamet.scalapb" %%% "scalapb-runtime" % scalapb.compiler.Version.scalapbVersion
         )
     },
     Test / fork := virtualAxes.value.contains(VirtualAxis.jvm)


### PR DESCRIPTION
## Summary

Use `%%%` instead of `%%` for `scalapb-runtime` in the non-JVM protobuf dependency branch, so that the Scala.js artifact (`scalapb-runtime_sjs1_3`) is resolved instead of the JVM-only one (`scalapb-runtime_3`), which transitively pulls in `protobuf-java` and breaks the Scala.js linker.

This was introduced in #1821 when the dependency was changed from `protobuf-runtime-scala` to `scalapb-runtime` but the `%%%` operator was accidentally changed to `%%`.

### Before (broken — 0.18.51)

The published POM for `smithy4s-protobuf_sjs1_3` depends on:
- `scalapb-runtime_3` (JVM only)
- `protobuf-java` (JVM only)
- `lenses_3` (JVM only)

### After (fixed)

The published POM depends on:
- `scalapb-runtime_sjs1_3` (Scala.js compatible)

Fixes #1915