### PR TITLE
Render Maven Central in smithy-build.json when present in resolvers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ When adding entries, please treat them as if they could end up in a release any 
 
 Thank you!
 
+# Unreleased / next patch release
+
+- Render Maven Central in smithy-build.json when present in resolvers in [#1933](https://github.com/disneystreaming/smithy4s/pull/1933)
+
 # 0.19.0
 
 ## Binary-Compatible-Friendly Codegen Enabled in Core Module in [#1900](https://github.com/disneystreaming/smithy4s/pull/1900)

--- a/modules/codegen-plugin/src/sbt-test/codegen-plugin/update-lsp-config/expected.json
+++ b/modules/codegen-plugin/src/sbt-test/codegen-plugin/update-lsp-config/expected.json
@@ -11,6 +11,9 @@
         ],
         "repositories" : [
             {
+                "url" : "https://repo1.maven.org/maven2"
+            },
+            {
                 "url" : "https://oss.sonatype.org/content/repositories/snapshots"
             },
             {

--- a/modules/codegen-plugin/src/smithy4s/codegen/GenerateSmithyBuild.scala
+++ b/modules/codegen-plugin/src/smithy4s/codegen/GenerateSmithyBuild.scala
@@ -123,7 +123,7 @@ private[codegen] object GenerateSmithyBuild {
       .foldLeft(ListSet.empty[String])(_ + _)
 
   private val prepareResolvers: PartialFunction[Resolver, String] = {
-    case mr: MavenRepository if !mr.root.contains("repo1.maven.org") => mr.root
+    case mr: MavenRepository => mr.root
   }
 
   private def prepareInputDirs(

--- a/modules/mill-codegen-plugin/src-mill-1/smithy4s/codegen/LSP.scala
+++ b/modules/mill-codegen-plugin/src-mill-1/smithy4s/codegen/LSP.scala
@@ -64,10 +64,7 @@ object LSP extends ExternalModule with LSPCompat {
     val reposTask = Task
       .traverse(effectiveModules)(_.repositoriesTask)
       .map {
-        _.flatten.collect {
-          case r: MavenRepository if !r.root.contains("repo1.maven.org") =>
-            r.root
-        }
+        _.flatten.collect { case r: MavenRepository => r.root }
       }
       .map(s => ListSet(s*))
 

--- a/modules/mill-codegen-plugin/src-mill-shared/smithy4s/codegen/LSP.scala
+++ b/modules/mill-codegen-plugin/src-mill-shared/smithy4s/codegen/LSP.scala
@@ -47,11 +47,7 @@ object LSP extends ExternalModule with LSPCompat {
     val reposTask = Target
       .traverse(s4sModules)(_.repositoriesTask)
       .map {
-        _.flatten
-          .collect {
-            case r: MavenRepository if !r.root.contains("repo1.maven.org") =>
-              r.root
-          }
+        _.flatten.collect { case r: MavenRepository => r.root }
       }
       .map(s => ListSet(s: _*))
 

--- a/modules/mill-codegen-plugin/test/src-mill-0_11/smithy4s/codegen/mill/SmithyLSPConfigSpec.scala
+++ b/modules/mill-codegen-plugin/test/src-mill-0_11/smithy4s/codegen/mill/SmithyLSPConfigSpec.scala
@@ -72,6 +72,7 @@ class SmithyLSPConfigSpec extends munit.FunSuite {
           |       "com.disneystreaming.smithy4s:smithy4s-protocol:${smithy4s.codegen.BuildInfo.version}"
           |    ],
           |    "repositories": [
+          |       { "url": "https://repo1.maven.org/maven2" },
           |       { "url": "https://some.corpo.example.com/artifactory" }
           |    ]
           |  }

--- a/modules/mill-codegen-plugin/test/src-mill-0_12/smithy4s/codegen/mill/SmithyLSPConfigSpec.scala
+++ b/modules/mill-codegen-plugin/test/src-mill-0_12/smithy4s/codegen/mill/SmithyLSPConfigSpec.scala
@@ -70,6 +70,7 @@ class SmithyLSPConfigSpec extends munit.FunSuite {
             |       "com.disneystreaming.smithy4s:smithy4s-protocol:${smithy4s.codegen.BuildInfo.version}"
             |    ],
             |    "repositories": [
+            |       { "url": "https://repo1.maven.org/maven2" },
             |       { "url": "https://some.corpo.example.com/artifactory" }
             |    ]
             |  }

--- a/modules/mill-codegen-plugin/test/src-mill-1/smithy4s/codegen/mill/SmithyLSPConfigSpec.scala
+++ b/modules/mill-codegen-plugin/test/src-mill-1/smithy4s/codegen/mill/SmithyLSPConfigSpec.scala
@@ -74,6 +74,7 @@ class SmithyLSPConfigSpec extends munit.FunSuite {
             |       "com.disneystreaming.smithy4s:smithy4s-protocol:${smithy4s.codegen.BuildInfo.version}"
             |    ],
             |    "repositories": [
+            |       { "url": "https://repo1.maven.org/maven2" },
             |       { "url": "https://some.corpo.example.com/artifactory" }
             |    ]
             |  }


### PR DESCRIPTION
Previously, smithy4sUpdateLSPConfig (sbt) and LSP/updateConfig (mill) explicitly filtered out repo1.maven.org from the rendered repositories. This meant that adding a custom resolver removed the Maven Central fallback that smithy-cli would otherwise use, since populating the list disables the default.

Now Maven Central is rendered when it's present in the resolver list, and omitted when the user has deliberately removed it.

Fixes #1631

## PR Checklist (not all items are relevant to all PRs)

- [ ] Added unit-tests (for runtime code)
- [ ] Added bootstrapped code + smoke tests (when the rendering logic is modified)
- [ ] Added build-plugins integration tests (when reflection loading is required at codegen-time)
- [ ] Added alloy compliance tests (when simpleRestJson protocol behaviour is expanded/updated)
- [ ] Updated dynamic module to match generated-code behaviour
- [ ] Added documentation
- [ ] Updated changelog
