### PR TITLE
0.19: fix scalapb-runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Thank you!
 
 - Add documentation for `UrlForm` serialization in [#1929](https://github.com/disneystreaming/smithy4s/pull/1929)
 - smithy4s-cats: provide transformations for EitherT in [#1932](https://github.com/disneystreaming/smithy4s/pull/1932)
+- Fix `scalapb-runtime` dependency in [#1945](https://github.com/disneystreaming/smithy4s/pull/1945)
 
 # 0.19.3
 

--- a/build.sbt
+++ b/build.sbt
@@ -854,7 +854,7 @@ lazy val protobuf = projectMatrix
         )
       else
         Seq(
-          "com.thesamet.scalapb" %% "scalapb-runtime" % scalapb.compiler.Version.scalapbVersion
+          "com.thesamet.scalapb" %%% "scalapb-runtime" % scalapb.compiler.Version.scalapbVersion
         )
     },
     Test / fork := virtualAxes.value.contains(VirtualAxis.jvm)


### PR DESCRIPTION
port #1923 - it slipped by in https://github.com/disneystreaming/smithy4s/pull/1914/changes/c7bcb95d3fc90e60659da22e18cfb976441f6729 . Apparently there were two `scalapb-runtime` deps, and each version got a different one fixed 😅 

this one is the one that matters, in `protobuf` (the other one, missing on 0.18, is in `bootstrapped` - not a big issue since `bootstrapped` isn't being published).

I can confirm this fixes linking issues in https://github.com/kubukoz/smithy-transcoder/pull/92

## PR Checklist (not all items are relevant to all PRs)

i'm not doing all that