### PR TITLE
0.19.4: changelog + bump GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,18 +53,18 @@ jobs:
       BUILD_KEY: ${{matrix.scalaVersion}}_${{matrix.scalaPlatform}}
     steps:
       - name: Checkout current branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ env.CHECKOUT_REF }}
 
       - name: Cache
-        uses: coursier/cache-action@v6
+        uses: coursier/cache-action@v8
         with:
           extraKey: ${{ env.BUILD_KEY }}
 
       - name: Setup Java and Scala
-        uses: coursier/setup-action@v1
+        uses: coursier/setup-action@v3
         with:
           jvm: temurin:1.17
           apps: sbt scala-cli
@@ -87,7 +87,7 @@ jobs:
           echo "Built $(cat version)"
 
       - name: Upload compilation cache
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: compilation-${{env.BUILD_KEY}}.zip
           path: /tmp/remote-cache
@@ -112,18 +112,18 @@ jobs:
       BUILD_KEY: ${{matrix.scalaVersion}}_${{matrix.scalaPlatform}}
     steps:
       - name: Checkout current branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ env.CHECKOUT_REF }}
 
       - name: Cache
-        uses: coursier/cache-action@v6
+        uses: coursier/cache-action@v8
         with:
           extraKey: ${{ env.BUILD_KEY }}
 
       - name: Setup Java and Scala
-        uses: coursier/setup-action@v1
+        uses: coursier/setup-action@v3
         with:
           jvm: temurin:1.17
           apps: sbt scala-cli
@@ -132,7 +132,7 @@ jobs:
         uses: sbt/setup-sbt@v1
 
       - name: Download compilation cache
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: compilation-${{env.BUILD_KEY}}.zip
           path: /tmp/remote-cache
@@ -155,18 +155,18 @@ jobs:
       BUILD_KEY: ${{matrix.scalaVersion}}_jvm
     steps:
       - name: Checkout current branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ env.CHECKOUT_REF }}
 
       - name: Cache
-        uses: coursier/cache-action@v6
+        uses: coursier/cache-action@v8
         with:
           extraKey: ${{ env.BUILD_KEY }}
 
       - name: Setup Java and Scala
-        uses: coursier/setup-action@v1
+        uses: coursier/setup-action@v3
         with:
           jvm: temurin:1.17
           apps: sbt
@@ -175,7 +175,7 @@ jobs:
         uses: sbt/setup-sbt@v1
 
       - name: Download compilation cache
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: compilation-${{env.BUILD_KEY}}.zip
           path: /tmp/remote-cache
@@ -188,18 +188,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout current branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ env.CHECKOUT_REF }}
 
       - name: Cache
-        uses: coursier/cache-action@v6
+        uses: coursier/cache-action@v8
         with:
           extraKey: checks
 
       - name: Setup Java and Scala
-        uses: coursier/setup-action@v1
+        uses: coursier/setup-action@v3
         with:
           jvm: temurin:1.17
           apps: sbt
@@ -220,18 +220,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout current branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ env.CHECKOUT_REF }}
 
       - name: Cache
-        uses: coursier/cache-action@v6
+        uses: coursier/cache-action@v8
         with:
           extraKey: docs
 
       - name: Setup Java and Scala
-        uses: coursier/setup-action@v1
+        uses: coursier/setup-action@v3
         with:
           jvm: temurin:1.17
           apps: sbt
@@ -240,7 +240,7 @@ jobs:
         uses: sbt/setup-sbt@v1
 
       - name: Download compilation cache (2_13_jvm)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: compilation-2_13_jvm.zip
           path: /tmp/remote-cache
@@ -258,7 +258,7 @@ jobs:
       tests: ${{ steps.list.outputs.tests }}
     steps:
       - name: Checkout current branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ env.CHECKOUT_REF }}
@@ -280,18 +280,18 @@ jobs:
         test: ${{ fromJSON(needs.sbt-plugin-discover.outputs.tests) }}
     steps:
       - name: Checkout current branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ env.CHECKOUT_REF }}
 
       - name: Cache
-        uses: coursier/cache-action@v6
+        uses: coursier/cache-action@v8
         with:
           extraKey: sbt-plugin
 
       - name: Setup Java and Scala
-        uses: coursier/setup-action@v1
+        uses: coursier/setup-action@v3
         with:
           jvm: temurin:1.17
           apps: sbt
@@ -300,7 +300,7 @@ jobs:
         uses: sbt/setup-sbt@v1
 
       - name: Download compilation cache (jvm)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: compilation-*_jvm.zip
           path: /tmp/remote-cache
@@ -321,18 +321,18 @@ jobs:
         project: ["millCodegenPlugin0_11", "millCodegenPlugin0_12", "millCodegenPlugin13"]
     steps:
       - name: Checkout current branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ env.CHECKOUT_REF }}
 
       - name: Cache
-        uses: coursier/cache-action@v6
+        uses: coursier/cache-action@v8
         with:
           extraKey: mill-plugin
 
       - name: Setup Java and Scala
-        uses: coursier/setup-action@v1
+        uses: coursier/setup-action@v3
         with:
           jvm: temurin:1.17
           apps: sbt
@@ -341,13 +341,13 @@ jobs:
         uses: sbt/setup-sbt@v1
 
       - name: Download compilation cache (2_13_jvm)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: compilation-2_13_jvm.zip
           path: /tmp/remote-cache/2_13_jvm
 
       - name: Download compilation cache (3_0_jvm)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: compilation-3_0_jvm.zip
           path: /tmp/remote-cache/3_0_jvm
@@ -409,13 +409,13 @@ jobs:
       BUILD_KEY: ${{matrix.scalaVersion}}_${{matrix.scalaPlatform}}
     steps:
       - name: Checkout current branch (full)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ env.CHECKOUT_REF }}
 
       - name: Setup Java and Scala
-        uses: coursier/setup-action@v1
+        uses: coursier/setup-action@v3
         with:
           jvm: temurin:1.17
           apps: sbt
@@ -424,12 +424,12 @@ jobs:
         uses: sbt/setup-sbt@v1
 
       - name: Cache
-        uses: coursier/cache-action@v6
+        uses: coursier/cache-action@v8
         with:
           extraKey: ${{ env.BUILD_KEY }}
 
       - name: Download compilation cache
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: compilation-${{env.BUILD_KEY}}.zip
           path: /tmp/remote-cache
@@ -457,7 +457,7 @@ jobs:
 
       - name: Upload signed staging slice
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: sona-staging-${{env.BUILD_KEY}}
           path: target/sona-staging
@@ -471,13 +471,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout current branch (full)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ env.CHECKOUT_REF }}
 
       - name: Setup Java and Scala
-        uses: coursier/setup-action@v1
+        uses: coursier/setup-action@v3
         with:
           jvm: temurin:1.17
           apps: sbt
@@ -486,12 +486,12 @@ jobs:
         uses: sbt/setup-sbt@v1
 
       - name: Cache
-        uses: coursier/cache-action@v6
+        uses: coursier/cache-action@v8
         with:
           extraKey: release-bundle
 
       - name: Download per-shard staging slices
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: sona-staging-*
           path: /tmp/staging
@@ -521,13 +521,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout current branch (full)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ env.CHECKOUT_REF }}
 
       - name: Setup Java and Scala
-        uses: coursier/setup-action@v1
+        uses: coursier/setup-action@v3
         with:
           jvm: temurin:1.17
           apps: sbt
@@ -536,7 +536,7 @@ jobs:
         uses: sbt/setup-sbt@v1
 
       - name: Cache
-        uses: coursier/cache-action@v6
+        uses: coursier/cache-action@v8
 
       - name: Resolve latest smithy4s-core version
         # export the version only when we trigger publish manually

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ When adding entries, please treat them as if they could end up in a release any 
 
 Thank you!
 
-# Unreleased / next patch
+# 0.19.4
 
 - Add documentation for `UrlForm` serialization in [#1929](https://github.com/disneystreaming/smithy4s/pull/1929)
 - smithy4s-cats: provide transformations for EitherT in [#1932](https://github.com/disneystreaming/smithy4s/pull/1932)


### PR DESCRIPTION
## Summary
- Update changelog for 0.19.4
- Bump GitHub Actions to latest major versions:
  - `actions/checkout` v4 → v6
  - `actions/upload-artifact` v4 → v7
  - `actions/download-artifact` v4 → v8
  - `coursier/setup-action` v1 → v3
  - `coursier/cache-action` v6 → v8