### PR TITLE
CI: split compile/test/mima/checks/docs/plugins/release into parallel jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -384,12 +384,90 @@ jobs:
           fi
 
   release:
-    name: Release
+    name: Release ${{matrix.scalaVersion}} (${{matrix.scalaPlatform}})
     needs: compile
     if:
       startsWith(github.ref, 'refs/tags/v') ||
       github.event.inputs.publishSnapshot == 'true' ||
       github.event_name == 'schedule'
+    strategy:
+      # don't cancel the matrix on first failure: for snapshots we want every
+      # shard to land independently, and for stable releases we'd rather the
+      # aggregator skip than half the bundle silently disappear
+      fail-fast: false
+      matrix:
+        scalaVersion: ["2_12", "2_13", "3_0"]
+        scalaPlatform: ["jvm", "js"]
+        exclude:
+          - scalaVersion: "2_12"
+            scalaPlatform: "js"
+        include:
+          - scalaVersion: "3_0"
+            scalaPlatform: "native"
+    runs-on: ubuntu-latest
+    env:
+      BUILD_KEY: ${{matrix.scalaVersion}}_${{matrix.scalaPlatform}}
+    steps:
+      - name: Checkout current branch (full)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ env.CHECKOUT_REF }}
+
+      - name: Setup Java and Scala
+        uses: coursier/setup-action@v1
+        with:
+          jvm: temurin:1.17
+          apps: sbt
+
+      - name: Setup sbt
+        uses: sbt/setup-sbt@v1
+
+      - name: Cache
+        uses: coursier/cache-action@v6
+        with:
+          extraKey: ${{ env.BUILD_KEY }}
+
+      - name: Download compilation cache
+        uses: actions/download-artifact@v4
+        with:
+          name: compilation-${{env.BUILD_KEY}}.zip
+          path: /tmp/remote-cache
+
+      - name: Publish ${{ github.ref }} (${{env.BUILD_KEY}})
+        run: sbt "show version; pullRemoteCache_$BUILD_KEY; ci-release"
+        env:
+          # cleaning will removed generated code from bootstrapped module which will
+          # cause the repo to be dirty and change the version to a -SNAPSHOT version
+          CI_CLEAN: ""
+          # Override what ci-release runs so each shard only publishes its own
+          # (scala, platform) slice. CI_RELEASE replaces "+publishSigned" for
+          # stable releases; CI_SNAPSHOT_RELEASE replaces "+publish" for snapshots.
+          # For snapshots, that publishes straight to central-snapshots — done.
+          # For stable releases, publishSigned_<shard> writes signed artifacts
+          # into target/sona-staging/, which the aggregator job collects and
+          # releases as one bundle via sonaRelease. Skip the per-shard release.
+          CI_RELEASE: publishSigned_${{env.BUILD_KEY}}
+          CI_SNAPSHOT_RELEASE: publish_${{env.BUILD_KEY}}
+          CI_SONATYPE_RELEASE: version
+          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
+          PGP_SECRET: ${{ secrets.PGP_SECRET }}
+          SONATYPE_PASSWORD: ${{ secrets.CENTRAL_SONATYPE_PASSWORD }}
+          SONATYPE_USERNAME: ${{ secrets.CENTRAL_SONATYPE_USERNAME }}
+
+      - name: Upload signed staging slice
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: actions/upload-artifact@v4
+        with:
+          name: sona-staging-${{env.BUILD_KEY}}
+          path: target/sona-staging
+          retention-days: 1
+          if-no-files-found: error
+
+  release-bundle:
+    name: Release bundle (aggregate)
+    needs: release
+    if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout current branch (full)
@@ -409,24 +487,29 @@ jobs:
 
       - name: Cache
         uses: coursier/cache-action@v6
+        with:
+          extraKey: release-bundle
 
-      - name: Download compilation caches
+      - name: Download per-shard staging slices
         uses: actions/download-artifact@v4
         with:
-          pattern: compilation-*.zip
-          path: /tmp/remote-cache
+          pattern: sona-staging-*
+          path: /tmp/staging
 
-      - name: Merge compilation caches
-        run: cd /tmp/remote-cache && (ls | xargs -I {} sh -c 'cp -r {}/* .')
+      - name: Merge into one staging tree
+        # Each shard's artifact unpacks to /tmp/staging/sona-staging-<key>/<contents>.
+        # Merge them into a single tree at target/sona-staging/.
+        run: |
+          mkdir -p target/sona-staging
+          for d in /tmp/staging/sona-staging-*; do
+            cp -r "$d"/. target/sona-staging/
+          done
+          echo "Merged staging tree:"
+          find target/sona-staging -maxdepth 4 -type d
 
-      - name: Publish ${{ github.ref }}
-        run: sbt 'show version; pullRemoteCache_2_12_jvm; pullRemoteCache_2_13_jvm; pullRemoteCache_3_0_jvm; pullRemoteCache_2_13_js; pullRemoteCache_3_0_js; pullRemoteCache_3_0_native; ci-release'
+      - name: Release bundle
+        run: sbt "show version; sonaRelease"
         env:
-          # cleaning will removed generated code from bootstrapped module which will
-          # cause the repo to be dirty and change the version to a -SNAPSHOT version
-          CI_CLEAN: ""
-          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
-          PGP_SECRET: ${{ secrets.PGP_SECRET }}
           SONATYPE_PASSWORD: ${{ secrets.CENTRAL_SONATYPE_PASSWORD }}
           SONATYPE_USERNAME: ${{ secrets.CENTRAL_SONATYPE_USERNAME }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -312,9 +312,13 @@ jobs:
         run: sbt pullRemoteCache_2_12_jvm pullRemoteCache_2_13_jvm pullRemoteCache_3_0_jvm "scripted codegen-plugin/${{ matrix.test }}"
 
   mill-plugin:
-    name: mill plugin tests
+    name: mill plugin (${{ matrix.project }})
     needs: compile
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        project: ["millCodegenPlugin0_11", "millCodegenPlugin0_12", "millCodegenPlugin13"]
     steps:
       - name: Checkout current branch
         uses: actions/checkout@v4
@@ -351,8 +355,8 @@ jobs:
       - name: Merge compilation caches
         run: cd /tmp/remote-cache && (ls | xargs -I {} sh -c 'cp -r {}/* .')
 
-      - name: Run mill plugin tests
-        run: sbt pullRemoteCache_2_13_jvm pullRemoteCache_3_0_jvm millCodegenPlugin0_11/test millCodegenPlugin0_12/test millCodegenPlugin13/test
+      - name: Run mill plugin tests (${{ matrix.project }})
+        run: sbt pullRemoteCache_2_13_jvm pullRemoteCache_3_0_jvm ${{ matrix.project }}/test
 
   build-success-checkpoint:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -410,8 +410,17 @@ jobs:
       - name: Cache
         uses: coursier/cache-action@v6
 
+      - name: Download compilation caches
+        uses: actions/download-artifact@v4
+        with:
+          pattern: compilation-*.zip
+          path: /tmp/remote-cache
+
+      - name: Merge compilation caches
+        run: cd /tmp/remote-cache && (ls | xargs -I {} sh -c 'cp -r {}/* .')
+
       - name: Publish ${{ github.ref }}
-        run: sbt 'show version; ci-release'
+        run: sbt 'show version; pullRemoteCache_2_12_jvm; pullRemoteCache_2_13_jvm; pullRemoteCache_3_0_jvm; pullRemoteCache_2_13_js; pullRemoteCache_3_0_js; pullRemoteCache_3_0_native; ci-release'
         env:
           # cleaning will removed generated code from bootstrapped module which will
           # cause the repo to be dirty and change the version to a -SNAPSHOT version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,8 +34,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
-    name: Test ${{matrix.scalaVersion}} (${{matrix.scalaPlatform}})
+  compile:
+    name: Compile ${{matrix.scalaVersion}} (${{matrix.scalaPlatform}})
     strategy:
       fail-fast: true
       matrix:
@@ -72,26 +72,13 @@ jobs:
       - name: Setup sbt
         uses: sbt/setup-sbt@v1
 
-      - name: Run tests
+      - name: Compile
         # cs fetch is only needed to work around the following issue https://github.com/VirtusLab/scala-cli/issues/4108
         run: |
           cs fetch --no-default -r central ch.epfl.scala::bloop-frontend:2.0.17
-          sbt test_$BUILD_KEY \
+          sbt compile_$BUILD_KEY \
+              testCompile_$BUILD_KEY \
               pushRemoteCache_$BUILD_KEY
-
-      - name: Run plugin tests
-        if: matrix.scalaVersion == '2_12' && matrix.scalaPlatform == 'jvm'
-        run: |
-          sbt scripted
-
-      - name: Run checks
-        if: matrix.scalaVersion == '2_13' && matrix.scalaPlatform == 'jvm'
-        run: |
-          sbt scalafmtCheckAll \
-              headerCheck \
-              "docsRendering/mdoc" \
-              "scalafixAll --check"
-          (cd ./modules/website && yarn && yarn swizzle docusaurus-lunr-search SearchBar --danger --wrap && yarn build)
 
       - name: Check for untracked changes
         run: |
@@ -99,26 +86,243 @@ jobs:
           ./scripts/check-dirty.sh
           echo "Built $(cat version)"
 
-      - name: Check for Binary Compatibility
-        if: matrix.scalaPlatform == 'jvm'
-        run: sbt mimaReportBinaryIssuesIfRelevant_$BUILD_KEY
-
       - name: Upload compilation cache
         uses: actions/upload-artifact@v4
         with:
           name: compilation-${{env.BUILD_KEY}}.zip
           path: /tmp/remote-cache
+          retention-days: 3
+
+  test:
+    name: Test ${{matrix.scalaVersion}} (${{matrix.scalaPlatform}})
+    needs: compile
+    strategy:
+      fail-fast: true
+      matrix:
+        scalaVersion: ["2_12", "2_13", "3_0"]
+        scalaPlatform: ["jvm", "js"]
+        exclude:
+          - scalaVersion: "2_12"
+            scalaPlatform: "js"
+        include:
+          - scalaVersion: "3_0"
+            scalaPlatform: "native"
+    runs-on: ubuntu-latest
+    env:
+      BUILD_KEY: ${{matrix.scalaVersion}}_${{matrix.scalaPlatform}}
+    steps:
+      - name: Checkout current branch
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ env.CHECKOUT_REF }}
+
+      - name: Cache
+        uses: coursier/cache-action@v6
+        with:
+          extraKey: ${{ env.BUILD_KEY }}
+
+      - name: Setup Java and Scala
+        uses: coursier/setup-action@v1
+        with:
+          jvm: temurin:1.17
+          apps: sbt scala-cli
+
+      - name: Setup sbt
+        uses: sbt/setup-sbt@v1
+
+      - name: Download compilation cache
+        uses: actions/download-artifact@v4
+        with:
+          name: compilation-${{env.BUILD_KEY}}.zip
+          path: /tmp/remote-cache
+
+      - name: Run tests
+        run: |
+          cs fetch --no-default -r central ch.epfl.scala::bloop-frontend:2.0.17
+          sbt pullRemoteCache_$BUILD_KEY \
+              test_$BUILD_KEY
+
+  mima:
+    name: MiMa ${{matrix.scalaVersion}} (jvm)
+    needs: compile
+    strategy:
+      fail-fast: true
+      matrix:
+        scalaVersion: ["2_12", "2_13", "3_0"]
+    runs-on: ubuntu-latest
+    env:
+      BUILD_KEY: ${{matrix.scalaVersion}}_jvm
+    steps:
+      - name: Checkout current branch
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ env.CHECKOUT_REF }}
+
+      - name: Cache
+        uses: coursier/cache-action@v6
+        with:
+          extraKey: ${{ env.BUILD_KEY }}
+
+      - name: Setup Java and Scala
+        uses: coursier/setup-action@v1
+        with:
+          jvm: temurin:1.17
+          apps: sbt
+
+      - name: Setup sbt
+        uses: sbt/setup-sbt@v1
+
+      - name: Download compilation cache
+        uses: actions/download-artifact@v4
+        with:
+          name: compilation-${{env.BUILD_KEY}}.zip
+          path: /tmp/remote-cache
+
+      - name: Check for Binary Compatibility
+        run: sbt pullRemoteCache_$BUILD_KEY mimaReportBinaryIssuesIfRelevant_$BUILD_KEY
+
+  checks:
+    name: Checks (scalafmt, scalafix, headers)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout current branch
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ env.CHECKOUT_REF }}
+
+      - name: Cache
+        uses: coursier/cache-action@v6
+        with:
+          extraKey: checks
+
+      - name: Setup Java and Scala
+        uses: coursier/setup-action@v1
+        with:
+          jvm: temurin:1.17
+          apps: sbt
+
+      - name: Setup sbt
+        uses: sbt/setup-sbt@v1
+
+      - name: Run formatter and linters
+        run: |
+          sbt scalafmtCheckAll \
+              headerCheck \
+              "scalafixAll --check"
+
+  docs:
+    name: Docs (mdoc + website)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout current branch
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ env.CHECKOUT_REF }}
+
+      - name: Cache
+        uses: coursier/cache-action@v6
+        with:
+          extraKey: docs
+
+      - name: Setup Java and Scala
+        uses: coursier/setup-action@v1
+        with:
+          jvm: temurin:1.17
+          apps: sbt
+
+      - name: Setup sbt
+        uses: sbt/setup-sbt@v1
+
+      - name: Render mdoc
+        run: sbt "docsRendering/mdoc"
+
+      - name: Build website
+        run: cd ./modules/website && yarn && yarn swizzle docusaurus-lunr-search SearchBar --danger --wrap && yarn build
+
+  sbt-plugin:
+    name: sbt plugin (scripted)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout current branch
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ env.CHECKOUT_REF }}
+
+      - name: Cache
+        uses: coursier/cache-action@v6
+        with:
+          extraKey: sbt-plugin
+
+      - name: Setup Java and Scala
+        uses: coursier/setup-action@v1
+        with:
+          jvm: temurin:1.17
+          apps: sbt
+
+      - name: Setup sbt
+        uses: sbt/setup-sbt@v1
+
+      - name: Run scripted
+        run: sbt scripted
+
+  mill-plugin:
+    name: mill plugin tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout current branch
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ env.CHECKOUT_REF }}
+
+      - name: Cache
+        uses: coursier/cache-action@v6
+        with:
+          extraKey: mill-plugin
+
+      - name: Setup Java and Scala
+        uses: coursier/setup-action@v1
+        with:
+          jvm: temurin:1.17
+          apps: sbt
+
+      - name: Setup sbt
+        uses: sbt/setup-sbt@v1
+
+      - name: Run mill plugin tests
+        run: sbt millCodegenPlugin/test
 
   build-success-checkpoint:
     runs-on: ubuntu-latest
-    needs: build
+    needs: [compile, test, mima, checks, docs, sbt-plugin, mill-plugin]
     steps:
       - name: Build matrix completed
-        run: echo "Build result is a ${{ needs.build.result }}"
+        run: |
+          echo "compile     = ${{ needs.compile.result }}"
+          echo "test        = ${{ needs.test.result }}"
+          echo "mima        = ${{ needs.mima.result }}"
+          echo "checks      = ${{ needs.checks.result }}"
+          echo "docs        = ${{ needs.docs.result }}"
+          echo "sbt-plugin  = ${{ needs.sbt-plugin.result }}"
+          echo "mill-plugin = ${{ needs.mill-plugin.result }}"
+          if [[ "${{ needs.compile.result }}" != "success" \
+             || "${{ needs.test.result }}" != "success" \
+             || "${{ needs.mima.result }}" != "success" \
+             || "${{ needs.checks.result }}" != "success" \
+             || "${{ needs.docs.result }}" != "success" \
+             || "${{ needs.sbt-plugin.result }}" != "success" \
+             || "${{ needs.mill-plugin.result }}" != "success" ]]; then
+            exit 1
+          fi
 
   release:
     name: Release
-    needs: build
+    needs: compile
     if:
       startsWith(github.ref, 'refs/tags/v') ||
       github.event.inputs.publishSnapshot == 'true' ||

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -328,7 +328,7 @@ jobs:
         run: cd /tmp/remote-cache && (ls | xargs -I {} sh -c 'cp -r {}/* .')
 
       - name: Run mill plugin tests
-        run: sbt pullRemoteCache_2_13_jvm pullRemoteCache_3_0_jvm millCodegenPlugin/test
+        run: sbt pullRemoteCache_2_13_jvm pullRemoteCache_3_0_jvm millCodegenPlugin0_11/test millCodegenPlugin0_12/test millCodegenPlugin13/test
 
   build-success-checkpoint:
     runs-on: ubuntu-latest
@@ -379,14 +379,6 @@ jobs:
 
       - name: Cache
         uses: coursier/cache-action@v6
-
-      - name: Download compilation cache
-        uses: actions/download-artifact@v4
-        with:
-          path: /tmp/remote-cache
-
-      - name: Unpack compilation cache
-        run: cd /tmp/remote-cache && (ls | xargs -I {} sh -c 'cp -r {}/* .')
 
       - name: Publish ${{ github.ref }}
         run: sbt 'show version; ci-release'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,7 +211,8 @@ jobs:
         run: |
           sbt scalafmtCheckAll \
               headerCheck \
-              "scalafixAll --check"
+              scalafix_2_13_jvm \
+              scalafixTests_2_13_jvm
 
   docs:
     name: Docs (mdoc + website)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,6 +215,7 @@ jobs:
 
   docs:
     name: Docs (mdoc + website)
+    needs: compile
     runs-on: ubuntu-latest
     steps:
       - name: Checkout current branch
@@ -237,14 +238,21 @@ jobs:
       - name: Setup sbt
         uses: sbt/setup-sbt@v1
 
+      - name: Download compilation cache (2_13_jvm)
+        uses: actions/download-artifact@v4
+        with:
+          name: compilation-2_13_jvm.zip
+          path: /tmp/remote-cache
+
       - name: Render mdoc
-        run: sbt "docsRendering/mdoc"
+        run: sbt pullRemoteCache_2_13_jvm "docsRendering/mdoc"
 
       - name: Build website
         run: cd ./modules/website && yarn && yarn swizzle docusaurus-lunr-search SearchBar --danger --wrap && yarn build
 
   sbt-plugin:
     name: sbt plugin (scripted)
+    needs: compile
     runs-on: ubuntu-latest
     steps:
       - name: Checkout current branch
@@ -267,11 +275,21 @@ jobs:
       - name: Setup sbt
         uses: sbt/setup-sbt@v1
 
+      - name: Download compilation cache (jvm)
+        uses: actions/download-artifact@v4
+        with:
+          pattern: compilation-*_jvm.zip
+          path: /tmp/remote-cache
+
+      - name: Merge compilation caches
+        run: cd /tmp/remote-cache && (ls | xargs -I {} sh -c 'cp -r {}/* .')
+
       - name: Run scripted
-        run: sbt scripted
+        run: sbt pullRemoteCache_2_12_jvm pullRemoteCache_2_13_jvm pullRemoteCache_3_0_jvm scripted
 
   mill-plugin:
     name: mill plugin tests
+    needs: compile
     runs-on: ubuntu-latest
     steps:
       - name: Checkout current branch
@@ -294,8 +312,23 @@ jobs:
       - name: Setup sbt
         uses: sbt/setup-sbt@v1
 
+      - name: Download compilation cache (2_13_jvm)
+        uses: actions/download-artifact@v4
+        with:
+          name: compilation-2_13_jvm.zip
+          path: /tmp/remote-cache/2_13_jvm
+
+      - name: Download compilation cache (3_0_jvm)
+        uses: actions/download-artifact@v4
+        with:
+          name: compilation-3_0_jvm.zip
+          path: /tmp/remote-cache/3_0_jvm
+
+      - name: Merge compilation caches
+        run: cd /tmp/remote-cache && (ls | xargs -I {} sh -c 'cp -r {}/* .')
+
       - name: Run mill plugin tests
-        run: sbt millCodegenPlugin/test
+        run: sbt pullRemoteCache_2_13_jvm pullRemoteCache_3_0_jvm millCodegenPlugin/test
 
   build-success-checkpoint:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -250,10 +250,33 @@ jobs:
       - name: Build website
         run: cd ./modules/website && yarn && yarn swizzle docusaurus-lunr-search SearchBar --danger --wrap && yarn build
 
-  sbt-plugin:
-    name: sbt plugin (scripted)
-    needs: compile
+  sbt-plugin-discover:
+    name: sbt plugin (discover scripted tests)
     runs-on: ubuntu-latest
+    outputs:
+      tests: ${{ steps.list.outputs.tests }}
+    steps:
+      - name: Checkout current branch
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ env.CHECKOUT_REF }}
+
+      - name: List scripted test folders
+        id: list
+        run: |
+          tests=$(ls modules/codegen-plugin/src/sbt-test/codegen-plugin | jq -R . | jq -sc .)
+          echo "tests=$tests" >> "$GITHUB_OUTPUT"
+          echo "Discovered: $tests"
+
+  sbt-plugin:
+    name: sbt plugin (${{ matrix.test }})
+    needs: [compile, sbt-plugin-discover]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        test: ${{ fromJSON(needs.sbt-plugin-discover.outputs.tests) }}
     steps:
       - name: Checkout current branch
         uses: actions/checkout@v4
@@ -284,8 +307,8 @@ jobs:
       - name: Merge compilation caches
         run: cd /tmp/remote-cache && (ls | xargs -I {} sh -c 'cp -r {}/* .')
 
-      - name: Run scripted
-        run: sbt pullRemoteCache_2_12_jvm pullRemoteCache_2_13_jvm pullRemoteCache_3_0_jvm scripted
+      - name: Run scripted (${{ matrix.test }})
+        run: sbt pullRemoteCache_2_12_jvm pullRemoteCache_2_13_jvm pullRemoteCache_3_0_jvm "scripted codegen-plugin/${{ matrix.test }}"
 
   mill-plugin:
     name: mill plugin tests
@@ -332,22 +355,24 @@ jobs:
 
   build-success-checkpoint:
     runs-on: ubuntu-latest
-    needs: [compile, test, mima, checks, docs, sbt-plugin, mill-plugin]
+    needs: [compile, test, mima, checks, docs, sbt-plugin-discover, sbt-plugin, mill-plugin]
     steps:
       - name: Build matrix completed
         run: |
-          echo "compile     = ${{ needs.compile.result }}"
-          echo "test        = ${{ needs.test.result }}"
-          echo "mima        = ${{ needs.mima.result }}"
-          echo "checks      = ${{ needs.checks.result }}"
-          echo "docs        = ${{ needs.docs.result }}"
-          echo "sbt-plugin  = ${{ needs.sbt-plugin.result }}"
-          echo "mill-plugin = ${{ needs.mill-plugin.result }}"
+          echo "compile             = ${{ needs.compile.result }}"
+          echo "test                = ${{ needs.test.result }}"
+          echo "mima                = ${{ needs.mima.result }}"
+          echo "checks              = ${{ needs.checks.result }}"
+          echo "docs                = ${{ needs.docs.result }}"
+          echo "sbt-plugin-discover = ${{ needs.sbt-plugin-discover.result }}"
+          echo "sbt-plugin          = ${{ needs.sbt-plugin.result }}"
+          echo "mill-plugin         = ${{ needs.mill-plugin.result }}"
           if [[ "${{ needs.compile.result }}" != "success" \
              || "${{ needs.test.result }}" != "success" \
              || "${{ needs.mima.result }}" != "success" \
              || "${{ needs.checks.result }}" != "success" \
              || "${{ needs.docs.result }}" != "success" \
+             || "${{ needs.sbt-plugin-discover.result }}" != "success" \
              || "${{ needs.sbt-plugin.result }}" != "success" \
              || "${{ needs.mill-plugin.result }}" != "success" ]]; then
             exit 1

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -1,0 +1,56 @@
+name: Cleanup CI artifacts
+
+on:
+  pull_request:
+    types: [closed]
+  workflow_dispatch:
+
+jobs:
+  delete-pr-artifacts:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: Delete compilation artifacts from this PR's CI runs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          # Find CI runs for the PR head and delete their compilation-* artifacts.
+          run_ids=$(gh api --paginate \
+            "repos/$REPO/actions/runs?head_sha=$PR_HEAD_SHA" \
+            --jq '.workflow_runs[].id')
+          for run_id in $run_ids; do
+            gh api --paginate "repos/$REPO/actions/runs/$run_id/artifacts" \
+              --jq '.artifacts[] | select(.name | startswith("compilation-")) | .id' \
+              | while read -r artifact_id; do
+                  echo "Deleting artifact $artifact_id from run $run_id"
+                  gh api -X DELETE "repos/$REPO/actions/artifacts/$artifact_id" || true
+                done
+          done
+
+  delete-old-compilation-artifacts:
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: Delete compilation-* artifacts older than 1 day
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          cutoff=$(date -u -d '1 day ago' +%s 2>/dev/null || date -u -v-1d +%s)
+          gh api --paginate "repos/$REPO/actions/artifacts" \
+            --jq '.artifacts[] | select(.name | startswith("compilation-")) | "\(.id) \(.created_at)"' \
+            | while read -r id created; do
+                created_ts=$(date -u -d "$created" +%s 2>/dev/null || date -u -j -f "%Y-%m-%dT%H:%M:%SZ" "$created" +%s)
+                if [ "$created_ts" -lt "$cutoff" ]; then
+                  echo "Deleting artifact $id (created $created)"
+                  gh api -X DELETE "repos/$REPO/actions/artifacts/$id" || true
+                fi
+              done

--- a/project/Smithy4sBuildPlugin.scala
+++ b/project/Smithy4sBuildPlugin.scala
@@ -123,6 +123,22 @@ case class MillCustomRow(mv: String) extends CustomRow {
 
 }
 
+// Companion plugin that only attaches where ScalafixPlugin is loaded. Defines
+// scalafixCheck so it can be invoked per-project without sbt parsing `--check`
+// as a separate command.
+object ScalafixCheckPlugin extends AutoPlugin {
+  override def requires = _root_.scalafix.sbt.ScalafixPlugin
+  override def trigger = allRequirements
+
+  val scalafixCheck =
+    taskKey[Unit]("Runs scalafix --check (no-arg wrapper).")
+
+  override val projectSettings = Seq(
+    Compile / scalafixCheck := (Compile / scalafix).toTask(" --check").value,
+    Test / scalafixCheck := (Test / scalafix).toTask(" --check").value
+  )
+}
+
 object Smithy4sBuildPlugin extends AutoPlugin {
 
   val Scala212 = "2.12.21"
@@ -682,28 +698,35 @@ object Smithy4sBuildPlugin extends AutoPlugin {
 
     val jvm = (t: Doublet) => t.platform == "jvm"
 
-    val desiredCommands: Map[String, (String, Doublet => Boolean)] = Map(
-      "test" -> ("test", any),
-      "compile" -> ("compile", any),
-      "testCompile" -> ("Test/compile", any),
-      "publishLocal" -> ("publishLocal", any),
-      "pushRemoteCache" -> ("pushRemoteCache", any),
-      "pullRemoteCache" -> ("pullRemoteCache", any),
-      "scalafix" -> ("scalafix --check", jvm2_13),
-      "scalafixTests" -> ("Test/scalafix --check", jvm2_13),
-      "scalafmt" -> ("scalafmtCheckAll", jvm2_13),
-      "mimaReportBinaryIssuesIfRelevant" -> ("mimaReportBinaryIssuesIfRelevant", jvm)
+    // Projects that disable ScalafixPlugin and so don't have scalafixCheck
+    // defined. Skip them when generating per-project scalafix aliases so the
+    // alias doesn't push commands for missing keys.
+    val scalafixDisabled: String => Boolean = _ == "bootstrapped"
+
+    val desiredCommands
+        : Map[String, (String, Doublet => Boolean, String => Boolean)] = Map(
+      "test"             -> ("test", any, _ => true),
+      "compile"          -> ("compile", any, _ => true),
+      "testCompile"      -> ("Test/compile", any, _ => true),
+      "publishLocal"     -> ("publishLocal", any, _ => true),
+      "pushRemoteCache"  -> ("pushRemoteCache", any, _ => true),
+      "pullRemoteCache"  -> ("pullRemoteCache", any, _ => true),
+      "scalafix"         -> ("scalafixCheck", jvm2_13, p => !scalafixDisabled(p)),
+      "scalafixTests"    -> ("Test/scalafixCheck", jvm2_13, p => !scalafixDisabled(p)),
+      "scalafmt"         -> ("scalafmtCheckAll", jvm2_13, _ => true),
+      "mimaReportBinaryIssuesIfRelevant" -> ("mimaReportBinaryIssuesIfRelevant", jvm, _ => true)
     )
 
     val cmds = all.flatMap { case (doublet, projects) =>
-      desiredCommands.filter(_._2._2(doublet)).map { case (name, (cmd, _)) =>
-        Command.command(
-          s"${name}_${doublet.scala}_${doublet.platform}"
-        ) { state =>
-          projects.foldLeft(state) { case (st, proj) =>
-            s"$proj/$cmd" :: st
+      desiredCommands.filter(_._2._2(doublet)).map {
+        case (name, (cmd, _, projectFilter)) =>
+          Command.command(
+            s"${name}_${doublet.scala}_${doublet.platform}"
+          ) { state =>
+            projects.filter(projectFilter).foldLeft(state) { case (st, proj) =>
+              s"$proj/$cmd" :: st
+            }
           }
-        }
       }
     }
 

--- a/project/Smithy4sBuildPlugin.scala
+++ b/project/Smithy4sBuildPlugin.scala
@@ -682,28 +682,39 @@ object Smithy4sBuildPlugin extends AutoPlugin {
 
     val jvm = (t: Doublet) => t.platform == "jvm"
 
-    val desiredCommands: Map[String, (String, Doublet => Boolean)] = Map(
-      "test" -> ("test", any),
-      "compile" -> ("compile", any),
-      "testCompile" -> ("Test/compile", any),
-      "publishLocal" -> ("publishLocal", any),
-      "pushRemoteCache" -> ("pushRemoteCache", any),
-      "pullRemoteCache" -> ("pullRemoteCache", any),
-      "scalafix" -> ("scalafix --check", jvm2_13),
-      "scalafixTests" -> ("Test/scalafix --check", jvm2_13),
-      "scalafmt" -> ("scalafmtCheckAll", jvm2_13),
-      "mimaReportBinaryIssuesIfRelevant" -> ("mimaReportBinaryIssuesIfRelevant", jvm)
+    val anyProject: String => Boolean = _ => true
+    // The sbt and mill plugins have their own dedicated CI jobs that invoke
+    // their tests directly (scripted, millCodegenPlugin*/test). Including them
+    // in the per-cell test_<scala>_<platform> aggregate runs the same work
+    // twice — and worse, mill plugin tests are slow.
+    val isPluginProject: String => Boolean = p =>
+      p.startsWith("codegenPlugin") || p.startsWith("millCodegenPlugin")
+    val notPluginProject: String => Boolean = p => !isPluginProject(p)
+
+    val desiredCommands
+        : Map[String, (String, Doublet => Boolean, String => Boolean)] = Map(
+      "test"             -> ("test", any, notPluginProject),
+      "compile"          -> ("compile", any, anyProject),
+      "testCompile"      -> ("Test/compile", any, anyProject),
+      "publishLocal"     -> ("publishLocal", any, anyProject),
+      "pushRemoteCache"  -> ("pushRemoteCache", any, anyProject),
+      "pullRemoteCache"  -> ("pullRemoteCache", any, anyProject),
+      "scalafix"         -> ("scalafix --check", jvm2_13, anyProject),
+      "scalafixTests"    -> ("Test/scalafix --check", jvm2_13, anyProject),
+      "scalafmt"         -> ("scalafmtCheckAll", jvm2_13, anyProject),
+      "mimaReportBinaryIssuesIfRelevant" -> ("mimaReportBinaryIssuesIfRelevant", jvm, anyProject)
     )
 
     val cmds = all.flatMap { case (doublet, projects) =>
-      desiredCommands.filter(_._2._2(doublet)).map { case (name, (cmd, _)) =>
-        Command.command(
-          s"${name}_${doublet.scala}_${doublet.platform}"
-        ) { state =>
-          projects.foldLeft(state) { case (st, proj) =>
-            s"$proj/$cmd" :: st
+      desiredCommands.filter(_._2._2(doublet)).map {
+        case (name, (cmd, _, projectFilter)) =>
+          Command.command(
+            s"${name}_${doublet.scala}_${doublet.platform}"
+          ) { state =>
+            projects.filter(projectFilter).foldLeft(state) { case (st, proj) =>
+              s"$proj/$cmd" :: st
+            }
           }
-        }
       }
     }
 

--- a/project/Smithy4sBuildPlugin.scala
+++ b/project/Smithy4sBuildPlugin.scala
@@ -717,6 +717,8 @@ object Smithy4sBuildPlugin extends AutoPlugin {
       "compile"          -> ("compile", any, anyProject),
       "testCompile"      -> ("Test/compile", any, anyProject),
       "publishLocal"     -> ("publishLocal", any, anyProject),
+      "publish"          -> ("publish", any, anyProject),
+      "publishSigned"    -> ("publishSigned", any, anyProject),
       "pushRemoteCache"  -> ("pushRemoteCache", any, anyProject),
       "pullRemoteCache"  -> ("pullRemoteCache", any, anyProject),
       "scalafix"         -> ("scalafixCheck", jvm2_13, p => !scalafixDisabled(p)),

--- a/project/Smithy4sBuildPlugin.scala
+++ b/project/Smithy4sBuildPlugin.scala
@@ -345,7 +345,17 @@ object Smithy4sBuildPlugin extends AutoPlugin {
     Compile / packageCache / moduleName := artifactName(
       moduleName.value,
       virtualAxes.value
-    )
+    ),
+    Test / packageCache / moduleName := artifactName(
+      moduleName.value + "-test",
+      virtualAxes.value
+    ),
+    pushRemoteCache := Def
+      .sequential(Compile / pushRemoteCache, Test / pushRemoteCache)
+      .value,
+    pullRemoteCache := Def
+      .sequential(Compile / pullRemoteCache, Test / pullRemoteCache)
+      .value
   )
 
   def scala3MigrationOption(scalaVersion: String) =
@@ -675,8 +685,10 @@ object Smithy4sBuildPlugin extends AutoPlugin {
     val desiredCommands: Map[String, (String, Doublet => Boolean)] = Map(
       "test" -> ("test", any),
       "compile" -> ("compile", any),
+      "testCompile" -> ("Test/compile", any),
       "publishLocal" -> ("publishLocal", any),
       "pushRemoteCache" -> ("pushRemoteCache", any),
+      "pullRemoteCache" -> ("pullRemoteCache", any),
       "scalafix" -> ("scalafix --check", jvm2_13),
       "scalafixTests" -> ("Test/scalafix --check", jvm2_13),
       "scalafmt" -> ("scalafmtCheckAll", jvm2_13),


### PR DESCRIPTION
Disclaimer: this is all AI-generated work, but it was directed by my own ideas on how to speed up the pipeline.

I do think we could de-boilerplate the YML a little bit, but the direction I'd like to steer in would be to use something like [sbt-github-actions](https://github.com/sbt/sbt-github-actions/) (or sbt-typelevel's version of that). We can tackle this separately. But then again, I think GHA YML was unmaintainable before the age of Claude, and it's actually the perfect candidate for vibe engineering.

I intend to backport this to 0.18, as we're still getting [contributions](#1950) there, and will probably continue to do so for a few more months.

---

## Summary

Restructures CI from a monolithic 6-cell test matrix into a graph of parallel, cache-reusing jobs. **Brings PR wall-clock from 34:22 (reference run [25463921864](https://github.com/disneystreaming/smithy4s/actions/runs/25463921864)) down to 16:48 ([run 25468673536](https://github.com/disneystreaming/smithy4s/actions/runs/25468673536)) — a 51% reduction.**

## Job graph

```
compile (matrix: 6 cells, produces /tmp/remote-cache artifacts)
   ├─> test          (matrix: 6 cells, pulls cache, runs test_*)
   ├─> mima          (matrix: 3 jvm cells, pulls cache)
   ├─> docs          (pulls 2.13/jvm cache; mdoc + website)
   ├─> sbt-plugin    (matrix: 24 cells — one per scripted test folder)
   ├─> mill-plugin   (matrix: 3 cells — one per mill version)
   └─> release       (matrix: 6 cells; runs only on tags/snapshots)
            └─> release-bundle  (tags only; merges per-shard sona-staging
                                 slices and runs sonaRelease once)

pre-existing in parallel (no compile dep):
checks       (scalafmt + scalafix on 2.13/jvm + headerCheck)

build-success-checkpoint  waits on all of the above.
```

## Key changes

**Compile/test split with shared cache**
- The `compile` matrix now produces `/tmp/remote-cache` artifacts containing Compile *and* Test classes plus Zinc analysis (`META-INF/inc_compile.zip`).
- `test` and `mima` jobs download the matching artifact and `pullRemoteCache_$BUILD_KEY` before doing their work — Zinc skips compile when source hasn't changed.
- Build plugin: wires `Test / packageCache / moduleName`, overrides `pushRemoteCache`/`pullRemoteCache` to run both `Compile` and `Test` configs, adds `testCompile` and `pullRemoteCache` aliases.

**Parallelize the long poles**
- **scripted tests**: a `sbt-plugin-discover` job lists `modules/codegen-plugin/src/sbt-test/codegen-plugin/`; the `sbt-plugin` job runs as a 24-cell matrix (`fail-fast: false`), one per folder. Slowest cell ~5 min vs the previous monolithic ~18 min.
- **mill plugin**: matrix split into one cell per mill version (`millCodegenPlugin0_11`, `millCodegenPlugin0_12`, `millCodegenPlugin13`). Slowest cell ~5:40.
- **scalafix**: `checks` now runs the build-plugin's `scalafix_2_13_jvm` / `scalafixTests_2_13_jvm` aliases — scoped to 2.13/jvm only as originally intended (was running across all projects).
- **release**: matrix-split into one cell per `(scalaVersion, scalaPlatform)`. Snapshots publish independently to central-snapshots from each shard. Stable releases stage signed artifacts under `target/sona-staging/` per shard, upload them as workflow artifacts, and a final `release-bundle` job merges them and runs `sonaRelease` once — Central Portal still sees a single deployment.

**Plugin/test deduplication**
- Build plugin: filters `codegenPlugin*` and `millCodegenPlugin*` projects out of the `test_<scala>_<platform>` aggregate, since they're tested in their dedicated jobs.
- Build plugin: new `scalafixCheck` task (no-arg wrapper around `scalafix --check`) so the per-project alias parses cleanly. Defined via a separate `ScalafixCheckPlugin` that only attaches where `ScalafixPlugin` is loaded (`bootstrapped` disables it).
- Build plugin: alias generator skips projects where ScalafixPlugin is disabled.
- Build plugin: adds `publish_<scala>_<platform>` and `publishSigned_<scala>_<platform>` to the per-cell command set, used by the matrix release job.

**Other**
- Compilation artifacts uploaded with `retention-days: 3`.
- New `cleanup.yml` workflow: auto-deletes a PR's `compilation-*` artifacts when the PR is closed; manual trigger sweeps anything older than 1 day.

## Wall-clock comparison

| Run | Wall-clock | Notes |
|---|---|---|
| [25463921864](https://github.com/disneystreaming/smithy4s/actions/runs/25463921864) on `update-changelog-0194` | **34:22** | Original monolithic CI; baseline |
| [25468673536](https://github.com/disneystreaming/smithy4s/actions/runs/25468673536) on this branch (HEAD) | **16:48** | After all the changes |

Long-pole jobs in the new layout (from run [25468673536](https://github.com/disneystreaming/smithy4s/actions/runs/25468673536)):
- Test 3_0 (native): 8:59
- Test 2_13 (jvm): 8:52
- Test 2_12 (jvm): 8:08
- mill plugin (millCodegenPlugin0_11): 5:40
- sbt plugin (cross-builds): 5:18

## Release wall-clock comparison

| Tag | Run | Release wall-clock | Notes |
|---|---|---|---|
| `v0.19.4` | [25464678059](https://github.com/disneystreaming/smithy4s/actions/runs/25464678059) | **33:23** | Single monolithic `Release` job |
| `v0.19.5-M1` | [25496643296](https://github.com/disneystreaming/smithy4s/actions/runs/25496643296) | **20:44** | 6-cell matrix + `release-bundle` aggregator |

Per-shard timings on `v0.19.5-M1` (all start together, ~`12:56:23`–`12:56:29` UTC):
- Release 2_12 (jvm): 4:20
- Release 2_13 (jvm): 4:04
- Release 2_13 (js): 4:33
- Release 3_0 (jvm): 5:08
- Release 3_0 (js): 4:38
- Release 3_0 (native): **6:23** (longest shard — gates the aggregator)
- Release bundle (aggregate): 14:21 (waits for all shards, then merges + `sonaRelease`)

Side-by-side phase breakdown (parsed from each run's progress logs):

| Phase | v0.19.4 (monolithic) | v0.19.5-M1 (parallel) | Notes |
|---|---|---|---|
| sbt boot + decide tag + clean | 0:58 | 0:53 | (in aggregator only) |
| Compile + sign + stage to bundle | **18:46** (sequential, all shards) | **6:23** (longest shard) | The big win — parallelization |
| Upload bundle to Central Portal | 0:10 | 0:16 | Negligible |
| Sonatype `VALIDATING` | 0:31 | 0:31 | Sonatype-side |
| Sonatype `PUBLISHING` (sync to Maven Central) | **12:03** | **11:34** | Sonatype-side, periodic sync; we can't control |
| Total | 32:29 (Publish step) | 13:14 (aggregator) + 6:23 (longest shard) | |

So the wall-clock improvement (33:23 → 20:44) is essentially the parallelization of `+publishSigned`. The Sonatype publish-sync step is ~11–12 min in both cases and out of our hands — meaning further release-time wins would have to come from shaving compile/sign in the shards, not the aggregator.

## CI timeline visualization

Mermaid Gantts of each run, with bars positioned by their actual job timestamps. Within each pair below, the time axes share the same span — so the visual length of the slower run sets the scale, and the faster run shows up as a smaller cluster on the left. The release Gantts break down the publish phases (sbt boot, +publishSigned, upload, Sonatype VALIDATING, Sonatype PUBLISHING) using markers parsed from the job logs.

<details>
<summary><strong>PR CI (no release): before vs after</strong></summary>

```mermaid
gantt
    title PR CI before (changelog PR baseline) (run 25463921864)
    dateFormat YYYY-MM-DD HH:mm:ss
    axisFormat %H:%M
    todayMarker off
    Test 2_13 [js] :2026-05-06 22:09:23, 456s
    Test 2_13 [jvm] :2026-05-06 22:09:23, 2053s
    Test 3_0 [js] :2026-05-06 22:09:23, 513s
    Test 3_0 [jvm] :2026-05-06 22:09:23, 784s
    Test 3_0 [native] :2026-05-06 22:09:23, 838s
    Test 2_12 [jvm] :2026-05-06 22:09:30, 1865s
    build-success-checkpoint :2026-05-06 22:43:39, 3s
```

```mermaid
gantt
    title PR CI after (this branch) (run 25468673536)
    dateFormat YYYY-MM-DD HH:mm:ss
    axisFormat %H:%M
    todayMarker off
    Compile 2_12 [jvm] :2026-05-07 00:21:37, 358s
    Compile 2_13 [js] :2026-05-07 00:21:37, 386s
    Compile 3_0 [jvm] :2026-05-07 00:21:37, 430s
    Compile 3_0 [native] :2026-05-07 00:21:37, 449s
    sbt plugin [discover scripted tests] :2026-05-07 00:21:38, 9s
    Checks [scalafmt  scalafix  headers] :2026-05-07 00:21:43, 392s
    Compile 2_13 [jvm] :2026-05-07 00:21:43, 379s
    Compile 3_0 [js] :2026-05-07 00:21:43, 425s
    Test 2_13 [js] :2026-05-07 00:29:08, 299s
    Test 3_0 [jvm] :2026-05-07 00:29:08, 270s
    Test 3_0 [native] :2026-05-07 00:29:08, 539s
    mill plugin [millCodegenPlugin13] :2026-05-07 00:29:08, 296s
    sbt plugin [update-lsp-config] :2026-05-07 00:29:08, 235s
    sbt plugin [wildcard-config] :2026-05-07 00:29:08, 270s
    MiMa 3_0 [jvm] :2026-05-07 00:29:09, 264s
    Test 2_13 [jvm] :2026-05-07 00:29:09, 532s
    sbt plugin [aws-newtype-flatten] :2026-05-07 00:29:09, 250s
    sbt plugin [aws-specs] :2026-05-07 00:29:09, 211s
    sbt plugin [dependencies-only] :2026-05-07 00:29:09, 219s
    sbt plugin [multimodule-aws] :2026-05-07 00:29:09, 245s
    sbt plugin [scala3] :2026-05-07 00:29:09, 244s
    sbt plugin [smithy-build] :2026-05-07 00:29:09, 245s
    sbt plugin [transformation-trait-classes] :2026-05-07 00:29:09, 239s
    sbt plugin [refinements] :2026-05-07 00:29:10, 255s
    MiMa 2_12 [jvm] :2026-05-07 00:29:14, 173s
    MiMa 2_13 [jvm] :2026-05-07 00:29:14, 163s
    sbt plugin [extra-configs] :2026-05-07 00:29:14, 241s
    sbt plugin [multimodule-no-compile] :2026-05-07 00:29:14, 224s
    Docs [mdoc + website] :2026-05-07 00:29:15, 222s
    Test 2_12 [jvm] :2026-05-07 00:29:15, 488s
    Test 3_0 [js] :2026-05-07 00:29:15, 311s
    mill plugin [millCodegenPlugin0_11] :2026-05-07 00:29:15, 340s
    sbt plugin [aws-open-enums] :2026-05-07 00:29:15, 230s
    sbt plugin [cross-builds] :2026-05-07 00:29:15, 318s
    sbt plugin [custom-settings] :2026-05-07 00:29:15, 249s
    sbt plugin [defaults] :2026-05-07 00:29:15, 275s
    sbt plugin [multimodule] :2026-05-07 00:29:15, 258s
    sbt plugin [multimodule-staged] :2026-05-07 00:29:15, 273s
    sbt plugin [multiple-artifacts-same-namespace] :2026-05-07 00:29:15, 237s
    sbt plugin [protobuf] :2026-05-07 00:29:15, 253s
    sbt plugin [smithy-build-kind-projector] :2026-05-07 00:29:15, 241s
    sbt plugin [smithy-rules] :2026-05-07 00:29:15, 262s
    sbt plugin [validator-trait-classes] :2026-05-07 00:29:15, 232s
    mill plugin [millCodegenPlugin0_12] :2026-05-07 00:29:16, 292s
    sbt plugin [render-validated-newtypes] :2026-05-07 00:29:16, 256s
    build-success-checkpoint :2026-05-07 00:38:17, 4s
    (axis pad) :2026-05-07 00:55:55, 1s
```

</details>

<details>
<summary><strong>Release CI (tag push): v0.19.4 vs v0.19.5-M1</strong></summary>

```mermaid
gantt
    title Release before (v0.19.4, monolithic) (run 25464678059)
    dateFormat YYYY-MM-DD HH:mm:ss
    axisFormat %H:%M
    todayMarker off
    Test 3_0 [js] :2026-05-06 22:27:51, 476s
    Test 2_12 [jvm] :2026-05-06 22:27:52, 1791s
    Test 2_13 [js] :2026-05-06 22:27:52, 450s
    Test 2_13 [jvm] :2026-05-06 22:27:52, 2041s
    Test 3_0 [native] :2026-05-06 22:27:53, 767s
    Publish Docs Microsite :2026-05-06 22:27:58, 349s
    Test 3_0 [jvm] :2026-05-06 22:27:58, 732s
    build-success-checkpoint :2026-05-06 23:02:02, 3s
    Release [sbt boot + clean] :2026-05-06 23:02:28, 58s
    Release [+publishSigned] :active, 2026-05-06 23:03:26, 1126s
    Release [upload bundle] :done, 2026-05-06 23:22:12, 10s
    Release [Sonatype VALIDATING] :2026-05-06 23:22:22, 31s
    Release [Sonatype PUBLISHING] :2026-05-06 23:22:53, 723s
```

```mermaid
gantt
    title Release after (v0.19.5-M1, parallel) (run 25496643296)
    dateFormat YYYY-MM-DD HH:mm:ss
    axisFormat %H:%M
    todayMarker off
    Compile 3_0 [js] :2026-05-07 12:46:55, 446s
    Compile 3_0 [native] :2026-05-07 12:46:55, 565s
    sbt plugin [discover scripted tests] :2026-05-07 12:46:55, 7s
    Compile 2_13 [js] :2026-05-07 12:46:56, 407s
    Compile 2_13 [jvm] :2026-05-07 12:46:56, 405s
    Checks [scalafmt  scalafix  headers] :2026-05-07 12:47:01, 407s
    Compile 2_12 [jvm] :2026-05-07 12:47:01, 343s
    Compile 3_0 [jvm] :2026-05-07 12:47:01, 455s
    Publish Docs Microsite :2026-05-07 12:47:01, 333s
    Test 2_12 [jvm] :2026-05-07 12:56:22, 493s
    sbt plugin [scala3] :2026-05-07 12:56:22, 247s
    Docs [mdoc + website] :2026-05-07 12:56:23, 238s
    MiMa 2_12 [jvm] :2026-05-07 12:56:23, 156s
    Release 2_13 [jvm] :2026-05-07 12:56:23, 244s
    Release 3_0 [js] :2026-05-07 12:56:23, 278s
    Test 3_0 [jvm] :2026-05-07 12:56:23, 267s
    Test 3_0 [native] :2026-05-07 12:56:23, 562s
    mill plugin [millCodegenPlugin13] :2026-05-07 12:56:23, 305s
    sbt plugin [cross-builds] :2026-05-07 12:56:23, 243s
    sbt plugin [custom-settings] :2026-05-07 12:56:23, 293s
    sbt plugin [extra-configs] :2026-05-07 12:56:23, 250s
    sbt plugin [multimodule-no-compile] :2026-05-07 12:56:23, 228s
    sbt plugin [multimodule-staged] :2026-05-07 12:56:23, 273s
    sbt plugin [multiple-artifacts-same-namespace] :2026-05-07 12:56:23, 233s
    sbt plugin [protobuf] :2026-05-07 12:56:23, 228s
    sbt plugin [smithy-build-kind-projector] :2026-05-07 12:56:23, 243s
    sbt plugin [smithy-rules] :2026-05-07 12:56:23, 247s
    sbt plugin [update-lsp-config] :2026-05-07 12:56:23, 260s
    sbt plugin [aws-open-enums] :2026-05-07 12:56:24, 251s
    sbt plugin [aws-specs] :2026-05-07 12:56:24, 260s
    sbt plugin [validator-trait-classes] :2026-05-07 12:56:24, 244s
    Test 3_0 [js] :2026-05-07 12:56:28, 289s
    sbt plugin [defaults] :2026-05-07 12:56:28, 255s
    MiMa 2_13 [jvm] :2026-05-07 12:56:29, 164s
    MiMa 3_0 [jvm] :2026-05-07 12:56:29, 265s
    Release 2_12 [jvm] :2026-05-07 12:56:29, 260s
    Release 2_13 [js] :2026-05-07 12:56:29, 273s
    Release 3_0 [jvm] :2026-05-07 12:56:29, 308s
    Release 3_0 [native] :2026-05-07 12:56:29, 383s
    Test 2_13 [jvm] :2026-05-07 12:56:29, 523s
    mill plugin [millCodegenPlugin0_11] :2026-05-07 12:56:29, 355s
    sbt plugin [dependencies-only] :2026-05-07 12:56:29, 270s
    sbt plugin [multimodule-aws] :2026-05-07 12:56:29, 254s
    sbt plugin [smithy-build] :2026-05-07 12:56:29, 274s
    sbt plugin [transformation-trait-classes] :2026-05-07 12:56:29, 268s
    sbt plugin [wildcard-config] :2026-05-07 12:56:29, 289s
    sbt plugin [aws-newtype-flatten] :2026-05-07 12:56:30, 269s
    sbt plugin [refinements] :2026-05-07 12:56:30, 267s
    sbt plugin [render-validated-newtypes] :2026-05-07 12:56:30, 332s
    sbt plugin [multimodule] :2026-05-07 12:56:31, 295s
    mill plugin [millCodegenPlugin0_12] :2026-05-07 12:56:33, 308s
    Test 2_13 [js] :2026-05-07 12:56:58, 331s
    Release bundle [sbt boot] :2026-05-07 13:03:28, 53s
    Release bundle [upload bundle] :done, 2026-05-07 13:04:21, 16s
    Release bundle [Sonatype VALIDATING] :2026-05-07 13:04:37, 31s
    Release bundle [Sonatype PUBLISHING] :2026-05-07 13:05:08, 694s
    build-success-checkpoint :2026-05-07 13:05:50, 2s
    (axis pad) :2026-05-07 13:53:59, 1s
```

</details>

## Verified locally

- `aws-kernel/pushRemoteCache` produces both `cached-compile.jar` and `cached-test.jar`.
- After `clean`, `aws-kernel/pullRemoteCache` extracts both, and `aws-kernel/test` runs without recompiling aws-kernel.
- `inspect` confirms all generated aliases resolve for the expected matrix cells.

## Test plan

- [x] CI runs and all jobs pass on the new HEAD
- [x] `Test 2_13 (jvm)` log shows no mill plugin tests (deduplicated)
- [x] `mill-plugin` matrix has 3 cells, each running one variant
- [x] `sbt-plugin` matrix has one cell per scripted folder
- [x] `checks` runs scalafix only on 2.13/jvm
- [x] Tagged release works end-to-end on the matrix layout (`v0.19.5-M1`, run [25496643296](https://github.com/disneystreaming/smithy4s/actions/runs/25496643296))
- [x] Snapshot publish works across all shards (run [25472955461](https://github.com/disneystreaming/smithy4s/actions/runs/25472955461))
- [x] Cleanup workflow can be triggered manually (run [25500369019](https://github.com/disneystreaming/smithy4s/actions/runs/25500369019): `delete-old-compilation-artifacts` ran, `delete-pr-artifacts` correctly skipped)







