### PR TITLE
CI: separate link step for js/native test cells (on top of #1952)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,8 +34,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
-    name: Test ${{matrix.scalaVersion}} (${{matrix.scalaPlatform}})
+  compile:
+    name: Compile ${{matrix.scalaVersion}} (${{matrix.scalaPlatform}})
     strategy:
       fail-fast: true
       matrix:
@@ -72,26 +72,13 @@ jobs:
       - name: Setup sbt
         uses: sbt/setup-sbt@v1
 
-      - name: Run tests
+      - name: Compile
         # cs fetch is only needed to work around the following issue https://github.com/VirtusLab/scala-cli/issues/4108
         run: |
           cs fetch --no-default -r central ch.epfl.scala::bloop-frontend:2.0.17
-          sbt test_$BUILD_KEY \
+          sbt compile_$BUILD_KEY \
+              testCompile_$BUILD_KEY \
               pushRemoteCache_$BUILD_KEY
-
-      - name: Run plugin tests
-        if: matrix.scalaVersion == '2_12' && matrix.scalaPlatform == 'jvm'
-        run: |
-          sbt scripted
-
-      - name: Run checks
-        if: matrix.scalaVersion == '2_13' && matrix.scalaPlatform == 'jvm'
-        run: |
-          sbt scalafmtCheckAll \
-              headerCheck \
-              "docsRendering/mdoc" \
-              "scalafixAll --check"
-          (cd ./modules/website && yarn && yarn swizzle docusaurus-lunr-search SearchBar --danger --wrap && yarn build)
 
       - name: Check for untracked changes
         run: |
@@ -99,26 +86,243 @@ jobs:
           ./scripts/check-dirty.sh
           echo "Built $(cat version)"
 
-      - name: Check for Binary Compatibility
-        if: matrix.scalaPlatform == 'jvm'
-        run: sbt mimaReportBinaryIssuesIfRelevant_$BUILD_KEY
-
       - name: Upload compilation cache
         uses: actions/upload-artifact@v4
         with:
           name: compilation-${{env.BUILD_KEY}}.zip
           path: /tmp/remote-cache
+          retention-days: 3
+
+  test:
+    name: Test ${{matrix.scalaVersion}} (${{matrix.scalaPlatform}})
+    needs: compile
+    strategy:
+      fail-fast: true
+      matrix:
+        scalaVersion: ["2_12", "2_13", "3_0"]
+        scalaPlatform: ["jvm", "js"]
+        exclude:
+          - scalaVersion: "2_12"
+            scalaPlatform: "js"
+        include:
+          - scalaVersion: "3_0"
+            scalaPlatform: "native"
+    runs-on: ubuntu-latest
+    env:
+      BUILD_KEY: ${{matrix.scalaVersion}}_${{matrix.scalaPlatform}}
+    steps:
+      - name: Checkout current branch
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ env.CHECKOUT_REF }}
+
+      - name: Cache
+        uses: coursier/cache-action@v6
+        with:
+          extraKey: ${{ env.BUILD_KEY }}
+
+      - name: Setup Java and Scala
+        uses: coursier/setup-action@v1
+        with:
+          jvm: temurin:1.17
+          apps: sbt scala-cli
+
+      - name: Setup sbt
+        uses: sbt/setup-sbt@v1
+
+      - name: Download compilation cache
+        uses: actions/download-artifact@v4
+        with:
+          name: compilation-${{env.BUILD_KEY}}.zip
+          path: /tmp/remote-cache
+
+      - name: Run tests
+        run: |
+          cs fetch --no-default -r central ch.epfl.scala::bloop-frontend:2.0.17
+          sbt pullRemoteCache_$BUILD_KEY \
+              test_$BUILD_KEY
+
+  mima:
+    name: MiMa ${{matrix.scalaVersion}} (jvm)
+    needs: compile
+    strategy:
+      fail-fast: true
+      matrix:
+        scalaVersion: ["2_12", "2_13", "3_0"]
+    runs-on: ubuntu-latest
+    env:
+      BUILD_KEY: ${{matrix.scalaVersion}}_jvm
+    steps:
+      - name: Checkout current branch
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ env.CHECKOUT_REF }}
+
+      - name: Cache
+        uses: coursier/cache-action@v6
+        with:
+          extraKey: ${{ env.BUILD_KEY }}
+
+      - name: Setup Java and Scala
+        uses: coursier/setup-action@v1
+        with:
+          jvm: temurin:1.17
+          apps: sbt
+
+      - name: Setup sbt
+        uses: sbt/setup-sbt@v1
+
+      - name: Download compilation cache
+        uses: actions/download-artifact@v4
+        with:
+          name: compilation-${{env.BUILD_KEY}}.zip
+          path: /tmp/remote-cache
+
+      - name: Check for Binary Compatibility
+        run: sbt pullRemoteCache_$BUILD_KEY mimaReportBinaryIssuesIfRelevant_$BUILD_KEY
+
+  checks:
+    name: Checks (scalafmt, scalafix, headers)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout current branch
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ env.CHECKOUT_REF }}
+
+      - name: Cache
+        uses: coursier/cache-action@v6
+        with:
+          extraKey: checks
+
+      - name: Setup Java and Scala
+        uses: coursier/setup-action@v1
+        with:
+          jvm: temurin:1.17
+          apps: sbt
+
+      - name: Setup sbt
+        uses: sbt/setup-sbt@v1
+
+      - name: Run formatter and linters
+        run: |
+          sbt scalafmtCheckAll \
+              headerCheck \
+              "scalafixAll --check"
+
+  docs:
+    name: Docs (mdoc + website)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout current branch
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ env.CHECKOUT_REF }}
+
+      - name: Cache
+        uses: coursier/cache-action@v6
+        with:
+          extraKey: docs
+
+      - name: Setup Java and Scala
+        uses: coursier/setup-action@v1
+        with:
+          jvm: temurin:1.17
+          apps: sbt
+
+      - name: Setup sbt
+        uses: sbt/setup-sbt@v1
+
+      - name: Render mdoc
+        run: sbt "docsRendering/mdoc"
+
+      - name: Build website
+        run: cd ./modules/website && yarn && yarn swizzle docusaurus-lunr-search SearchBar --danger --wrap && yarn build
+
+  sbt-plugin:
+    name: sbt plugin (scripted)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout current branch
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ env.CHECKOUT_REF }}
+
+      - name: Cache
+        uses: coursier/cache-action@v6
+        with:
+          extraKey: sbt-plugin
+
+      - name: Setup Java and Scala
+        uses: coursier/setup-action@v1
+        with:
+          jvm: temurin:1.17
+          apps: sbt
+
+      - name: Setup sbt
+        uses: sbt/setup-sbt@v1
+
+      - name: Run scripted
+        run: sbt scripted
+
+  mill-plugin:
+    name: mill plugin tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout current branch
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ env.CHECKOUT_REF }}
+
+      - name: Cache
+        uses: coursier/cache-action@v6
+        with:
+          extraKey: mill-plugin
+
+      - name: Setup Java and Scala
+        uses: coursier/setup-action@v1
+        with:
+          jvm: temurin:1.17
+          apps: sbt
+
+      - name: Setup sbt
+        uses: sbt/setup-sbt@v1
+
+      - name: Run mill plugin tests
+        run: sbt millCodegenPlugin/test
 
   build-success-checkpoint:
     runs-on: ubuntu-latest
-    needs: build
+    needs: [compile, test, mima, checks, docs, sbt-plugin, mill-plugin]
     steps:
       - name: Build matrix completed
-        run: echo "Build result is a ${{ needs.build.result }}"
+        run: |
+          echo "compile     = ${{ needs.compile.result }}"
+          echo "test        = ${{ needs.test.result }}"
+          echo "mima        = ${{ needs.mima.result }}"
+          echo "checks      = ${{ needs.checks.result }}"
+          echo "docs        = ${{ needs.docs.result }}"
+          echo "sbt-plugin  = ${{ needs.sbt-plugin.result }}"
+          echo "mill-plugin = ${{ needs.mill-plugin.result }}"
+          if [[ "${{ needs.compile.result }}" != "success" \
+             || "${{ needs.test.result }}" != "success" \
+             || "${{ needs.mima.result }}" != "success" \
+             || "${{ needs.checks.result }}" != "success" \
+             || "${{ needs.docs.result }}" != "success" \
+             || "${{ needs.sbt-plugin.result }}" != "success" \
+             || "${{ needs.mill-plugin.result }}" != "success" ]]; then
+            exit 1
+          fi
 
   release:
     name: Release
-    needs: build
+    needs: compile
     if:
       startsWith(github.ref, 'refs/tags/v') ||
       github.event.inputs.publishSnapshot == 'true' ||

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,6 +137,13 @@ jobs:
           name: compilation-${{env.BUILD_KEY}}.zip
           path: /tmp/remote-cache
 
+      - name: Link tests (js/native only)
+        if: matrix.scalaPlatform != 'jvm'
+        run: |
+          cs fetch --no-default -r central ch.epfl.scala::bloop-frontend:2.0.17
+          sbt pullRemoteCache_$BUILD_KEY \
+              testLink_$BUILD_KEY
+
       - name: Run tests
         run: |
           cs fetch --no-default -r central ch.epfl.scala::bloop-frontend:2.0.17

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -328,7 +328,7 @@ jobs:
         run: cd /tmp/remote-cache && (ls | xargs -I {} sh -c 'cp -r {}/* .')
 
       - name: Run mill plugin tests
-        run: sbt pullRemoteCache_2_13_jvm pullRemoteCache_3_0_jvm millCodegenPlugin/test
+        run: sbt pullRemoteCache_2_13_jvm pullRemoteCache_3_0_jvm millCodegenPlugin0_11/test millCodegenPlugin0_12/test millCodegenPlugin13/test
 
   build-success-checkpoint:
     runs-on: ubuntu-latest
@@ -379,14 +379,6 @@ jobs:
 
       - name: Cache
         uses: coursier/cache-action@v6
-
-      - name: Download compilation cache
-        uses: actions/download-artifact@v4
-        with:
-          path: /tmp/remote-cache
-
-      - name: Unpack compilation cache
-        run: cd /tmp/remote-cache && (ls | xargs -I {} sh -c 'cp -r {}/* .')
 
       - name: Publish ${{ github.ref }}
         run: sbt 'show version; ci-release'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,6 +215,7 @@ jobs:
 
   docs:
     name: Docs (mdoc + website)
+    needs: compile
     runs-on: ubuntu-latest
     steps:
       - name: Checkout current branch
@@ -237,14 +238,21 @@ jobs:
       - name: Setup sbt
         uses: sbt/setup-sbt@v1
 
+      - name: Download compilation cache (2_13_jvm)
+        uses: actions/download-artifact@v4
+        with:
+          name: compilation-2_13_jvm.zip
+          path: /tmp/remote-cache
+
       - name: Render mdoc
-        run: sbt "docsRendering/mdoc"
+        run: sbt pullRemoteCache_2_13_jvm "docsRendering/mdoc"
 
       - name: Build website
         run: cd ./modules/website && yarn && yarn swizzle docusaurus-lunr-search SearchBar --danger --wrap && yarn build
 
   sbt-plugin:
     name: sbt plugin (scripted)
+    needs: compile
     runs-on: ubuntu-latest
     steps:
       - name: Checkout current branch
@@ -267,11 +275,21 @@ jobs:
       - name: Setup sbt
         uses: sbt/setup-sbt@v1
 
+      - name: Download compilation cache (jvm)
+        uses: actions/download-artifact@v4
+        with:
+          pattern: compilation-*_jvm.zip
+          path: /tmp/remote-cache
+
+      - name: Merge compilation caches
+        run: cd /tmp/remote-cache && (ls | xargs -I {} sh -c 'cp -r {}/* .')
+
       - name: Run scripted
-        run: sbt scripted
+        run: sbt pullRemoteCache_2_12_jvm pullRemoteCache_2_13_jvm pullRemoteCache_3_0_jvm scripted
 
   mill-plugin:
     name: mill plugin tests
+    needs: compile
     runs-on: ubuntu-latest
     steps:
       - name: Checkout current branch
@@ -294,8 +312,23 @@ jobs:
       - name: Setup sbt
         uses: sbt/setup-sbt@v1
 
+      - name: Download compilation cache (2_13_jvm)
+        uses: actions/download-artifact@v4
+        with:
+          name: compilation-2_13_jvm.zip
+          path: /tmp/remote-cache/2_13_jvm
+
+      - name: Download compilation cache (3_0_jvm)
+        uses: actions/download-artifact@v4
+        with:
+          name: compilation-3_0_jvm.zip
+          path: /tmp/remote-cache/3_0_jvm
+
+      - name: Merge compilation caches
+        run: cd /tmp/remote-cache && (ls | xargs -I {} sh -c 'cp -r {}/* .')
+
       - name: Run mill plugin tests
-        run: sbt millCodegenPlugin/test
+        run: sbt pullRemoteCache_2_13_jvm pullRemoteCache_3_0_jvm millCodegenPlugin/test
 
   build-success-checkpoint:
     runs-on: ubuntu-latest

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -1,0 +1,56 @@
+name: Cleanup CI artifacts
+
+on:
+  pull_request:
+    types: [closed]
+  workflow_dispatch:
+
+jobs:
+  delete-pr-artifacts:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: Delete compilation artifacts from this PR's CI runs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          # Find CI runs for the PR head and delete their compilation-* artifacts.
+          run_ids=$(gh api --paginate \
+            "repos/$REPO/actions/runs?head_sha=$PR_HEAD_SHA" \
+            --jq '.workflow_runs[].id')
+          for run_id in $run_ids; do
+            gh api --paginate "repos/$REPO/actions/runs/$run_id/artifacts" \
+              --jq '.artifacts[] | select(.name | startswith("compilation-")) | .id' \
+              | while read -r artifact_id; do
+                  echo "Deleting artifact $artifact_id from run $run_id"
+                  gh api -X DELETE "repos/$REPO/actions/artifacts/$artifact_id" || true
+                done
+          done
+
+  delete-old-compilation-artifacts:
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: Delete compilation-* artifacts older than 1 day
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          cutoff=$(date -u -d '1 day ago' +%s 2>/dev/null || date -u -v-1d +%s)
+          gh api --paginate "repos/$REPO/actions/artifacts" \
+            --jq '.artifacts[] | select(.name | startswith("compilation-")) | "\(.id) \(.created_at)"' \
+            | while read -r id created; do
+                created_ts=$(date -u -d "$created" +%s 2>/dev/null || date -u -j -f "%Y-%m-%dT%H:%M:%SZ" "$created" +%s)
+                if [ "$created_ts" -lt "$cutoff" ]; then
+                  echo "Deleting artifact $id (created $created)"
+                  gh api -X DELETE "repos/$REPO/actions/artifacts/$id" || true
+                fi
+              done

--- a/project/Smithy4sBuildPlugin.scala
+++ b/project/Smithy4sBuildPlugin.scala
@@ -707,7 +707,26 @@ object Smithy4sBuildPlugin extends AutoPlugin {
       }
     }
 
-    cmds
+    // testLink_<scala>_<platform>: link tests without running them, so the
+    // js/native test job can isolate linking (memory-heavy) from running.
+    val linkCmds = all.flatMap { case (doublet, projects) =>
+      val taskOpt = doublet.platform match {
+        case "js"     => Some("Test/fastLinkJS")
+        case "native" => Some("Test/nativeLink")
+        case _        => None
+      }
+      taskOpt.map { task =>
+        Command.command(
+          s"testLink_${doublet.scala}_${doublet.platform}"
+        ) { state =>
+          projects.foldLeft(state) { case (st, proj) =>
+            s"$proj/$task" :: st
+          }
+        }
+      }
+    }
+
+    cmds ++ linkCmds
   }
 
   def configureScalaJSProject(proj: Project): Project = {

--- a/project/Smithy4sBuildPlugin.scala
+++ b/project/Smithy4sBuildPlugin.scala
@@ -345,7 +345,17 @@ object Smithy4sBuildPlugin extends AutoPlugin {
     Compile / packageCache / moduleName := artifactName(
       moduleName.value,
       virtualAxes.value
-    )
+    ),
+    Test / packageCache / moduleName := artifactName(
+      moduleName.value + "-test",
+      virtualAxes.value
+    ),
+    pushRemoteCache := Def
+      .sequential(Compile / pushRemoteCache, Test / pushRemoteCache)
+      .value,
+    pullRemoteCache := Def
+      .sequential(Compile / pullRemoteCache, Test / pullRemoteCache)
+      .value
   )
 
   def scala3MigrationOption(scalaVersion: String) =
@@ -675,8 +685,10 @@ object Smithy4sBuildPlugin extends AutoPlugin {
     val desiredCommands: Map[String, (String, Doublet => Boolean)] = Map(
       "test" -> ("test", any),
       "compile" -> ("compile", any),
+      "testCompile" -> ("Test/compile", any),
       "publishLocal" -> ("publishLocal", any),
       "pushRemoteCache" -> ("pushRemoteCache", any),
+      "pullRemoteCache" -> ("pullRemoteCache", any),
       "scalafix" -> ("scalafix --check", jvm2_13),
       "scalafixTests" -> ("Test/scalafix --check", jvm2_13),
       "scalafmt" -> ("scalafmtCheckAll", jvm2_13),


### PR DESCRIPTION
**Stacked on top of #1952.**

Splits the js/native test cells into two steps: link first, then run. Linker work (Test/fastLinkJS for Scala.js, Test/nativeLink for Scala Native) is memory-heavy; today it runs concurrently with test execution, creating avoidable peak memory pressure on the runners.

Adds a `testLink_<scala>_<platform>` alias generated by the build plugin, only for js and native doublets. JVM cells skip the link step via an `if:` guard.

**Why:** the linker is single-threaded per module but multiple modules can link in parallel — competing for memory with concurrently-running tests for already-linked modules. By isolating linking, we let it use the full runner without contention, and the test step starts from cached linker output.

## Test plan

- [ ] Link step runs only for js/native cells
- [ ] Test step skips relink (linker output cached on disk)
- [ ] No OOMs on JS/Native cells
- [ ] Total wall-clock for js/native cells vs. #1952 baseline