### PR TITLE
0.18 Modernize CI (backport of #1952)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
-    name: Test ${{matrix.scalaVersion}} (${{matrix.scalaPlatform}})
+  compile:
+    name: Compile ${{matrix.scalaVersion}} (${{matrix.scalaPlatform}})
     strategy:
       fail-fast: true
       matrix:
@@ -63,23 +63,17 @@ jobs:
           jvm: temurin:1.17
           apps: sbt scala-cli
 
-      - name: Run tests
+      - name: Setup sbt
+        uses: sbt/setup-sbt@v1
+
+      - name: Compile
+        # cs fetch is only needed to work around the following issue https://github.com/VirtusLab/scala-cli/issues/4108
         run: |
-          sbt test_$BUILD_KEY \
+          cs fetch --no-default -r central ch.epfl.scala::bloop-frontend:2.0.17
+          sbt compile_$BUILD_KEY \
+              testCompile_$BUILD_KEY \
               pushRemoteCache_$BUILD_KEY
 
-      - name: Run plugin tests
-        if: matrix.scalaVersion == '2_12' && matrix.scalaPlatform == 'jvm'
-        run: |
-          sbt scripted
-
-      - name: Run checks
-        if: matrix.scalaVersion == '2_13' && matrix.scalaPlatform == 'jvm'
-        run: |
-          sbt scalafmtCheckAll \
-              headerCheck \
-              "docsRendering/mdoc"
-          (cd ./modules/website && yarn && yarn swizzle docusaurus-lunr-search SearchBar --danger --wrap && yarn build)
 
       - name: Check for untracked changes
         run: |
@@ -87,30 +81,388 @@ jobs:
           ./scripts/check-dirty.sh
           echo "Built $(cat version)"
 
-      - name: Check for Binary Compatibility
-        if: matrix.scalaPlatform == 'jvm'
-        run: sbt mimaReportBinaryIssuesIfRelevant_$BUILD_KEY
-
       - name: Upload compilation cache
         uses: actions/upload-artifact@v4
         with:
           name: compilation-${{env.BUILD_KEY}}.zip
           path: /tmp/remote-cache
+          retention-days: 3
+
+  test:
+    name: Test ${{matrix.scalaVersion}} (${{matrix.scalaPlatform}})
+    needs: compile
+    strategy:
+      fail-fast: true
+      matrix:
+        scalaVersion: ["2_12", "2_13", "3_0"]
+        scalaPlatform: ["jvm", "js"]
+        exclude:
+          - scalaVersion: "2_12"
+            scalaPlatform: "js"
+        include:
+          - scalaVersion: "3_0"
+            scalaPlatform: "native"
+    runs-on: ubuntu-latest
+    env:
+      BUILD_KEY: ${{matrix.scalaVersion}}_${{matrix.scalaPlatform}}
+    steps:
+      - name: Checkout current branch
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ env.CHECKOUT_REF }}
+
+      - name: Cache
+        uses: coursier/cache-action@v6
+        with:
+          extraKey: ${{ env.BUILD_KEY }}
+
+      - name: Setup Java and Scala
+        uses: coursier/setup-action@v1
+        with:
+          jvm: temurin:1.17
+          apps: sbt scala-cli
+
+      - name: Setup sbt
+        uses: sbt/setup-sbt@v1
+
+      - name: Download compilation cache
+        uses: actions/download-artifact@v4
+        with:
+          name: compilation-${{env.BUILD_KEY}}.zip
+          path: /tmp/remote-cache
+
+      - name: Run tests
+        run: |
+          cs fetch --no-default -r central ch.epfl.scala::bloop-frontend:2.0.17
+          sbt pullRemoteCache_$BUILD_KEY \
+              test_$BUILD_KEY
+
+  mima:
+    name: MiMa ${{matrix.scalaVersion}} (jvm)
+    needs: compile
+    strategy:
+      fail-fast: true
+      matrix:
+        scalaVersion: ["2_12", "2_13", "3_0"]
+    runs-on: ubuntu-latest
+    env:
+      BUILD_KEY: ${{matrix.scalaVersion}}_jvm
+    steps:
+      - name: Checkout current branch
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ env.CHECKOUT_REF }}
+
+      - name: Cache
+        uses: coursier/cache-action@v6
+        with:
+          extraKey: ${{ env.BUILD_KEY }}
+
+      - name: Setup Java and Scala
+        uses: coursier/setup-action@v1
+        with:
+          jvm: temurin:1.17
+          apps: sbt
+
+      - name: Setup sbt
+        uses: sbt/setup-sbt@v1
+
+      - name: Download compilation cache
+        uses: actions/download-artifact@v4
+        with:
+          name: compilation-${{env.BUILD_KEY}}.zip
+          path: /tmp/remote-cache
+
+      - name: Check for Binary Compatibility
+        run: sbt pullRemoteCache_$BUILD_KEY mimaReportBinaryIssuesIfRelevant_$BUILD_KEY
+
+  checks:
+    name: Checks (scalafmt, scalafix, headers)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout current branch
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ env.CHECKOUT_REF }}
+
+      - name: Cache
+        uses: coursier/cache-action@v6
+        with:
+          extraKey: checks
+
+      - name: Setup Java and Scala
+        uses: coursier/setup-action@v1
+        with:
+          jvm: temurin:1.17
+          apps: sbt
+
+      - name: Setup sbt
+        uses: sbt/setup-sbt@v1
+
+      - name: Run formatter and linters
+        run: |
+          sbt scalafmtCheckAll \
+              headerCheck \
+              scalafix_2_13_jvm \
+              scalafixTests_2_13_jvm
+
+  docs:
+    name: Docs (mdoc + website)
+    needs: compile
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout current branch
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ env.CHECKOUT_REF }}
+
+      - name: Cache
+        uses: coursier/cache-action@v6
+        with:
+          extraKey: docs
+
+      - name: Setup Java and Scala
+        uses: coursier/setup-action@v1
+        with:
+          jvm: temurin:1.17
+          apps: sbt
+
+      - name: Setup sbt
+        uses: sbt/setup-sbt@v1
+
+      - name: Download compilation cache (2_13_jvm)
+        uses: actions/download-artifact@v4
+        with:
+          name: compilation-2_13_jvm.zip
+          path: /tmp/remote-cache
+
+      - name: Render mdoc
+        run: sbt pullRemoteCache_2_13_jvm "docsRendering/mdoc"
+
+      - name: Build website
+        run: cd ./modules/website && yarn && yarn swizzle docusaurus-lunr-search SearchBar --danger --wrap && yarn build
+
+  sbt-plugin-discover:
+    name: sbt plugin (discover scripted tests)
+    runs-on: ubuntu-latest
+    outputs:
+      tests: ${{ steps.list.outputs.tests }}
+    steps:
+      - name: Checkout current branch
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ env.CHECKOUT_REF }}
+
+      - name: List scripted test folders
+        id: list
+        run: |
+          tests=$(ls modules/codegen-plugin/src/sbt-test/codegen-plugin | jq -R . | jq -sc .)
+          echo "tests=$tests" >> "$GITHUB_OUTPUT"
+          echo "Discovered: $tests"
+
+  sbt-plugin:
+    name: sbt plugin (${{ matrix.test }})
+    needs: [compile, sbt-plugin-discover]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        test: ${{ fromJSON(needs.sbt-plugin-discover.outputs.tests) }}
+    steps:
+      - name: Checkout current branch
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ env.CHECKOUT_REF }}
+
+      - name: Cache
+        uses: coursier/cache-action@v6
+        with:
+          extraKey: sbt-plugin
+
+      - name: Setup Java and Scala
+        uses: coursier/setup-action@v1
+        with:
+          jvm: temurin:1.17
+          apps: sbt
+
+      - name: Setup sbt
+        uses: sbt/setup-sbt@v1
+
+      - name: Download compilation cache (jvm)
+        uses: actions/download-artifact@v4
+        with:
+          pattern: compilation-*_jvm.zip
+          path: /tmp/remote-cache
+
+      - name: Merge compilation caches
+        run: cd /tmp/remote-cache && (ls | xargs -I {} sh -c 'cp -r {}/* .')
+
+      - name: Run scripted (${{ matrix.test }})
+        run: sbt pullRemoteCache_2_12_jvm pullRemoteCache_2_13_jvm pullRemoteCache_3_0_jvm "scripted codegen-plugin/${{ matrix.test }}"
+
+  mill-plugin:
+    name: mill plugin (${{ matrix.project }})
+    needs: compile
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        project: ["millCodegenPlugin0_11", "millCodegenPlugin0_12", "millCodegenPlugin13"]
+    steps:
+      - name: Checkout current branch
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ env.CHECKOUT_REF }}
+
+      - name: Cache
+        uses: coursier/cache-action@v6
+        with:
+          extraKey: mill-plugin
+
+      - name: Setup Java and Scala
+        uses: coursier/setup-action@v1
+        with:
+          jvm: temurin:1.17
+          apps: sbt
+
+      - name: Setup sbt
+        uses: sbt/setup-sbt@v1
+
+      - name: Download compilation cache (2_13_jvm)
+        uses: actions/download-artifact@v4
+        with:
+          name: compilation-2_13_jvm.zip
+          path: /tmp/remote-cache/2_13_jvm
+
+      - name: Download compilation cache (3_0_jvm)
+        uses: actions/download-artifact@v4
+        with:
+          name: compilation-3_0_jvm.zip
+          path: /tmp/remote-cache/3_0_jvm
+
+      - name: Merge compilation caches
+        run: cd /tmp/remote-cache && (ls | xargs -I {} sh -c 'cp -r {}/* .')
+
+      - name: Run mill plugin tests (${{ matrix.project }})
+        run: sbt pullRemoteCache_2_13_jvm pullRemoteCache_3_0_jvm ${{ matrix.project }}/test
 
   build-success-checkpoint:
     runs-on: ubuntu-latest
-    needs: build
+    needs: [compile, test, mima, checks, docs, sbt-plugin-discover, sbt-plugin, mill-plugin]
     steps:
       - name: Build matrix completed
-        run: echo "Build result is a ${{ needs.build.result }}"
+        run: |
+          echo "compile             = ${{ needs.compile.result }}"
+          echo "test                = ${{ needs.test.result }}"
+          echo "mima                = ${{ needs.mima.result }}"
+          echo "checks              = ${{ needs.checks.result }}"
+          echo "docs                = ${{ needs.docs.result }}"
+          echo "sbt-plugin-discover = ${{ needs.sbt-plugin-discover.result }}"
+          echo "sbt-plugin          = ${{ needs.sbt-plugin.result }}"
+          echo "mill-plugin         = ${{ needs.mill-plugin.result }}"
+          if [[ "${{ needs.compile.result }}" != "success" \
+             || "${{ needs.test.result }}" != "success" \
+             || "${{ needs.mima.result }}" != "success" \
+             || "${{ needs.checks.result }}" != "success" \
+             || "${{ needs.docs.result }}" != "success" \
+             || "${{ needs.sbt-plugin-discover.result }}" != "success" \
+             || "${{ needs.sbt-plugin.result }}" != "success" \
+             || "${{ needs.mill-plugin.result }}" != "success" ]]; then
+            exit 1
+          fi
 
   release:
-    name: Release
-    needs: build
+    name: Release ${{matrix.scalaVersion}} (${{matrix.scalaPlatform}})
+    needs: compile
     if:
       startsWith(github.ref, 'refs/tags/v') ||
       github.event.inputs.publishSnapshot == 'true' ||
       github.event_name == 'schedule'
+    strategy:
+      # don't cancel the matrix on first failure: for snapshots we want every
+      # shard to land independently, and for stable releases we'd rather the
+      # aggregator skip than half the bundle silently disappear
+      fail-fast: false
+      matrix:
+        scalaVersion: ["2_12", "2_13", "3_0"]
+        scalaPlatform: ["jvm", "js"]
+        exclude:
+          - scalaVersion: "2_12"
+            scalaPlatform: "js"
+        include:
+          - scalaVersion: "3_0"
+            scalaPlatform: "native"
+    runs-on: ubuntu-latest
+    env:
+      BUILD_KEY: ${{matrix.scalaVersion}}_${{matrix.scalaPlatform}}
+    steps:
+      - name: Checkout current branch (full)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ env.CHECKOUT_REF }}
+
+      - name: Setup Java and Scala
+        uses: coursier/setup-action@v1
+        with:
+          jvm: temurin:1.17
+          apps: sbt
+
+      - name: Setup sbt
+        uses: sbt/setup-sbt@v1
+
+      - name: Cache
+        uses: coursier/cache-action@v6
+        with:
+          extraKey: ${{ env.BUILD_KEY }}
+
+      - name: Download compilation cache
+        uses: actions/download-artifact@v4
+        with:
+          name: compilation-${{env.BUILD_KEY}}.zip
+          path: /tmp/remote-cache
+
+      - name: Publish ${{ github.ref }} (${{env.BUILD_KEY}})
+        run: sbt "show version; pullRemoteCache_$BUILD_KEY; ci-release"
+        env:
+          # cleaning will removed generated code from bootstrapped module which will
+          # cause the repo to be dirty and change the version to a -SNAPSHOT version
+          CI_CLEAN: ""
+          # Override what ci-release runs so each shard only publishes its own
+          # (scala, platform) slice. CI_RELEASE replaces "+publishSigned" for
+          # stable releases; CI_SNAPSHOT_RELEASE replaces "+publish" for snapshots.
+          # For snapshots, that publishes straight to central-snapshots — done.
+          # For stable releases, publishSigned_<shard> writes signed artifacts
+          # into target/sona-staging/, which the aggregator job collects and
+          # releases as one bundle via sonaRelease. Skip the per-shard release.
+          CI_RELEASE: publishSigned_${{env.BUILD_KEY}}
+          CI_SNAPSHOT_RELEASE: publish_${{env.BUILD_KEY}}
+          CI_SONATYPE_RELEASE: version
+          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
+          PGP_SECRET: ${{ secrets.PGP_SECRET }}
+          SONATYPE_PASSWORD: ${{ secrets.CENTRAL_SONATYPE_PASSWORD }}
+          SONATYPE_USERNAME: ${{ secrets.CENTRAL_SONATYPE_USERNAME }}
+
+      - name: Upload signed staging slice
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: actions/upload-artifact@v4
+        with:
+          name: sona-staging-${{env.BUILD_KEY}}
+          path: target/sona-staging
+          retention-days: 1
+          if-no-files-found: error
+
+  release-bundle:
+    name: Release bundle (aggregate)
+    needs: release
+    if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout current branch (full)
@@ -126,23 +478,29 @@ jobs:
 
       - name: Cache
         uses: coursier/cache-action@v6
+        with:
+          extraKey: release-bundle
 
-      - name: Download compilation cache
+      - name: Download per-shard staging slices
         uses: actions/download-artifact@v4
         with:
-          path: /tmp/remote-cache
+          pattern: sona-staging-*
+          path: /tmp/staging
 
-      - name: Unpack compilation cache
-        run: cd /tmp/remote-cache && (ls | xargs -I {} sh -c 'cp -r {}/* .')
+      - name: Merge into one staging tree
+        # Each shard's artifact unpacks to /tmp/staging/sona-staging-<key>/<contents>.
+        # Merge them into a single tree at target/sona-staging/.
+        run: |
+          mkdir -p target/sona-staging
+          for d in /tmp/staging/sona-staging-*; do
+            cp -r "$d"/. target/sona-staging/
+          done
+          echo "Merged staging tree:"
+          find target/sona-staging -maxdepth 4 -type d
 
-      - name: Publish ${{ github.ref }}
-        run: sbt 'show version; ci-release'
+      - name: Release bundle
+        run: sbt "show version; sonaRelease"
         env:
-          # cleaning will removed generated code from bootstrapped module which will
-          # cause the repo to be dirty and change the version to a -SNAPSHOT version
-          CI_CLEAN: ""
-          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
-          PGP_SECRET: ${{ secrets.PGP_SECRET }}
           SONATYPE_PASSWORD: ${{ secrets.CENTRAL_SONATYPE_PASSWORD }}
           SONATYPE_USERNAME: ${{ secrets.CENTRAL_SONATYPE_USERNAME }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,7 +179,7 @@ jobs:
         run: sbt pullRemoteCache_$BUILD_KEY mimaReportBinaryIssuesIfRelevant_$BUILD_KEY
 
   checks:
-    name: Checks (scalafmt, scalafix, headers)
+    name: Checks (scalafmt, headers)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout current branch
@@ -205,9 +205,7 @@ jobs:
       - name: Run formatter and linters
         run: |
           sbt scalafmtCheckAll \
-              headerCheck \
-              scalafix_2_13_jvm \
-              scalafixTests_2_13_jvm
+              headerCheck
 
   docs:
     name: Docs (mdoc + website)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,17 +48,17 @@ jobs:
       BUILD_KEY: ${{matrix.scalaVersion}}_${{matrix.scalaPlatform}}
     steps:
       - name: Checkout current branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Cache
-        uses: coursier/cache-action@v6
+        uses: coursier/cache-action@v8
         with:
           extraKey: ${{ env.BUILD_KEY }}
 
       - name: Setup Java and Scala
-        uses: coursier/setup-action@v1
+        uses: coursier/setup-action@v3
         with:
           jvm: temurin:1.17
           apps: sbt scala-cli
@@ -82,7 +82,7 @@ jobs:
           echo "Built $(cat version)"
 
       - name: Upload compilation cache
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: compilation-${{env.BUILD_KEY}}.zip
           path: /tmp/remote-cache
@@ -107,18 +107,18 @@ jobs:
       BUILD_KEY: ${{matrix.scalaVersion}}_${{matrix.scalaPlatform}}
     steps:
       - name: Checkout current branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ env.CHECKOUT_REF }}
 
       - name: Cache
-        uses: coursier/cache-action@v6
+        uses: coursier/cache-action@v8
         with:
           extraKey: ${{ env.BUILD_KEY }}
 
       - name: Setup Java and Scala
-        uses: coursier/setup-action@v1
+        uses: coursier/setup-action@v3
         with:
           jvm: temurin:1.17
           apps: sbt scala-cli
@@ -127,7 +127,7 @@ jobs:
         uses: sbt/setup-sbt@v1
 
       - name: Download compilation cache
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: compilation-${{env.BUILD_KEY}}.zip
           path: /tmp/remote-cache
@@ -150,18 +150,18 @@ jobs:
       BUILD_KEY: ${{matrix.scalaVersion}}_jvm
     steps:
       - name: Checkout current branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ env.CHECKOUT_REF }}
 
       - name: Cache
-        uses: coursier/cache-action@v6
+        uses: coursier/cache-action@v8
         with:
           extraKey: ${{ env.BUILD_KEY }}
 
       - name: Setup Java and Scala
-        uses: coursier/setup-action@v1
+        uses: coursier/setup-action@v3
         with:
           jvm: temurin:1.17
           apps: sbt
@@ -170,7 +170,7 @@ jobs:
         uses: sbt/setup-sbt@v1
 
       - name: Download compilation cache
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: compilation-${{env.BUILD_KEY}}.zip
           path: /tmp/remote-cache
@@ -183,18 +183,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout current branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ env.CHECKOUT_REF }}
 
       - name: Cache
-        uses: coursier/cache-action@v6
+        uses: coursier/cache-action@v8
         with:
           extraKey: checks
 
       - name: Setup Java and Scala
-        uses: coursier/setup-action@v1
+        uses: coursier/setup-action@v3
         with:
           jvm: temurin:1.17
           apps: sbt
@@ -213,18 +213,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout current branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ env.CHECKOUT_REF }}
 
       - name: Cache
-        uses: coursier/cache-action@v6
+        uses: coursier/cache-action@v8
         with:
           extraKey: docs
 
       - name: Setup Java and Scala
-        uses: coursier/setup-action@v1
+        uses: coursier/setup-action@v3
         with:
           jvm: temurin:1.17
           apps: sbt
@@ -233,7 +233,7 @@ jobs:
         uses: sbt/setup-sbt@v1
 
       - name: Download compilation cache (2_13_jvm)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: compilation-2_13_jvm.zip
           path: /tmp/remote-cache
@@ -251,7 +251,7 @@ jobs:
       tests: ${{ steps.list.outputs.tests }}
     steps:
       - name: Checkout current branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ env.CHECKOUT_REF }}
@@ -273,18 +273,18 @@ jobs:
         test: ${{ fromJSON(needs.sbt-plugin-discover.outputs.tests) }}
     steps:
       - name: Checkout current branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ env.CHECKOUT_REF }}
 
       - name: Cache
-        uses: coursier/cache-action@v6
+        uses: coursier/cache-action@v8
         with:
           extraKey: sbt-plugin
 
       - name: Setup Java and Scala
-        uses: coursier/setup-action@v1
+        uses: coursier/setup-action@v3
         with:
           jvm: temurin:1.17
           apps: sbt
@@ -293,7 +293,7 @@ jobs:
         uses: sbt/setup-sbt@v1
 
       - name: Download compilation cache (jvm)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: compilation-*_jvm.zip
           path: /tmp/remote-cache
@@ -314,18 +314,18 @@ jobs:
         project: ["millCodegenPlugin0_11", "millCodegenPlugin0_12", "millCodegenPlugin13"]
     steps:
       - name: Checkout current branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ env.CHECKOUT_REF }}
 
       - name: Cache
-        uses: coursier/cache-action@v6
+        uses: coursier/cache-action@v8
         with:
           extraKey: mill-plugin
 
       - name: Setup Java and Scala
-        uses: coursier/setup-action@v1
+        uses: coursier/setup-action@v3
         with:
           jvm: temurin:1.17
           apps: sbt
@@ -334,13 +334,13 @@ jobs:
         uses: sbt/setup-sbt@v1
 
       - name: Download compilation cache (2_13_jvm)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: compilation-2_13_jvm.zip
           path: /tmp/remote-cache/2_13_jvm
 
       - name: Download compilation cache (3_0_jvm)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: compilation-3_0_jvm.zip
           path: /tmp/remote-cache/3_0_jvm
@@ -402,13 +402,13 @@ jobs:
       BUILD_KEY: ${{matrix.scalaVersion}}_${{matrix.scalaPlatform}}
     steps:
       - name: Checkout current branch (full)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ env.CHECKOUT_REF }}
 
       - name: Setup Java and Scala
-        uses: coursier/setup-action@v1
+        uses: coursier/setup-action@v3
         with:
           jvm: temurin:1.17
           apps: sbt
@@ -417,12 +417,12 @@ jobs:
         uses: sbt/setup-sbt@v1
 
       - name: Cache
-        uses: coursier/cache-action@v6
+        uses: coursier/cache-action@v8
         with:
           extraKey: ${{ env.BUILD_KEY }}
 
       - name: Download compilation cache
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: compilation-${{env.BUILD_KEY}}.zip
           path: /tmp/remote-cache
@@ -450,7 +450,7 @@ jobs:
 
       - name: Upload signed staging slice
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: sona-staging-${{env.BUILD_KEY}}
           path: target/sona-staging
@@ -464,23 +464,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout current branch (full)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Setup Java and Scala
-        uses: coursier/setup-action@v1
+        uses: coursier/setup-action@v3
         with:
           jvm: temurin:1.17
           apps: sbt
 
       - name: Cache
-        uses: coursier/cache-action@v6
+        uses: coursier/cache-action@v8
         with:
           extraKey: release-bundle
 
       - name: Download per-shard staging slices
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: sona-staging-*
           path: /tmp/staging
@@ -510,18 +510,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout current branch (full)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Setup Java and Scala
-        uses: coursier/setup-action@v1
+        uses: coursier/setup-action@v3
         with:
           jvm: temurin:1.17
           apps: sbt
 
       - name: Cache
-        uses: coursier/cache-action@v6
+        uses: coursier/cache-action@v8
 
       - name: Resolve latest smithy4s-core version
         # export the version only when we trigger publish manually

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -1,0 +1,56 @@
+name: Cleanup CI artifacts
+
+on:
+  pull_request:
+    types: [closed]
+  workflow_dispatch:
+
+jobs:
+  delete-pr-artifacts:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: Delete compilation artifacts from this PR's CI runs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          # Find CI runs for the PR head and delete their compilation-* artifacts.
+          run_ids=$(gh api --paginate \
+            "repos/$REPO/actions/runs?head_sha=$PR_HEAD_SHA" \
+            --jq '.workflow_runs[].id')
+          for run_id in $run_ids; do
+            gh api --paginate "repos/$REPO/actions/runs/$run_id/artifacts" \
+              --jq '.artifacts[] | select(.name | startswith("compilation-")) | .id' \
+              | while read -r artifact_id; do
+                  echo "Deleting artifact $artifact_id from run $run_id"
+                  gh api -X DELETE "repos/$REPO/actions/artifacts/$artifact_id" || true
+                done
+          done
+
+  delete-old-compilation-artifacts:
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: Delete compilation-* artifacts older than 1 day
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          cutoff=$(date -u -d '1 day ago' +%s 2>/dev/null || date -u -v-1d +%s)
+          gh api --paginate "repos/$REPO/actions/artifacts" \
+            --jq '.artifacts[] | select(.name | startswith("compilation-")) | "\(.id) \(.created_at)"' \
+            | while read -r id created; do
+                created_ts=$(date -u -d "$created" +%s 2>/dev/null || date -u -j -f "%Y-%m-%dT%H:%M:%SZ" "$created" +%s)
+                if [ "$created_ts" -lt "$cutoff" ]; then
+                  echo "Deleting artifact $id (created $created)"
+                  gh api -X DELETE "repos/$REPO/actions/artifacts/$id" || true
+                fi
+              done

--- a/project/Smithy4sBuildPlugin.scala
+++ b/project/Smithy4sBuildPlugin.scala
@@ -122,6 +122,22 @@ case class MillCustomRow(mv: String) extends CustomRow {
 
 }
 
+// Companion plugin that only attaches where ScalafixPlugin is loaded. Defines
+// scalafixCheck so it can be invoked per-project without sbt parsing `--check`
+// as a separate command.
+object ScalafixCheckPlugin extends AutoPlugin {
+  override def requires = _root_.scalafix.sbt.ScalafixPlugin
+  override def trigger = allRequirements
+
+  val scalafixCheck =
+    taskKey[Unit]("Runs scalafix --check (no-arg wrapper).")
+
+  override val projectSettings = Seq(
+    Compile / scalafixCheck := (Compile / scalafix).toTask(" --check").value,
+    Test / scalafixCheck := (Test / scalafix).toTask(" --check").value
+  )
+}
+
 object Smithy4sBuildPlugin extends AutoPlugin {
 
   val Scala212 = "2.12.21"
@@ -340,7 +356,17 @@ object Smithy4sBuildPlugin extends AutoPlugin {
     Compile / packageCache / moduleName := artifactName(
       moduleName.value,
       virtualAxes.value
-    )
+    ),
+    Test / packageCache / moduleName := artifactName(
+      moduleName.value + "-test",
+      virtualAxes.value
+    ),
+    pushRemoteCache := Def
+      .sequential(Compile / pushRemoteCache, Test / pushRemoteCache)
+      .value,
+    pullRemoteCache := Def
+      .sequential(Compile / pullRemoteCache, Test / pullRemoteCache)
+      .value
   )
 
   def scala3MigrationOption(scalaVersion: String) =
@@ -666,26 +692,45 @@ object Smithy4sBuildPlugin extends AutoPlugin {
 
     val jvm = (t: Doublet) => t.platform == "jvm"
 
-    val desiredCommands: Map[String, (String, Doublet => Boolean)] = Map(
-      "test" -> ("test", any),
-      "compile" -> ("compile", any),
-      "publishLocal" -> ("publishLocal", any),
-      "pushRemoteCache" -> ("pushRemoteCache", any),
-      "scalafix" -> ("scalafix --check", jvm2_13),
-      "scalafixTests" -> ("Test/scalafix --check", jvm2_13),
-      "scalafmt" -> ("scalafmtCheckAll", jvm2_13),
-      "mimaReportBinaryIssuesIfRelevant" -> ("mimaReportBinaryIssuesIfRelevant", jvm)
+    val anyProject: String => Boolean = _ => true
+    // The sbt and mill plugins have their own dedicated CI jobs that invoke
+    // their tests directly (scripted, millCodegenPlugin*/test). Including them
+    // in the per-cell test_<scala>_<platform> aggregate runs the same work
+    // twice — and worse, mill plugin tests are slow.
+    val isPluginProject: String => Boolean = p =>
+      p.startsWith("codegenPlugin") || p.startsWith("millCodegenPlugin")
+    val notPluginProject: String => Boolean = p => !isPluginProject(p)
+    // Projects that disable ScalafixPlugin and so don't have scalafixCheck
+    // defined. Skip them when generating per-project scalafix aliases so the
+    // alias doesn't push commands for missing keys.
+    val scalafixDisabled: String => Boolean = _ == "bootstrapped"
+
+    val desiredCommands
+        : Map[String, (String, Doublet => Boolean, String => Boolean)] = Map(
+      "test"             -> ("test", any, notPluginProject),
+      "compile"          -> ("compile", any, anyProject),
+      "testCompile"      -> ("Test/compile", any, anyProject),
+      "publishLocal"     -> ("publishLocal", any, anyProject),
+      "publish"          -> ("publish", any, anyProject),
+      "publishSigned"    -> ("publishSigned", any, anyProject),
+      "pushRemoteCache"  -> ("pushRemoteCache", any, anyProject),
+      "pullRemoteCache"  -> ("pullRemoteCache", any, anyProject),
+      "scalafix"         -> ("scalafixCheck", jvm2_13, p => !scalafixDisabled(p)),
+      "scalafixTests"    -> ("Test/scalafixCheck", jvm2_13, p => !scalafixDisabled(p)),
+      "scalafmt"         -> ("scalafmtCheckAll", jvm2_13, anyProject),
+      "mimaReportBinaryIssuesIfRelevant" -> ("mimaReportBinaryIssuesIfRelevant", jvm, anyProject)
     )
 
     val cmds = all.flatMap { case (doublet, projects) =>
-      desiredCommands.filter(_._2._2(doublet)).map { case (name, (cmd, _)) =>
-        Command.command(
-          s"${name}_${doublet.scala}_${doublet.platform}"
-        ) { state =>
-          projects.foldLeft(state) { case (st, proj) =>
-            s"$proj/$cmd" :: st
+      desiredCommands.filter(_._2._2(doublet)).map {
+        case (name, (cmd, _, projectFilter)) =>
+          Command.command(
+            s"${name}_${doublet.scala}_${doublet.platform}"
+          ) { state =>
+            projects.filter(projectFilter).foldLeft(state) { case (st, proj) =>
+              s"$proj/$cmd" :: st
+            }
           }
-        }
       }
     }
 


### PR DESCRIPTION
Backport #1952 to 0.18.

Scalafix wasn't checked in the 0.18 days, and I don't want to change that at this point, so it's not part of the matrix. The plugin stays though - fewer changes are good.