### PR TITLE
Set dependency cooldown as a precaution against avoidable supply chain attacks

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -10,3 +10,6 @@ dependencyOverrides = [
 ]
 
 updates.limit = 4
+updates.cooldown = {
+  minimumAge = "7 days"
+}


### PR DESCRIPTION


Context: https://github.com/scala-steward-org/scala-steward/pull/3762