### PR TITLE
relax default ns filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,16 @@ When adding entries, please treat them as if they could end up in a release any 
 
 Thank you!
 
+# 0.19.6
+
+- Relax default filter in codegen module to allow generating namespaces that start with `smithy.` as long as they are not `smithy.api` in [#1968](https://github.com/disneystreaming/smithy4s/pull/1968)
+
 # 0.19.5 
 
 - Port of [#1950](https://github.com/disneystreaming/smithy4s/pull/1950) to 0.19 series
   codegen: Add `smithy4sCodegen` metadata key for render-time package remapping. Supports `packagePrefix` (prepend a prefix to all generated packages), `packageMappings` (per-namespace overrides), and `excludedNamespaces` (skip namespaces from codegen). See [Package Remapping](https://disneystreaming.github.io/smithy4s/docs/codegen/customisation/package-remapping) for details.
 - codegen: Add `allowedNamespaces` field to the `smithy4sCodegen` Smithy metadata key — restricts codegen to the listed namespace patterns. When the build-tool `allowedNamespaces` / `excludedNamespaces` settings are also set, the two sources are unioned.
 - codegen: Deprecate the build-tool `allowedNamespaces` / `excludedNamespaces` settings (sbt `smithy4sAllowedNamespaces` / `smithy4sExcludedNamespaces`, the equivalent mill targets, and the CLI `--allowed-ns` / `--excluded-ns` flags) in favor of the `smithy4sCodegen` Smithy metadata key.
-- Relax default filter in codegen module to allow generating namespaces that start with `smithy.` as long as they are not `smithy.api` in [#1968](https://github.com/disneystreaming/smithy4s/pull/1968)
 
 # 0.19.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Thank you!
   codegen: Add `smithy4sCodegen` metadata key for render-time package remapping. Supports `packagePrefix` (prepend a prefix to all generated packages), `packageMappings` (per-namespace overrides), and `excludedNamespaces` (skip namespaces from codegen). See [Package Remapping](https://disneystreaming.github.io/smithy4s/docs/codegen/customisation/package-remapping) for details.
 - codegen: Add `allowedNamespaces` field to the `smithy4sCodegen` Smithy metadata key — restricts codegen to the listed namespace patterns. When the build-tool `allowedNamespaces` / `excludedNamespaces` settings are also set, the two sources are unioned.
 - codegen: Deprecate the build-tool `allowedNamespaces` / `excludedNamespaces` settings (sbt `smithy4sAllowedNamespaces` / `smithy4sExcludedNamespaces`, the equivalent mill targets, and the CLI `--allowed-ns` / `--excluded-ns` flags) in favor of the `smithy4sCodegen` Smithy metadata key.
+- Relax default filter in codegen module to allow generating namespaces that start with `smithy.` as long as they are not `smithy.api` in [#1968](https://github.com/disneystreaming/smithy4s/pull/1968)
 
 # 0.19.4
 

--- a/build.sbt
+++ b/build.sbt
@@ -1056,7 +1056,6 @@ lazy val complianceTests = projectMatrix
   .dependsOn(core)
   .settings(
     name := "compliance-tests",
-    Compile / allowedNamespaces := Seq("smithy.test"),
     Compile / smithy4sDependencies ++= Seq(Dependencies.Smithy.testTraits),
     Compile / sourceGenerators := Seq(genSmithyScala(Compile).taskValue),
     libraryDependencies ++= {
@@ -1114,6 +1113,7 @@ lazy val bootstrapped = projectMatrix
     ),
     smithy4sDependencies ++= Seq(
       Dependencies.Smithy.testTraits,
+      Dependencies.Smithy.smokeTestTraits,
       Dependencies.Smithy.awsTraits,
       Dependencies.Smithy.waiters
     ),

--- a/modules/bootstrapped/src/generated/smithy4s/example/SmokeTestOperationOutput.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/SmokeTestOperationOutput.scala
@@ -1,0 +1,25 @@
+package smithy4s.example
+
+import smithy4s.Hints
+import smithy4s.Schema
+import smithy4s.ShapeId
+import smithy4s.ShapeTag
+import smithy4s.schema.Schema.string
+import smithy4s.schema.Schema.struct
+
+final case class SmokeTestOperationOutput(test: Option[String] = None)
+
+object SmokeTestOperationOutput extends ShapeTag.Companion[SmokeTestOperationOutput] {
+  val id: ShapeId = ShapeId("smithy4s.example", "SmokeTestOperationOutput")
+
+  val hints: Hints = Hints(
+    Hints.dynamic(ShapeId("smithy.api", "output"), smithy4s.Document.obj()),
+  )
+
+  // constructor using the original order from the spec
+  private def make(test: Option[String]): SmokeTestOperationOutput = SmokeTestOperationOutput(test)
+
+  implicit val schema: Schema[SmokeTestOperationOutput] = struct[SmokeTestOperationOutput](
+    string.optional[SmokeTestOperationOutput]("test", _.test),
+  )(make).withId(id).addHints(hints)
+}

--- a/modules/codegen/src/smithy4s/codegen/internals/CodegenImpl.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/CodegenImpl.scala
@@ -239,7 +239,7 @@ private[codegen] object CodegenImpl { self =>
       case None =>
         namespaces
           .filterNot(_.startsWith("aws."))
-          .filterNot(_.startsWith("smithy."))
+          .filterNot(_.startsWith("smithy.api"))
           .filterNot(ns => reserved.exists(ns.startsWith))
           .filterNot(namespace => excluded.exists(_.matches(namespace)))
           .filterNot(alreadyGenerated)

--- a/modules/codegen/test/src/smithy4s/codegen/internals/CodegenImplSpec.scala
+++ b/modules/codegen/test/src/smithy4s/codegen/internals/CodegenImplSpec.scala
@@ -281,7 +281,10 @@ final class CodegenImplSpec extends munit.FunSuite {
       )
       .map { case (_, result) => result.namespace }
       .toSet
-    assertEquals(generatedNamespaces.filterNot(_.startsWith("smithy")), expectedCodegenNamespaces)
+    assertEquals(
+      generatedNamespaces.filterNot(_.startsWith("smithy")),
+      expectedCodegenNamespaces
+    )
 
   }
 }

--- a/modules/codegen/test/src/smithy4s/codegen/internals/CodegenImplSpec.scala
+++ b/modules/codegen/test/src/smithy4s/codegen/internals/CodegenImplSpec.scala
@@ -281,7 +281,7 @@ final class CodegenImplSpec extends munit.FunSuite {
       )
       .map { case (_, result) => result.namespace }
       .toSet
-    assertEquals(generatedNamespaces, expectedCodegenNamespaces)
+    assertEquals(generatedNamespaces.filterNot(_.startsWith("smithy")), expectedCodegenNamespaces)
 
   }
 }

--- a/modules/codegen/test/src/smithy4s/codegen/internals/CodegenImplSpec.scala
+++ b/modules/codegen/test/src/smithy4s/codegen/internals/CodegenImplSpec.scala
@@ -281,8 +281,9 @@ final class CodegenImplSpec extends munit.FunSuite {
       )
       .map { case (_, result) => result.namespace }
       .toSet
+    val filterOut = Set("smithy.test", "smithy.protocols", "smithy.openapi")
     assertEquals(
-      generatedNamespaces.filterNot(_.startsWith("smithy")),
+      generatedNamespaces.filterNot(filterOut.contains(_)),
       expectedCodegenNamespaces
     )
 

--- a/modules/codegen/test/src/smithy4s/codegen/internals/TestUtils.scala
+++ b/modules/codegen/test/src/smithy4s/codegen/internals/TestUtils.scala
@@ -53,6 +53,8 @@ object TestUtils {
       loc: Location
   ): Unit = {
     val scalaResults = generateScalaCode(smithySpec).values.toList
+      // filter out smithy dependencies for the sake of assertions
+      .filterNot(_.startsWith("package smithy"))
     Assertions.assertEquals(
       scalaResults.map(_.trim()).sorted,
       expectedScalaCode.map(_.trim()).toList.sorted

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -22,6 +22,7 @@ object Dependencies {
     val smithyVersion = "1.69.0"
     val model = org % "smithy-model" % smithyVersion
     val testTraits = org % "smithy-protocol-test-traits" % smithyVersion
+    val smokeTestTraits = org % "smithy-smoke-test-traits" % smithyVersion
     val build = org % "smithy-build" % smithyVersion
     val diff = org % "smithy-diff" % smithyVersion
     val awsTraits = org % "smithy-aws-traits" % smithyVersion

--- a/sampleSpecs/smokeTest.smithy
+++ b/sampleSpecs/smokeTest.smithy
@@ -1,0 +1,21 @@
+$version: "2"
+
+namespace smithy4s.example
+
+use smithy.test#smokeTests
+
+@smokeTests([
+    {
+        id: "SmokeTestExample"
+        params: {}
+        expect: {
+            success: {}
+        }
+    }
+])
+@http(method: "GET", uri: "/smoke/test")
+operation SmokeTestOperation {
+    output := {
+        test: String
+    }
+}


### PR DESCRIPTION
By default, smithy4s was filtering out all namespaces that started with  from codegen. This is problematic because it does not generate every  namespace inside of the core module. So if you want to use another module, there isn't a great way to do it. This relaxes the constraint to make it only prevent codegeneration on things that are already generated in core (which is smithy.api).

## PR Checklist (not all items are relevant to all PRs)

- [ ] Added unit-tests (for runtime code)
- [x] Added bootstrapped code + smoke tests (when the rendering logic is modified)
- [ ] Added build-plugins integration tests (when reflection loading is required at codegen-time)
- [ ] Added alloy compliance tests (when simpleRestJson protocol behaviour is expanded/updated)
- [ ] Updated dynamic module to match generated-code behaviour
- [ ] Added documentation
- [x] Updated changelog
