### PR TITLE
Backport #1970 to 0.18: opt out of coursier's default repositories during codegen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ When adding entries, please treat them as if they could end up in a release any 
 
 Thank you!
 
+# 0.18.54
+
+* codegen: Add a way to opt out of coursier's default repositories (e.g. Maven Central, ivy2Local) when resolving codegen dependencies. Sbt: set `smithy4sAllowDefaultRepositories := false`. Mill: override `def smithy4sAllowDefaultRepositories = false`. CLI: pass `--no-default-repositories` to `generate`/`dump-model`. Useful for users behind an internal repository proxy that mirrors Maven Central. Defaults to `true` for backwards compatibility. See [#1969](https://github.com/disneystreaming/smithy4s/issues/1969).
+
 # 0.18.53
 
 * codegen: Add `smithy4sCodegen` metadata key for render-time package remapping. Supports `packagePrefix` (prepend a prefix to all generated packages), `packageMappings` (per-namespace overrides), and `excludedNamespaces` (skip namespaces from codegen). See [Package Remapping](https://disneystreaming.github.io/smithy4s/docs/codegen/customisation/package-remapping) for details.

--- a/modules/codegen-cli/src/smithy4s/codegen/cli/CodegenCommand.scala
+++ b/modules/codegen-cli/src/smithy4s/codegen/cli/CodegenCommand.scala
@@ -114,11 +114,12 @@ object CodegenCommand {
       transformersOpt,
       localJarsOpt,
       specsArgs,
-      smithyBuildOpt
+      smithyBuildOpt,
+      noDefaultRepositoriesOpt
     )
       .mapN {
         // format: off
-        case (output, resourseOutput, skip, discoverModels, allowedNS, excludedNS, repositories, dependencies, transformers, localJars, specsArgs, smithyBuild) =>
+        case (output, resourseOutput, skip, discoverModels, allowedNS, excludedNS, repositories, dependencies, transformers, localJars, specsArgs, smithyBuild, allowDefaultRepositories) =>
         // format: on
           val dependenciesWithDefaults = {
             import Defaults._
@@ -136,7 +137,8 @@ object CodegenCommand {
             dependenciesWithDefaults,
             transformers.getOrElse(List.empty),
             localJars.getOrElse(List.empty),
-            smithyBuild
+            smithyBuild,
+            allowDefaultRepositories
           )
       }
 

--- a/modules/codegen-cli/src/smithy4s/codegen/cli/DumpModelCommand.scala
+++ b/modules/codegen-cli/src/smithy4s/codegen/cli/DumpModelCommand.scala
@@ -29,7 +29,8 @@ object DumpModelCommand {
     repositoriesOpt.map(_.getOrElse(Nil)),
     dependenciesOpt.map(_.getOrElse(Nil)),
     transformersOpt.map(_.getOrElse(Nil)),
-    localJarsOpt.map(_.getOrElse(Nil))
+    localJarsOpt.map(_.getOrElse(Nil)),
+    noDefaultRepositoriesOpt
   ).mapN(DumpModelArgs.apply)
 
   val command: Command[Smithy4sCommand.DumpModel] =

--- a/modules/codegen-cli/src/smithy4s/codegen/cli/Options.scala
+++ b/modules/codegen-cli/src/smithy4s/codegen/cli/Options.scala
@@ -96,4 +96,13 @@ object Options {
         "Comma-delimited list of local JAR files containing smithy files"
       )
       .orNone
+
+  val noDefaultRepositoriesOpt: Opts[Boolean] =
+    Opts
+      .flag(
+        "no-default-repositories",
+        "Disable coursier's default repositories (e.g. Maven Central, ivy2Local) when resolving codegen dependencies. When set, only the repositories passed via --repositories are used."
+      )
+      .orFalse
+      .map(disabled => !disabled)
 }

--- a/modules/codegen-cli/test/src/smithy4s/codegen/cli/CommandParsingSpec.scala
+++ b/modules/codegen-cli/test/src/smithy4s/codegen/cli/CommandParsingSpec.scala
@@ -41,7 +41,8 @@ object CommandParsingSpec extends FunSuite {
               dependencies = defaultDependencies,
               transformers = Nil,
               localJars = Nil,
-              smithyBuild = None
+              smithyBuild = None,
+              allowDefaultRepositories = true
             )
           )
         )
@@ -72,7 +73,8 @@ object CommandParsingSpec extends FunSuite {
         "--transformers",
         "t1,t2",
         "--local-jars",
-        "lib1.jar,lib2.jar"
+        "lib1.jar,lib2.jar",
+        "--no-default-repositories"
       )
     )
 
@@ -98,7 +100,8 @@ object CommandParsingSpec extends FunSuite {
                 os.pwd / "lib1.jar",
                 os.pwd / "lib2.jar"
               ),
-              smithyBuild = Some(os.pwd / "smithy-build.json")
+              smithyBuild = Some(os.pwd / "smithy-build.json"),
+              allowDefaultRepositories = false
             )
           )
         )
@@ -115,7 +118,8 @@ object CommandParsingSpec extends FunSuite {
               repositories = Nil,
               dependencies = Nil,
               transformers = Nil,
-              localJars = Nil
+              localJars = Nil,
+              allowDefaultRepositories = true
             )
           )
         )
@@ -134,7 +138,8 @@ object CommandParsingSpec extends FunSuite {
         "--transformers",
         "t1,t2",
         "--local-jars",
-        "lib1.jar,lib2.jar"
+        "lib1.jar,lib2.jar",
+        "--no-default-repositories"
       )
     )
     expect(
@@ -152,7 +157,8 @@ object CommandParsingSpec extends FunSuite {
               localJars = List(
                 os.pwd / "lib1.jar",
                 os.pwd / "lib2.jar"
-              )
+              ),
+              allowDefaultRepositories = false
             )
           )
         )

--- a/modules/codegen-plugin/src/smithy4s/codegen/JsonConverters.scala
+++ b/modules/codegen-plugin/src/smithy4s/codegen/JsonConverters.scala
@@ -68,7 +68,7 @@ private[smithy4s] object JsonConverters {
     )
 
   // format: off
-  type GenTarget = List[PathRef] :*: os.Path :*: os.Path :*: Set[FileType] :*: Boolean:*: Option[Set[String]] :*: Option[Set[String]] :*: List[String] :*: List[String] :*: List[String] :*: List[PathRef] :*: Option[PathRef] :*: LNil
+  type GenTarget = List[PathRef] :*: os.Path :*: os.Path :*: Set[FileType] :*: Boolean:*: Option[Set[String]] :*: Option[Set[String]] :*: List[String] :*: List[String] :*: List[String] :*: List[PathRef] :*: Option[PathRef] :*: Boolean :*: LNil
   // format: on
 
   // `output` and `resourceOutput` are intentionally serialized as paths
@@ -88,6 +88,7 @@ private[smithy4s] object JsonConverters {
         ("transformers", ca.transformers) :*:
         ("localJars", ca.localJars.map(PathRef(_))) :*:
         ("smithyBuild", ca.smithyBuild.map(PathRef(_))) :*:
+        ("allowDefaultRepositories", ca.allowDefaultRepositories) :*:
         LNil
     },
     {
@@ -102,7 +103,8 @@ private[smithy4s] object JsonConverters {
           (_, dependencies) :*:
           (_, transformers) :*:
           (_, localJars) :*:
-          (_, smithyBuild) :*: LNil =>
+          (_, smithyBuild) :*:
+          (_, allowDefaultRepositories) :*: LNil =>
         CodegenArgs(
           specs.map(_.underlying),
           output,
@@ -115,7 +117,8 @@ private[smithy4s] object JsonConverters {
           dependencies,
           transformers,
           localJars.map(_.underlying),
-          smithyBuild.map(_.underlying)
+          smithyBuild.map(_.underlying),
+          allowDefaultRepositories
         )
     }
   )

--- a/modules/codegen-plugin/src/smithy4s/codegen/Smithy4sCodegenPlugin.scala
+++ b/modules/codegen-plugin/src/smithy4s/codegen/Smithy4sCodegenPlugin.scala
@@ -174,6 +174,16 @@ object Smithy4sCodegenPlugin extends AutoPlugin {
           "List of modules containing AWS specifications that should be added to the classpath used by Smithy4s during code-generation"
         ).mkString(" ")
       )
+
+    val smithy4sAllowDefaultRepositories =
+      settingKey[Boolean](
+        List(
+          "Whether coursier's default repositories (e.g. Maven Central, ivy2Local) should be queried when resolving codegen dependencies",
+          "in addition to those declared via sbt's `resolvers`. Defaults to `true` for backwards compatibility.",
+          "Set to `false` if you want code-generation to only query the repositories declared via sbt's `resolvers`",
+          "(equivalent of coursier CLI's `--no-default`)."
+        ).mkString(" ")
+      )
   }
 
   import autoImport._
@@ -195,6 +205,7 @@ object Smithy4sCodegenPlugin extends AutoPlugin {
     config / smithy4sResourceDir := (config / resourceManaged).value,
     config / smithy4sCodegen := cachedSmithyCodegen(config).value,
     config / smithy4sSmithyLibrary := true,
+    config / smithy4sAllowDefaultRepositories := true,
     smithy4sAwsSpecs := Seq.empty,
     smithy4sAwsSpecsVersion := smithy4s.codegen.AwsSpecs.knownVersion,
     Compile / smithy4sAwsSpecDependencies := {
@@ -445,6 +456,7 @@ object Smithy4sCodegenPlugin extends AutoPlugin {
       (conf / resolvers).value.toList.collect { case m: MavenRepository =>
         m.root
       }
+    val allowDefaultRepos = (conf / smithy4sAllowDefaultRepositories).value
     val transforms = (conf / smithy4sModelTransformers).value
     val s = (conf / streams).value
     val skipResources: Set[FileType] =
@@ -471,7 +483,8 @@ object Smithy4sCodegenPlugin extends AutoPlugin {
       dependencies = List.empty,
       transformers = transforms,
       localJars = localJars,
-      smithyBuild = smithyBuildValue
+      smithyBuild = smithyBuildValue,
+      allowDefaultRepositories = allowDefaultRepos
     )
 
     val cacheStoreFactory = s.cacheStoreFactory.sub(scalaVersion.value)

--- a/modules/codegen/src/smithy4s/codegen/CodegenArgs.scala
+++ b/modules/codegen/src/smithy4s/codegen/CodegenArgs.scala
@@ -31,7 +31,8 @@ final case class CodegenArgs(
     dependencies: List[String],
     transformers: List[String],
     localJars: List[os.Path],
-    smithyBuild: Option[os.Path]
+    smithyBuild: Option[os.Path],
+    allowDefaultRepositories: Boolean = true
 ) {
   def skipScala: Boolean = skip(FileType.Scala)
   def skipOpenapi: Boolean = skip(FileType.Openapi)

--- a/modules/codegen/src/smithy4s/codegen/DumpModelArgs.scala
+++ b/modules/codegen/src/smithy4s/codegen/DumpModelArgs.scala
@@ -21,5 +21,6 @@ final case class DumpModelArgs(
     repositories: List[String],
     dependencies: List[String],
     transformers: List[String],
-    localJars: List[os.Path]
+    localJars: List[os.Path],
+    allowDefaultRepositories: Boolean = true
 )

--- a/modules/codegen/src/smithy4s/codegen/internals/CodegenImpl.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/CodegenImpl.scala
@@ -43,7 +43,8 @@ private[codegen] object CodegenImpl { self =>
       args.repositories,
       withBuiltinTransformers(args.transformers),
       args.discoverModels,
-      args.localJars
+      args.localJars,
+      args.allowDefaultRepositories
     )
 
     val (scalaFiles, smithyResources) = if (!args.skipScala) {
@@ -252,7 +253,8 @@ private[codegen] object CodegenImpl { self =>
       args.repositories,
       withBuiltinTransformers(args.transformers),
       discoverModels = false,
-      args.localJars
+      args.localJars,
+      args.allowDefaultRepositories
     )
     val flattenedModel =
       ModelTransformer.create().flattenAndRemoveMixins(model)

--- a/modules/codegen/src/smithy4s/codegen/internals/ModelLoader.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/ModelLoader.scala
@@ -43,13 +43,15 @@ private[codegen] object ModelLoader {
       repositories: List[String],
       transformers: List[String],
       discoverModels: Boolean,
-      localJars: List[os.Path]
+      localJars: List[os.Path],
+      allowDefaultRepositories: Boolean
   ): (ClassLoader, Model) = {
     val currentClassLoader = this.getClass().getClassLoader()
     val deps = resolveDependencies(
       dependencies :+ protocolDependency,
       localJars,
-      repositories
+      repositories,
+      allowDefaultRepositories
     )
 
     val modelsInJars = deps.flatMap { file =>
@@ -137,7 +139,8 @@ private[codegen] object ModelLoader {
   private def resolveDependencies(
       dependencies: List[String],
       localJars: List[os.Path],
-      repositories: List[String]
+      repositories: List[String],
+      allowDefaultRepositories: Boolean
   ): Seq[File] = {
     val maybeRepos = RepositoryParser.repositories(repositories).either
     val maybeDeps = DependencyParser
@@ -162,10 +165,11 @@ private[codegen] object ModelLoader {
     }
     val resolvedDeps: Seq[java.io.File] =
       if (deps.nonEmpty) {
-        val fetch = Fetch(FileCache())
-          .addRepositories(repos: _*)
-          .addDependencies(deps: _*)
-        fetch.run()
+        val baseFetch = Fetch(FileCache())
+        val withRepos =
+          if (allowDefaultRepositories) baseFetch.addRepositories(repos: _*)
+          else baseFetch.withRepositories(repos)
+        withRepos.addDependencies(deps: _*).run()
       } else {
         Seq.empty
       }

--- a/modules/codegen/test/src/smithy4s/codegen/internals/ModelLoaderSpec.scala
+++ b/modules/codegen/test/src/smithy4s/codegen/internals/ModelLoaderSpec.scala
@@ -31,7 +31,8 @@ class ModelLoaderSpec extends FunSuite {
         repositories,
         transformers = Nil,
         discoverModels = false,
-        localJars = Nil
+        localJars = Nil,
+        allowDefaultRepositories = true
       )
       ._2
 

--- a/modules/mill-codegen-plugin/src-mill-1/smithy4s/codegen/mill/Smithy4sModule.scala
+++ b/modules/mill-codegen-plugin/src-mill-1/smithy4s/codegen/mill/Smithy4sModule.scala
@@ -95,6 +95,12 @@ trait Smithy4sModule extends ScalaModule {
       }
   }
 
+  /** Whether coursier's default repositories (e.g. Maven Central, ivy2Local) should
+   *  be queried when resolving codegen dependencies, in addition to those declared
+   *  via Mill's `repositoriesTask`. Defaults to `true` for backwards compatibility.
+   */
+  def smithy4sAllowDefaultRepositories: T[Boolean] = Task { true }
+
   def smithy4sVersion: T[String] = BuildInfo.version
   def smithy4sSmithyLibrary: T[Boolean] = true
 
@@ -237,7 +243,8 @@ trait Smithy4sModule extends ScalaModule {
       dependencies = List.empty,
       transformers = smithy4sModelTransformers(),
       localJars = allLocalJars,
-      smithyBuild = smithyBuildFile
+      smithyBuild = smithyBuildFile,
+      allowDefaultRepositories = smithy4sAllowDefaultRepositories()
     )
 
     Smithy4s.generateToDisk(args)

--- a/modules/mill-codegen-plugin/src-mill-shared/smithy4s/codegen/mill/Smithy4sModuleCommon.scala
+++ b/modules/mill-codegen-plugin/src-mill-shared/smithy4s/codegen/mill/Smithy4sModuleCommon.scala
@@ -92,6 +92,12 @@ trait Smithy4sModuleCommon extends ScalaModule {
       repository.root
     }
 
+  /** Whether coursier's default repositories (e.g. Maven Central, ivy2Local) should
+   *  be queried when resolving codegen dependencies, in addition to those declared
+   *  via Mill's `repositoriesTask`. Defaults to `true` for backwards compatibility.
+   */
+  def smithy4sAllowDefaultRepositories: T[Boolean] = true
+
   def smithy4sVersion: T[String] = BuildInfo.version
   def smithy4sSmithyLibrary: T[Boolean] = true
 
@@ -235,7 +241,8 @@ trait Smithy4sModuleCommon extends ScalaModule {
       dependencies = List.empty,
       transformers = smithy4sModelTransformers(),
       localJars = allLocalJars,
-      smithyBuild = smithyBuildFile
+      smithyBuild = smithyBuildFile,
+      allowDefaultRepositories = smithy4sAllowDefaultRepositories()
     )
 
     Smithy4s.generateToDisk(args)


### PR DESCRIPTION
## Summary
- Backport of #1970 to the `series/0.18` branch.
- Adds an `allowDefaultRepositories` field on `CodegenArgs` / `DumpModelArgs` (default `true`). When `false`, `Fetch` uses `withRepositories` instead of `addRepositories`, so coursier's default repository list (Maven Central, ivy2Local, ...) is replaced by the user-supplied list rather than augmented with it.
- Surfaced as:
  - sbt: `smithy4sAllowDefaultRepositories: SettingKey[Boolean]`
  - Mill (0.11/0.12/1.x): `def smithy4sAllowDefaultRepositories: T[Boolean]`
  - CLI: `--no-default-repositories` on `generate` and `dump-model`
- Useful for users behind an internal repository proxy that mirrors Maven Central, where querying both can hit Maven Central rate limits (HTTP 429).

Fixes #1969.

## Conflict resolution notes
- `CHANGELOG.md`: added a new `# 0.18.54` entry in the existing 0.18 bullet style; discarded the 0.19-only sections that came along with the cherry-pick.
- `JsonConverters.scala`: kept the existing 0.18 style (no `IsoLList.Aux` annotation, no extra parens around `ca: CodegenArgs`) and added the new `allowDefaultRepositories` field.

The mill 0.11/0.12 modules inherit from `Smithy4sModuleCommon` (shared), so they pick up the new setting automatically — no extra changes needed there.

## Test plan
- [ ] CI passes on `series/0.18`

🤖 Generated with [Claude Code](https://claude.com/claude-code)