### PR TITLE
Bump sbt-codegen plugin's sbt cross-build version to 2.0.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -542,7 +542,7 @@ lazy val codegenPlugin = (projectMatrix in file("modules/codegen-plugin"))
     (pluginCrossBuild / sbtVersion) := {
       scalaBinaryVersion.value match {
         case "2.12" => "1.12.4"
-        case _      => "2.0.0-RC9"
+        case _      => "2.0.0"
       }
     },
     libraryDependencies += {


### PR DESCRIPTION
Bumps the sbt version the `sbt-codegen` plugin cross-builds against (Scala 3 / sbt 2 axis) from `2.0.0-RC9` to the final `2.0.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)