### PR TITLE
BugFix : ClassCastException when encoding DArray backed by Object[]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Thank you!
 # 0.19.8
 
 - Support `@structurePattern` targeting unions using `{label}` and `{value}` magic identifiers in [#1978](https://github.com/disneystreaming/smithy4s/pull/1978)
-- Fix `ClassCastException` when encoding non-empty `Document` arrays backed by `Object[]` in [#1981](https://github.com/disneystreaming/smithy4s/pull/1981). This completes the fix for [#1158](https://github.com/disneystreaming/smithy4s/issues/1158), which only handled empty arrays.
+- Fix `ClassCastException` when encoding non-empty `Document` arrays in [#1981](https://github.com/disneystreaming/smithy4s/pull/1981). The `decodeValue` method's final `Arrays.copyOf(arr, i)` call compiles to the erased `Arrays.copyOf(Object[], int)` overload, and since its result flows directly into `ArraySeq.unsafeWrapArray(Object)`, the compiler omits the checkcast back to `Document[]`. Bytecode rewriters (shading/proguard) can expose this, resulting in an `ArraySeq` backed by `Object[]` at runtime. Extends the fix for [#1158](https://github.com/disneystreaming/smithy4s/issues/1158).
 
 # 0.19.7
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Thank you!
 # 0.19.8
 
 - Support `@structurePattern` targeting unions using `{label}` and `{value}` magic identifiers in [#1978](https://github.com/disneystreaming/smithy4s/pull/1978)
+- Fix `ClassCastException` when encoding non-empty `Document` arrays backed by `Object[]` in [#1981](https://github.com/disneystreaming/smithy4s/pull/1981). This completes the fix for [#1158](https://github.com/disneystreaming/smithy4s/issues/1158), which only handled empty arrays.
 
 # 0.19.7
 

--- a/modules/json/src/smithy4s/json/internals/SchemaVisitorJCodec.scala
+++ b/modules/json/src/smithy4s/json/internals/SchemaVisitorJCodec.scala
@@ -521,7 +521,8 @@ private[smithy4s] class SchemaVisitorJCodec(
               // DArray values built via Iterator.map(...).toIndexedSeq (e.g. in DocumentEncoderSchemaVisitor)
               // produce ArraySeq backed by Object[], making an unchecked cast crash at runtime.
               // See https://github.com/disneystreaming/smithy4s/issues/1158
-              case x: ArraySeq[_] if x.unsafeArray.isInstanceOf[Array[Document]] =>
+              case x: ArraySeq[_]
+                  if x.unsafeArray.isInstanceOf[Array[Document]] =>
                 val xs = x.unsafeArray.asInstanceOf[Array[Document]]
                 var i = 0
                 while (i < xs.length) {

--- a/modules/json/src/smithy4s/json/internals/SchemaVisitorJCodec.scala
+++ b/modules/json/src/smithy4s/json/internals/SchemaVisitorJCodec.scala
@@ -518,7 +518,11 @@ private[smithy4s] class SchemaVisitorJCodec(
             out.writeArrayStart()
             a.value match {
               // Fast path: only safe when the backing array is actually Array[Document].
-              // DArray values built in some edge use-cases produce ArraySeq backed by Object[], making an unchecked cast crash at runtime.
+              // The `else java.util.Arrays.copyOf(arr, i)` in `decodeValue` compiles to
+              // `Arrays.copyOf(Object[], int)` whose return type is Object[]. Since the
+              // result flows directly into `ArraySeq.unsafeWrapArray(Object)`, the compiler
+              // elides the checkcast back to Document[]. Bytecode rewriters (shading/proguard)
+              // can expose this: the ArraySeq ends up backed by Object[] at runtime.
               // See https://github.com/disneystreaming/smithy4s/issues/1158
               case x: ArraySeq[_]
                   if x.unsafeArray.isInstanceOf[Array[Document]] =>

--- a/modules/json/src/smithy4s/json/internals/SchemaVisitorJCodec.scala
+++ b/modules/json/src/smithy4s/json/internals/SchemaVisitorJCodec.scala
@@ -517,18 +517,16 @@ private[smithy4s] class SchemaVisitorJCodec(
           case a: DArray =>
             out.writeArrayStart()
             a.value match {
-              // short-circuiting on empty arrays to avoid the downcast to array of documents
-              // which has proven to be dangerous in Scala 3:
-              // https://github.com/disneystreaming/smithy4s/issues/1158
-              case x: ArraySeq[_] =>
-                if (x.isEmpty) ()
-                else {
-                  val xs = x.unsafeArray.asInstanceOf[Array[Document]]
-                  var i = 0
-                  while (i < xs.length) {
-                    encodeValue(xs(i), out)
-                    i += 1
-                  }
+              // Fast path: only safe when the backing array is actually Array[Document].
+              // DArray values built via Iterator.map(...).toIndexedSeq (e.g. in DocumentEncoderSchemaVisitor)
+              // produce ArraySeq backed by Object[], making an unchecked cast crash at runtime.
+              // See https://github.com/disneystreaming/smithy4s/issues/1158
+              case x: ArraySeq[_] if x.unsafeArray.isInstanceOf[Array[Document]] =>
+                val xs = x.unsafeArray.asInstanceOf[Array[Document]]
+                var i = 0
+                while (i < xs.length) {
+                  encodeValue(xs(i), out)
+                  i += 1
                 }
               case xs =>
                 xs.foreach(encodeValue(_, out))

--- a/modules/json/src/smithy4s/json/internals/SchemaVisitorJCodec.scala
+++ b/modules/json/src/smithy4s/json/internals/SchemaVisitorJCodec.scala
@@ -518,8 +518,7 @@ private[smithy4s] class SchemaVisitorJCodec(
             out.writeArrayStart()
             a.value match {
               // Fast path: only safe when the backing array is actually Array[Document].
-              // DArray values built via Iterator.map(...).toIndexedSeq (e.g. in DocumentEncoderSchemaVisitor)
-              // produce ArraySeq backed by Object[], making an unchecked cast crash at runtime.
+              // DArray values built in some edge use-cases produce ArraySeq backed by Object[], making an unchecked cast crash at runtime.
               // See https://github.com/disneystreaming/smithy4s/issues/1158
               case x: ArraySeq[_]
                   if x.unsafeArray.isInstanceOf[Array[Document]] =>

--- a/modules/json/test/src/smithy4s/json/SchemaVisitorJCodecTests.scala
+++ b/modules/json/test/src/smithy4s/json/SchemaVisitorJCodecTests.scala
@@ -44,6 +44,7 @@ import smithy4s.schema.Schema
 import smithy4s.schema.Schema._
 import smithy4s.time._
 
+import scala.collection.immutable.ArraySeq
 import scala.collection.immutable.ListMap
 import scala.concurrent.duration._
 import scala.util.Try
@@ -628,6 +629,19 @@ class SchemaVisitorJCodecTests() extends FunSuite {
     val documentJson = writeToString(doc)
     val expected =
       """[]"""
+
+    val decoded = readFromString[Document](documentJson)
+
+    expect.same(documentJson, expected)
+    expect.same(decoded, doc)
+  }
+
+  test("document arrays backed by Object[] can be encoded") {
+    val objectArray: Array[Any] = Array(Document.fromString("hello"), Document.fromInt(42))
+    val doc: Document = Document.DArray(ArraySeq.unsafeWrapArray(objectArray).asInstanceOf[IndexedSeq[Document]])
+    val documentJson = writeToString(doc)
+    val expected =
+      """["hello",42]"""
 
     val decoded = readFromString[Document](documentJson)
 

--- a/modules/json/test/src/smithy4s/json/SchemaVisitorJCodecTests.scala
+++ b/modules/json/test/src/smithy4s/json/SchemaVisitorJCodecTests.scala
@@ -637,8 +637,11 @@ class SchemaVisitorJCodecTests() extends FunSuite {
   }
 
   test("document arrays backed by Object[] can be encoded") {
-    val objectArray: Array[Any] = Array(Document.fromString("hello"), Document.fromInt(42))
-    val doc: Document = Document.DArray(ArraySeq.unsafeWrapArray(objectArray).asInstanceOf[IndexedSeq[Document]])
+    val objectArray: Array[Any] =
+      Array(Document.fromString("hello"), Document.fromInt(42))
+    val doc: Document = Document.DArray(
+      ArraySeq.unsafeWrapArray(objectArray).asInstanceOf[IndexedSeq[Document]]
+    )
     val documentJson = writeToString(doc)
     val expected =
       """["hello",42]"""

--- a/modules/json/test/src/smithy4s/json/SchemaVisitorJCodecTests.scala
+++ b/modules/json/test/src/smithy4s/json/SchemaVisitorJCodecTests.scala
@@ -44,7 +44,7 @@ import smithy4s.schema.Schema
 import smithy4s.schema.Schema._
 import smithy4s.time._
 
-import scala.collection.immutable.ArraySeq
+import scala.collection.compat.immutable.ArraySeq
 import scala.collection.immutable.ListMap
 import scala.concurrent.duration._
 import scala.util.Try


### PR DESCRIPTION
The previous fix for #1158 only short-circuited on empty arrays. Non-empty ArraySeq instances backed by Object[] (produced by Iterator.map(...).toIndexedSeq in DocumentEncoderSchemaVisitor) still triggered the unsafe cast to Array[Document].

Guard the fast path with an isInstanceOf check on the underlying array, falling back to the safe foreach path when the runtime type doesn't match.

## PR Checklist (not all items are relevant to all PRs)

- [x] Added unit-tests (for runtime code)
- [x] Updated changelog
