### PR TITLE
Codegen 'eviction'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ When adding entries, please treat them as if they could end up in a release any 
 
 Thank you!
 
+# 0.19.11
+
+- codegen: Fix an `IllegalAccessError` (e.g. `class ...IncludeClosures cannot access its abstract superclass ...BackwardCompatHelper`) that could occur during `smithy4sCodegen` when a project dependency pulled a different version of a Smithy library (`smithy-build`, `smithy-model`, etc.) than the one bundled with the codegen plugin. The model-loading `URLClassLoader` used the plugin classloader as its parent, so a duplicate copy of a plugin-provided module on the child loader could split a package across two classloaders and break package-private access. The codegen now drops any dependency already provided by the parent classloader (tracked via the new `BuildInfo.codegenDependencies`) from the child classloader, so Smithy versions no longer need to be aligned between the plugin and the project's dependencies.
+
 # 0.19.10
 
 -  Fix codegen bug where string literals containing both `$` and `"` generated code that failed to compile on Scala 2.12 

--- a/build.sbt
+++ b/build.sbt
@@ -413,7 +413,21 @@ lazy val codegen = projectMatrix
       "alloyOrg" -> Dependencies.Alloy.org,
       "alloyVersion" -> Dependencies.Alloy.alloyVersion,
       "smithy4sOrg" -> organization.value,
-      "protocolArtifactName" -> "smithy4s-protocol"
+      "protocolArtifactName" -> "smithy4s-protocol",
+      // The transitive module coordinates ("org:name") present on the codegen
+      // classpath. At runtime these are what the sbt/mill plugin classloader (the
+      // parent of the model-loading URLClassLoader) already provides. ModelLoader
+      // uses this list to drop duplicate copies of these modules from the child
+      // classloader, which would otherwise split a package across two loaders and
+      // break package-private access (e.g. smithy's IncludeClosures extending the
+      // package-private BackwardCompatHelper). See ModelLoader.dropParentProvidedJars.
+      BuildInfoKey.map(Runtime / managedClasspath) { case (_, cp) =>
+        "codegenDependencies" -> cp
+          .flatMap(_.get(sbt.Keys.moduleID.key))
+          .map(m => s"${m.organization}:${m.name}")
+          .distinct
+          .toList
+      }
     ),
     buildInfoPackage := "smithy4s.codegen",
     libraryDependencies ++= Seq(

--- a/modules/codegen/src/smithy4s/codegen/internals/ModelLoader.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/ModelLoader.scala
@@ -80,7 +80,17 @@ private[codegen] object ModelLoader {
     }
 
     val validatorClassLoader = locally {
-      val jarUrls = deps.map(_.toURI().toURL()).toArray
+      // Only jars that are NOT already provided by the parent classloader go onto
+      // the child. Keeping a second copy of a parent-provided module here would put
+      // the same package on two different loaders; if a class on one loader extends
+      // a package-private class of the same package on the other loader, the JVM
+      // denies the access with an IllegalAccessError (two distinct runtime packages).
+      // Model *files* are unaffected: `modelsInJars` above is still computed from the
+      // full `deps`, so shapes contributed by these jars are still imported.
+      val jarUrls =
+        dropParentProvidedJars(deps, BuildInfo.codegenDependencies)
+          .map(_.toURI().toURL())
+          .toArray
       new URLClassLoader(jarUrls, currentClassLoader)
     }
 
@@ -139,6 +149,45 @@ private[codegen] object ModelLoader {
 
     (validatorClassLoader, postTransformationModel)
   }
+
+  /** Drops from `jars` any artifact whose module is already present on the parent
+    * classloader, identified by the `org:name` coordinates baked into
+    * `BuildInfo.codegenDependencies`.
+    *
+    * Matching is done on the resolved jar's path rather than its module metadata,
+    * because by the time dependencies reach the codegen core (via the sbt/mill
+    * plugins) the `ModuleID` metadata has been dropped and only files remain. Both
+    * the Coursier cache (Maven layout, `org` split on `.`) and the Ivy cache (dotted
+    * `org` as a single segment) encode the coordinates as a `/<org>/<name>/` path
+    * segment, so anchoring on that segment matches reliably while avoiding
+    * false positives between similarly named modules (e.g. `smithy-build` must not
+    * match `smithy-build-tools`).
+    */
+  private[internals] def dropParentProvidedJars(
+      jars: Seq[File],
+      parentModules: Seq[String]
+  ): Seq[File] = {
+    val fragments = parentModules.flatMap(moduleCoordinatePathFragments)
+    jars.filterNot { jar =>
+      val path = jar.getAbsolutePath.replace('\\', '/')
+      fragments.exists(path.contains)
+    }
+  }
+
+  /** The `/<org>/<name>/` path fragments under which an artifact for the given
+    * `org:name` coordinate is stored, for both the Maven (Coursier) and Ivy layouts.
+    */
+  private[internals] def moduleCoordinatePathFragments(
+      coordinate: String
+  ): List[String] =
+    coordinate.split(":") match {
+      case Array(org, name) if org.nonEmpty && name.nonEmpty =>
+        List(
+          "/" + org.replace('.', '/') + "/" + name + "/",
+          "/" + org + "/" + name + "/"
+        ).distinct
+      case _ => Nil
+    }
 
   private[internals] def parseDependencies(
       dependencies: List[String],

--- a/modules/codegen/test/src/smithy4s/codegen/internals/ModelLoaderSpec.scala
+++ b/modules/codegen/test/src/smithy4s/codegen/internals/ModelLoaderSpec.scala
@@ -21,6 +21,7 @@ import munit._
 import software.amazon.smithy.model.Model
 import software.amazon.smithy.model.shapes.ShapeId
 
+import java.io.File
 import java.util.stream.Collectors
 import scala.jdk.CollectionConverters._
 
@@ -100,6 +101,97 @@ class ModelLoaderSpec extends FunSuite {
     )
 
     model.expectShape(ShapeId.from("testlibrary#MyString"))
+  }
+
+  test(
+    "dropParentProvidedJars removes jars for modules already on the parent classloader"
+  ) {
+    val parentModules = List(
+      "software.amazon.smithy:smithy-build",
+      "software.amazon.smithy:smithy-model",
+      "com.disneystreaming.alloy:alloy-core"
+    )
+    val jars = List(
+      // Coursier cache (Maven layout)
+      new File(
+        "/root/.cache/coursier/v1/https/repo1.maven.org/maven2/software/amazon/smithy/smithy-build/1.72.0/smithy-build-1.72.0.jar"
+      ),
+      new File(
+        "/root/.cache/coursier/v1/https/repo1.maven.org/maven2/software/amazon/smithy/smithy-model/1.72.0/smithy-model-1.72.0.jar"
+      ),
+      // Ivy local (dotted org, no version in filename)
+      new File(
+        "/root/.ivy2/local/com.disneystreaming.alloy/alloy-core/0.3.40/jars/alloy-core.jar"
+      ),
+      // A jar unique to the child (not on the parent) must be kept
+      new File(
+        "/root/.cache/coursier/v1/https/repo1.maven.org/maven2/com/example/my-shapes/1.0.0/my-shapes-1.0.0.jar"
+      )
+    )
+
+    val kept = ModelLoader.dropParentProvidedJars(jars, parentModules)
+
+    assertEquals(kept.map(_.getName), List("my-shapes-1.0.0.jar"))
+  }
+
+  test(
+    "dropParentProvidedJars does not confuse a module with a same-prefixed module"
+  ) {
+    val parentModules = List("software.amazon.smithy:smithy-build")
+    val jars = List(
+      new File(
+        "/cache/software/amazon/smithy/smithy-build/1.72.0/smithy-build-1.72.0.jar"
+      ),
+      new File(
+        "/cache/software/amazon/smithy/smithy-build-tools/1.72.0/smithy-build-tools-1.72.0.jar"
+      )
+    )
+
+    val kept = ModelLoader.dropParentProvidedJars(jars, parentModules)
+
+    assertEquals(kept.map(_.getName), List("smithy-build-tools-1.72.0.jar"))
+  }
+
+  test("dropParentProvidedJars keeps everything when the parent list is empty") {
+    val jars = List(
+      new File(
+        "/cache/software/amazon/smithy/smithy-build/1.72.0/smithy-build-1.72.0.jar"
+      )
+    )
+    assertEquals(ModelLoader.dropParentProvidedJars(jars, Nil), jars)
+  }
+
+  test(
+    "ModelLoader keeps a resolved conflicting smithy-build off the child classloader"
+  ) {
+    // Regression test for the IllegalAccessError that arose when a dependency
+    // dragged a newer smithy-build (containing IncludeClosures, whose superclass
+    // BackwardCompatHelper is package-private) onto the child URLClassLoader while
+    // the parent classloader held a different smithy-build version.
+    assert(
+      smithy4s.codegen.BuildInfo.codegenDependencies
+        .contains("software.amazon.smithy:smithy-build"),
+      "test precondition: smithy-build must be a parent-provided module"
+    )
+
+    val (classLoader, _) = ModelLoader.load(
+      specs = Set.empty,
+      dependencies = List("software.amazon.smithy:smithy-build:1.72.0"),
+      repositories = Nil,
+      transformers = Nil,
+      discoverModels = false,
+      localJars = Nil,
+      allowDefaultRepositories = true
+    )
+
+    val urls = classLoader match {
+      case u: java.net.URLClassLoader => u.getURLs.toList.map(_.toString)
+      case _                          => Nil
+    }
+    assert(
+      !urls.exists(_.contains("/software/amazon/smithy/smithy-build/")),
+      s"smithy-build should be filtered off the child classloader, got: $urls"
+    )
   }
 
   test("parseDependencies rejects a malformed dependency string") {

--- a/modules/codegen/test/src/smithy4s/codegen/internals/ModelLoaderSpec.scala
+++ b/modules/codegen/test/src/smithy4s/codegen/internals/ModelLoaderSpec.scala
@@ -152,7 +152,9 @@ class ModelLoaderSpec extends FunSuite {
     assertEquals(kept.map(_.getName), List("smithy-build-tools-1.72.0.jar"))
   }
 
-  test("dropParentProvidedJars keeps everything when the parent list is empty") {
+  test(
+    "dropParentProvidedJars keeps everything when the parent list is empty"
+  ) {
     val jars = List(
       new File(
         "/cache/software/amazon/smithy/smithy-build/1.72.0/smithy-build-1.72.0.jar"


### PR DESCRIPTION
This is a fix for the issue that recently popped up in CI (without us even bumping any versions) due to the dynamo pom.xml file specifying a range and a new smithy-build version getting pulled transitively.

This change is effectively putting an `eviction` in place so that the child class loader does not duplicate what the parent class loader has already loaded.

See changelog entry for more detail.

---

Typical disclaimer: I used AI in the creation of this PR. AI helped to identify the root cause of the issue, @yisraelU helped to come up with the idea of "eviction" as a solution from there, and I had the idea of using `BuildInfo` to filter the class paths this way. From there it was a slam dunk for Claude to implement the fix as described. There you go.. everyone gets credit, even our good friend, Claude.

## PR Checklist (not all items are relevant to all PRs)

- [x] Added unit-tests (for runtime code)
- [ ] Added bootstrapped code + smoke tests (when the rendering logic is modified)
- [ ] Added build-plugins integration tests (when reflection loading is required at codegen-time)
- [ ] Added alloy compliance tests (when simpleRestJson protocol behaviour is expanded/updated)
- [ ] Updated dynamic module to match generated-code behaviour
- [ ] Added documentation
- [x] Updated changelog
