### PR TITLE
Fix decoding for local date

### DIFF
--- a/modules/json/src/smithy4s/json/internals/SchemaVisitorJCodec.scala
+++ b/modules/json/src/smithy4s/json/internals/SchemaVisitorJCodec.scala
@@ -445,7 +445,9 @@ private[smithy4s] class SchemaVisitorJCodec(
       def expecting: String = "localDate"
 
       def decodeValue(cursor: Cursor, in: JsonReader): LocalDate =
-        LocalDate.parseUnsafe(in.readString(null))
+        LocalDate
+          .parse(in.readString(null))
+          .getOrElse(in.decodeError("expected " + expecting))
 
       def encodeValue(x: LocalDate, out: JsonWriter): Unit =
         out.writeNonEscapedAsciiVal(x.toString())

--- a/modules/json/test/src/smithy4s/json/SchemaVisitorJCodecTests.scala
+++ b/modules/json/test/src/smithy4s/json/SchemaVisitorJCodecTests.scala
@@ -283,6 +283,17 @@ class SchemaVisitorJCodecTests() extends FunSuite {
 
   }
 
+  test("throw PayloadError for invalid local date") {
+    try {
+      implicit val schema: Schema[LocalDate] = localdate
+
+      readFromString[LocalDate]("\"2026-33-12\"")
+      fail("Unexpected success")
+    } catch {
+      case PayloadError(_, expected, _) => expect.same(expected, "localDate")
+    }
+  }
+
   test("Optional encode from present value") {
     val foo = Foo(1, Some(2))
     val json = """{"a":1,"_b":2}"""


### PR DESCRIPTION
## PR Checklist (not all items are relevant to all PRs)

- [x] Added unit-tests (for runtime code)
- [ ] Added bootstrapped code + smoke tests (when the rendering logic is modified)
- [ ] Added build-plugins integration tests (when reflection loading is required at codegen-time)
- [ ] Added alloy compliance tests (when simpleRestJson protocol behaviour is expanded/updated)
- [ ] Updated dynamic module to match generated-code behaviour
- [ ] Added documentation
- [ ] Updated changelog
