### PR TITLE
Apply fieldFilter on response metadata too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ When adding entries, please treat them as if they could end up in a release any 
 
 Thank you!
 
+# 0.19.12
+
+- http4s: Fix the configured `FieldFilter` not being applied when a server encodes response metadata (e.g. HTTP headers) in [#1992](https://github.com/disneystreaming/smithy4s/pull/1992). `SimpleRestJsonBuilder.withFieldFilter(...)` now affects response header/metadata encoding on the server, matching the behavior already present on the client request side.
+
 # 0.19.11
 
 - codegen: Fix an `IllegalAccessError` (e.g. `class ...IncludeClosures cannot access its abstract superclass ...BackwardCompatHelper`) that could occur during `smithy4sCodegen` when a project dependency pulled a different version of a Smithy library (`smithy-build`, `smithy-model`, etc.) than the one bundled with the codegen plugin. The model-loading `URLClassLoader` used the plugin classloader as its parent, so a duplicate copy of a plugin-provided module on the child loader could split a package across two classloaders and break package-private access. The codegen now drops any dependency already provided by the parent classloader (tracked via the new `BuildInfo.codegenDependencies`) from the child classloader, so Smithy versions no longer need to be aligned between the plugin and the project's dependencies.

--- a/modules/http4s/src/smithy4s/http4s/internals/SimpleRestJsonCodecs.scala
+++ b/modules/http4s/src/smithy4s/http4s/internals/SimpleRestJsonCodecs.scala
@@ -93,7 +93,7 @@ private[http4s] class SimpleRestJsonCodecs(
       .withErrorBodyEncoders(payloadEncoders)
       .withErrorTypeHeaders(errorHeaders: _*)
       .withMetadataDecoders(Metadata.Decoder)
-      .withMetadataEncoders(Metadata.Encoder)
+      .withMetadataEncoders(Metadata.Encoder.withFieldFilter(fieldFilter))
       .withBaseResponse(_ => baseResponse.pure[F])
       .withResponseMediaType("application/json")
       .withWriteEmptyStructs(!_.isUnit)

--- a/modules/http4s/test/src/smithy4s/http4s/NullsAndDefaultEncodingSuite.scala
+++ b/modules/http4s/test/src/smithy4s/http4s/NullsAndDefaultEncodingSuite.scala
@@ -55,7 +55,10 @@ object NullsAndDefaultEncodingSuite extends SimpleIOSuite with CirceInstances {
   test("routes - FieldFilter.EncodeAll") {
     runServerTest(fieldFilter = FieldFilter.EncodeAll).map { response =>
       expect.same(
-        Map(ci"required-header-with-default" -> "required-header-with-default"),
+        Map(
+          ci"optional-header-with-default" -> "optional-header-with-default",
+          ci"required-header-with-default" -> "required-header-with-default"
+        ),
         response.headers
       ) &&
       expect.same(


### PR DESCRIPTION
We currently apply the field filter on the bodies, as well as the request metadata encoder on the client-side, but the server-side metadata encoder doesn't apply it (it just uses the default).

Updated the existing test to match expected behavior.

## PR Checklist (not all items are relevant to all PRs)

- [x] Added unit-tests (for runtime code)
- [ ] Added bootstrapped code + smoke tests (when the rendering logic is modified)
- [ ] Added build-plugins integration tests (when reflection loading is required at codegen-time)
- [ ] Added alloy compliance tests (when simpleRestJson protocol behaviour is expanded/updated)
- [ ] Updated dynamic module to match generated-code behaviour
- [ ] Added documentation
- [x] Updated changelog
