### PR TITLE
Accept ivy repositories + inline some adapted code from coursier (0.18)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ When adding entries, please treat them as if they could end up in a release any 
 
 Thank you!
 
+# 0.18.57
+
+* codegen: Accept ivy-style repositories (e.g. `ivy:` URLs) when resolving codegen dependencies in [#1994](https://github.com/disneystreaming/smithy4s/pull/1994).
+
 # 0.18.56
 
 * codegen: Use Coursier's Java interface for dependency resolution, avoiding Scala 2.13 dependency conflicts when cross-building the sbt plugin for Scala 3 / sbt 2.x in [#1983](https://github.com/disneystreaming/smithy4s/pull/1983).

--- a/modules/codegen/src/smithy4s/codegen/internals/ModelLoader.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/ModelLoader.scala
@@ -19,7 +19,7 @@ package internals
 
 import coursierapi.Dependency
 import coursierapi.Fetch
-import coursierapi.MavenRepository
+import coursierapi.Repository
 import coursierapi.ScalaVersion
 import software.amazon.smithy.build.ProjectionTransformer
 import software.amazon.smithy.build.TransformContext
@@ -163,7 +163,7 @@ private[codegen] object ModelLoader {
   // wiring can be unit-tested without performing any network resolution.
   private[internals] def buildFetch(
       dependencies: List[Dependency],
-      repositories: List[MavenRepository],
+      repositories: List[Repository],
       allowDefaultRepositories: Boolean
   ): Fetch = {
     val baseFetch = Fetch.create()
@@ -183,7 +183,13 @@ private[codegen] object ModelLoader {
       ScalaVersion.of(smithy4s.codegen.BuildInfo.scalaBinaryVersion)
 
     val deps = parseDependencies(dependencies, scalaVersion)
-    val repos = repositories.map(MavenRepository.of)
+    val repos = RepositoryParser.repositories(repositories).toEither match {
+      case Left(errorMessages) =>
+        throw new IllegalArgumentException(
+          s"Failed to parse repositories with errors: ${errorMessages.toList}"
+        )
+      case Right(r) => r.toList
+    }
 
     val resolvedDeps: Seq[java.io.File] =
       if (deps.nonEmpty) {

--- a/modules/codegen/src/smithy4s/codegen/internals/Repositories.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/Repositories.scala
@@ -1,0 +1,96 @@
+/*
+ *  Copyright 2021-2026 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package smithy4s.codegen.internals
+
+import coursierapi.MavenRepository
+import coursierapi.IvyRepository
+
+// Adapted from coursier's own `Repositories` object, Copyright the coursier
+// contributors, licensed under the Apache License, Version 2.0
+// (http://www.apache.org/licenses/LICENSE-2.0):
+// https://github.com/coursier/coursier/blob/main/modules/coursier/shared/src/main/scala/coursier/Repositories.scala
+// Adapted to build `coursierapi` types (`MavenRepository.of`/`IvyRepository.of`,
+// literal Ivy pattern strings) instead of coursier-core's own `Repository` model
+// (`MavenRepository(...)` apply syntax, `IvyRepository.fromPattern`, structured
+// `coursier.ivy.Pattern`). To be replaced once equivalents land in coursier-interface.
+private[internals] object Repositories {
+
+  // Corresponds to coursier's default Ivy pattern:
+  // [organisation]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)[revision]/[type]s/[artifact](-[classifier]).[ext]
+  private val ivyDefaultPattern =
+    "[organisation]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)[revision]/[type]s/[artifact](-[classifier]).[ext]"
+
+  def central: MavenRepository =
+    MavenRepository.of("https://repo1.maven.org/maven2")
+  def sonatype(name: String): MavenRepository =
+    MavenRepository.of(s"https://oss.sonatype.org/content/repositories/$name")
+  def sonatypeS01(name: String): MavenRepository =
+    MavenRepository.of(
+      s"https://s01.oss.sonatype.org/content/repositories/$name"
+    )
+  def bintray(id: String): MavenRepository =
+    MavenRepository.of(s"https://dl.bintray.com/$id")
+  def bintray(owner: String, repo: String): MavenRepository =
+    bintray(s"$owner/$repo")
+  def bintrayIvy(id: String): IvyRepository =
+    IvyRepository.of(
+      s"https://dl.bintray.com/${id.stripSuffix("/")}/$ivyDefaultPattern"
+    )
+  def typesafe(id: String): MavenRepository =
+    MavenRepository.of(s"https://repo.typesafe.com/typesafe/$id")
+  def typesafeIvy(id: String): IvyRepository =
+    IvyRepository.of(
+      s"https://repo.typesafe.com/typesafe/ivy-$id/$ivyDefaultPattern"
+    )
+  def sbtPlugin(id: String): IvyRepository =
+    IvyRepository.of(
+      s"https://repo.scala-sbt.org/scalasbt/sbt-plugin-$id/$ivyDefaultPattern"
+    )
+  def sbtMaven(id: String): MavenRepository =
+    MavenRepository.of(s"https://repo.scala-sbt.org/scalasbt/maven-$id")
+  def scalaIntegration: MavenRepository =
+    MavenRepository.of(
+      "https://scala-ci.typesafe.com/artifactory/scala-integration"
+    )
+  def jitpack: MavenRepository =
+    MavenRepository.of("https://jitpack.io")
+  def clojars: MavenRepository =
+    MavenRepository.of("https://repo.clojars.org")
+  def jcenter: MavenRepository =
+    MavenRepository.of("https://jcenter.bintray.com")
+  def google: MavenRepository =
+    MavenRepository.of("https://maven.google.com")
+
+  // https://storage-download.googleapis.com/maven-central/index.html
+  def centralGcs: MavenRepository =
+    MavenRepository.of(
+      "https://maven-central.storage-download.googleapis.com/maven2"
+    )
+  def centralGcsEu: MavenRepository =
+    MavenRepository.of(
+      "https://maven-central-eu.storage-download.googleapis.com/maven2"
+    )
+  def centralGcsAsia: MavenRepository =
+    MavenRepository.of(
+      "https://maven-central-asia.storage-download.googleapis.com/maven2"
+    )
+
+  def apache(id: String): MavenRepository =
+    MavenRepository.of(
+      s"https://repository.apache.org/content/repositories/$id"
+    )
+}

--- a/modules/codegen/src/smithy4s/codegen/internals/RepositoryParser.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/RepositoryParser.scala
@@ -1,0 +1,247 @@
+/*
+ *  Copyright 2021-2026 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package smithy4s.codegen
+package internals
+
+import cats.data.ValidatedNel
+import cats.syntax.all._
+import coursierapi.Credentials
+import coursierapi.IvyRepository
+import coursierapi.MavenRepository
+import coursierapi.Repository
+
+import java.io.File
+import java.net.MalformedURLException
+import java.net.URL
+
+// Adapted from coursier's own repository parsing, Copyright the coursier
+// contributors, licensed under the Apache License, Version 2.0
+// (http://www.apache.org/licenses/LICENSE-2.0):
+//   - https://github.com/coursier/coursier/blob/main/modules/coursier/shared/src/main/scala/coursier/parse/RepositoryParser.scala
+//   - https://github.com/coursier/coursier/blob/main/modules/coursier/jvm/src/main/scala/coursier/internal/PlatformRepositoryParser.scala
+//     (inlined below as this object's `repository`/`LocalRepositories`)
+//   - https://github.com/coursier/coursier/blob/main/modules/coursier/shared/src/main/scala/coursier/internal/SharedRepositoryParser.scala
+//     (inlined below as `SharedRepositoryParser`)
+// Adapted to build `coursierapi` types instead of coursier-core's own `Repository`
+// model, since coursierapi has no public equivalent of this alias/pattern parsing
+// (see ModelLoader.scala for why). To be replaced once equivalents land in
+// coursier-interface upstream.
+private[internals] object RepositoryParser {
+
+  def repositories(inputs: Seq[String]): ValidatedNel[String, Seq[Repository]] =
+    inputs.toVector
+      .traverse(s => repository(s).toValidatedNel)
+      .map(_.toSeq)
+
+  def repository(input: String): Either[String, Repository] =
+    repository(input, maybeFile = false)
+
+  def repository(
+      input: String,
+      maybeFile: Boolean
+  ): Either[String, Repository] =
+    if (input == "ivy2local" || input == "ivy2Local")
+      Right(LocalRepositories.ivy2Local)
+    else if (input == "ivy2cache" || input == "ivy2Cache")
+      Right(LocalRepositories.Dangerous.ivy2Cache)
+    else if (input == "m2Local" || input == "m2local")
+      Right(LocalRepositories.Dangerous.maven2Local)
+    else {
+      val repo = SharedRepositoryParser.repository(input)
+
+      val url = repo.map {
+        case m: MavenRepository =>
+          m.getBase()
+        case i: IvyRepository =>
+          // FIXME We're not handling metadataPattern here
+          constantPrefixOf(i.getPattern())
+        case r =>
+          sys.error(s"Unrecognized repository: $r")
+      }
+
+      val validatedUrl = url.flatMap { url0 =>
+        try Right(new URL(url0))
+        catch {
+          case e: MalformedURLException =>
+            val urlErrorMsg =
+              "Error parsing URL " + url0 + Option(e.getMessage).fold("")(
+                " (" + _ + ")"
+              )
+
+            if (url0.contains(File.separatorChar)) {
+              val f = new File(url0)
+              if (f.exists() && !f.isDirectory)
+                Left(s"$urlErrorMsg, and $url0 not a directory")
+              else
+                Right(f.toURI.toURL)
+            } else
+              Left(urlErrorMsg)
+        }
+      }
+
+      validatedUrl.flatMap { url =>
+        Option(url.getUserInfo) match {
+          case None =>
+            repo
+          case Some(userInfo) =>
+            val (user, password) = userInfo.split(":", 2) match {
+              case Array(user, password) => (user, password)
+              case Array(user)           => (user, "")
+            }
+
+            val auth = Credentials
+              .of(user, password)
+              .withHttpsOnly(url.getProtocol != "http")
+
+            val baseUrl = new java.net.URL(
+              url.getProtocol,
+              url.getHost,
+              url.getPort,
+              url.getFile
+            ).toString
+
+            repo.map {
+              case _: MavenRepository =>
+                MavenRepository.of(baseUrl).withCredentials(auth)
+              case i: IvyRepository =>
+                val prefix = constantPrefixOf(i.getPattern())
+                val rest = i.getPattern().substring(prefix.length())
+                IvyRepository
+                  .of(baseUrl + rest, i.getMetadataPattern())
+                  .withCredentials(auth)
+                  .withDropInfoAttributes(i.getDropInfoAttributes())
+              case r =>
+                sys.error(s"Unrecognized repository: $r")
+            }
+        }
+      }
+    }
+
+  // coursierapi's Repository model has no structured Pattern/Chunk type like
+  // coursier-core's IvyRepository.pattern.chunks - patterns are plain strings.
+  // This extracts the literal (non-placeholder, non-optional) prefix, e.g.
+  // "https://host/repo/" out of "https://host/repo/[organisation]/[module]/...",
+  // standing in for "the constant chunks preceding the first Var/Opt chunk".
+  private def constantPrefixOf(pattern: String): String = {
+    val idx = pattern.indexWhere(c => c == '[' || c == '(')
+    if (idx < 0) pattern else pattern.substring(0, idx)
+  }
+
+  // Corresponds to coursier's default Ivy pattern:
+  // [organisation]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)[revision]/[type]s/[artifact](-[classifier]).[ext]
+  private val ivyDefaultPattern =
+    "[organisation]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)[revision]/[type]s/[artifact](-[classifier]).[ext]"
+
+  // A JVM-only reimplementation of coursier-core's `coursier.LocalRepositories`,
+  // built on `coursierapi` types instead of coursier-core's own `Repository` model.
+  private object LocalRepositories {
+
+    private def ivy2HomeUri: String = {
+      val path = sys.props
+        .get("coursier.ivy.home")
+        .orElse(sys.props.get("ivy.home"))
+        .getOrElse(sys.props("user.home") + "/.ivy2/")
+      val str = new File(path).toURI().toString()
+      if (str.endsWith("/")) str else str + "/"
+    }
+
+    def ivy2Local: IvyRepository =
+      IvyRepository
+        .of(ivy2HomeUri + "local/" + ivyDefaultPattern)
+        .withDropInfoAttributes(true)
+
+    object Dangerous {
+      def ivy2Cache: IvyRepository =
+        IvyRepository
+          .of(
+            ivy2HomeUri + "cache/" +
+              "(scala_[scalaVersion]/)(sbt_[sbtVersion]/)[organisation]/[module]/[type]s/[artifact]-[revision](-[classifier]).[ext]",
+            ivy2HomeUri + "cache/" +
+              "(scala_[scalaVersion]/)(sbt_[sbtVersion]/)[organisation]/[module]/[type]-[revision](-[classifier]).[ext]"
+          )
+          .withDropInfoAttributes(true)
+
+      def maven2Local: MavenRepository = {
+        val str = new File(sys.props("user.home")).toURI().toString()
+        val homeUri = if (str.endsWith("/")) str else str + "/"
+        MavenRepository.of(homeUri + ".m2/repository")
+      }
+    }
+  }
+
+  // A JVM-only reimplementation of coursier-core's `coursier.internal.SharedRepositoryParser`,
+  // built on `coursierapi` types instead of coursier-core's own `Repository` model.
+  private object SharedRepositoryParser {
+
+    def repository(s: String): Either[String, Repository] =
+      if (s == "central")
+        Right(Repositories.central)
+      else if (s.startsWith("sonatype:"))
+        Right(Repositories.sonatype(s.stripPrefix("sonatype:")))
+      else if (s.startsWith("sonatype-s01:"))
+        Right(Repositories.sonatypeS01(s.stripPrefix("sonatype-s01:")))
+      else if (s.startsWith("bintray:")) {
+        val s0 = s.stripPrefix("bintray:")
+        val id =
+          if (s.contains("/")) s0
+          else s0 + "/maven"
+
+        Right(Repositories.bintray(id))
+      } else if (s.startsWith("bintray-ivy:"))
+        Right(Repositories.bintrayIvy(s.stripPrefix("bintray-ivy:")))
+      else if (s.startsWith("typesafe:ivy-"))
+        Right(Repositories.typesafeIvy(s.stripPrefix("typesafe:ivy-")))
+      else if (s.startsWith("typesafe:"))
+        Right(Repositories.typesafe(s.stripPrefix("typesafe:")))
+      else if (s.startsWith("sbt-maven:"))
+        Right(Repositories.sbtMaven(s.stripPrefix("sbt-maven:")))
+      else if (s.startsWith("sbt-plugin:"))
+        Right(Repositories.sbtPlugin(s.stripPrefix("sbt-plugin:")))
+      else if (s == "scala-integration" || s == "scala-nightlies")
+        Right(Repositories.scalaIntegration)
+      else if (s.startsWith("ivy:")) {
+        val s0 = s.stripPrefix("ivy:")
+        val sepIdx = s0.indexOf('|')
+        if (sepIdx < 0)
+          Right(IvyRepository.of(s0))
+        else {
+          val mainPart = s0.substring(0, sepIdx)
+          val metadataPart = s0.substring(sepIdx + 1)
+          Right(IvyRepository.of(mainPart, metadataPart))
+        }
+      } else if (s == "jitpack")
+        Right(Repositories.jitpack)
+      else if (s == "clojars")
+        Right(Repositories.clojars)
+      else if (s == "jcenter")
+        Right(Repositories.jcenter)
+      else if (s == "google")
+        Right(Repositories.google)
+      else if (s == "gcs")
+        Right(Repositories.centralGcs)
+      else if (s == "gcs-eu")
+        Right(Repositories.centralGcsEu)
+      else if (s == "gcs-asia")
+        Right(Repositories.centralGcsAsia)
+      else if (s.startsWith("apache:"))
+        Right(Repositories.apache(s.stripPrefix("apache:")))
+      else
+        Right(MavenRepository.of(s))
+
+  }
+
+}

--- a/modules/codegen/test/src/smithy4s/codegen/internals/RepositoryParserSpec.scala
+++ b/modules/codegen/test/src/smithy4s/codegen/internals/RepositoryParserSpec.scala
@@ -1,0 +1,145 @@
+/*
+ *  Copyright 2021-2026 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package smithy4s.codegen.internals
+
+// Adapted from coursier's own repository parser tests, Copyright the coursier
+// contributors, licensed under the Apache License, Version 2.0
+// (http://www.apache.org/licenses/LICENSE-2.0):
+// https://github.com/coursier/coursier/blob/main/modules/coursier/shared/src/test/scala/coursier/tests/parse/RepositoryParserTests.scala
+// Ported from utest to munit (this module's test framework), and from
+// coursier-core's `Repository` model to `coursierapi` types, to match
+// `RepositoryParser.scala`. This whole file is a stopgap: it should be deleted
+// once `RepositoryParser.scala` itself is deleted, i.e. once coursier-interface
+// exposes an equivalent of coursier-core's alias/pattern repository parsing.
+import coursierapi.IvyRepository
+import coursierapi.MavenRepository
+import coursierapi.Repository
+import munit._
+
+class RepositoryParserSpec extends FunSuite {
+
+  private def isMavenRepo(repo: Repository): Boolean =
+    repo match {
+      case _: MavenRepository => true
+      case _                  => false
+    }
+
+  private def isIvyRepo(repo: Repository): Boolean =
+    repo match {
+      case _: IvyRepository => true
+      case _                => false
+    }
+
+  test("bintray-ivy:") {
+    val obtained = RepositoryParser.repository("bintray-ivy:scalameta/maven")
+    assert(obtained.exists(isIvyRepo))
+  }
+
+  test("bintray:") {
+    val obtained = RepositoryParser.repository("bintray:scalameta/maven")
+    assert(obtained.exists(isMavenRepo))
+  }
+
+  test("sbt-plugin:") {
+    val res = RepositoryParser.repository("sbt-plugin:releases")
+    assert(res.exists(isIvyRepo))
+  }
+
+  test("typesafe:ivy-") {
+    val res = RepositoryParser.repository("typesafe:ivy-releases")
+    assert(res.exists(isIvyRepo))
+  }
+
+  test("typesafe:") {
+    val res = RepositoryParser.repository("typesafe:releases")
+    assert(res.exists(isMavenRepo))
+  }
+
+  test("scala-nightlies") {
+    val res = RepositoryParser.repository("scala-nightlies")
+    assert(res.exists(isMavenRepo))
+  }
+
+  test("scala-integration") {
+    val res = RepositoryParser.repository("scala-integration")
+    assert(res.exists(isMavenRepo))
+  }
+
+  test("jitpack") {
+    val res = RepositoryParser.repository("jitpack")
+    assert(res.exists(isMavenRepo))
+  }
+
+  test("clojars") {
+    val res = RepositoryParser.repository("clojars")
+    assert(res.exists(isMavenRepo))
+  }
+
+  test("jcenter") {
+    val res = RepositoryParser.repository("jcenter")
+    assert(res.exists(isMavenRepo))
+  }
+
+  test("google") {
+    val res = RepositoryParser.repository("google")
+    assert(res.exists(isMavenRepo))
+  }
+
+  test("gcs") {
+    val res = RepositoryParser.repository("gcs")
+    assert(res.exists(isMavenRepo))
+  }
+
+  test("gcs-eu") {
+    val res = RepositoryParser.repository("gcs-eu")
+    assert(res.exists(isMavenRepo))
+  }
+
+  test("gcs-asia") {
+    val res = RepositoryParser.repository("gcs-asia")
+    assert(res.exists(isMavenRepo))
+  }
+
+  test("ivy with metadata") {
+    val mainPattern =
+      "http://repo/cache/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)[organisation]/[module]/[type]s/[artifact]-[revision](-[classifier]).[ext]"
+    val metadataPattern =
+      "http://repo/cache/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)[organisation]/[module]/[type]-[revision](-[classifier]).[ext]"
+
+    val repo = s"ivy:$mainPattern|$metadataPattern"
+
+    // Unlike coursier-core's `IvyRepository.parse` (which validates the pattern
+    // and returns an `Either`), `coursierapi.IvyRepository.of` is a dumb
+    // constructor that can't fail - see RepositoryParser.scala's own note on
+    // why that matters here.
+    val expected = IvyRepository.of(mainPattern, metadataPattern)
+
+    val res = RepositoryParser.repository(repo)
+    assertEquals(res, Right(expected))
+  }
+
+  test("apache: snapshots") {
+    val res = RepositoryParser.repository("apache:snapshots")
+    assert(res.exists(isMavenRepo))
+  }
+
+  test("apache: releases") {
+    val res = RepositoryParser.repository("apache:releases")
+    assert(res.exists(isMavenRepo))
+  }
+
+}


### PR DESCRIPTION
## PR Checklist (not all items are relevant to all PRs)

- [ ] Added unit-tests (for runtime code)
- [ ] Added bootstrapped code + smoke tests (when the rendering logic is modified)
- [ ] Added build-plugins integration tests (when reflection loading is required at codegen-time)
- [ ] Added alloy compliance tests (when simpleRestJson protocol behaviour is expanded/updated)
- [ ] Updated dynamic module to match generated-code behaviour
- [ ] Added documentation
- [x] Updated changelog

## Summary
Accept ivy repositories + inline (and adapt) certain parsing utils from `coursier-core`

`generateSmithy4s/smithy4sCodegen` fails to resolve dependencies from `ivy2Local` (and other `coursier-core` repo aliases) since smithy4s 0.18.56, breaking the `localSnapshot` workflow entirely.

Root cause: #1977/#1983 (moving `ModelLoader` from `coursier-core` to `coursier-interface`) replaced `coursier.parse.RepositoryParser.repositories(...)` with `repositories.map(MavenRepository.of)`. `coursierapi.MavenRepository.of` does no alias/pattern parsing at all. I think it was just an overlook, and because of it ivy repos are not supported;

This PR reintroduces `coursier-core's` alias/pattern parsing (`RepositoryParser` + `SharedRepositoryParser` + `Repositories`) as inlined code, adapted to `coursierapi` types. `ModelLoader` just uses these new copied/adapted classes. 

This is meant as a temporary solution: all of it should be deleted once `coursier-interface` exposes an equivalent alias-parsing API upstream.

Licensing note: the ported logic and tests are adapted from coursier (Apache License 2.0). Each file carries a header attributing the source and noting what was changed. 