### PR TITLE
Fix greedy label matching when followed by static segment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Thank you!
 # 0.19.12
 
 - http4s: Fix the configured `FieldFilter` not being applied when a server encodes response metadata (e.g. HTTP headers) in [#1992](https://github.com/disneystreaming/smithy4s/pull/1992). `SimpleRestJsonBuilder.withFieldFilter(...)` now affects response header/metadata encoding on the server, matching the behavior already present on the client request side.
+- Fix `@http` routes never matching when a greedy label (`{foo+}`) is followed by a static segment (e.g. `/base/{foo+}/end`) in [#1998](https://github.com/disneystreaming/smithy4s/pull/1998). `matchPath` only accumulated greedy segments when the greedy label was the last path segment, so such routes always 404'd.
 
 # 0.19.11
 

--- a/modules/bootstrapped/test/src/smithy4s/http/MatchPathSpec.scala
+++ b/modules/bootstrapped/test/src/smithy4s/http/MatchPathSpec.scala
@@ -87,6 +87,36 @@ class MatchPathSpec() extends munit.FunSuite with munit.ScalaCheckSuite {
     expect.eql(result, Some(expected))
   }
 
+  test("Allows for greedy labels followed by a static segment") {
+    // /base/{foo*}/end
+    val path: List[PathSegment] =
+      List(
+        PathSegment.static("base"),
+        PathSegment.greedy("foo"),
+        PathSegment.static("end")
+      )
+    val expected = Map("foo" -> "a/b")
+    val result = doMatch(path)("base", "a", "b", "end")
+
+    expect.eql(result, Some(expected))
+  }
+
+  test(
+    "Greedy labels capture segments equal to the trailing static segment"
+  ) {
+    // /base/{foo*}/end
+    val path: List[PathSegment] =
+      List(
+        PathSegment.static("base"),
+        PathSegment.greedy("foo"),
+        PathSegment.static("end")
+      )
+    val expected = Map("foo" -> "a/end/b")
+    val result = doMatch(path)("base", "a", "end", "b", "end")
+
+    expect.eql(result, Some(expected))
+  }
+
   test("Match several segments") {
     // /{foo}/bar/{baz}
     val path: List[PathSegment] =

--- a/modules/bootstrapped/test/src/smithy4s/http/MatchPathSpec.scala
+++ b/modules/bootstrapped/test/src/smithy4s/http/MatchPathSpec.scala
@@ -101,6 +101,19 @@ class MatchPathSpec() extends munit.FunSuite with munit.ScalaCheckSuite {
     expect.eql(result, Some(expected))
   }
 
+  test("Rejects a mismatched static segment after a greedy label") {
+    // /base/{foo*}/end
+    val path: List[PathSegment] =
+      List(
+        PathSegment.static("base"),
+        PathSegment.greedy("foo"),
+        PathSegment.static("end")
+      )
+    val result = doMatch(path)("base", "a", "b", "not-end")
+
+    expect.eql(result, None)
+  }
+
   test(
     "Greedy labels capture segments equal to the trailing static segment"
   ) {

--- a/modules/core/src/smithy4s/http/matchPath.scala
+++ b/modules/core/src/smithy4s/http/matchPath.scala
@@ -30,31 +30,24 @@ object matchPath extends smithy4s.ScalaCompat {
     def matchPathAux(
         path: List[PathSegment],
         i: Int,
-        acc: Map[String, String],
-        greedyAcc: List[String]
+        acc: Map[String, String]
     ): Option[Map[String, String]] =
       path match {
         case Nil if i >= size => Some(acc)
         case StaticSegment(value) :: lt
             if i < size && compareStrings(value, received(i)) =>
-          matchPathAux(lt, i + 1, acc, Nil)
+          matchPathAux(lt, i + 1, acc)
         case (LabelSegment(name) :: lt) if i < size =>
-          matchPathAux(lt, i + 1, acc + (name -> received(i)), Nil)
-        case (GreedySegment(name) :: StaticSegment(value) :: lt)
-            if i < size && compareStrings(
-              value,
-              received(i)
-            ) && greedyAcc.nonEmpty =>
-          val value = greedyAcc.reverse.mkString("/")
-          matchPathAux(lt, i + 1, acc + (name -> value), Nil)
-        case p @ (GreedySegment(_) :: Nil) if i < size =>
-          matchPathAux(p, i + 1, acc, received(i) :: greedyAcc)
-        case GreedySegment(name) :: Nil if greedyAcc.nonEmpty =>
-          val value = greedyAcc.reverse.mkString("/")
-          Some(acc + (name -> value))
+          matchPathAux(lt, i + 1, acc + (name -> received(i)))
+        case GreedySegment(name) :: lt =>
+          val end = size - lt.length
+          if (end > i) {
+            val value = received.slice(i, end).mkString("/")
+            matchPathAux(lt, end, acc + (name -> value))
+          } else None
         case _ => None
       }
-    matchPathAux(path, 0, Map.empty, List.empty)
+    matchPathAux(path, 0, Map.empty)
   }
 
   private[http] def make(str: String): IndexedSeq[String] =


### PR DESCRIPTION
## Summary
- Routes like `/base/{foo+}/end` never matched, always 404ing
- `greedyAcc` was only ever populated when the greedy label was the last segment, so the `GreedySegment :: StaticSegment` branch's guard could never be satisfied
- Rewrote greedy matching to split on the fixed-length suffix after the greedy segment

Fixes #1997

## PR Checklist (not all items are relevant to all PRs)

- [x] Added unit-tests (for runtime code)
- [ ] Added bootstrapped code + smoke tests (when the rendering logic is modified) — not applicable, no rendering logic touched
- [ ] Added build-plugins integration tests (when reflection loading is required at codegen-time) — not applicable
- [ ] Added alloy compliance tests (when simpleRestJson protocol behaviour is expanded/updated) — this is a bug fix to existing path-matching behavior, no alloy-side test added
- [ ] Updated dynamic module to match generated-code behaviour — not applicable, `matchPath` is shared runtime code used by both codegen and the dynamic module
- [ ] Added documentation — not applicable, internal routing fix
- [x] Updated changelog