### PR TITLE
Fix precision loss for large BigInteger/BigDecimal values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Thank you!
 # 0.19.12
 
 - http4s: Fix the configured `FieldFilter` not being applied when a server encodes response metadata (e.g. HTTP headers) in [#1992](https://github.com/disneystreaming/smithy4s/pull/1992). `SimpleRestJsonBuilder.withFieldFilter(...)` now affects response header/metadata encoding on the server, matching the behavior already present on the client request side.
+- codegen: Fix `BigInteger`/`BigDecimal` default values and `@range` bounds losing precision when they don't fit in an `Int`/`Double` (e.g. `4294967296` becoming `0`, `9007199254740993` becoming `9007199254740992`), in [#2002](https://github.com/disneystreaming/smithy4s/pull/2002), fixing [#2001](https://github.com/disneystreaming/smithy4s/issues/2001). Values are now carried exactly and rendered as `scala.math.BigDecimal("...")`/`scala.math.BigInt("...")` string literals. Integer `Document` defaults beyond the `Long` range are rendered with `Document.fromBigDecimal` instead of wrapping. As a side effect, `@range` bounds on integer literals now print without a trailing `.0` in validation error messages (e.g. `Input must be >= 1` instead of `>= 1.0`).
 - Fix `@http` routes never matching when a greedy label (`{foo+}`) is followed by a static segment (e.g. `/base/{foo+}/end`) in [#1998](https://github.com/disneystreaming/smithy4s/pull/1998). `matchPath` only accumulated greedy segments when the greedy label was the last path segment, so such routes always 404'd.
 
 # 0.19.11

--- a/modules/bootstrapped/src/generated/com/amazonaws/dynamodb/ListTablesInputLimit.scala
+++ b/modules/bootstrapped/src/generated/com/amazonaws/dynamodb/ListTablesInputLimit.scala
@@ -10,6 +10,6 @@ import smithy4s.schema.Schema.int
 object ListTablesInputLimit extends Newtype[Int] {
   val id: ShapeId = ShapeId("com.amazonaws.dynamodb", "ListTablesInputLimit")
   val hints: Hints = Hints.empty
-  val underlyingSchema: Schema[Int] = int.withId(id).addHints(hints).validated(smithy.api.Range(min = Some(scala.math.BigDecimal(1.0)), max = Some(scala.math.BigDecimal(100.0))))
+  val underlyingSchema: Schema[Int] = int.withId(id).addHints(hints).validated(smithy.api.Range(min = Some(scala.math.BigDecimal("1")), max = Some(scala.math.BigDecimal("100"))))
   implicit val schema: Schema[ListTablesInputLimit] = bijection(underlyingSchema, asBijection)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/BigNumeric.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/BigNumeric.scala
@@ -1,0 +1,30 @@
+package smithy4s.example
+
+import smithy4s.Document
+import smithy4s.Hints
+import smithy4s.Schema
+import smithy4s.ShapeId
+import smithy4s.ShapeTag
+import smithy4s.schema.Schema.bigdecimal
+import smithy4s.schema.Schema.bigint
+import smithy4s.schema.Schema.document
+import smithy4s.schema.Schema.long
+import smithy4s.schema.Schema.struct
+
+final case class BigNumeric(bi: BigInt = scala.math.BigInt("4294967296"), bd: BigDecimal = scala.math.BigDecimal("9007199254740993"), doc: Document = smithy4s.Document.fromBigDecimal(scala.math.BigDecimal("18446744073709551616")), l: Option[Long] = None)
+
+object BigNumeric extends ShapeTag.Companion[BigNumeric] {
+  val id: ShapeId = ShapeId("smithy4s.example", "BigNumeric")
+
+  val hints: Hints = Hints.empty
+
+  // constructor using the original order from the spec
+  private def make(bi: BigInt, bd: BigDecimal, l: Option[Long], doc: Document): BigNumeric = BigNumeric(bi, bd, doc, l)
+
+  implicit val schema: Schema[BigNumeric] = struct[BigNumeric](
+    bigint.field[BigNumeric]("bi", _.bi).addHints(Hints.dynamic(ShapeId("smithy.api", "default"), smithy4s.Document.fromLong(4294967296L))),
+    bigdecimal.field[BigNumeric]("bd", _.bd).addHints(Hints.dynamic(ShapeId("smithy.api", "default"), smithy4s.Document.fromLong(9007199254740993L))),
+    long.validated(smithy.api.Range(min = Some(scala.math.BigDecimal("-9007199254740993")), max = Some(scala.math.BigDecimal("9007199254740993")))).optional[BigNumeric]("l", _.l),
+    document.field[BigNumeric]("doc", _.doc).addHints(Hints.dynamic(ShapeId("smithy.api", "default"), smithy4s.Document.fromBigDecimal(scala.math.BigDecimal("18446744073709551616")))),
+  )(make).withId(id).addHints(hints)
+}

--- a/modules/bootstrapped/src/generated/smithy4s/example/HasConstrainedNewtypes.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/HasConstrainedNewtypes.scala
@@ -19,7 +19,7 @@ object HasConstrainedNewtypes extends ShapeTag.Companion[HasConstrainedNewtypes]
   implicit val schema: Schema[HasConstrainedNewtypes] = struct[HasConstrainedNewtypes](
     BucketName.schema.validated(smithy.api.Length(min = Some(1L), max = None)).required[HasConstrainedNewtypes]("a", _.a),
     CityId.schema.validated(smithy.api.Length(min = Some(1L), max = None)).required[HasConstrainedNewtypes]("b", _.b),
-    ObjectSize.schema.validated(smithy.api.Range(min = Some(scala.math.BigDecimal(1.0)), max = None)).optional[HasConstrainedNewtypes]("c", _.c),
+    ObjectSize.schema.validated(smithy.api.Range(min = Some(scala.math.BigDecimal("1")), max = None)).optional[HasConstrainedNewtypes]("c", _.c),
     SomeIndexSeq.underlyingSchema.validated(smithy.api.Length(min = Some(1L), max = None)).optional[HasConstrainedNewtypes]("d", _.d),
     PNG.schema.validated(smithy.api.Length(min = Some(1L), max = None)).optional[HasConstrainedNewtypes]("e", _.e),
   )(make).withId(id).addHints(hints)

--- a/modules/bootstrapped/src/generated/smithy4s/example/Numeric.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/Numeric.scala
@@ -13,7 +13,7 @@ import smithy4s.schema.Schema.long
 import smithy4s.schema.Schema.short
 import smithy4s.schema.Schema.struct
 
-final case class Numeric(i: Int = 1, f: Float = 1.0f, d: Double = 1.0d, s: Short = 1, l: Long = 9999999999L, bi: BigInt = scala.math.BigInt(1), bd: BigDecimal = scala.math.BigDecimal(1.0))
+final case class Numeric(i: Int = 1, f: Float = 1.0f, d: Double = 1.0d, s: Short = 1, l: Long = 9999999999L, bi: BigInt = scala.math.BigInt("1"), bd: BigDecimal = scala.math.BigDecimal("1"))
 
 object Numeric extends ShapeTag.Companion[Numeric] {
   val id: ShapeId = ShapeId("smithy4s.example", "Numeric")

--- a/modules/bootstrapped/src/generated/smithy4s/example/Queries.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/Queries.scala
@@ -34,7 +34,7 @@ object Queries extends ShapeTag.Companion[Queries] {
     Numbers.schema.optional[Queries]("ie", _.ie).addHints(Hints.dynamic(ShapeId("smithy.api", "httpQuery"), smithy4s.Document.fromString("nums"))),
     OpenNums.schema.optional[Queries]("on", _.on).addHints(Hints.dynamic(ShapeId("smithy.api", "httpQuery"), smithy4s.Document.fromString("openNums"))),
     OpenNumsStr.schema.optional[Queries]("ons", _.ons).addHints(Hints.dynamic(ShapeId("smithy.api", "httpQuery"), smithy4s.Document.fromString("openNumsStr"))),
-    double.validated(smithy.api.Range(min = Some(scala.math.BigDecimal(0.0)), max = Some(scala.math.BigDecimal(100.0)))).optional[Queries]("dbl", _.dbl).addHints(Hints.dynamic(ShapeId("smithy.api", "httpQuery"), smithy4s.Document.fromString("dbl"))),
+    double.validated(smithy.api.Range(min = Some(scala.math.BigDecimal("0")), max = Some(scala.math.BigDecimal("100")))).optional[Queries]("dbl", _.dbl).addHints(Hints.dynamic(ShapeId("smithy.api", "httpQuery"), smithy4s.Document.fromString("dbl"))),
     StringMap.underlyingSchema.optional[Queries]("slm", _.slm).addHints(Hints.dynamic(ShapeId("smithy.api", "httpQueryParams"), smithy4s.Document.obj())),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/RangeCheck.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/RangeCheck.scala
@@ -20,6 +20,6 @@ object RangeCheck extends ShapeTag.Companion[RangeCheck] {
   private def make(qty: Int): RangeCheck = RangeCheck(qty)
 
   implicit val schema: Schema[RangeCheck] = struct[RangeCheck](
-    int.validated(smithy.api.Range(min = Some(scala.math.BigDecimal(1.0)), max = None)).required[RangeCheck]("qty", _.qty),
+    int.validated(smithy.api.Range(min = Some(scala.math.BigDecimal("1")), max = None)).required[RangeCheck]("qty", _.qty),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/StructureConstrainingEnum.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/StructureConstrainingEnum.scala
@@ -21,6 +21,6 @@ object StructureConstrainingEnum extends ShapeTag.Companion[StructureConstrainin
 
   implicit val schema: Schema[StructureConstrainingEnum] = struct[StructureConstrainingEnum](
     Letters.schema.validated(smithy.api.Length(min = Some(2L), max = None)).validated(smithy.api.Pattern(s"$$aaa$$")).optional[StructureConstrainingEnum]("letter", _.letter),
-    FaceCard.schema.validated(smithy.api.Range(min = None, max = Some(scala.math.BigDecimal(1.0)))).optional[StructureConstrainingEnum]("card", _.card),
+    FaceCard.schema.validated(smithy.api.Range(min = None, max = Some(scala.math.BigDecimal("1")))).optional[StructureConstrainingEnum]("card", _.card),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/StructureWithScalaImports.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/StructureWithScalaImports.scala
@@ -19,6 +19,6 @@ object StructureWithScalaImports extends ShapeTag.Companion[StructureWithScalaIm
   private def make(teenage: Option[Age]): StructureWithScalaImports = StructureWithScalaImports(teenage)
 
   implicit val schema: Schema[StructureWithScalaImports] = struct[StructureWithScalaImports](
-    Age.schema.validated(smithy.api.Range(min = Some(scala.math.BigDecimal(13.0)), max = Some(scala.math.BigDecimal(19.0)))).optional[StructureWithScalaImports]("teenage", _.teenage),
+    Age.schema.validated(smithy.api.Range(min = Some(scala.math.BigDecimal("13")), max = Some(scala.math.BigDecimal("19")))).optional[StructureWithScalaImports]("teenage", _.teenage),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/ValidationChecks.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/ValidationChecks.scala
@@ -21,6 +21,6 @@ object ValidationChecks extends ShapeTag.Companion[ValidationChecks] {
   implicit val schema: Schema[ValidationChecks] = struct[ValidationChecks](
     string.validated(smithy.api.Length(min = Some(1L), max = Some(10L))).optional[ValidationChecks]("str", _.str).addHints(Hints.dynamic(ShapeId("smithy.api", "httpQuery"), smithy4s.Document.fromString("str"))),
     StringList.underlyingSchema.validated(smithy.api.Length(min = Some(1L), max = Some(10L))).optional[ValidationChecks]("lst", _.lst).addHints(Hints.dynamic(ShapeId("smithy.api", "httpQuery"), smithy4s.Document.fromString("lst"))),
-    int.validated(smithy.api.Range(min = Some(scala.math.BigDecimal(1.0)), max = Some(scala.math.BigDecimal(10.0)))).optional[ValidationChecks]("int", _.int).addHints(Hints.dynamic(ShapeId("smithy.api", "httpQuery"), smithy4s.Document.fromString("int"))),
+    int.validated(smithy.api.Range(min = Some(scala.math.BigDecimal("1")), max = Some(scala.math.BigDecimal("10")))).optional[ValidationChecks]("int", _.int).addHints(Hints.dynamic(ShapeId("smithy.api", "httpQuery"), smithy4s.Document.fromString("int"))),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/src/generated/smithy4s/example/protobuf/RefinedIntWrapped.scala
+++ b/modules/bootstrapped/src/generated/smithy4s/example/protobuf/RefinedIntWrapped.scala
@@ -20,6 +20,6 @@ object RefinedIntWrapped extends ShapeTag.Companion[RefinedIntWrapped] {
   private def make(int: Int): RefinedIntWrapped = RefinedIntWrapped(int)
 
   implicit val schema: Schema[RefinedIntWrapped] = struct[RefinedIntWrapped](
-    int.validated(smithy.api.Range(min = Some(scala.math.BigDecimal(1.0)), max = Some(scala.math.BigDecimal(10.0)))).required[RefinedIntWrapped]("int", _.int),
+    int.validated(smithy.api.Range(min = Some(scala.math.BigDecimal("1")), max = Some(scala.math.BigDecimal("10")))).required[RefinedIntWrapped]("int", _.int),
   )(make).withId(id).addHints(hints)
 }

--- a/modules/bootstrapped/test/src/smithy4s/http/internals/MetadataSpec.scala
+++ b/modules/bootstrapped/test/src/smithy4s/http/internals/MetadataSpec.scala
@@ -128,7 +128,7 @@ class MetadataSpec() extends FunSuite {
     "length required to be >= 1 and <= 10, but was 11"
 
   val constraintMessage2 =
-    if (!Platform.isJS) "Input must be >= 1.0 and <= 10.0, but was 11.0"
+    if (!Platform.isJS) "Input must be >= 1 and <= 10, but was 11.0"
     else "Input must be >= 1 and <= 10, but was 11"
 
   // ///////////////////////////////////////////////////////////

--- a/modules/codegen/src/smithy4s/codegen/internals/Renderer.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/Renderer.scala
@@ -1902,15 +1902,16 @@ private[internals] class Renderer(compilationUnit: CompilationUnit) { self =>
     // The asInstanceOf is needed for Scala 3 compatibility since it doesn't refine T through the Aux type alias.
     (prim match {
       case Primitive.BigDecimal =>
-        (bd: BigDecimal) => line"scala.math.BigDecimal($bd)"
-      case Primitive.BigInteger => (bi: BigInt) => line"scala.math.BigInt($bi)"
-      case Primitive.Unit       => (_: Unit) => line"()"
-      case Primitive.Double     => (t: Double) => line"${t.toString}d"
-      case Primitive.Float      => (t: Float) => line"${t.toString}f"
-      case Primitive.Long       => (t: Long) => line"${t.toString}L"
-      case Primitive.Int        => (t: Int) => line"${t.toString}"
-      case Primitive.Short      => (t: Short) => line"${t.toString}"
-      case Primitive.Bool       => (t: Boolean) => line"${t.toString}"
+        (bd: BigDecimal) => line"scala.math.BigDecimal(${renderStringLiteral(bd.toString)})"
+      case Primitive.BigInteger =>
+        (bi: BigInt) => line"scala.math.BigInt(${renderStringLiteral(bi.toString)})"
+      case Primitive.Unit   => (_: Unit) => line"()"
+      case Primitive.Double => (t: Double) => line"${t.toString}d"
+      case Primitive.Float  => (t: Float) => line"${t.toString}f"
+      case Primitive.Long   => (t: Long) => line"${t.toString}L"
+      case Primitive.Int    => (t: Int) => line"${t.toString}"
+      case Primitive.Short  => (t: Short) => line"${t.toString}"
+      case Primitive.Bool   => (t: Boolean) => line"${t.toString}"
       case Primitive.Uuid =>
         (uuid: java.util.UUID) => line"java.util.UUID.fromString(${renderStringLiteral(uuid.toString)})"
       case Primitive.String => (s: String) => renderStringLiteral(s)
@@ -1948,10 +1949,12 @@ private[internals] class Renderer(compilationUnit: CompilationUnit) { self =>
       def nullNode(x: NullNode): Line =
         line"smithy4s.Document.nullDoc"
       def numberNode(x: NumberNode): Line =
-        if (x.isFloatingPointNumber()) {
-          line"smithy4s.Document.fromDouble(${x.getValue.doubleValue()}d)"
-        } else {
-          line"smithy4s.Document.fromLong(${x.getValue.longValue()}L)"
+        x.getValue match {
+          case n @ (_: java.math.BigInteger | _: java.math.BigDecimal) =>
+            line"smithy4s.Document.fromBigDecimal(${renderPrimitive(Primitive.BigDecimal)(BigDecimal(n.toString))})"
+          case n if x.isFloatingPointNumber() =>
+            line"smithy4s.Document.fromDouble(${n.doubleValue()}d)"
+          case n => line"smithy4s.Document.fromLong(${n.longValue()}L)"
         }
       def objectNode(x: ObjectNode): Line = {
         val members = x.getMembers.asScala.map { member =>

--- a/modules/codegen/src/smithy4s/codegen/internals/SmithyToIR.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/SmithyToIR.scala
@@ -1678,15 +1678,12 @@ private[codegen] class SmithyToIR(
         TypedNode.PrimitiveTN(Primitive.Float, Some(num.floatValue()))
       case (N.NumberNode(num), Primitive.Short) =>
         TypedNode.PrimitiveTN(Primitive.Short, Some(num.shortValue()))
-      case (N.NumberNode(num), Primitive.BigDecimal) =>
-        TypedNode.PrimitiveTN(
-          Primitive.BigDecimal,
-          Some(BigDecimal(num.doubleValue()))
-        )
-      case (N.NumberNode(num), Primitive.BigInteger) =>
+      case (N.BigDecimalNode(bd), Primitive.BigDecimal) =>
+        TypedNode.PrimitiveTN(Primitive.BigDecimal, Some(bd))
+      case (N.BigDecimalNode(bd), Primitive.BigInteger) =>
         TypedNode.PrimitiveTN(
           Primitive.BigInteger,
-          Some(BigInt(num.intValue()))
+          Some(bd.toBigIntExact.getOrElse(notSupported((node, p))))
         )
       // Boolean
       case (N.BooleanNode(bool), Primitive.Bool) =>

--- a/modules/codegen/src/smithy4s/codegen/internals/package.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/package.scala
@@ -160,6 +160,14 @@ package object internals {
         extends NodeExtractor(node =>
           node.asNumberNode().asScala.map(_.getValue())
         )
+    private[internals] object BigDecimalNode
+        extends NodeExtractor(node =>
+          node
+            .asNumberNode()
+            .asScala
+            .flatMap(_.asBigDecimal().asScala)
+            .map(scala.math.BigDecimal(_))
+        )
     private[internals] object NullNode {
       def unapply(node: Node): Boolean = node.isNullNode()
     }

--- a/modules/codegen/test/src/smithy4s/codegen/internals/RendererSpec.scala
+++ b/modules/codegen/test/src/smithy4s/codegen/internals/RendererSpec.scala
@@ -822,4 +822,65 @@ final class RendererSpec extends munit.ScalaCheckSuite {
       "val underlyingSchema: Schema[Map[String, Nullable[String]]] = map(string, string.nullable)"
     assert(mapDefinition.contains(sparseMapSchema))
   }
+
+  test("large numeric defaults and range bounds are rendered exactly") {
+    val smithy =
+      """
+        |$version: "2.0"
+        |
+        |namespace smithy4s
+        |
+        |structure BigNumbers {
+        |  bigInt: BigInteger = 4294967296
+        |  bigDec: BigDecimal = 9007199254740993
+        |  @range(max: 9007199254740993)
+        |  long: Long
+        |  doc: Document = 18446744073709551616
+        |  fracDoc: Document = 1.5e400
+        |  frac: BigDecimal = 0.1000000000000000055511151231257827
+        |}
+        |""".stripMargin
+
+    val contents = generateScalaCode(smithy).values
+    val definition =
+      contents.find(_.contains("object BigNumbers")).getOrElse {
+        fail("No BigNumbers definition")
+      }
+
+    assert(
+      definition.contains(
+        """bigInt: BigInt = scala.math.BigInt("4294967296")"""
+      )
+    )
+    assert(
+      definition.contains(
+        """bigDec: BigDecimal = scala.math.BigDecimal("9007199254740993")"""
+      )
+    )
+    assert(
+      definition.contains(
+        """max = Some(scala.math.BigDecimal("9007199254740993"))"""
+      )
+    )
+    assert(
+      definition.contains(
+        """smithy4s.Document.fromBigDecimal(scala.math.BigDecimal("18446744073709551616"))"""
+      )
+    )
+    assert(
+      definition.contains(
+        """smithy4s.Document.fromBigDecimal(scala.math.BigDecimal("1.5E+400"))"""
+      )
+    )
+    assert(
+      definition.contains(
+        """smithy4s.Document.fromBigDecimal(scala.math.BigDecimal("0.1000000000000000055511151231257827"))"""
+      )
+    )
+    assert(
+      !definition.contains(
+        """scala.math.BigDecimal("9007199254740992")"""
+      )
+    )
+  }
 }

--- a/modules/json/test/src/smithy4s/json/SchemaVisitorJCodecTests.scala
+++ b/modules/json/test/src/smithy4s/json/SchemaVisitorJCodecTests.scala
@@ -656,7 +656,7 @@ class SchemaVisitorJCodecTests() extends FunSuite {
     val json = """{"qty":0}"""
     val result = util.Try(readFromString[RangeCheck](json))
     expect(
-      result.failed.get.getMessage == "Input must be >= 1.0, but was 0.0 (path: .qty)" ||
+      result.failed.get.getMessage == "Input must be >= 1, but was 0.0 (path: .qty)" ||
         result.failed.get.getMessage == "Input must be >= 1, but was 0 (path: .qty)" // js
     )
   }

--- a/sampleSpecs/numeric.smithy
+++ b/sampleSpecs/numeric.smithy
@@ -11,3 +11,11 @@ structure Numeric {
     bi: BigInteger = 1
     bd: BigDecimal = 1
 }
+
+structure BigNumeric {
+    bi: BigInteger = 4294967296
+    bd: BigDecimal = 9007199254740993
+    @range(min: -9007199254740993, max: 9007199254740993)
+    l: Long
+    doc: Document = 18446744073709551616
+}


### PR DESCRIPTION
## Summary
- `SmithyToIR` converted `BigInteger` defaults with `intValue()` and `BigDecimal` defaults / `@range` bounds with `doubleValue()`, so `4294967296` became `BigInt(0)` and `9007199254740993` became `9007199254740992`
- Values now come from `NumberNode.asBigDecimal()` and are rendered as `scala.math.BigDecimal("...")` / `scala.math.BigInt("...")` string literals so any magnitude compiles
- `Document` number literals that are `BigInteger`/`BigDecimal` go through `Document.fromBigDecimal` instead of wrapping via `longValue()` (2^64 used to render as `fromLong(0L)`)
- Side effect: integer range bounds no longer carry a `.0` in validation messages (`>= 1` instead of `>= 1.0`), two test expectations updated

Fixes #2001

## PR Checklist (not all items are relevant to all PRs)

- [x] Added unit-tests (for runtime code)
- [x] Added bootstrapped code + smoke tests (when the rendering logic is modified)
- [ ] Added build-plugins integration tests (when reflection loading is required at codegen-time) - not applicable
- [ ] Added alloy compliance tests (when simpleRestJson protocol behaviour is expanded/updated) - not applicable
- [ ] Updated dynamic module to match generated-code behaviour - not applicable, codegen only
- [ ] Added documentation - not applicable
- [x] Updated changelog
